### PR TITLE
feat(chatbot): Phase 3 — Agent Framework spike with AsAIFunction wrapper

### DIFF
--- a/Common/GA.Business.ML/Agents/AgentFramework/OrchestratorSkillTools.cs
+++ b/Common/GA.Business.ML/Agents/AgentFramework/OrchestratorSkillTools.cs
@@ -1,0 +1,44 @@
+namespace GA.Business.ML.Agents.AgentFramework;
+
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Wraps deterministic <see cref="IOrchestratorSkill"/> instances as
+/// <see cref="AIFunction"/>s so a Microsoft Agent Framework <c>AIAgent</c> can
+/// invoke them via tool-calling. This is the Phase 3 spike entry-point per the
+/// migration recommendation §"Phase 3 — Agent Framework spike".
+/// </summary>
+/// <remarks>
+/// <para>The agent does not lose the deterministic-fast-path guarantee: when an
+/// <c>AIAgent</c> selects this tool, the underlying skill still computes the
+/// answer purely from the GA domain — the LLM only invokes it. If the agent
+/// chooses NOT to call the tool, the skill simply isn't run.</para>
+/// <para>Provider DTOs do not leak: the wrapper accepts a <c>string</c> input
+/// and returns a <c>string</c> answer (the skill's <c>Result</c>). The agent's
+/// trace records the tool name and arguments, redactable by the chatbot's
+/// observability hooks before persistence.</para>
+/// </remarks>
+public static class OrchestratorSkillTools
+{
+    /// <summary>
+    /// Returns an <see cref="AIFunction"/> that an agent can call to invoke the
+    /// supplied deterministic skill. The function name is
+    /// <c>ga_skill_{Name lowercased}</c> so it cannot collide with MCP tool
+    /// namespaces. The description is the skill's <c>Description</c>.
+    /// </summary>
+    public static AIFunction AsAIFunction(this IOrchestratorSkill skill)
+    {
+        ArgumentNullException.ThrowIfNull(skill);
+
+        var name = $"ga_skill_{skill.Name.ToLowerInvariant().Replace(' ', '_')}";
+
+        return AIFunctionFactory.Create(
+            async (string message, CancellationToken ct) =>
+            {
+                var response = await skill.ExecuteAsync(message, ct);
+                return response.Result;
+            },
+            name,
+            skill.Description);
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/AgentFrameworkSpikeTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/AgentFrameworkSpikeTests.cs
@@ -1,0 +1,248 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.AgentFramework;
+using GA.Business.ML.Agents.Skills;
+using GA.Business.ML.Extensions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+/// <summary>
+/// Phase 3 spike: prove the Agent Framework integration shape works without
+/// touching <c>ProductionOrchestrator</c>, per the migration recommendation
+/// §"Phase 3 — Agent Framework spike".
+/// </summary>
+/// <remarks>
+/// <para><b>Verified in this fixture:</b></para>
+/// <list type="bullet">
+///   <item>An <see cref="AIAgent"/> can be constructed over an
+///         <see cref="IChatClient"/> resolved through <see cref="IChatClientFactory"/>.</item>
+///   <item>A <see cref="FileBasedSkillsProvider"/> attaches via
+///         <see cref="ChatClientAgentOptions.AIContextProviders"/>.</item>
+///   <item>A deterministic <see cref="IOrchestratorSkill"/> can be exposed as
+///         an <see cref="AIFunction"/> for tool-calling without leaking GA
+///         types into the function signature.</item>
+///   <item>End-to-end <c>agent.RunAsync</c> over a fake <see cref="IChatClient"/>
+///         returns the expected text and propagates cancellation.</item>
+/// </list>
+/// <para>Stack: <c>Microsoft.Agents.AI 1.3.0</c> + <c>Microsoft.Extensions.AI 10.5.1</c>.
+/// Earlier preview pairs had an ABI mismatch on <c>ChatOptions.ContinuationToken</c>;
+/// the bump lifted that gate. Pin both packages together when bumping.</para>
+/// </remarks>
+[TestFixture]
+public class AgentFrameworkSpikeTests
+{
+    private static IChatClientFactory FactoryFor(IChatClient client)
+    {
+        var mock = new Mock<IChatClientFactory>();
+        mock.Setup(f => f.Create(It.IsAny<string>())).Returns(client);
+        return mock.Object;
+    }
+
+    private static IChatClient FakeClient(string responseText)
+    {
+        var mock = new Mock<IChatClient>();
+        mock.Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+        return mock.Object;
+    }
+
+    private static string FreshSkillsDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "ga-af-spike-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Test]
+    public void SkillsAgentBuilder_BuildsRunnableAgent()
+    {
+        var skillsDir = FreshSkillsDir();
+        try
+        {
+            var agent = SkillsAgentBuilder.Build(
+                FactoryFor(FakeClient("hello from agent")),
+                purpose: "skill-md",
+                skillsDirectory: skillsDir,
+                agentName: "TestAgent");
+
+            Assert.That(agent, Is.Not.Null);
+            Assert.That(agent, Is.InstanceOf<ChatClientAgent>());
+        }
+        finally
+        {
+            try { Directory.Delete(skillsDir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public async Task SkillsAgentBuilder_RunsEndToEnd()
+    {
+        // End-to-end agent run was previously gated by an ABI mismatch between
+        // Microsoft.Agents.AI 1.0.0-preview.251028.1 (compiled against MEAI 9.10.1)
+        // and our MEAI. Stable Agents.AI 1.3.0 + MEAI 10.5.x removed that gap.
+        var skillsDir = FreshSkillsDir();
+        try
+        {
+            var agent = SkillsAgentBuilder.Build(
+                FactoryFor(FakeClient("hello from agent")),
+                purpose: "skill-md",
+                skillsDirectory: skillsDir);
+
+            var session = await agent.CreateSessionAsync();
+            var response = await agent.RunAsync("hi", session);
+
+            Assert.That(response.Text, Is.EqualTo("hello from agent"));
+        }
+        finally
+        {
+            try { Directory.Delete(skillsDir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public void SkillsAgentBuilder_RunAsync_PropagatesCancellation()
+    {
+        var skillsDir = FreshSkillsDir();
+        try
+        {
+            var clientMock = new Mock<IChatClient>();
+            clientMock.Setup(c => c.GetResponseAsync(
+                    It.IsAny<IEnumerable<ChatMessage>>(),
+                    It.IsAny<ChatOptions?>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>(
+                    async (_, _, ct) =>
+                    {
+                        await Task.Delay(Timeout.Infinite, ct);
+                        return new ChatResponse(new ChatMessage(ChatRole.Assistant, "unreachable"));
+                    });
+
+            var agent = SkillsAgentBuilder.Build(
+                FactoryFor(clientMock.Object),
+                purpose: "skill-md",
+                skillsDirectory: skillsDir);
+
+            using var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+            var session = agent.CreateSessionAsync().GetAwaiter().GetResult();
+            Assert.That(
+                async () => await agent.RunAsync("hi", session, cancellationToken: cts.Token),
+                Throws.InstanceOf<OperationCanceledException>());
+        }
+        finally
+        {
+            try { Directory.Delete(skillsDir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public void SkillsAgentBuilder_HasExpectedAgentName()
+    {
+        var skillsDir = FreshSkillsDir();
+        try
+        {
+            var agent = SkillsAgentBuilder.Build(
+                FactoryFor(FakeClient("ok")),
+                purpose: "skill-md",
+                skillsDirectory: skillsDir,
+                agentName: "MyTestAgent");
+
+            // Name flows from ChatClientAgentOptions → ChatClientAgent.Name.
+            // Verifying it round-trips proves the options were applied.
+            Assert.That(agent.Name, Is.EqualTo("MyTestAgent"));
+        }
+        finally
+        {
+            try { Directory.Delete(skillsDir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public void SkillsAgentBuilder_NullArguments_Throw()
+    {
+        var skillsDir = FreshSkillsDir();
+        try
+        {
+            Assert.That(
+                () => SkillsAgentBuilder.Build(null!, "skill-md", skillsDir),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => SkillsAgentBuilder.Build(FactoryFor(FakeClient("x")), "", skillsDir),
+                Throws.ArgumentException);
+            Assert.That(
+                () => SkillsAgentBuilder.Build(FactoryFor(FakeClient("x")), "skill-md", ""),
+                Throws.ArgumentException);
+        }
+        finally
+        {
+            try { Directory.Delete(skillsDir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public async Task ModesSkill_ExposedAsAIFunction_ReturnsScaleModeAnswer()
+    {
+        var modes = new ModesSkill(NullLogger<ModesSkill>.Instance);
+        var fn = modes.AsAIFunction();
+
+        Assert.That(fn.Name, Is.EqualTo("ga_skill_modes"));
+        Assert.That(fn.Description, Does.Contain("modes of the major scale"));
+
+        var args = new Dictionary<string, object?> { ["message"] = "list the modes" };
+        var result = await fn.InvokeAsync(new AIFunctionArguments(args));
+        var resultText = result?.ToString() ?? string.Empty;
+
+        Assert.That(resultText, Does.Contain("Ionian"));
+        Assert.That(resultText, Does.Contain("Lydian"));
+        Assert.That(resultText, Does.Contain("Locrian"));
+    }
+
+    [Test]
+    public async Task AsAIFunction_PropagatesCancellation()
+    {
+        // Build a skill that blocks until cancellation, wrap it as an AIFunction,
+        // and verify cancellation propagates through the function-invocation surface.
+        var slowSkill = new Mock<IOrchestratorSkill>();
+        slowSkill.Setup(s => s.Name).Returns("Slow");
+        slowSkill.Setup(s => s.Description).Returns("test slow skill");
+        slowSkill.Setup(s => s.ExecuteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                 .Returns<string, CancellationToken>(async (_, ct) =>
+                 {
+                     await Task.Delay(Timeout.Infinite, ct);
+                     return new GA.Business.ML.Agents.AgentResponse { AgentId = "test", Result = "unreachable", Confidence = 0f };
+                 });
+
+        var fn = slowSkill.Object.AsAIFunction();
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+        try
+        {
+            await fn.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+            {
+                ["message"] = "anything",
+            }), cts.Token);
+            Assert.Fail("expected OperationCanceledException to propagate");
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Pass();
+        }
+    }
+
+    [Test]
+    public void AsAIFunction_NullSkill_Throws()
+    {
+        IOrchestratorSkill? nullSkill = null;
+        Assert.That(
+            () => nullSkill!.AsAIFunction(),
+            Throws.ArgumentNullException);
+    }
+}


### PR DESCRIPTION
Fourth and final of the 4-PR stack — depends on #66.

Aligns with [`docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md`](../blob/main/docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md) §\"Phase 3 — Agent Framework spike\".

## Summary
- **\`IOrchestratorSkill.AsAIFunction()\`** — extension that exposes any deterministic skill as a \`Microsoft.Extensions.AI.AIFunction\` with name \`ga_skill_<name>\`. The agent can call the tool; the skill computes from the GA domain — provider DTOs do not leak across the AIFunction signature.
- **End-to-end agent run works** — \`SkillsAgentBuilder\` builds a runnable \`ChatClientAgent\`. \`agent.RunAsync\` returns expected text, cancellation propagates, agent name flows from options. (Was blocked pre-1.3.0 by \`ChatOptions.ContinuationToken\` ABI mismatch — \`Microsoft.Agents.AI 1.3.0\` + MEAI 10.5.1 lifted that gate.)

## Test plan
- [x] **6 new \`AgentFrameworkSpikeTests\`**: builds runnable agent, agent name round-trips, end-to-end \`RunAsync\` returns expected text, RunAsync cancellation propagates, ModesSkill→AIFunction returns mode list, AIFunction cancellation propagates, null-skill guard
- [x] All earlier-phase tests still green
- [x] \`ProductionOrchestrator\` is NOT touched — spike is isolated under \`Common/GA.Business.ML/Agents/AgentFramework/\`
- [x] UI contract unchanged

## Stack — final
- ⬅ #64 — Phase 0 baseline + deterministic skill improvements
- ⬅ #65 — Phase 1 \`IChatClientFactory\` + Anthropic isolation
- ⬅ #66 — Phase 2 file-based skills provider + \`skills/\` layout (parent)
- this PR — Phase 3 Agent Framework spike + \`AsAIFunction\`

## Deferred per the brief
- **Phase 4 — A2A boundary**: defer; revisit after Phase 3 has soaked.
- **Phase 5 — workflow migration**: defer to QA Architect Tribunal Phase 1 (already scheduled \`trig_01WdRGSqgxah5PD46wg8u4Qq\` for 2026-05-18). That's the natural integration point — QA Tribunal is the doc's named candidate for the first multi-step workflow.

## One-way doors
- **\`AIFunction\` name format \`ga_skill_<name>\`** — collision-safe with the GA MCP tool namespace; future skills should follow the same prefix.
- **\`Microsoft.Agents.AI 1.3.0\` + MEAI 10.5.1 pinned together** — the 1.3.0 → MEAI 10.5.x dependency is rigid; bump them as a pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)