### PR TITLE
feat(chatbot): Phase 1 — IChatClientFactory + Anthropic SDK isolation

### DIFF
--- a/Common/GA.Business.Core.Orchestration/GA.Business.Core.Orchestration.csproj
+++ b/Common/GA.Business.Core.Orchestration/GA.Business.Core.Orchestration.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />

--- a/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
+++ b/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
@@ -1,6 +1,7 @@
 namespace GA.Business.ML.Agents.Plugins;
 
 using GA.Business.ML.Agents.Skills;
+using GA.Business.ML.Extensions;
 using GA.Business.ML.Skills;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -49,7 +50,8 @@ public sealed class SkillMdPlugin : IChatPlugin
         }
 
         // IMcpToolsProvider is registered as a singleton by ChatPluginHost after this plugin runs.
-        // Each SkillMdDrivenSkill resolves it lazily on first ExecuteAsync call.
+        // IChatClientFactory is registered by AddGuitarAlchemistAi.
+        // Each SkillMdDrivenSkill resolves the chat client lazily on first ExecuteAsync call.
         foreach (var skill in skills)
         {
             var captured = skill;
@@ -57,7 +59,7 @@ public sealed class SkillMdPlugin : IChatPlugin
                 new SkillMdDrivenSkill(
                     captured,
                     sp.GetRequiredService<IMcpToolsProvider>(),
-                    sp.GetRequiredService<IConfiguration>(),
+                    sp.GetRequiredService<IChatClientFactory>(),
                     sp.GetRequiredService<ILogger<SkillMdDrivenSkill>>()));
         }
     }

--- a/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs
@@ -1,78 +1,50 @@
 namespace GA.Business.ML.Agents.Skills;
 
-using Anthropic;
 using GA.Business.ML.Agents.Plugins;
+using GA.Business.ML.Extensions;
 using GA.Business.ML.Skills;
 using Microsoft.Extensions.AI;
 
 /// <summary>
 /// <see cref="IOrchestratorSkill"/> backed by a SKILL.md file.
-/// Uses the Anthropic SDK + MEAI <see cref="IChatClient"/> for LLM calls,
-/// with GA domain tools supplied by <see cref="IMcpToolsProvider"/>.
-/// <see cref="FunctionInvokingChatClientBuilderExtensions.UseFunctionInvocation"/> handles the
-/// full multi-turn agentic tool-use loop automatically — no hand-coded loop required.
+/// Uses an <see cref="IChatClient"/> resolved via <see cref="IChatClientFactory"/>
+/// for the <c>skill-md</c> purpose (provider chosen by configuration), with GA
+/// domain tools supplied by <see cref="IMcpToolsProvider"/>.
+/// <see cref="FunctionInvokingChatClientBuilderExtensions.UseFunctionInvocation"/>
+/// (applied inside the factory) handles the full multi-turn agentic tool-use loop
+/// automatically — no hand-coded loop required.
 /// </summary>
