### PR TITLE
fix(tests): TestWebApplicationFactory fixture for GaApi.Tests (CI hotfix #3)

### DIFF
--- a/Tests/Apps/GaApi.Tests/TestInfrastructure/TestPaths.cs
+++ b/Tests/Apps/GaApi.Tests/TestInfrastructure/TestPaths.cs
@@ -1,0 +1,27 @@
+namespace GaApi.Tests;
+
+using System.Runtime.CompilerServices;
+
+internal static class TestPaths
+{
+    public static string RepositoryRoot([CallerFilePath] string sourceFile = "")
+    {
+        var directory = new DirectoryInfo(Path.GetDirectoryName(sourceFile)
+            ?? throw new InvalidOperationException("Source file path is unavailable."));
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "AllProjects.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException($"Repository root could not be located from {sourceFile}.");
+    }
+
+    public static string RepositoryPath(params string[] segments) =>
+        Path.Combine([RepositoryRoot(), ..segments]);
+}

--- a/Tests/Apps/GaApi.Tests/TestInfrastructure/TestWebApplicationFactory.cs
+++ b/Tests/Apps/GaApi.Tests/TestInfrastructure/TestWebApplicationFactory.cs
@@ -1,0 +1,17 @@
+namespace GaApi.Tests;
+
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override IEnumerable<Assembly> GetTestAssemblies() =>
+        [typeof(TestWebApplicationFactory).Assembly];
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseContentRoot(TestPaths.RepositoryPath("Apps", "ga-server", "GaApi"));
+        base.ConfigureWebHost(builder);
+    }
+}


### PR DESCRIPTION
## Summary

Third hotfix in the same producer/consumer chain. PR #60 updated 14 test files under `Tests/Apps/GaApi.Tests/` to use `new TestWebApplicationFactory()` but the fixture itself lived in an untracked `TestInfrastructure/` directory. PR #61 added the equivalent fixture for `GA.MusicTheory.Service.Tests` but missed this sibling project's fixture.

## Files added

- `Tests/Apps/GaApi.Tests/TestInfrastructure/TestPaths.cs` (27 LOC)
- `Tests/Apps/GaApi.Tests/TestInfrastructure/TestWebApplicationFactory.cs` (17 LOC)

## Verification (CI-equivalent — user WIP temporarily isolated)

- `dotnet build Tests/Apps/GaApi.Tests --output <fresh-dir>` → **0 errors** with the WIP `Common/GA.Business.ML/Quality/*` directory and `QaArchitectAgentTests.cs` modifications stashed aside, simulating a clean CI checkout.
- All 14 `error CS0246: 'TestWebApplicationFactory' could not be found` errors from #61's CI are resolved.

## What is NOT in this PR

User's in-progress Phase 1 QA work remains unstaged — `Common/GA.Business.ML/Quality/{QaDiffAnalyzer,QaVerdictJson,QaVerdictModels,QaVerdictStore,QaVerdictValidation}.cs`, `Tests/Common/GA.Business.ML.Tests/Unit/QaDiffAnalyzerTests.cs`, and the refactored `QAArchitectAgent.cs` + `QaArchitectAgentTests.cs` that move types to the new `Quality` namespace. That refactor lands in a future Phase 1 PR (scheduled agent fires 2026-05-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)