### PR TITLE
fix(skills): deterministic skill load order across OSes (unblocks main CI)

### DIFF
--- a/Common/GA.Business.ML/Skills/SkillMdLoader.cs
+++ b/Common/GA.Business.ML/Skills/SkillMdLoader.cs
@@ -12,8 +12,13 @@ public static class SkillMdLoader
         if (!Directory.Exists(rootPath))
             return [];
 
+        // WHY OrderBy: Directory.EnumerateFiles is OS-dependent — Windows returns
+        // alphabetic order, Linux (CI) returns filesystem (inode) order. Tests
+        // and downstream code expect deterministic load order so the chatbot
+        // sees a stable skill context. Ordinal comparer keeps it culture-free.
         return Directory
             .EnumerateFiles(rootPath, "SKILL.md", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.Ordinal)
             .Select(SkillMdParser.TryParse)
             .OfType<SkillMd>()
             .Where(s => s.Triggers.Count > 0)


### PR DESCRIPTION
## Summary

**Unblocks main CI**, which has been failing since PR #68 with `Failed InvokingAsync_MultipleSkillsMatch_ConcatenatedInLoadOrder`. Root cause is `Directory.EnumerateFiles` returning OS-dependent order — alphabetic on Windows, filesystem (inode) order on Linux. The test writes `skill-a` + `skill-b` and asserts A precedes B in the concatenated agent context; passed on dev machines, failed on the Linux CI runner.

## Fix

One-line change in `Common/GA.Business.ML/Skills/SkillMdLoader.cs`:

```csharp
.OrderBy(path => path, StringComparer.Ordinal)
```

Ordinal comparer (not culture-aware) keeps load order stable across locales as well as platforms.

## Why this matters beyond the test

The skill provider concatenates SKILL.md bodies into the agent's `Instructions` context. Non-deterministic load order means the agent could see different prompts on different machines for the same skill set — bad for prompt-cache hits, bad for behavioral reproducibility, bad for debugging.

## Verification

- `dotnet test --filter "FullyQualifiedName~FileBasedSkillsProvider"` → **Passed: 9, Failed: 0**, Skipped: 1 (the skip is `InvokingAsync_LoadsRealQaArchitectSkillFromRepo` which needs a specific repo state — unrelated).

## Scope

Pure 1-line addition, no new dependencies, no producer/consumer chain. The kind of fix that's reversible by `git revert` if anything looks wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)