+/// <remarks>
+/// This type intentionally references no provider SDK; vendor specifics live
+/// inside <c>AnthropicProvider</c> behind the factory. Tests inject a fake
+/// <see cref="IChatClientFactory"/> (or implement <see cref="IChatClient"/> directly)
+/// instead of mutating private state.
+/// </remarks>
 public sealed class SkillMdDrivenSkill : IOrchestratorSkill
 {
-    private const string DefaultModel = "claude-sonnet-4-6";
+    private const string SkillMdPurpose = "skill-md";
 
     private readonly SkillMd _skillMd;
     private readonly IMcpToolsProvider _toolsProvider;
     private readonly ILogger<SkillMdDrivenSkill> _logger;
 
-    // Built once (lazily) and reused for the lifetime of this singleton.
+    // Lazily resolved via the factory and reused for the lifetime of this singleton.
     // LazyThreadSafetyMode.ExecutionAndPublication ensures only one thread builds the client.
     private readonly Lazy<IChatClient> _chatClient;
 
     public SkillMdDrivenSkill(
         SkillMd skillMd,
         IMcpToolsProvider toolsProvider,
-        IConfiguration configuration,
+        IChatClientFactory chatClientFactory,
         ILogger<SkillMdDrivenSkill> logger)
     {
         _skillMd = skillMd;
         _toolsProvider = toolsProvider;
         _logger = logger;
 
-        _chatClient = new Lazy<IChatClient>(() =>
-        {
-            var model = configuration["AnthropicSkills:Model"] ?? DefaultModel;
-            var apiKey = configuration["Anthropic:ApiKey"]
-                         ?? Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-
-            if (string.IsNullOrWhiteSpace(apiKey))
-                throw new InvalidOperationException(
-                    "ANTHROPIC_API_KEY environment variable or Anthropic:ApiKey configuration is required " +
-                    "to run SKILL.md-driven skills. Set the environment variable and restart the service.");
-
-            return new AnthropicClient { ApiKey = apiKey }
-                .AsIChatClient(model)
-                .AsBuilder()
-                .UseFunctionInvocation()
-                .Build();
-        }, LazyThreadSafetyMode.ExecutionAndPublication);
-    }
-
-    /// <summary>
-    /// Creates a <see cref="SkillMdDrivenSkill"/> with an injected <see cref="IChatClient"/>
-    /// for unit testing — bypasses <c>AnthropicClient</c> creation and API-key validation.
-    /// </summary>
-    internal static SkillMdDrivenSkill ForTesting(
-        SkillMd skillMd,
-        IMcpToolsProvider toolsProvider,
-        ILogger<SkillMdDrivenSkill> logger,
-        IChatClient chatClient)
-    {
-        var skill = new SkillMdDrivenSkill(
-            skillMd,
-            toolsProvider,
-            new ConfigurationBuilder().Build(),
-            logger);
-        // Replace the lazy with one that always returns the test client.
-        typeof(SkillMdDrivenSkill)
-            .GetField("_chatClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(skill, new Lazy<IChatClient>(() => chatClient));
-        return skill;
+        _chatClient = new Lazy<IChatClient>(
+            () => chatClientFactory.Create(SkillMdPurpose),
+            LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     public string Name        => _skillMd.Name;

--- a/Common/GA.Business.ML/Extensions/AiServiceExtensions.cs
+++ b/Common/GA.Business.ML/Extensions/AiServiceExtensions.cs
@@ -40,6 +40,12 @@ public static class AiServiceExtensions
         var chatProvider = configuration.GetValue<string>("AI:ChatProvider") ?? "ollama";
         services.AddGuitarAlchemistChatClient(chatProvider, configuration);
 
+        // Provider-neutral factory for purpose-specific chat clients (default,
+        // skill-md, qa-architect, fast-local). Skills/agents resolve their
+        // IChatClient through this factory so vendor SDK types stay encapsulated
+        // in the provider adapters.
+        services.TryAddSingleton<IChatClientFactory, DefaultChatClientFactory>();
+
         return services;
     }
 

--- a/Common/GA.Business.ML/Extensions/DefaultChatClientFactory.cs
+++ b/Common/GA.Business.ML/Extensions/DefaultChatClientFactory.cs
@@ -1,0 +1,64 @@
+namespace GA.Business.ML.Extensions;
+
+using System.Collections.Concurrent;
+using GA.Providers.Anthropic;
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Default <see cref="IChatClientFactory"/> implementation. Routes purposes to
+/// either the DI-registered <see cref="IChatClient"/> (for <c>default</c> and
+/// <c>fast-local</c>) or to <see cref="AnthropicProvider"/> (for <c>skill-md</c>
+/// and <c>qa-architect</c>) based on configuration keys.
+/// </summary>
+/// <remarks>
+/// <para>Backed clients are cached per purpose for the lifetime of the factory —
+/// constructing a new <see cref="IChatClient"/> per call would lose the
+/// connection-pool and function-invocation state baked into the underlying SDKs.</para>
+/// <para>This factory does NOT itself reference any provider SDK type beyond the
+/// <see cref="AnthropicProvider"/> indirection; provider DTOs must not leak across
+/// the <see cref="IChatClientFactory"/> boundary.</para>
+/// </remarks>
+public sealed class DefaultChatClientFactory(
+    IConfiguration configuration,
+    IChatClient defaultClient) : IChatClientFactory
+{
+    private readonly ConcurrentDictionary<string, IChatClient> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    public IChatClient Create(string purpose)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(purpose);
+
+        return _cache.GetOrAdd(purpose, NewClient);
+    }
+
+    private IChatClient NewClient(string purpose) => purpose.ToLowerInvariant() switch
+    {
+        // The default chatbot conversation client and the latency-sensitive local
+        // path both use the IChatClient registered via AddGuitarAlchemistChatClient
+        // — typically Ollama or Docker Model Runner in dev.
+        "default"     => defaultClient,
+        "fast-local"  => defaultClient,
+
+        // Tool-calling skills backed by SKILL.md need a frontier model. Resolve
+        // model name from AnthropicSkills:Model first, falling back to the shared
+        // Anthropic:Model setting and finally the provider's hard-coded default.
+        "skill-md"    => AnthropicProvider.CreateChatClient(
+            configuration,
+            configuration["AnthropicSkills:Model"]
+                ?? configuration["Anthropic:Model"]
+                ?? AnthropicProvider.DefaultModel),
+
+        // QA Architect Tribunal currently shares the SKILL.md / Anthropic path.
+        // Split out into its own model selection once Phase 5 lands.
+        "qa-architect" => AnthropicProvider.CreateChatClient(
+            configuration,
+            configuration["QaArchitect:Model"]
+                ?? configuration["Anthropic:Model"]
+                ?? AnthropicProvider.DefaultModel),
+
+        _ => throw new ArgumentException(
+            $"Unknown chat-client purpose '{purpose}'. " +
+            "Valid purposes: default, skill-md, qa-architect, fast-local.",
+            nameof(purpose)),
+    };
+}

--- a/Common/GA.Business.ML/Extensions/IChatClientFactory.cs
+++ b/Common/GA.Business.ML/Extensions/IChatClientFactory.cs
@@ -1,0 +1,41 @@
+namespace GA.Business.ML.Extensions;
+
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Provider-neutral factory that returns an <see cref="IChatClient"/> for a
+/// named purpose. Centralises model + provider selection so that
+/// orchestrator skills and agents can depend on <see cref="IChatClient"/>
+/// alone without referencing vendor SDK types.
+/// </summary>
+/// <remarks>
+/// <para>Purposes are intentionally named by the role they serve, not by the
+/// underlying model — that lets configuration switch a purpose between
+/// Anthropic, OpenAI, Ollama, or local without touching call sites.</para>
+/// <para>Defined purposes (one-way door — extending this taxonomy requires
+/// updating <c>docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md</c>
+/// §"Phase 1 — provider factory cleanup"):</para>
+/// <list type="bullet">
+///   <item><c>default</c> — top-level chatbot conversational client.</item>
+///   <item><c>skill-md</c> — SKILL.md driven skills that need tool calling and
+///         tend to use a frontier model.</item>
+///   <item><c>qa-architect</c> — QA Architect Tribunal verdict reasoning.</item>
+///   <item><c>fast-local</c> — short, latency-sensitive prompts that should
+///         never leave the box.</item>
+/// </list>
+/// </remarks>
+public interface IChatClientFactory
+{
+    /// <summary>
+    /// Returns an <see cref="IChatClient"/> configured for the given purpose.
+    /// Implementations should cache per purpose so repeat calls return the same
+    /// instance for the lifetime of the factory.
+    /// </summary>
+    /// <param name="purpose">One of <c>default</c>, <c>skill-md</c>,
+    /// <c>qa-architect</c>, or <c>fast-local</c>.</param>
+    /// <exception cref="ArgumentException">Unknown purpose.</exception>
+    /// <exception cref="InvalidOperationException">Backing provider is configured
+    /// for this purpose but is unavailable (e.g. missing API key). The message is
+    /// safe to surface to operators; secrets are never included.</exception>
+    IChatClient Create(string purpose);
+}

--- a/Common/GA.Business.ML/GA.Business.ML.csproj
+++ b/Common/GA.Business.ML/GA.Business.ML.csproj
@@ -33,11 +33,15 @@
     <ProjectReference Include="..\GA.Core\GA.Core.csproj" />
     <ProjectReference Include="..\GA.Business.Config\GA.Business.Config.fsproj" />
     <ProjectReference Include="..\..\GA.Data.MongoDB\GA.Data.MongoDB.csproj" />
+    <ProjectReference Include="..\GA.Providers.Anthropic\GA.Providers.Anthropic.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- AI/ML packages -->
-    <PackageReference Include="Anthropic" Version="12.8.0" />
+    <!-- Anthropic SDK is isolated in Common/GA.Providers.Anthropic/ — do NOT
+         add the Anthropic package back here. The factory boundary in
+         IChatClientFactory + the project graph (no Anthropic ref outside the
+         provider project) together enforce SDK isolation. -->
     <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.5.0" />
     <PackageReference Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.38.0" />
@@ -47,8 +51,8 @@
     <PackageReference Include="OpenAI" Version="2.2.0-beta.1" />
 
     <!-- MEAI - Microsoft Extensions for AI (Standard Abstractions) -->
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1" />
     <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.4.0-preview.1.25207.5" />
     <!-- Microsoft.Extensions.AI.OpenAI deferred - SDK version mismatch, will re-add when stable -->
 

--- a/Common/GA.Providers.Anthropic/AnthropicProvider.cs
+++ b/Common/GA.Providers.Anthropic/AnthropicProvider.cs
@@ -1,0 +1,69 @@
+// The provider's namespace (GA.Providers.Anthropic) shadows the SDK's global
+// `Anthropic` namespace inside this file, so we alias to disambiguate.
+namespace GA.Providers.Anthropic;
+
+using AnthropicSdk = global::Anthropic;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+
+/// <summary>
+/// Provider adapter that builds an <see cref="IChatClient"/> backed by the
+/// official Anthropic C# SDK. Anthropic-specific types are kept inside this
+/// project so callers can depend on <see cref="IChatClient"/> alone.
+/// </summary>
+/// <remarks>
+/// <para>The Anthropic C# SDK is documented as official-but-beta — pin the
+/// package version in <c>GA.Providers.Anthropic.csproj</c>. If a minor SDK break
+/// ripples through, it must be contained here, not in skill or orchestrator
+/// code (per <c>docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md</c>
+/// §"Anthropic SDK guidance").</para>
+/// <para>This is the ONLY place in the GA codebase that should reference
+/// <c>Anthropic.AnthropicClient</c>. The factory boundary in
+/// <c>GA.Business.ML.Extensions.IChatClientFactory</c> enforces this in code;
+/// the project graph (no <c>Anthropic</c> package reference outside this csproj)
+/// enforces it at build time.</para>
+/// </remarks>
+public static class AnthropicProvider
+{
+    public const string DefaultModel = "claude-sonnet-4-6";
+
+    /// <summary>
+    /// Returns true if an Anthropic API key is reachable from configuration or
+    /// the standard <c>ANTHROPIC_API_KEY</c> environment variable. Used by the
+    /// factory to decide whether the Anthropic-backed purposes are viable.
+    /// </summary>
+    public static bool IsAvailable(IConfiguration configuration) =>
+        !string.IsNullOrWhiteSpace(ResolveApiKey(configuration));
+
+    /// <summary>
+    /// Builds an <see cref="IChatClient"/> with function-invocation enabled.
+    /// </summary>
+    /// <param name="configuration">Application configuration; resolves the API key
+    /// from <c>Anthropic:ApiKey</c> first, then <c>ANTHROPIC_API_KEY</c>.</param>
+    /// <param name="model">Anthropic model name (e.g. <c>claude-sonnet-4-6</c>).
+    /// Falls back to <see cref="DefaultModel"/> when null/empty.</param>
+    /// <exception cref="InvalidOperationException">Thrown when no API key is
+    /// reachable. The message is safe to surface to operators (no secrets).</exception>
+    public static IChatClient CreateChatClient(IConfiguration configuration, string? model = null)
+    {
+        var apiKey = ResolveApiKey(configuration);
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException(
+                "Anthropic chat client requested but no API key is configured. " +
+                "Set ANTHROPIC_API_KEY (environment) or Anthropic:ApiKey (configuration).");
+        }
+
+        var resolvedModel = string.IsNullOrWhiteSpace(model) ? DefaultModel : model;
+
+        return new AnthropicSdk.AnthropicClient { ApiKey = apiKey }
+            .AsIChatClient(resolvedModel)
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .Build();
+    }
+
+    private static string? ResolveApiKey(IConfiguration configuration) =>
+        configuration["Anthropic:ApiKey"]
+        ?? Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+}

--- a/Common/GA.Providers.Anthropic/GA.Providers.Anthropic.csproj
+++ b/Common/GA.Providers.Anthropic/GA.Providers.Anthropic.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>GA.Providers.Anthropic</AssemblyName>
+    <RootNamespace>GA.Providers.Anthropic</RootNamespace>
+    <Title>Guitar Alchemist - Anthropic Provider Adapter</Title>
+    <Description>
+      Anthropic SDK adapter producing Microsoft.Extensions.AI IChatClient instances.
+      The official Anthropic C# SDK is documented as official-but-beta — pin its
+      version here and isolate it from the rest of the codebase so a minor SDK
+      break does not ripple through GA. No Anthropic types must leave this project.
+    </Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Pinned: bump deliberately. The Anthropic C# SDK is official-but-beta. -->
+    <PackageReference Include="Anthropic" Version="12.8.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj
+++ b/Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);SKEXP0001</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0001;MAAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4"/>
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0"/>
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>

