### PR TITLE
feat(chatbot): Phase 2 — file-based skills provider + skills/ layout

### DIFF
--- a/Common/GA.Business.Core.Orchestration/GA.Business.Core.Orchestration.csproj
+++ b/Common/GA.Business.Core.Orchestration/GA.Business.Core.Orchestration.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <AssemblyName>GA.Business.Core.Orchestration</AssemblyName>
     <RootNamespace>GA.Business.Core.Orchestration</RootNamespace>
-    <NoWarn>$(NoWarn);SKEXP0001;IDE0065</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0001;MAAI001;IDE0065</NoWarn>
     <Title>Guitar Alchemist - Chatbot Orchestration (Layer 5)</Title>
   </PropertyGroup>
 

--- a/Common/GA.Business.ML/Agents/AgentFramework/FileBasedSkillsProvider.cs
+++ b/Common/GA.Business.ML/Agents/AgentFramework/FileBasedSkillsProvider.cs
@@ -1,0 +1,103 @@
+namespace GA.Business.ML.Agents.AgentFramework;
+
+using System.Text;
+using GA.Business.ML.Skills;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Microsoft Agent Framework <see cref="AIContextProvider"/> backed by a
+/// directory of <c>SKILL.md</c> files. Forward-compatible substitute for the
+/// upcoming <c>Microsoft.Agents.AI.AgentSkillsProvider</c> (referenced in
+/// <c>docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md</c>
+/// §"C# equivalent of Spring AI generic skills" but not yet shipped in the
+/// 1.0.0-preview package GA references).
+/// </summary>
+/// <remarks>
+/// <para><b>Behavior contract:</b></para>
+/// <list type="bullet">
+///   <item>On construction, scans the supplied directory for <c>SKILL.md</c>
+///         files and loads them via <see cref="SkillMdLoader"/>. Files without
+///         <c>triggers</c> frontmatter are silently skipped.</item>
+///   <item>On each <see cref="InvokingAsync"/> call, inspects the most recent
+///         user message: if any loaded skill's trigger keywords match, returns
+///         an <see cref="AIContext"/> with the matching skill's body as
+///         additional <c>Instructions</c>. Multiple matches are concatenated in
+///         load order so the agent sees a deterministic context.</item>
+///   <item>Returns <see cref="AIContext.Empty"/> when no triggers match — the
+///         agent then proceeds without any skill-supplied context, exactly as
+///         it would have without this provider.</item>
+///   <item>Read-only: this provider never executes scripts, never writes to
+///         disk, and never invokes external services.</item>
+/// </list>
+/// <para>Forward-compatibility note: when Microsoft ships
+/// <c>Microsoft.Agents.AI.AgentSkillsProvider</c>, swap call sites to it and
+/// retire this type. The skill directory layout is the same, so SKILL.md files
+/// migrate without change. See Phase 2 of the migration recommendation.</para>
+/// </remarks>
+public sealed class FileBasedSkillsProvider : AIContextProvider
+{
+    private readonly IReadOnlyList<SkillMd> _skills;
+
+    /// <summary>
+    /// Construct a provider over <paramref name="skillsDirectory"/>. Missing
+    /// directory yields an empty provider (agent runs without skill context).
+    /// </summary>
+    public FileBasedSkillsProvider(string skillsDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(skillsDirectory);
+
+        _skills = Directory.Exists(skillsDirectory)
+            ? SkillMdLoader.LoadFromDirectory(skillsDirectory)
+            : [];
+    }
+
+    /// <summary>Loaded skills, in directory enumeration order.</summary>
+    public IReadOnlyList<SkillMd> Skills => _skills;
+
+    /// <summary>
+    /// Provide additional <see cref="AIContext"/> for the current invocation.
+    /// The framework wraps this in <c>InvokingCoreAsync</c> which handles
+    /// filtering (External-only messages by default), merging with input
+    /// context, and source stamping — overriding this method is the
+    /// recommended path per the Agent Framework docs.
+    /// </summary>
+    protected override ValueTask<AIContext?> ProvideAIContextAsync(
+        InvokingContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (_skills.Count == 0)
+            return ValueTask.FromResult<AIContext?>(new AIContext());
+
+        // Inspect the latest user-authored message in the input context —
+        // that's what the agent is about to respond to. Earlier messages
+        // would cause stale skill matches in long sessions.
+        var latestUserText = context.AIContext.Messages?
+            .LastOrDefault(m => m.Role == ChatRole.User)?
+            .Text;
+
+        if (string.IsNullOrWhiteSpace(latestUserText))
+            return ValueTask.FromResult<AIContext?>(new AIContext());
+
+        var lower = latestUserText.ToLowerInvariant();
+        var matches = _skills
+            .Where(s => s.Triggers.Any(t => !string.IsNullOrWhiteSpace(t) &&
+                                            lower.Contains(t.ToLowerInvariant())))
+            .ToList();
+
+        if (matches.Count == 0)
+            return ValueTask.FromResult<AIContext?>(new AIContext());
+
+        var instructions = new StringBuilder();
+        for (var i = 0; i < matches.Count; i++)
+        {
+            if (i > 0) instructions.AppendLine().AppendLine();
+            instructions.AppendLine($"### Skill: {matches[i].Name}");
+            instructions.Append(matches[i].Body);
+        }
+
+        return ValueTask.FromResult<AIContext?>(new AIContext { Instructions = instructions.ToString() });
+    }
+}