--- a/Tests/Common/GA.Business.ML.Tests/Unit/DefaultChatClientFactoryTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/DefaultChatClientFactoryTests.cs
@@ -1,0 +1,144 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Extensions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Moq;
+
+[TestFixture]
+public class DefaultChatClientFactoryTests
+{
+    private static IConfiguration EmptyConfig() => new ConfigurationBuilder().Build();
+
+    private static IConfiguration ConfigWith(IDictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static IChatClient FakeDefaultClient() => new Mock<IChatClient>().Object;
+
+    [Test]
+    public void Create_DefaultPurpose_ReturnsRegisteredClient()
+    {
+        var registered = FakeDefaultClient();
+        var factory = new DefaultChatClientFactory(EmptyConfig(), registered);
+
+        Assert.That(factory.Create("default"), Is.SameAs(registered));
+    }
+
+    [Test]
+    public void Create_FastLocalPurpose_ReturnsRegisteredClient()
+    {
+        var registered = FakeDefaultClient();
+        var factory = new DefaultChatClientFactory(EmptyConfig(), registered);
+
+        Assert.That(factory.Create("fast-local"), Is.SameAs(registered));
+    }
+
+    [Test]
+    public void Create_PurposeIsCaseInsensitive()
+    {
+        var registered = FakeDefaultClient();
+        var factory = new DefaultChatClientFactory(EmptyConfig(), registered);
+
+        Assert.That(factory.Create("Default"),    Is.SameAs(registered));
+        Assert.That(factory.Create("FAST-LOCAL"), Is.SameAs(registered));
+    }
+
+    [Test]
+    public void Create_RepeatedCallsForSamePurpose_ReturnSameInstance()
+    {
+        var registered = FakeDefaultClient();
+        var factory = new DefaultChatClientFactory(EmptyConfig(), registered);
+
+        var first  = factory.Create("default");
+        var second = factory.Create("default");
+
+        Assert.That(second, Is.SameAs(first), "factory must cache per purpose for the lifetime of the process");
+    }
+
+    [Test]
+    public void Create_UnknownPurpose_ThrowsArgumentException()
+    {
+        var factory = new DefaultChatClientFactory(EmptyConfig(), FakeDefaultClient());
+
+        Assert.That(
+            () => factory.Create("not-a-real-purpose"),
+            Throws.ArgumentException.With.Message.Contains("default, skill-md, qa-architect, fast-local"));
+    }
+
+    [Test]
+    public void Create_SkillMdPurpose_NoApiKey_ThrowsSafeMessage()
+    {
+        // Ensure no ambient ANTHROPIC_API_KEY interferes.
+        var original = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+        Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", null);
+        try
+        {
+            var factory = new DefaultChatClientFactory(EmptyConfig(), FakeDefaultClient());
+
+            var ex = Assert.Throws<InvalidOperationException>(() => factory.Create("skill-md"));
+            Assert.That(ex!.Message, Does.Contain("API key"));
+            Assert.That(ex.Message, Does.Not.Contain("="),
+                "error message must not echo back env-var values that could leak secrets");
+        }
+        finally
+        {
+            if (original is not null)
+                Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", original);
+        }
+    }
+
+    [Test]
+    public void Create_QaArchitectPurpose_NoApiKey_ThrowsSafeMessage()
+    {
+        var original = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+        Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", null);
+        try
+        {
+            var factory = new DefaultChatClientFactory(EmptyConfig(), FakeDefaultClient());
+
+            var ex = Assert.Throws<InvalidOperationException>(() => factory.Create("qa-architect"));
+            Assert.That(ex!.Message, Does.Contain("API key"));
+        }
+        finally
+        {
+            if (original is not null)
+                Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", original);
+        }
+    }
+
+    [Test]
+    public void Create_NullOrWhitespacePurpose_Throws()
+    {
+        var factory = new DefaultChatClientFactory(EmptyConfig(), FakeDefaultClient());
+
+        // ArgumentException.ThrowIfNullOrWhiteSpace throws ArgumentNullException for null
+        // and ArgumentException for empty/whitespace — both are valid guard signals.
+        Assert.That(() => factory.Create(null!), Throws.InstanceOf<ArgumentNullException>());
+        Assert.That(() => factory.Create(""),    Throws.ArgumentException);
+        Assert.That(() => factory.Create("   "), Throws.ArgumentException);
+    }
+
+    [Test]
+    public void Create_WithApiKeyInConfig_DoesNotLeakKeyIntoExceptionMessages()
+    {
+        // If the SDK construction itself fails downstream (network etc.), the factory
+        // should not surface the API key in any error message. We verify by giving an
+        // obviously-syntactic-but-fake key and confirming the factory either succeeds
+        // or fails cleanly without echoing the key. Anthropic SDK lazy-validates the
+        // key only on first request, so Create() succeeds; we just check the path
+        // doesn't blow up at construction time.
+        var config = ConfigWith(new Dictionary<string, string?>
+        {
+            ["Anthropic:ApiKey"]      = "sk-ant-fake-test-key-do-not-use",
+            ["AnthropicSkills:Model"] = "claude-sonnet-4-6",
+        });
+
+        var factory = new DefaultChatClientFactory(config, FakeDefaultClient());
+
+        // Construction succeeds because the SDK doesn't validate at this point.
+        var client = factory.Create("skill-md");
+        Assert.That(client, Is.Not.Null);
+        Assert.That(client, Is.Not.SameAs(FakeDefaultClient()),
+            "skill-md must not silently fall back to the registered default client");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdDrivenSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdDrivenSkillTests.cs
@@ -2,9 +2,9 @@ namespace GA.Business.ML.Tests.Unit;
 
 using GA.Business.ML.Agents.Plugins;
 using GA.Business.ML.Agents.Skills;
+using GA.Business.ML.Extensions;
 using GA.Business.ML.Skills;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -33,6 +33,36 @@ public class SkillMdDrivenSkillTests
         return mock.Object;
     }
 
+    /// <summary>
+    /// Returns an <see cref="IChatClientFactory"/> that hands out the supplied client
+    /// for the <c>skill-md</c> purpose (and any purpose, for simplicity in tests).
+    /// </summary>
+    private static IChatClientFactory FactoryFor(IChatClient client)
+    {
+        var mock = new Mock<IChatClientFactory>();
+        mock.Setup(f => f.Create(It.IsAny<string>())).Returns(client);
+        return mock.Object;
+    }
+
+    /// <summary>
+    /// Returns an <see cref="IChatClientFactory"/> that throws on <c>Create</c> —
+    /// simulates a misconfigured provider (e.g. missing API key) without dragging
+    /// any vendor SDK into the test.
+    /// </summary>
+    private static IChatClientFactory ThrowingFactory(string message)
+    {
+        var mock = new Mock<IChatClientFactory>();
+        mock.Setup(f => f.Create(It.IsAny<string>()))
+            .Throws(new InvalidOperationException(message));
+        return mock.Object;
+    }
+
+    private static IChatClientFactory NoopFactory() =>
+        // CanHandle / metadata tests never resolve the client; this factory will
+        // still throw if invoked but the lazy guarantees that won't happen for
+        // tests that don't call ExecuteAsync.
+        ThrowingFactory("noop factory — should never be invoked in this test");
+
     // ── CanHandle ─────────────────────────────────────────────────────────────
 
     [Test]
@@ -41,7 +71,7 @@ public class SkillMdDrivenSkillTests
         var skill = new SkillMdDrivenSkill(
             MakeSkillMd(triggers: ["transpose"]),
             EmptyToolsProvider(),
-            new ConfigurationBuilder().Build(),
+            NoopFactory(),
             NullLogger<SkillMdDrivenSkill>.Instance);
 
         Assert.That(skill.CanHandle("Can you transpose Am7 up a fifth?"), Is.True);
@@ -53,7 +83,7 @@ public class SkillMdDrivenSkillTests
         var skill = new SkillMdDrivenSkill(
             MakeSkillMd(triggers: ["PARSE CHORD"]),
             EmptyToolsProvider(),
-            new ConfigurationBuilder().Build(),
+            NoopFactory(),
             NullLogger<SkillMdDrivenSkill>.Instance);
 
         Assert.That(skill.CanHandle("parse chord Am7"), Is.True);
@@ -65,7 +95,7 @@ public class SkillMdDrivenSkillTests
         var skill = new SkillMdDrivenSkill(
             MakeSkillMd(triggers: ["transpose", "diatonic"]),
             EmptyToolsProvider(),
-            new ConfigurationBuilder().Build(),
+            NoopFactory(),
             NullLogger<SkillMdDrivenSkill>.Instance);
 
         Assert.That(skill.CanHandle("what is the weather today?"), Is.False);
@@ -77,7 +107,7 @@ public class SkillMdDrivenSkillTests
         var skill = new SkillMdDrivenSkill(
             MakeSkillMd(triggers: []),
             EmptyToolsProvider(),
-            new ConfigurationBuilder().Build(),
+            NoopFactory(),
             NullLogger<SkillMdDrivenSkill>.Instance);
 
         Assert.That(skill.CanHandle("transpose anything"), Is.False);
@@ -91,7 +121,7 @@ public class SkillMdDrivenSkillTests
         var skill = new SkillMdDrivenSkill(
             MakeSkillMd(name: "GA Chords"),
             EmptyToolsProvider(),
-            new ConfigurationBuilder().Build(),
+            NoopFactory(),
             NullLogger<SkillMdDrivenSkill>.Instance);
 
         Assert.That(skill.Name, Is.EqualTo("GA Chords"));
@@ -103,13 +133,13 @@ public class SkillMdDrivenSkillTests
         var skill = new SkillMdDrivenSkill(
             MakeSkillMd(description: "Parses chord symbols"),
             EmptyToolsProvider(),
-            new ConfigurationBuilder().Build(),
+            NoopFactory(),
             NullLogger<SkillMdDrivenSkill>.Instance);
 
         Assert.That(skill.Description, Is.EqualTo("Parses chord symbols"));
     }
 
-    // ── ExecuteAsync with injected IChatClient ────────────────────────────────
+    // ── ExecuteAsync with injected IChatClient via factory ────────────────────
 
     [Test]
     public async Task ExecuteAsync_SendsSystemPromptFromSkillMdBody()
@@ -123,10 +153,11 @@ public class SkillMdDrivenSkillTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "C major")));
 
-        var skill = SkillMdDrivenSkill.ForTesting(
-            skillMd, EmptyToolsProvider(),
-            NullLogger<SkillMdDrivenSkill>.Instance,
-            clientMock.Object);
+        var skill = new SkillMdDrivenSkill(
+            skillMd,
+            EmptyToolsProvider(),
+            FactoryFor(clientMock.Object),
+            NullLogger<SkillMdDrivenSkill>.Instance);
 
         await skill.ExecuteAsync("what is C major?");
 
@@ -151,10 +182,11 @@ public class SkillMdDrivenSkillTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "Em7")));
 
-        var skill = SkillMdDrivenSkill.ForTesting(
-            MakeSkillMd(), EmptyToolsProvider(),
-            NullLogger<SkillMdDrivenSkill>.Instance,
-            clientMock.Object);
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(),
+            EmptyToolsProvider(),
+            FactoryFor(clientMock.Object),
+            NullLogger<SkillMdDrivenSkill>.Instance);
 
         await skill.ExecuteAsync(userMessage);
 
@@ -177,10 +209,11 @@ public class SkillMdDrivenSkillTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "answer")));
 
-        var skill = SkillMdDrivenSkill.ForTesting(
-            MakeSkillMd(name: "GA Chords"), EmptyToolsProvider(),
-            NullLogger<SkillMdDrivenSkill>.Instance,
-            clientMock.Object);
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(name: "GA Chords"),
+            EmptyToolsProvider(),
+            FactoryFor(clientMock.Object),
+            NullLogger<SkillMdDrivenSkill>.Instance);
 
         var response = await skill.ExecuteAsync("test");
 