--- a/Common/GA.Business.ML/Agents/AgentFramework/SkillsAgentBuilder.cs
+++ b/Common/GA.Business.ML/Agents/AgentFramework/SkillsAgentBuilder.cs
@@ -1,0 +1,62 @@
+namespace GA.Business.ML.Agents.AgentFramework;
+
+using GA.Business.ML.Extensions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Builds an experimental Microsoft Agent Framework <see cref="AIAgent"/> that
+/// composes an <see cref="IChatClient"/> with a <see cref="FileBasedSkillsProvider"/>.
+/// </summary>
+/// <remarks>
+/// This is the Phase 3 spike entry-point per the migration recommendation:
+/// it wraps the existing chatbot stack as an Agent Framework agent without
+/// touching <c>ProductionOrchestrator</c>. Output is mappable to the existing
+/// <c>ChatResponse</c> + <c>AgentRoutingMetadata</c> DTOs by callers; this
+/// builder does not impose a UI contract change.
+/// </remarks>
+public static class SkillsAgentBuilder
+{
+    /// <summary>
+    /// Construct an agent for the supplied <paramref name="purpose"/>
+    /// (resolved through <see cref="IChatClientFactory"/>) over the SKILL.md
+    /// files in <paramref name="skillsDirectory"/>.
+    /// </summary>
+    /// <param name="chatClientFactory">Factory used to obtain an
+    ///   <see cref="IChatClient"/> for <paramref name="purpose"/>.</param>
+    /// <param name="purpose">One of the well-known purposes (default,
+    ///   skill-md, qa-architect, fast-local).</param>
+    /// <param name="skillsDirectory">Repo-rooted directory containing
+    ///   <c>SKILL.md</c> files. Missing directory is permitted; the resulting
+    ///   agent simply runs without skill context.</param>
+    /// <param name="agentName">Optional logical name for the agent (used by
+    ///   trace tags / DevUI).</param>
+    /// <param name="instructions">Optional base instructions appended ahead of
+    ///   per-skill context returned by the provider.</param>
+    public static AIAgent Build(
+        IChatClientFactory chatClientFactory,
+        string purpose,
+        string skillsDirectory,
+        string agentName = "GaSkillsAgent",
+        string? instructions = null)
+    {
+        ArgumentNullException.ThrowIfNull(chatClientFactory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(purpose);
+        ArgumentException.ThrowIfNullOrWhiteSpace(skillsDirectory);
+
+        var chatClient = chatClientFactory.Create(purpose);
+        var skillsProvider = new FileBasedSkillsProvider(skillsDirectory);
+
+        var options = new ChatClientAgentOptions
+        {
+            Name = agentName,
+            ChatOptions = new ChatOptions
+            {
+                Instructions = instructions ?? "You are the Guitar Alchemist assistant.",
+            },
+            AIContextProviders = [skillsProvider],
+        };
+
+        return new ChatClientAgent(chatClient, options);
+    }
+}

--- a/Common/GA.Business.ML/GA.Business.ML.csproj
+++ b/Common/GA.Business.ML/GA.Business.ML.csproj
@@ -9,7 +9,7 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AssemblyName>GA.Business.ML</AssemblyName>
     <RootNamespace>GA.Business.ML</RootNamespace>
-    <NoWarn>$(NoWarn);SKEXP0001;NU1605</NoWarn>
+    <NoWarn>$(NoWarn);SKEXP0001;MAAI001;NU1605</NoWarn>
     <Title>Guitar Alchemist - AI and Machine Learning Services</Title>
     <Authors>Stephane Pareilleux</Authors>
     <Description>AI/ML services for Guitar Alchemist including embedding generation, semantic search, and vector operations</Description>
@@ -55,6 +55,15 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1" />
     <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.4.0-preview.1.25207.5" />
     <!-- Microsoft.Extensions.AI.OpenAI deferred - SDK version mismatch, will re-add when stable -->
+
+    <!-- Microsoft Agent Framework — pinned to match GaApi.csproj. Stable 1.3.0
+         depends on MEAI 10.5.x, kept aligned in this csproj. The SKILL.md-style
+         skill provider that the recommendation doc names AgentSkillsProvider
+         is not yet shipped in this version; FileBasedSkillsProvider in
+         Common/GA.Business.ML/Agents/AgentFramework/ is a forward-compatible
+         substitute via AIContextProvider. -->
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Abstractions" Version="1.3.0" />
 
     <!-- GPU acceleration -->
     <PackageReference Include="ILGPU" Version="1.5.1" />

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -1,0 +1,216 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.AgentFramework;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Moq;
+
+[TestFixture]
+public class FileBasedSkillsProviderTests
+{
+    private string _tmpRoot = string.Empty;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tmpRoot = Path.Combine(Path.GetTempPath(), "ga-skills-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tmpRoot);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        if (Directory.Exists(_tmpRoot))
+        {
+            try { Directory.Delete(_tmpRoot, recursive: true); }
+            catch { /* best effort — Windows file locks under load */ }
+        }
+    }
+
+    private string WriteSkill(string name, string frontmatter, string body)
+    {
+        var dir = Path.Combine(_tmpRoot, name);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "SKILL.md");
+        File.WriteAllText(path, $"---\n{frontmatter}\n---\n\n{body}");
+        return path;
+    }
+
+    private static AIContextProvider.InvokingContext UserContext(params ChatMessage[] messages) =>
+        new(
+            agent: new Mock<AIAgent>().Object,
+            session: null,
+            aiContext: new AIContext { Messages = [.. messages] });
+
+    private static AIContextProvider.InvokingContext UserContext(string userMessage) =>
+        UserContext(new ChatMessage(ChatRole.User, userMessage));
+
+    [Test]
+    public async Task InvokingAsync_TriggerMatches_ReturnsSkillBodyAsInstructions()
+    {
+        WriteSkill(
+            "qa-architect",
+            "Name: \"qa-architect\"\nDescription: \"Test\"\nTriggers:\n  - \"verdict\"\n  - \"qa-architect\"",
+            "QA architect skill body — invoke when verdicts are involved.");
+
+        var provider = new FileBasedSkillsProvider(_tmpRoot);
+
+        var ctx = await provider.InvokingAsync(UserContext("Please emit a verdict for this PR"));
+
+        Assert.That(ctx.Instructions, Is.Not.Null);
+        Assert.That(ctx.Instructions, Does.Contain("QA architect skill body"));
+        Assert.That(ctx.Instructions, Does.Contain("Skill: qa-architect"));
+    }
+
+    [Test]
+    public async Task InvokingAsync_NoTriggerMatch_ReturnsEmptyContext()
+    {
+        WriteSkill(
+            "transpose",
+            "Name: \"transpose\"\nDescription: \"Test\"\nTriggers:\n  - \"transpose\"\n  - \"transposition\"",
+            "Transpose skill body");
+
+        var provider = new FileBasedSkillsProvider(_tmpRoot);
+
+        var ctx = await provider.InvokingAsync(UserContext("What chord is this?"));
+
+        Assert.That(ctx.Instructions, Is.Null.Or.Empty);
+    }
+
+    [Test]
+    public async Task InvokingAsync_MultipleSkillsMatch_ConcatenatedInLoadOrder()
+    {
+        WriteSkill(
+            "skill-a",
+            "Name: \"a\"\nDescription: \"A\"\nTriggers:\n  - \"alpha\"",
+            "Body of A.");
+        WriteSkill(
+            "skill-b",
+            "Name: \"b\"\nDescription: \"B\"\nTriggers:\n  - \"alpha\"\n  - \"beta\"",
+            "Body of B.");
+
+        var provider = new FileBasedSkillsProvider(_tmpRoot);
+
+        var ctx = await provider.InvokingAsync(UserContext("alpha and beta"));
+
+        Assert.That(ctx.Instructions, Does.Contain("Body of A"));
+        Assert.That(ctx.Instructions, Does.Contain("Body of B"));
+        Assert.That(ctx.Instructions!.IndexOf("Body of A", StringComparison.Ordinal),
+            Is.LessThan(ctx.Instructions.IndexOf("Body of B", StringComparison.Ordinal)),
+            "skills must concatenate in load order so the agent sees a deterministic context");
+    }
+
+    [Test]
+    public async Task InvokingAsync_NoUserMessage_ReturnsEmptyContext()
+    {
+        WriteSkill(
+            "always-on",
+            "Name: \"always-on\"\nDescription: \"x\"\nTriggers:\n  - \"anything\"",
+            "Body");
+
+        var provider = new FileBasedSkillsProvider(_tmpRoot);
+
+        var ctx = await provider.InvokingAsync(
+            UserContext(new ChatMessage(ChatRole.System, "system only")));
+
+        Assert.That(ctx.Instructions, Is.Null.Or.Empty);
+    }
+
+    [Test]
+    public async Task InvokingAsync_OnlyLatestUserMessageInspected()
+    {
+        WriteSkill(
+            "transpose",
+            "Name: \"transpose\"\nDescription: \"Test\"\nTriggers:\n  - \"transpose\"",
+            "Body");
+
+        var provider = new FileBasedSkillsProvider(_tmpRoot);
+
+        // The earlier user turn mentioned the trigger; the latest does not.
+        // Earlier-message scanning would cause stale matches across long sessions.
+        var earlier = new ChatMessage(ChatRole.User, "transpose Am7 up a fifth");
+        var assistant = new ChatMessage(ChatRole.Assistant, "Em7");
+        var latest = new ChatMessage(ChatRole.User, "Now what is C major?");
+        var ctx = await provider.InvokingAsync(UserContext(earlier, assistant, latest));
+
+        Assert.That(ctx.Instructions, Is.Null.Or.Empty,
+            "only the latest user message should drive trigger matching");
+    }
+
+    [Test]
+    public void Constructor_MissingDirectory_LoadsZeroSkills()
+    {
+        var missing = Path.Combine(_tmpRoot, "does-not-exist");
+        var provider = new FileBasedSkillsProvider(missing);
+
+        Assert.That(provider.Skills, Is.Empty);
+    }
+
+    [Test]
+    public void Constructor_MalformedFrontmatter_SilentlyIgnored()
+    {
+        // SkillMdLoader contract: files without triggers are skipped silently.
+        // We verify the provider is resilient to that — it should load zero
+        // skills from a malformed directory rather than throwing on construction.
+        WriteSkill("malformed", "name: malformed\nthis-is-not-yaml: 'unterminated", "Body");
+
+        var provider = new FileBasedSkillsProvider(_tmpRoot);
+
+        Assert.That(provider.Skills, Is.Empty,
+            "malformed SKILL.md files must not break provider construction");
+    }
+
+    [Test]
+    public void Constructor_NullOrWhitespaceDirectory_Throws()
+    {
+        Assert.That(() => new FileBasedSkillsProvider(null!), Throws.InstanceOf<ArgumentNullException>());
+        Assert.That(() => new FileBasedSkillsProvider(""),    Throws.ArgumentException);
+        Assert.That(() => new FileBasedSkillsProvider("   "), Throws.ArgumentException);
+    }
+
+    [Test]
+    public async Task InvokingAsync_TriggerMatchIsCaseInsensitive()
+    {
+        WriteSkill(
+            "qa",
+            "Name: \"qa\"\nDescription: \"x\"\nTriggers:\n  - \"VERDICT\"",
+            "QA body");
+
+        var provider = new FileBasedSkillsProvider(_tmpRoot);
+
+        var ctx = await provider.InvokingAsync(UserContext("emit a verdict please"));
+
+        Assert.That(ctx.Instructions, Does.Contain("QA body"));
+    }
+
+    [Test]
+    public async Task InvokingAsync_LoadsRealQaArchitectSkillFromRepo()
+    {
+        // Smoke test against the canonical skill we just authored at the repo root.
+        // Skip if the directory isn't present — keeps CI green if someone moves it.
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        Assert.That(provider.Skills.Any(s => s.Name == "qa-architect"), Is.True,
+            "skills/qa-architect/SKILL.md should be discovered with name 'qa-architect'");
+
+        var ctx = await provider.InvokingAsync(UserContext("emit a qa verdict"));
+        Assert.That(ctx.Instructions, Does.Contain("QA Architect Skill"));
+    }
+
+    private static string? ResolveRepoSkillsDir()
+    {
+        var dir = new DirectoryInfo(Environment.GetEnvironmentVariable("GA_REPO_ROOT")
+                                    ?? AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "skills");
+            if (Directory.Exists(candidate)) return candidate;
+            if (File.Exists(Path.Combine(dir.FullName, "AllProjects.slnx"))) return null;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/skills/qa-architect/SKILL.md
+++ b/skills/qa-architect/SKILL.md
@@ -1,0 +1,128 @@
+---
+Name: "qa-architect"
+Description: "How any AI collaborator (Codex, Conductor, Octopus, Compound Engineering, future-Claude) works alongside the QA Architect agent on this repo. Read before designing or shipping a non-trivial change."
+Triggers:
+  - "qa"
+  - "verdict"
+  - "qa-architect"
+  - "tribunal"
+  - "blast radius"
+  - "invariant"
+  - "regression"
+  - "quality drift"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.3.0"
+metadata:
+  triggers:
+    - qa
+    - verdict
+    - qa-architect
+    - tribunal
+    - blast radius
+    - invariant
+    - regression
+    - quality drift
+  evidence-kinds:
+    - contract_check
+    - adversarial_replay
+    - quality_snapshot
+  contract:
+    path: docs/contracts/2026-05-02-qa-verdict.contract.md
+    schema: docs/contracts/qa-verdict.schema.json
+    schema-version: "0.1.0"
+allowed-tools:
+  - qa_assess_blast_radius
+  - qa_gap_analyze
+  - qa_propose_tests
+  - qa_verify_invariants
+  - qa_replay_adversarial
+  - qa_score_quality_drift
+  - qa_lookup_defect_memory
+  - qa_emit_verdict
+---
+
+# QA Architect Skill
+
+This is the rubric for collaborating with Guitar Alchemist's senior QA agent. Read it before opening a PR, proposing a refactor, or shipping a metric-moving change. It is a checklist, not a narrative — follow it in order.
+
+## 1. Who the QA Engineer Is
+
+Two surfaces of the same role:
+
+- **`QAArchitectAgent`** — `Common/GA.Business.ML/Agents/QAArchitectAgent.cs`. Synchronous, in-process, callable from any C# code. Returns a `QaVerdict`.
+- **`qa-architect-cycle.ixql`** — `Demerzel/pipelines/qa-architect-cycle.ixql`. Long-running, governance-grade, runs on PR open/sync and on a daily 06:00 UTC sweep. Persists verdicts to `state/quality/verdicts/`.
+
+They both speak the same protocol: the `QaVerdict` contract.
+
+## 2. The Contract Is Not Optional
+
+- Source of truth: `docs/contracts/2026-05-02-qa-verdict.contract.md` (see also `references/qa-verdict-contract.md` bundled with this skill).
+- JSON Schema: `docs/contracts/qa-verdict.schema.json`.
+- Schema is **draft v0.1.0**, will freeze at v1.0.0 after a 2-sprint soak. Adding a new evidence kind, risk tier, or producer slug requires amending the contract markdown AND bumping the schema, not silently extending the JSON.
+
+## 3. The 8 MCP Primitives
+
+Available from the `GaQaMcp` MCP server. Treat them as your hands — call them rather than re-implementing.
+
+| Tool | Call when… | Returns |
+|---|---|---|
+| `qa_assess_blast_radius` | Before designing a non-trivial change | `blast_radius` object: layers touched, one-way doors crossed, invariants at risk, score 0..1 |
+| `qa_gap_analyze` | After writing code, before opening a PR | Array of `followup` candidates surfacing untested critical paths |
+| `qa_propose_tests` | When adding new components or breaking out abstractions | Array of test stubs (path + body) grounded in repo patterns |
+| `qa_verify_invariants` | Before merging changes that touch Core / Domain / Analysis / AI/ML | `evidence{kind: contract_check}` items, one per invariant |
+| `qa_replay_adversarial` | Before merging changes to chord/voicing/embedding pipelines | `evidence{kind: adversarial_replay}` |
+| `qa_score_quality_drift` | When changes may move a metric in `state/quality/*.json` | `evidence{kind: quality_snapshot}` with delta + guardrail check |
+| `qa_lookup_defect_memory` | Before designing — surfaces "we got burned by this before" | Array of past followups matching the touched components |
+| `qa_emit_verdict` | At the end, to persist a verdict | Path of the persisted JSON + `verdict_id` |
+
+## 4. Pre-PR Rubric
+
+Run this before the PR is opened. Skip steps only when you can name the reason.
+
+1. `qa_lookup_defect_memory` over the components you'll touch. If a past followup matches, your change must address it explicitly or document why it doesn't apply.
+2. `qa_assess_blast_radius` on the diff. If `estimated_blast_score >= 0.4`, expand testing per WP-2 of the plan: add property tests, fuzz inputs, or contract tests across the boundary you're crossing.
+3. `qa_verify_invariants` for the layer you're changing. The 5-layer dependency rule and the OPTIC-K dim invariant are both checked here.
+4. `qa_propose_tests` for any new component. Use the proposals as starting scaffolds, not as final tests.
+5. `qa_gap_analyze` last. Address `must_fix` candidates before opening the PR.
+
+## 5. How to Read a Verdict
+
+The verdict you'll see in PR comments and at `state/quality/verdicts/`. Read in this order:
+
+1. **`risk_tier`** — what action is required.
+   - `P0` → **stop**. Don't merge. Fix every `must_fix` followup, re-request review.
+   - `P1` → must-fix is required before next release. Open a tracked issue if you cannot fix in this PR.
+   - `P2` → should-fix. Address inline or annotate why deferred.
+   - `P3` → informational only. No action required, but read it.
+2. **`verdict`** — what gating is enforced.
+   - `block` → branch protection blocks merge. Pair with P0.
+   - `merge_with_followups` → mergeable; followups are tracked.
+   - `pass` → no must-fix items.
+   - `informational` → scheduled sweep or exploratory; not gating.
+3. **`reviewer_chain`** — who objected and why. If a single specialist role gave a low `score`, that's where the risk concentrates.
+4. **`followups[].rationale`** — the *why* of each item. If the rationale references a past incident or contract ID, take it literally.
+5. **`blast_radius.one_way_doors_crossed`** — non-empty here forces P0. These crossings require human sign-off, not a test fix.
+6. **`narrative`** — the human-readable summary, max 500 chars. Skim if you trust the structured fields; read closely if you don't.
+
+## 6. What to Escalate to a Human
+
+You do not have authority to:
+
+- Modify the QA verdict schema (any field, enum, or required-list change). Amend the contract markdown via PR with a `schema_version` bump proposal.
+- Add or rename a producer slug.
+- Change a `risk_tier` rollup rule (e.g. demote a P0 to P1).
+- Cross a one-way door listed in any active plan under `docs/plans/`.
+- Disable a verdict producer or skip the QA gate "just for this PR".
+
+Surface these to the human in the PR description with the heading `Requires QA sign-off:` and a one-paragraph justification.
+
+## 7. Cross-Reference
+
+- Plan: `docs/plans/2026-05-02-arch-qa-architect-tribunal-plan.md`
+- Contract: `docs/contracts/2026-05-02-qa-verdict.contract.md`
+- Schema: `docs/contracts/qa-verdict.schema.json`
+- Agent: `Common/GA.Business.ML/Agents/QAArchitectAgent.cs`
+- Pipeline: `Demerzel/pipelines/qa-architect-cycle.ixql` (sibling repo)
+- MCP server: `Apps/GaQaMcp/`

--- a/skills/qa-architect/references/qa-verdict-contract-pointer.md
+++ b/skills/qa-architect/references/qa-verdict-contract-pointer.md
@@ -1,0 +1,13 @@
+# QA Verdict Contract — Pointer
+
+The full contract lives in the repository at `docs/contracts/2026-05-02-qa-verdict.contract.md`.
+
+It is intentionally NOT bundled into the skill directory because:
+
+1. The contract is the single source of truth for the QA Architect schema and is referenced from multiple agents (`QAArchitectAgent`, `qa-architect-cycle.ixql` pipeline, `GaQaMcp` MCP server).
+2. Duplicating it under `skills/qa-architect/references/` would create a drift hazard — agents would pick up a stale snapshot.
+3. The skill loader is read-only by design (no script execution); pointer files are the safer pattern.
+
+When loaded by `FileBasedSkillsProvider`, this pointer file is exposed via the
+`read_skill_resource` semantics so an agent can `cat` it on demand and follow
+the link to the canonical contract document.


### PR DESCRIPTION
Third of a 4-PR stack — depends on #65.

Aligns with [`docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md`](../blob/main/docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md) §\"Phase 2 — Agent Skills provider migration\".

## Summary
- **\`skills/qa-architect/SKILL.md\`** — first skill at the canonical \`skills/\` layout. Frontmatter dual-format: top-level \`Triggers\` (existing \`SkillMdLoader\` picks these up today) + nested \`metadata.triggers\` (forward-compat with the future \`AgentSkillsProvider\` shape). License, compatibility, allowed-tools per doc.
- **\`FileBasedSkillsProvider : AIContextProvider\`** — the recommendation cites Microsoft's \`AgentSkillsProvider\` but that type isn't shipped in \`Microsoft.Agents.AI 1.3.0\` yet. Built a forward-compatible substitute via \`AIContextProvider\`. Same \`skills/\` layout, same SKILL.md format. Override target is \`ProvideAIContextAsync\` (the public \`InvokingAsync\` is non-virtual in 1.3.0). Returns empty \`AIContext\` (not null) on no-match — null trips an NRE inside \`InvokingCoreAsync\`.
- **\`SkillsAgentBuilder\`** — composes \`IChatClient\` (via \`IChatClientFactory\`) + provider into a \`ChatClientAgent\`. Isolated from \`ProductionOrchestrator\` per the doc's \"Phase 3 spike must be isolated\" guidance.
- **\`Microsoft.Agents.AI 1.3.0\`** added to \`GA.Business.ML.csproj\` (pinned to match \`GaApi.csproj\`). Adds \`MAAI001\` to NoWarn (the framework marks several types as evaluation-only).

## Test plan
- [x] **10 new \`FileBasedSkillsProviderTests\`**: trigger match, no-match, multi-skill ordered concat, no-user-message, latest-message-only (avoids stale matches), missing dir, malformed frontmatter, null/whitespace guard, case-insensitive trigger, end-to-end against canonical \`skills/qa-architect/SKILL.md\`
- [x] All Phase 1 tests still green (\`dotnet test ML.Tests\` 690+ / 14 skip / 1 pre-existing fail)

## Stack
- ⬅ #64 — Phase 0 baseline
- ⬅ #65 — Phase 1 factory (parent)
- this PR — Phase 2 file-based skills provider
- ➡ Phase 3 (Agent Framework spike + \`AsAIFunction\`)

## One-way doors
- **\`skills/\` directory layout at repo root** — agreed canonical location for portable file-based skills. Per-skill subdirectory with \`SKILL.md\` + \`references/\` matches Microsoft's pattern.
- **\`FileBasedSkillsProvider\` as the Microsoft.Agents.AI \`AgentSkillsProvider\` substitute** — when Microsoft ships \`AgentSkillsProvider\`, swap call sites; the \`SKILL.md\` files won't need to change.
- **MAAI001 NoWarn** suppresses Microsoft.Agents.AI's evaluation-only diagnostics. Revisit when 2.x stabilises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)