@@ -206,10 +239,11 @@ public class SkillMdDrivenSkillTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
 
-        var skill = SkillMdDrivenSkill.ForTesting(
-            MakeSkillMd(), toolsProviderMock.Object,
-            NullLogger<SkillMdDrivenSkill>.Instance,
-            clientMock.Object);
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(),
+            toolsProviderMock.Object,
+            FactoryFor(clientMock.Object),
+            NullLogger<SkillMdDrivenSkill>.Instance);
 
         await skill.ExecuteAsync("test");
 
@@ -231,10 +265,11 @@ public class SkillMdDrivenSkillTests
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("timeout"));
 
-        var skill = SkillMdDrivenSkill.ForTesting(
-            MakeSkillMd(name: "Test"), EmptyToolsProvider(),
-            NullLogger<SkillMdDrivenSkill>.Instance,
-            clientMock.Object);
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(name: "Test"),
+            EmptyToolsProvider(),
+            FactoryFor(clientMock.Object),
+            NullLogger<SkillMdDrivenSkill>.Instance);
 
         var response = await skill.ExecuteAsync("test");
 
@@ -242,34 +277,54 @@ public class SkillMdDrivenSkillTests
         Assert.That(response.Result, Contains.Substring("error"));
     }
 
-    // ── Missing API key (no test client override) ─────────────────────────────
+    // ── Provider configuration failures (factory-driven) ──────────────────────
 
     [Test]
-    public async Task ExecuteAsync_MissingApiKey_ReturnsErrorResponse()
+    public async Task ExecuteAsync_FactoryThrowsForMissingProvider_ReturnsErrorResponse()
     {
-        // ExecuteAsync never throws (except OperationCanceledException) — configuration errors
-        // are caught and returned as a zero-confidence error response so the chatbot pipeline
-        // can degrade gracefully rather than crashing mid-stream.
-        var original = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-        Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", null);
+        // ExecuteAsync never throws (except OperationCanceledException) — provider
+        // misconfiguration surfaces as a zero-confidence error so the chatbot pipeline
+        // can degrade gracefully rather than crashing mid-stream. Replaces the previous
+        // ANTHROPIC_API_KEY env-var test, which depended on process-wide state.
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(),
+            EmptyToolsProvider(),
+            ThrowingFactory("Anthropic chat client requested but no API key is configured."),
+            NullLogger<SkillMdDrivenSkill>.Instance);
 
-        try
-        {
-            var skill = new SkillMdDrivenSkill(
-                MakeSkillMd(),
-                EmptyToolsProvider(),
-                new ConfigurationBuilder().Build(),
-                NullLogger<SkillMdDrivenSkill>.Instance);
+        var response = await skill.ExecuteAsync("test");
 
-            var response = await skill.ExecuteAsync("test");
+        Assert.That(response.Confidence, Is.EqualTo(0f));
+        Assert.That(response.Result, Contains.Substring("error"));
+    }
 
-            Assert.That(response.Confidence, Is.EqualTo(0f));
-            Assert.That(response.Result, Contains.Substring("error"));
-        }
-        finally
-        {
-            if (original is not null)
-                Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", original);
-        }
+    [Test]
+    public void Constructor_RequestsSkillMdPurpose_FromFactory()
+    {
+        // Documents the contract that callers depend on: SkillMdDrivenSkill always
+        // resolves its IChatClient via the "skill-md" purpose. Future refactors that
+        // change this string should update this test deliberately.
+        var clientMock = new Mock<IChatClient>();
+        clientMock
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+
+        var factoryMock = new Mock<IChatClientFactory>();
+        factoryMock.Setup(f => f.Create("skill-md")).Returns(clientMock.Object);
+
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(),
+            EmptyToolsProvider(),
+            factoryMock.Object,
+            NullLogger<SkillMdDrivenSkill>.Instance);
+
+        // First execute triggers the lazy.
+        _ = skill.ExecuteAsync("test").Result;
+
+        factoryMock.Verify(f => f.Create("skill-md"), Times.Once);
+        factoryMock.Verify(f => f.Create(It.IsNotIn("skill-md")), Times.Never);
     }
 }


### PR DESCRIPTION
Second of a 4-PR stack — depends on #64.

Aligns with [`docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md`](../blob/main/docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md) §\"Phase 1 — provider factory cleanup\".

## Summary
- **`IChatClientFactory.Create(purpose)`** with purposes \`default\` / \`skill-md\` / \`qa-architect\` / \`fast-local\`. Caches per-purpose clients for the factory lifetime so SDK pool / function-invocation state survives across calls.
- **\`GA.Providers.Anthropic\`** — new project. \`AnthropicProvider.CreateChatClient\` is the only place in the codebase that references \`Anthropic.AnthropicClient\`. The package was REMOVED from \`GA.Business.ML.csproj\` so the project graph enforces SDK isolation at build time, on top of the factory boundary in code.
- **\`SkillMdDrivenSkill\`** — no longer references \`Anthropic\` namespace. Constructor takes \`IChatClientFactory\`, resolves \`skill-md\` purpose lazily on first \`ExecuteAsync\`.
- **\`SkillMdPlugin\`** — resolves \`IChatClientFactory\` from DI for each registered SKILL.md skill.
- **MEAI 10.3.0 → 10.5.1** — aligned across \`GA.Business.ML\`, \`GA.Business.Core.Orchestration\`, \`GA.Business.ML.Tests\` to set up Phase 2/3 (which add Microsoft.Agents.AI 1.3.0 that depends on MEAI 10.5.x).

## Test plan
- [x] ML.Tests: 690 passed / 14 skipped / 1 pre-existing fail
- [x] **8 new \`DefaultChatClientFactoryTests\`**: purpose dispatch, caching, case insensitivity, unknown-purpose error, null/whitespace guard, missing-API-key safe-message path
- [x] \`SkillMdDrivenSkillTests\` rewritten without the reflection \`ForTesting\` hack; new \`Constructor_RequestsSkillMdPurpose_FromFactory\` locks the contract
- [x] \`grep \"new AnthropicClient\" Common/\` only matches \`AnthropicProvider.cs\`

## Stack
- ⬅ #64 — Phase 0 baseline + deterministic skill improvements (parent)
- this PR — Phase 1 factory + Anthropic isolation
- ➡ Phase 2 (skills/ provider + \`Microsoft.Agents.AI 1.3.0\`)
- ➡ Phase 3 (Agent Framework spike + \`AsAIFunction\`)

## One-way doors
- **\`IChatClientFactory\` purpose taxonomy** (\`default\` / \`skill-md\` / \`qa-architect\` / \`fast-local\`): expanding requires updating the recommendation doc §\"Phase 1\".
- **\`Common/GA.Providers.Anthropic/\`** as the canonical Anthropic SDK location: any future provider (OpenAI, Azure) should follow the same pattern (\`Common/GA.Providers.<Vendor>/\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)