### PR TITLE
feat(chatbot): unified semantic intent dispatch — kill string classifiers

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
+++ b/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
@@ -2,8 +2,10 @@ namespace GA.Business.Core.Orchestration.Extensions;
 
 using GA.Business.Core.Orchestration.Abstractions;
 using GA.Business.Core.Orchestration.Clients;
+using GA.Business.Core.Orchestration.Intents;
 using GA.Business.Core.Orchestration.Services;
 using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Intents;
 using GA.Business.ML.Agents.Plugins;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -70,6 +72,24 @@ public static class ChatbotOrchestrationExtensions
 
         // Cross-agent delegation coordinator
         services.AddScoped<IAgentCoordinator, AgentCoordinator>();
+
+        // ── Semantic intent routing (replaces ad-hoc string classifiers) ──────
+        // Per docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md
+        // §"Routing classifiers": embedding-similarity dispatch for the four
+        // routing surfaces that previously used keyword regex —
+        // KeywordAlgebraPromptClassifier, IsAskingForOptimization, the per-skill
+        // CanHandle foreach, and the tab-analysis branch.
+        services.AddSingleton<SemanticIntentRouter>();
+        services.AddScoped<TabAnalysisOrchestrationService>();
+
+        services.AddSingleton<AlgebraIntent>();
+        services.AddSingleton<IIntent>(sp => sp.GetRequiredService<AlgebraIntent>());
+
+        services.AddScoped<TabOptimizeIntent>();
+        services.AddScoped<IIntent>(sp => sp.GetRequiredService<TabOptimizeIntent>());
+
+        services.AddScoped<TabAnalyzeIntent>();
+        services.AddScoped<IIntent>(sp => sp.GetRequiredService<TabAnalyzeIntent>());
 
         // Orchestrators — Scoped because they transitively depend on
         // SemanticRouter (Scoped) and SpectralRetrievalService (Scoped).

--- a/Common/GA.Business.Core.Orchestration/Intents/AlgebraIntent.cs
+++ b/Common/GA.Business.Core.Orchestration/Intents/AlgebraIntent.cs
@@ -1,0 +1,54 @@
+namespace GA.Business.Core.Orchestration.Intents;
+
+using GA.Business.Core.Orchestration.Abstractions;
+using GA.Business.ML.Agents.Intents;
+
+/// <summary>
+/// Routes set-class-algebra queries (Z-relations, prime forms, ICVs, Forte
+/// labels, set classes) to <see cref="IIxAlgebraService"/>. Replaces the
+/// legacy <c>KeywordAlgebraPromptClassifier</c> string-keyword path.
+/// </summary>
+/// <remarks>
+/// The service itself still does the work — this intent just carries the
+/// routing metadata so <see cref="SemanticIntentRouter"/> can dispatch via
+/// embedding similarity instead of keyword regex.
+/// </remarks>
+public sealed class AlgebraIntent(IIxAlgebraService algebraService) : IIntent
+{
+    public string Id => "algebra";
+
+    public string Description =>
+        "Computes atonal-set-theory facts about pitch-class sets: prime form, " +
+        "interval-class vector (ICV), Forte label, Z-relation between two sets, " +
+        "set-class summary. Pure finite math, no LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "Are 0146 and 0137 z-related?",
+        "What is the prime form of [0,1,4,6]?",
+        "Compute the ICV of {0,2,4,7}",
+        "Forte number for 0146",
+        "Are these Z-related: 0136 and 0146?",
+        "Set class summary for [0,1,3,7]",
+        "Interval-class vector of 014",
+    ];
+
+    public async Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default)
+    {
+        var answer = await algebraService.TryAnswerAsync(query, cancellationToken);
+        if (answer is null)
+        {
+            return new IntentResult(
+                Answer: "I couldn't extract a pitch-class set or recognise the algebra question. " +
+                        "Try a query like 'are 0146 and 0137 z-related' or 'prime form of [0,1,4,6]'.",
+                Confidence: 0.0f,
+                RoutingMethodOverride: "ix-algebra");
+        }
+
+        return new IntentResult(
+            Answer: answer.NaturalLanguageAnswer,
+            Confidence: 1.0f,
+            Evidence: answer.Facts.Select(kv => $"{kv.Key}: {kv.Value}").ToList(),
+            RoutingMethodOverride: "ix-algebra");
+    }
+}

--- a/Common/GA.Business.Core.Orchestration/Intents/IntentRegistrationExtensions.cs
+++ b/Common/GA.Business.Core.Orchestration/Intents/IntentRegistrationExtensions.cs
@@ -1,0 +1,44 @@
+namespace GA.Business.Core.Orchestration.Intents;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Intents;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// DI helpers for registering <see cref="IOrchestratorSkill"/> implementations
+/// alongside their <see cref="OrchestratorSkillIntent"/> adapter so they
+/// participate in <see cref="SemanticIntentRouter"/> dispatch.
+/// </summary>
+public static class IntentRegistrationExtensions
+{
+    /// <summary>
+    /// Registers <typeparamref name="TSkill"/> in the container three ways:
+    /// (a) as itself (for direct resolution),
+    /// (b) as <see cref="IOrchestratorSkill"/> (for the legacy <c>CanHandle</c>
+    ///     foreach in <c>ProductionOrchestrator</c>),
+    /// (c) as <see cref="IIntent"/> via <see cref="OrchestratorSkillIntent"/>
+    ///     (for <see cref="SemanticIntentRouter"/> dispatch).
+    /// </summary>
+    /// <param name="lifetime">Match the skill's natural lifetime — Singleton
+    /// for pure-domain skills, Scoped for skills that depend on
+    /// <c>IChatClient</c> (which is Scoped).</param>
+    public static IServiceCollection AddOrchestratorSkillIntent<TSkill>(
+        this IServiceCollection services,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        where TSkill : class, IOrchestratorSkill
+    {
+        services.Add(new ServiceDescriptor(typeof(TSkill), typeof(TSkill), lifetime));
+
+        services.Add(new ServiceDescriptor(
+            typeof(IOrchestratorSkill),
+            sp => sp.GetRequiredService<TSkill>(),
+            lifetime));
+
+        services.Add(new ServiceDescriptor(
+            typeof(IIntent),
+            sp => new OrchestratorSkillIntent(sp.GetRequiredService<TSkill>()),
+            lifetime));
+
+        return services;
+    }
+}

--- a/Common/GA.Business.Core.Orchestration/Intents/OrchestratorSkillIntent.cs
+++ b/Common/GA.Business.Core.Orchestration/Intents/OrchestratorSkillIntent.cs
@@ -1,0 +1,36 @@
+namespace GA.Business.Core.Orchestration.Intents;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Intents;
+
+/// <summary>
+/// Adapts an existing <see cref="IOrchestratorSkill"/> to the unified
+/// <see cref="IIntent"/> surface so it can participate in
+/// <see cref="SemanticIntentRouter"/> dispatch alongside non-skill intents
+/// (algebra, tab handling).
+/// </summary>
+/// <remarks>
+/// The adapter forwards <see cref="IIntent.Description"/> and
+/// <see cref="IIntent.ExamplePrompts"/> from the wrapped skill (skills must
+/// expose <c>ExamplePrompts</c> to opt in to semantic routing). Execution is
+/// delegated to the skill's existing <c>ExecuteAsync</c>; the wrapped
+/// <see cref="AgentResponse"/> is mapped back to <see cref="IntentResult"/>.
+/// </remarks>
+public sealed class OrchestratorSkillIntent(IOrchestratorSkill skill) : IIntent
+{
+    public string Id => $"skill.{skill.Name.ToLowerInvariant().Replace(' ', '-')}";
+
+    public string Description => skill.Description;
+
+    public IReadOnlyList<string> ExamplePrompts => skill.ExamplePrompts;
+
+    public async Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default)
+    {
+        var response = await skill.ExecuteAsync(query, cancellationToken);
+        return new IntentResult(
+            Answer: response.Result,
+            Confidence: response.Confidence,
+            Evidence: response.Evidence?.ToList(),
+            RoutingMethodOverride: "orchestrator-skill-semantic");
+    }
+}

--- a/Common/GA.Business.Core.Orchestration/Intents/TabIntents.cs
+++ b/Common/GA.Business.Core.Orchestration/Intents/TabIntents.cs
@@ -1,0 +1,68 @@
+namespace GA.Business.Core.Orchestration.Intents;
+
+using GA.Business.Core.Orchestration.Services;
+using GA.Business.ML.Agents.Intents;
+
+/// <summary>
+/// Routes "make this progression smoother / easier to play / optimize the
+/// fingering" queries to <see cref="TabAnalysisOrchestrationService.OptimizePathAsync"/>.
+/// Replaces the legacy <c>IsAskingForOptimization</c> keyword check
+/// (which over-matched on the bare word "easy" — a routing bug).
+/// </summary>
+public sealed class TabOptimizeIntent(TabAnalysisOrchestrationService service) : IIntent
+{
+    public string Id => "tab.optimize";
+
+    public string Description =>
+        "Optimises the fingering path of a tab to minimise hand movement and " +
+        "fret transitions. Requires a tab in the message (lines like " +
+        "`e|---0---3---|` or a compact diagram like `x-3-2-0-1-0`).";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "Make this progression smoother to play",
+        "Optimize the fingering for this tab",
+        "Find a better path through this tab",
+        "Re-calculate this tab for less hand movement",
+        "Smooth out the transitions in this tab",
+    ];
+
+    public async Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default)
+    {
+        var resp = await service.OptimizePathAsync(query, cancellationToken);
+        return new IntentResult(
+            Answer: resp.NaturalLanguageAnswer,
+            Confidence: 1.0f,
+            RoutingMethodOverride: "tab-optimize");
+    }
+}
+
+/// <summary>
+/// Routes tab-analysis queries (analyse this tab, what's the progression in
+/// this tab) to <see cref="TabAnalysisOrchestrationService.AnalyzeTabAsync"/>.
+/// </summary>
+public sealed class TabAnalyzeIntent(TabAnalysisOrchestrationService service) : IIntent
+{
+    public string Id => "tab.analyze";
+
+    public string Description =>
+        "Analyses a tab block: parses chords, finds modulation targets, suggests " +
+        "next chords. Requires a tab in the message.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "Analyse this tab",
+        "What's the chord progression in this tab?",
+        "Identify the chords in this tab",
+        "Walk me through this tab",
+    ];
+
+    public async Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default)
+    {
+        var resp = await service.AnalyzeTabAsync(query, cancellationToken);
+        return new IntentResult(
+            Answer: resp.NaturalLanguageAnswer,
+            Confidence: 1.0f,
+            RoutingMethodOverride: "tab-analyze");
+    }
+}

--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -1,5 +1,6 @@
 namespace GA.Business.Core.Orchestration.Plugins;
 
+using GA.Business.Core.Orchestration.Intents;
 using GA.Business.ML.Agents;
 using GA.Business.ML.Agents.Hooks;
 using GA.Business.ML.Agents.Memory;
@@ -24,18 +25,20 @@ public sealed class GaPlugin : IChatPlugin
         // ── Domain services required by skills ────────────────────────────────
         services.TryAddSingleton<IGrothendieckService, GrothendieckService>();
 
-        // ── Orchestrator skills (checked before LLM routing, first match wins) ─
-        // Pure-domain skills are Singleton (stateless, no scoped dependencies).
-        services.AddSingleton<IOrchestratorSkill, ChordInfoSkill>();
-        services.AddSingleton<IOrchestratorSkill, ScaleInfoSkill>();
-        services.AddSingleton<IOrchestratorSkill, ModesSkill>();
-        services.AddSingleton<IOrchestratorSkill, IntervalSkill>();
-        services.AddSingleton<IOrchestratorSkill, FretSpanSkill>();
-        services.AddSingleton<IOrchestratorSkill, ChordSubstitutionSkill>();
+        // ── Orchestrator skills (semantic dispatch via SemanticIntentRouter; ──
+        //     legacy CanHandle foreach kept as fallback). Each call registers
+        //     three things: the concrete skill, its IOrchestratorSkill binding,
+        //     and an OrchestratorSkillIntent adapter for the IIntent registry.
+        services.AddOrchestratorSkillIntent<ChordInfoSkill>();
+        services.AddOrchestratorSkillIntent<ScaleInfoSkill>();
+        services.AddOrchestratorSkillIntent<ModesSkill>();
+        services.AddOrchestratorSkillIntent<IntervalSkill>();
+        services.AddOrchestratorSkillIntent<FretSpanSkill>();
+        services.AddOrchestratorSkillIntent<ChordSubstitutionSkill>();
 
         // Skills using IChatClient are Scoped (IChatClient lifetime is Scoped).
-        services.AddScoped<IOrchestratorSkill, KeyIdentificationSkill>();
-        services.AddScoped<IOrchestratorSkill, ProgressionCompletionSkill>();
+        services.AddOrchestratorSkillIntent<KeyIdentificationSkill>(ServiceLifetime.Scoped);
+        services.AddOrchestratorSkillIntent<ProgressionCompletionSkill>(ServiceLifetime.Scoped);
 
         // ── Persistent memory ────────────────────────────────────────────────
         services.TryAddSingleton<MemoryStore>();

--- a/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
@@ -4,9 +4,11 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using GA.Business.Core.Orchestration.Abstractions;
+using GA.Business.Core.Orchestration.Intents;
 using GA.Business.Core.Orchestration.Models;
 using GA.Business.ML.Agents;
 using GA.Business.ML.Agents.Hooks;
+using GA.Business.ML.Agents.Intents;
 using GA.Business.ML.Embeddings;
 using GA.Business.ML.Retrieval;
 using GA.Business.ML.Tabs;
@@ -31,6 +33,8 @@ public class ProductionOrchestrator(
     IEnumerable<IOrchestratorSkill> orchestratorSkills,
     IEnumerable<IChatHook> chatHooks,
     ConversationHistoryStore historyStore,
+    SemanticIntentRouter intentRouter,
+    TabAnalysisOrchestrationService tabAnalysisService,
     IServiceProvider services) : IHarmonicChatOrchestrator
 {
     private readonly IReadOnlyList<IOrchestratorSkill> _skills = orchestratorSkills.ToList();
@@ -99,32 +103,20 @@ public class ProductionOrchestrator(
 
         var message = hookCtx.CurrentMessage;
 
-        var algebraResponse = await TryAnswerWithAlgebraAsync(message, ct);
-        if (algebraResponse is not null)
+        // ── Unified semantic intent dispatch (replaces the legacy algebra check
+        //    and the per-skill CanHandle foreach). One embedding similarity pass
+        //    over IIntent registrations covers algebra, deterministic skills,
+        //    and tab-handling intents. See
+        //    docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md
+        //    §"Routing classifiers".
+        var semanticResp = await TryDispatchViaIntentAsync(message, ct);
+        if (semanticResp is not null)
         {
-            foreach (var word in algebraResponse.NaturalLanguageAnswer.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            foreach (var word in semanticResp.NaturalLanguageAnswer.Split(' ', StringSplitOptions.RemoveEmptyEntries))
                 await onToken(word + " ");
 
-            historyStore.AddTurn(sessionId, "assistant", algebraResponse.NaturalLanguageAnswer);
-            return algebraResponse;
-        }
-
-        // ── Fast-path: domain-grounded skills bypass routing + LLM pipeline ──
-        foreach (var skill in _skills)
-        {
-            if (!skill.CanHandle(message)) continue;
-
-            var skillResp = await skill.ExecuteAsync(message, ct);
-
-            // Emit skill answer as word-level simulated tokens
-            foreach (var word in skillResp.Result.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-                await onToken(word + " ");
-
-            historyStore.AddTurn(sessionId, "assistant", skillResp.Result);
-            return new ChatResponse(
-                NaturalLanguageAnswer: skillResp.Result,
-                Candidates: [],
-                Routing: new AgentRoutingMetadata($"skill.{skill.Name}", skillResp.Confidence, "orchestrator-skill"));
+            historyStore.AddTurn(sessionId, "assistant", semanticResp.NaturalLanguageAnswer);
+            return semanticResp;
         }
 
         if (TrySelectDeterministicAgent(message, out var deterministicAgent, out var deterministicRouting))
@@ -158,15 +150,16 @@ public class ProductionOrchestrator(
             routing.Confidence,
             routing.RoutingMethod);
 
-        // For tab/path-optimization intents fall back to non-streaming path
+        // For tab/path-optimization intents fall back to non-streaming path.
+        // Dispatch by the LLM-extracted filter intent (no string-match keywords).
         if (routing.SelectedAgent.AgentId == AgentIds.Tab ||
             (filters?.Intent is "OptimizePath" or "AnalyzeTab"))
         {
             ChatResponse fallback;
-            if (filters?.Intent == "OptimizePath" || IsAskingForOptimization(req.Message))
-                fallback = await HandlePathOptimizationAsync(req.Message, ct);
+            if (filters?.Intent == "OptimizePath")
+                fallback = await tabAnalysisService.OptimizePathAsync(req.Message, ct);
             else
-                fallback = await HandleTabAnalysisAsync(req.Message, ct);
+                fallback = await tabAnalysisService.AnalyzeTabAsync(req.Message, ct);
 
             fallback = fallback with { Routing = routingMetadata, QueryFilters = filters };
 
@@ -247,27 +240,20 @@ public class ProductionOrchestrator(
 
         var message = hookCtx.CurrentMessage;
 
-        var algebraResponse = await TryAnswerWithAlgebraAsync(message, ct);
-        if (algebraResponse is not null)
+        // ── Unified semantic intent dispatch with the hook lifecycle ─────────
+        // One embedding similarity pass over IIntent registrations covers
+        // algebra, deterministic skills, and tab-handling intents. Replaces
+        // the legacy TryAnswerWithAlgebraAsync branch and the per-skill
+        // CanHandle foreach. See migration recommendation §"Routing classifiers".
+        var intentMatch = await intentRouter.RouteAsync(message, services, ct);
+        if (intentMatch is { } pick)
         {
-            sw.Stop();
-            activity?.SetTag("orchestration.branch", "algebra");
-            activity?.SetTag("orchestration.elapsed_ms", sw.ElapsedMilliseconds);
-            historyStore.AddTurn(sessionId, "assistant", algebraResponse.NaturalLanguageAnswer);
-            return algebraResponse;
-        }
-
-        // ── Fast-path: domain-grounded skills bypass routing + LLM pipeline ──
-        foreach (var skill in _skills)
-        {
-            if (!skill.CanHandle(message)) continue;
-
-            // OnBeforeSkill hooks
+            // OnBeforeSkill hooks (intent.Id replaces the legacy MatchedSkillName).
             var beforeCtx = new ChatHookContext
             {
                 OriginalMessage  = req.Message,
                 CurrentMessage   = message,
-                MatchedSkillName = skill.Name,
+                MatchedSkillName = pick.Intent.Id,
                 CorrelationId    = correlationId,
             };
             foreach (var hook in _hooks)
@@ -277,47 +263,61 @@ public class ProductionOrchestrator(
                 {
                     sw.Stop();
                     return new ChatResponse(
-                        NaturalLanguageAnswer: r.BlockedResponse?.Result ?? "Skill blocked.",
+                        NaturalLanguageAnswer: r.BlockedResponse?.Result ?? "Intent blocked.",
                         Candidates: [],
-                        Routing: new AgentRoutingMetadata($"hook.{skill.Name}", 1f, "hook-blocked"));
+                        Routing: new AgentRoutingMetadata($"hook.{pick.Intent.Id}", 1f, "hook-blocked"));
                 }
             }
 
-            var skillResp = await skill.ExecuteAsync(message, ct);
+            var intentResult = await pick.Intent.ExecuteAsync(message, ct);
+
+            // Map IntentResult back to AgentResponse for hook compatibility.
+            var skillRespForHooks = new AgentResponse
+            {
+                AgentId    = pick.Intent.Id,
+                Result     = intentResult.Answer,
+                Confidence = intentResult.Confidence,
+                Evidence   = intentResult.Evidence ?? [],
+                Assumptions = [],
+            };
 
             // OnAfterSkill hooks
             var afterCtx = new ChatHookContext
             {
                 OriginalMessage  = req.Message,
                 CurrentMessage   = message,
-                MatchedSkillName = skill.Name,
-                Response         = skillResp,
+                MatchedSkillName = pick.Intent.Id,
+                Response         = skillRespForHooks,
                 CorrelationId    = correlationId,
             };
             foreach (var hook in _hooks)
                 await hook.OnAfterSkill(afterCtx, ct);
 
             sw.Stop();
-            activity?.SetTag("orchestration.branch", $"skill.{skill.Name}");
+            activity?.SetTag("orchestration.branch", pick.Intent.Id);
             activity?.SetTag("orchestration.elapsed_ms", sw.ElapsedMilliseconds);
 
             var chatResp = new ChatResponse(
-                NaturalLanguageAnswer: skillResp.Result,
+                NaturalLanguageAnswer: intentResult.Answer,
                 Candidates: [],
-                Routing: new AgentRoutingMetadata($"skill.{skill.Name}", skillResp.Confidence, "orchestrator-skill"));
+                Routing: new AgentRoutingMetadata(
+                    pick.Intent.Id,
+                    Math.Min(intentResult.Confidence, pick.Confidence),
+                    intentResult.RoutingMethodOverride ?? "semantic-intent"));
 
             // OnResponseSent hooks (memory writing, analytics)
             var sentCtx = new ChatHookContext
             {
                 OriginalMessage  = req.Message,
                 CurrentMessage   = message,
-                MatchedSkillName = skill.Name,
-                Response         = skillResp,
+                MatchedSkillName = pick.Intent.Id,
+                Response         = skillRespForHooks,
                 CorrelationId    = correlationId,
             };
             foreach (var hook in _hooks)
                 await hook.OnResponseSent(sentCtx, ct);
 
+            historyStore.AddTurn(sessionId, "assistant", chatResp.NaturalLanguageAnswer);
             return chatResp;
         }
 
@@ -375,22 +375,27 @@ public class ProductionOrchestrator(
         activity?.SetTag(ChatbotActivitySource.TagRoutingConfidence, routing.Confidence);
 
         ChatResponse result;
-        var shouldOptimizePath = filters?.Intent == "OptimizePath" || IsAskingForOptimization(req.Message);
-        var shouldAnalyzeTab = routing.SelectedAgent.AgentId == AgentIds.Tab ||
-                               (filters?.Intent == "AnalyzeTab" && LooksLikeTabInput(req.Message));
+        // LLM-extracted filter intent drives tab branch — no string keyword check.
+        // (The semantic intent router upstream handles "make this smoother" /
+        // "analyse this tab" via TabOptimizeIntent / TabAnalyzeIntent before we
+        // reach this fallback, so this code only fires when the filter extractor
+        // tagged the intent OR the agent router routed to AgentIds.Tab.)
+        var shouldOptimizePath = filters?.Intent == "OptimizePath";
+        var shouldAnalyzeTab   = routing.SelectedAgent.AgentId == AgentIds.Tab ||
+                                 filters?.Intent == "AnalyzeTab";
 
         if (shouldAnalyzeTab || shouldOptimizePath)
         {
             if (shouldOptimizePath)
             {
                 activity?.SetTag("orchestration.branch", "tab.path_optimization");
-                var optimized = await HandlePathOptimizationAsync(req.Message, ct);
+                var optimized = await tabAnalysisService.OptimizePathAsync(req.Message, ct);
                 result = optimized with { Routing = routingMetadata, QueryFilters = filters };
             }
             else
             {
                 activity?.SetTag("orchestration.branch", "tab.analysis");
-                var analyzed = await HandleTabAnalysisAsync(req.Message, ct);
+                var analyzed = await tabAnalysisService.AnalyzeTabAsync(req.Message, ct);
                 result = analyzed with { Routing = routingMetadata, QueryFilters = filters };
             }
         }
@@ -475,152 +480,24 @@ public class ProductionOrchestrator(
                    RegexOptions.IgnoreCase);
     }
 
-    private async Task<ChatResponse> HandlePathOptimizationAsync(string query, CancellationToken ct)
+    /// <summary>
+    /// Streaming-path entry to the unified semantic intent dispatch — used by
+    /// <see cref="AnswerStreamingAsync"/>. Returns the intent's response or
+    /// null when no intent scored above threshold (caller falls through to
+    /// the LLM agent path).
+    /// </summary>
+    private async Task<ChatResponse?> TryDispatchViaIntentAsync(string message, CancellationToken ct)
     {
-        // Extract raw tab from query
-        var diagramMatch = Regex.Match(query, @"([x\d]{1,2}-){5}[x\d]{1,2}");
-        string tabText;
+        var match = await intentRouter.RouteAsync(message, services, ct);
+        if (match is not { } pick) return null;
 
-        if (diagramMatch.Success && !query.Contains('|'))
-        {
-            var parts = diagramMatch.Value.Split('-');
-            if (parts.Length == 6)
-            {
-                var sb = new StringBuilder();
-                for (int i = 5; i >= 0; i--)
-                    sb.AppendLine($"|--{parts[i]}--|");
-                tabText = sb.ToString();
-            }
-            else
-            {
-                tabText = ExtractTabLines(query);
-            }
-        }
-        else
-        {
-            tabText = ExtractTabLines(query);
-        }
-
-        var analysis = await tabAnalyzer.AnalyzeAsync(tabText);
-        if (analysis.Events.Count == 0)
-            return new ChatResponse("I couldn't find a valid tab to optimize.", []);
-
-        var solution = await tabSolver.SolveOptimalPathAsync(analysis.Events.Select(e => e.Document));
-        var alternatives = await altService.GetAlternativesAsync(analysis.Events.Select(e => e.Document));
-
-        var narrative = new StringBuilder();
-        narrative.AppendLine("I've re-calculated the optimal path for that progression to minimize hand movement and transitions.");
-        narrative.AppendLine();
-        narrative.AppendLine("**Optimized Tab:**");
-        narrative.AppendLine("```");
-        narrative.AppendLine(solution.TabContent);
-        narrative.AppendLine("```");
-        narrative.AppendLine($"*Optimization Score: {solution.TotalPhysicalCost:F1} physical cost units.*");
-
-        if (alternatives.Any())
-        {
-            narrative.AppendLine();
-            narrative.AppendLine("### Alternative Styles");
-            string[] stringNames = ["e", "B", "G", "D", "A", "E"];
-
-            foreach (var alt in alternatives)
-            {
-                narrative.AppendLine($"**{alt.Label}** ({alt.Description})");
-                narrative.AppendLine("```");
-                var sb = new StringBuilder();
-                for (int s = 0; s < 6; s++)
-                {
-                    sb.Append(stringNames[s] + "|");
-                    var stringIdx = s + 1;
-                    foreach (var chord in alt.Tab)
-                    {
-                        var pos = chord.FirstOrDefault(n => n.StringIndex.Value == stringIdx);
-                        if (pos != null) sb.Append($"-{pos.Fret}-");
-                        else sb.Append("-x-");
-                    }
-                    sb.AppendLine("|");
-                }
-                narrative.AppendLine(sb.ToString());
-                narrative.AppendLine("```");
-            }
-        }
-
+        var result = await pick.Intent.ExecuteAsync(message, ct);
         return new ChatResponse(
-            narrative.ToString(),
-            [],
-            DebugParams: new { Mode = "PathOptimization", Cost = solution.TotalPhysicalCost });
-    }
-
-    private async Task<ChatResponse> HandleTabAnalysisAsync(string tab, CancellationToken ct)
-    {
-        var result = await tabAnalyzer.AnalyzeAsync(tab);
-        if (result.Events.Count == 0)
-            return new ChatResponse("I detected tab but couldn't parse any chords.", [], DebugParams: new { Status = "Empty" });
-
-        var events = result.Events.ToList();
-        var embeddingTasks = events.Select(async e =>
-        {
-            try
-            {
-                var emb = await embeddingGenerator.GenerateEmbeddingAsync(e.Document);
-                return e with { Document = e.Document with { Embedding = emb } };
-            }
-            catch (Exception)
-            {
-                // Degrade gracefully — proceed without embedding for this event
-                return e;
-            }
-        }).ToList();
-
-        events = [.. await Task.WhenAll(embeddingTasks)];
-        var progression = events.Select(e => e.Document).ToList();
-
-        var targets = modulationAnalyzer.IdentifyTargets(progression);
-        var suggestions = await suggestionService.SuggestNextAsync(progression.Last(), topK: 3);
-
-        return presenter.FormatAnalysis(result, suggestions, targets);
-    }
-
-    private static bool IsAskingForOptimization(string query)
-    {
-        var q = query.ToLowerInvariant();
-        return q.Contains("smooth") || q.Contains("easy") || q.Contains("optimize") ||
-               q.Contains("ergonomic") || q.Contains("better path");
-    }
-
-    private static bool LooksLikeTabInput(string query)
-    {
-        if (string.IsNullOrWhiteSpace(query))
-            return false;
-
-        if (Regex.IsMatch(query, @"([x\d]{1,2}-){5}[x\d]{1,2}"))
-            return true;
-
-        var lines = query.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return lines.Any(l => l.Contains('|') || l.Contains("--"));
-    }
-
-    private static string ExtractTabLines(string query) =>
-        string.Join("\n", query.Split('\n').Where(l => l.Contains('|') || l.Contains("--")));
-
-    private async Task<ChatResponse?> TryAnswerWithAlgebraAsync(string message, CancellationToken ct)
-    {
-        if (!algebraPromptClassifier.IsAlgebraPrompt(message))
-        {
-            return null;
-        }
-
-        var algebraAnswer = await ixAlgebraService.TryAnswerAsync(message, ct);
-        if (algebraAnswer is null)
-        {
-            return null;
-        }
-
-        return new ChatResponse(
-            NaturalLanguageAnswer: algebraAnswer.NaturalLanguageAnswer,
+            NaturalLanguageAnswer: result.Answer,
             Candidates: [],
-            Routing: new AgentRoutingMetadata("algebra", 1f, "ix-algebra"),
-            DebugParams: new { Mode = "Algebra", QueryType = algebraAnswer.QueryType, algebraAnswer.Facts },
-            Grounding: algebraAnswer.Grounding);
+            Routing: new AgentRoutingMetadata(
+                pick.Intent.Id,
+                Math.Min(result.Confidence, pick.Confidence),
+                result.RoutingMethodOverride ?? "semantic-intent"));
     }
 }

--- a/Common/GA.Business.Core.Orchestration/Services/TabAnalysisOrchestrationService.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/TabAnalysisOrchestrationService.cs
@@ -1,0 +1,156 @@
+namespace GA.Business.Core.Orchestration.Services;
+
+using System.Text;
+using System.Text.RegularExpressions;
+using GA.Business.Core.Orchestration.Models;
+using GA.Business.ML.Embeddings;
+using GA.Business.ML.Retrieval;
+using GA.Business.ML.Tabs;
+
+/// <summary>
+/// Encapsulates tab-path optimization and tab-analysis flows previously
+/// embedded as private methods in <see cref="ProductionOrchestrator"/>.
+/// Extracting them lets the new intent layer
+/// (<c>TabOptimizeIntent</c>, <c>TabAnalyzeIntent</c>) call the same logic
+/// without leaking orchestrator internals.
+/// </summary>
+/// <remarks>
+/// All dependencies are already DI-registered for the orchestrator; this
+/// service is a Scoped facade over them.
+/// </remarks>
+public sealed partial class TabAnalysisOrchestrationService(
+    TabAnalysisService tabAnalyzer,
+    AdvancedTabSolver tabSolver,
+    AlternativeFingeringService altService,
+    MusicalEmbeddingGenerator embeddingGenerator,
+    ModulationAnalyzer modulationAnalyzer,
+    NextChordSuggestionService suggestionService,
+    TabPresentationService presenter)
+{
+    [GeneratedRegex(@"([x\d]{1,2}-){5}[x\d]{1,2}", RegexOptions.CultureInvariant)]
+    private static partial Regex CompactDiagramRegex();
+
+    /// <summary>
+    /// Re-calculates the optimal fingering path for a tab in the query —
+    /// minimises hand movement and transitions, returns the optimised tab
+    /// plus alternative-style suggestions.
+    /// </summary>
+    public async Task<ChatResponse> OptimizePathAsync(string query, CancellationToken cancellationToken = default)
+    {
+        var diagramMatch = CompactDiagramRegex().Match(query);
+        string tabText;
+
+        if (diagramMatch.Success && !query.Contains('|'))
+        {
+            var parts = diagramMatch.Value.Split('-');
+            if (parts.Length == 6)
+            {
+                var sb = new StringBuilder();
+                for (int i = 5; i >= 0; i--)
+                    sb.AppendLine($"|--{parts[i]}--|");
+                tabText = sb.ToString();
+            }
+            else
+            {
+                tabText = ExtractTabLines(query);
+            }
+        }
+        else
+        {
+            tabText = ExtractTabLines(query);
+        }
+
+        var analysis = await tabAnalyzer.AnalyzeAsync(tabText);
+        if (analysis.Events.Count == 0)
+        {
+            return new ChatResponse(
+                "I need a tab in the message to optimize a path. " +
+                "Paste a tab block (e.g. `e|---0---3---|` lines) or a compact diagram (e.g. `x-3-2-0-1-0`).",
+                []);
+        }
+
+        var solution = await tabSolver.SolveOptimalPathAsync(analysis.Events.Select(e => e.Document));
+        var alternatives = await altService.GetAlternativesAsync(analysis.Events.Select(e => e.Document));
+
+        var narrative = new StringBuilder();
+        narrative.AppendLine("I've re-calculated the optimal path for that progression to minimize hand movement and transitions.");
+        narrative.AppendLine();
+        narrative.AppendLine("**Optimized Tab:**");
+        narrative.AppendLine("```");
+        narrative.AppendLine(solution.TabContent);
+        narrative.AppendLine("```");
+        narrative.AppendLine($"*Optimization Score: {solution.TotalPhysicalCost:F1} physical cost units.*");
+
+        if (alternatives.Any())
+        {
+            narrative.AppendLine();
+            narrative.AppendLine("### Alternative Styles");
+            string[] stringNames = ["e", "B", "G", "D", "A", "E"];
+
+            foreach (var alt in alternatives)
+            {
+                narrative.AppendLine($"**{alt.Label}** ({alt.Description})");
+                narrative.AppendLine("```");
+                var sb = new StringBuilder();
+                for (int s = 0; s < 6; s++)
+                {
+                    sb.Append(stringNames[s] + "|");
+                    var stringIdx = s + 1;
+                    foreach (var chord in alt.Tab)
+                    {
+                        var pos = chord.FirstOrDefault(n => n.StringIndex.Value == stringIdx);
+                        if (pos != null) sb.Append($"-{pos.Fret}-");
+                        else sb.Append("-x-");
+                    }
+                    sb.AppendLine("|");
+                }
+                narrative.AppendLine(sb.ToString());
+                narrative.AppendLine("```");
+            }
+        }
+
+        return new ChatResponse(
+            narrative.ToString(),
+            [],
+            DebugParams: new { Mode = "PathOptimization", Cost = solution.TotalPhysicalCost });
+    }
+
+    /// <summary>
+    /// Analyses a tab block: parses chords, generates embeddings for each
+    /// event, identifies modulation targets, suggests next chords, and
+    /// formats via the presenter.
+    /// </summary>
+    public async Task<ChatResponse> AnalyzeTabAsync(string tab, CancellationToken cancellationToken = default)
+    {
+        var result = await tabAnalyzer.AnalyzeAsync(tab);
+        if (result.Events.Count == 0)
+            return new ChatResponse("I detected tab but couldn't parse any chords.", [], DebugParams: new { Status = "Empty" });
+
+        var events = result.Events.ToList();
+        var embeddingTasks = events.Select(async e =>
+        {
+            try
+            {
+                var emb = await embeddingGenerator.GenerateEmbeddingAsync(e.Document);
+                return e with { Document = e.Document with { Embedding = emb } };
+            }
+            catch (Exception)
+            {
+                // Degrade gracefully — proceed without embedding for this event
+                return e;
+            }
+        }).ToList();
+
+        events = [.. await Task.WhenAll(embeddingTasks)];
+        var progression = events.Select(e => e.Document).ToList();
+
+        var targets = modulationAnalyzer.IdentifyTargets(progression);
+        var suggestions = await suggestionService.SuggestNextAsync(progression.Last(), topK: 3);
+
+        return presenter.FormatAnalysis(result, suggestions, targets);
+    }
+
+    /// <summary>Extracts tab lines (containing <c>|</c> or <c>--</c>) from a query.</summary>
+    public static string ExtractTabLines(string query) =>
+        string.Join("\n", query.Split('\n').Where(l => l.Contains('|') || l.Contains("--")));
+}

--- a/Common/GA.Business.ML/Agents/AgentSkillBase.cs
+++ b/Common/GA.Business.ML/Agents/AgentSkillBase.cs
@@ -28,6 +28,13 @@ public abstract class AgentSkillBase(string agentId, IChatClient chatClient, ILo
     public abstract string Name { get; }
     public abstract string Description { get; }
 
+    /// <summary>
+    /// Canonical phrasings used by <c>SemanticIntentRouter</c>. Subclasses that
+    /// participate in semantic routing should override; default empty preserves
+    /// legacy <c>CanHandle</c>-only dispatch.
+    /// </summary>
+    public virtual IReadOnlyList<string> ExamplePrompts => [];
+
     // ── IOrchestratorSkill — implement in subclasses ──────────────────────────
 
     public abstract bool CanHandle(string message);

--- a/Common/GA.Business.ML/Agents/IOrchestratorSkill.cs
+++ b/Common/GA.Business.ML/Agents/IOrchestratorSkill.cs
@@ -19,11 +19,24 @@ public interface IOrchestratorSkill
     /// <summary>Human-readable name used for logging and trace tags.</summary>
     string Name { get; }
 
-    /// <summary>Declares what this skill handles (surfaced in chatbot capability lists).</summary>
+    /// <summary>Declares what this skill handles (surfaced in chatbot capability lists
+    /// and embedded by <c>SemanticIntentRouter</c> for routing).</summary>
     string Description { get; }
 
     /// <summary>
-    /// Fast, side-effect-free check — returns true when this skill can fully answer the message.
+    /// Canonical phrasings that should route to this skill — used by the unified
+    /// embedding-based <c>SemanticIntentRouter</c> (per
+    /// <c>docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md</c>
+    /// §"Routing classifiers"). Empty list means the skill participates in
+    /// routing only via <see cref="CanHandle"/> (legacy / fallback path).
+    /// Three to six representative examples is the sweet spot.
+    /// </summary>
+    IReadOnlyList<string> ExamplePrompts => [];
+
+    /// <summary>
+    /// Legacy fast path — string-matching predicate retained for the foreach
+    /// fallback in <c>ProductionOrchestrator</c>. New skills should prefer
+    /// <see cref="ExamplePrompts"/> and stub this to <c>false</c>.
     /// </summary>
     bool CanHandle(string message);
 

--- a/Common/GA.Business.ML/Agents/Intents/IIntent.cs
+++ b/Common/GA.Business.ML/Agents/Intents/IIntent.cs
@@ -1,0 +1,55 @@
+namespace GA.Business.ML.Agents.Intents;
+
+/// <summary>
+/// Single semantic surface for chatbot dispatch — replaces ad-hoc string-matching
+/// classifiers (<c>KeywordAlgebraPromptClassifier</c>, <c>IsAskingForOptimization</c>,
+/// per-skill <c>CanHandle</c> regexes). Each intent carries its routing metadata
+/// (<see cref="Description"/> + <see cref="ExamplePrompts"/>) AND its execution path.
+/// </summary>
+/// <remarks>
+/// <para>The router (<see cref="SemanticIntentRouter"/>) embeds every intent's
+/// description and example prompts at startup, then per-query computes cosine
+/// similarity and picks the top match above a confidence threshold. No LLM
+/// call is on the routing path — this is the "function over agent" pattern
+/// the migration recommendation doc requires.</para>
+/// <para>Intent <see cref="Id"/> values follow the convention
+/// <c>{category}.{name}</c> (e.g. <c>skill.modes</c>, <c>algebra</c>,
+/// <c>tab.optimize</c>). They surface in <c>AgentRoutingMetadata.AgentId</c>
+/// so traces tell you exactly which intent ran.</para>
+/// </remarks>
+public interface IIntent
+{
+    /// <summary>Stable identifier surfaced as the agent id in trace metadata.</summary>
+    string Id { get; }
+
+    /// <summary>One-paragraph description of what this intent answers. Embedded by
+    /// <see cref="SemanticIntentRouter"/> alongside the example prompts.</summary>
+    string Description { get; }
+
+    /// <summary>Canonical phrasings that should route to this intent. Three to six
+    /// representative examples is the sweet spot; the router takes the max
+    /// cosine similarity across all of them.</summary>
+    IReadOnlyList<string> ExamplePrompts { get; }
+
+    /// <summary>Run the intent against the user query. Implementations should
+    /// return a zero-confidence result rather than throwing for recoverable
+    /// errors (e.g. unparseable input) so the chatbot pipeline can degrade
+    /// gracefully.</summary>
+    Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Result returned from <see cref="IIntent.ExecuteAsync"/>.</summary>
+/// <param name="Answer">Natural-language answer.</param>
+/// <param name="Confidence">0.0 to 1.0. The router's match score is combined
+/// with this via <c>min</c> when surfacing the final routing confidence.</param>
+/// <param name="Evidence">Optional structured evidence items the chatbot may
+/// expose in traces.</param>
+/// <param name="RoutingMethodOverride">Optional override for the
+/// <c>routing.method</c> trace tag. Defaults to <c>"semantic-intent"</c> at the
+/// router level; intents that want their own brand (e.g. <c>"ix-algebra"</c>)
+/// can override here.</param>
+public sealed record IntentResult(
+    string Answer,
+    float Confidence = 1.0f,
+    IReadOnlyList<string>? Evidence = null,
+    string? RoutingMethodOverride = null);

--- a/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
+++ b/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
@@ -1,0 +1,187 @@
+namespace GA.Business.ML.Agents.Intents;
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Routes a user query to the best matching <see cref="IIntent"/> by cosine
+/// similarity between the query embedding and each intent's example-prompt
+/// embeddings. Replaces the legacy string-matching dispatch
+/// (<c>KeywordAlgebraPromptClassifier</c>, <c>IsAskingForOptimization</c>,
+/// per-skill <c>CanHandle</c> regexes).
+/// </summary>
+/// <remarks>
+/// <para><b>Algorithm:</b></para>
+/// <list type="number">
+///   <item>On first call, embed every intent's <see cref="IIntent.Description"/>
+///         + <see cref="IIntent.ExamplePrompts"/> (cached for the process
+///         lifetime — typically a one-time ~50ms cost at startup).</item>
+///   <item>Embed the incoming query.</item>
+///   <item>For each intent, compute the max cosine similarity across its
+///         description + examples.</item>
+///   <item>Return the highest scorer if its score crosses
+///         <see cref="MinConfidence"/>; otherwise return <c>null</c> so the
+///         orchestrator can fall through to its LLM-agent path.</item>
+/// </list>
+/// <para><b>This is a function, not an agent.</b> No LLM round-trip on the
+/// routing path. Cosine similarity is closed-form over fixed vectors. Per
+/// <c>docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md</c>
+/// §"Routing classifiers".</para>
+/// </remarks>
+public sealed class SemanticIntentRouter(
+    IEmbeddingGenerator<string, Embedding<float>>? textEmbeddings,
+    ILogger<SemanticIntentRouter> logger)
+{
+    private const float DefaultMinConfidence = 0.65f;
+
+    // Process-wide cache so intent vectors persist across requests. Keyed by
+    // <see cref="IIntent.Id"/>; each entry is [description, example1..exampleN].
+    private readonly Dictionary<string, float[][]> _intentEmbeddings = [];
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private volatile bool _embeddingsReady;
+
+    /// <summary>Cosine-similarity threshold above which an intent claims the query.</summary>
+    public float MinConfidence { get; init; } = DefaultMinConfidence;
+
+    /// <summary>
+    /// Selects the best intent for the query, or <c>null</c> if no intent
+    /// scores above <see cref="MinConfidence"/>.
+    /// </summary>
+    /// <param name="query">User message.</param>
+    /// <param name="services">Per-request <see cref="IServiceProvider"/>. The
+    /// router is Singleton; intents may be Scoped (e.g. those that take
+    /// <c>IChatClient</c>) so we resolve <c>IEnumerable&lt;IIntent&gt;</c> from
+    /// the caller's scope rather than capturing it at construction.</param>
+    /// <param name="cancellationToken">Cancellation.</param>
+    public async Task<IntentMatch?> RouteAsync(
+        string query,
+        IServiceProvider services,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return null;
+        if (textEmbeddings is null) return null;
+
+        var intents = services.GetServices<IIntent>().ToList();
+        var candidates = intents.Where(i => i.ExamplePrompts.Count > 0).ToList();
+        if (candidates.Count == 0) return null;
+
+        await EnsureExamplesEmbeddedAsync(candidates, cancellationToken);
+
+        float[] queryVec;
+        try
+        {
+            var queryEmbedding = await textEmbeddings.GenerateAsync(
+                [query], cancellationToken: cancellationToken);
+            queryVec = queryEmbedding[0].Vector.ToArray();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "SemanticIntentRouter: query embedding failed; routing falls through to LLM path");
+            return null;
+        }
+
+        IIntent? bestIntent = null;
+        var bestScore = float.NegativeInfinity;
+        string? bestExample = null;
+
+        foreach (var intent in candidates)
+        {
+            if (!_intentEmbeddings.TryGetValue(intent.Id, out var vectors)) continue;
+
+            // vectors[0] = description, vectors[1..n] = examples (aligned with
+            // intent.ExamplePrompts[i-1]).
+            for (var i = 0; i < vectors.Length; i++)
+            {
+                var score = Cosine(queryVec, vectors[i]);
+                if (score <= bestScore) continue;
+
+                bestScore = score;
+                bestIntent = intent;
+                bestExample = i == 0 ? intent.Description : intent.ExamplePrompts[i - 1];
+            }
+        }
+
+        if (bestIntent is null || bestScore < MinConfidence)
+        {
+            logger.LogDebug(
+                "SemanticIntentRouter: no intent above threshold {Threshold:F2} (best={Best} @ {Score:F3})",
+                MinConfidence, bestIntent?.Id ?? "<none>", bestScore);
+            return null;
+        }
+
+        logger.LogDebug(
+            "SemanticIntentRouter: routed to {Intent} via {Example!r} (score {Score:F3})",
+            bestIntent.Id, bestExample, bestScore);
+
+        return new IntentMatch(bestIntent, bestScore, bestExample ?? string.Empty);
+    }
+
+    private async Task EnsureExamplesEmbeddedAsync(
+        IReadOnlyList<IIntent> candidates, CancellationToken ct)
+    {
+        // Hot path: every intent we know about has already been embedded.
+        if (_embeddingsReady && candidates.All(c => _intentEmbeddings.ContainsKey(c.Id)))
+            return;
+
+        await _initLock.WaitAsync(ct);
+        try
+        {
+            // Re-check after acquiring the lock; another thread may have populated.
+            var missing = candidates.Where(c => !_intentEmbeddings.ContainsKey(c.Id)).ToList();
+            if (missing.Count == 0)
+            {
+                _embeddingsReady = true;
+                return;
+            }
+
+            foreach (var intent in missing)
+            {
+                var inputs = new List<string> { intent.Description };
+                inputs.AddRange(intent.ExamplePrompts);
+
+                var batch = await textEmbeddings!.GenerateAsync(inputs, cancellationToken: ct);
+                _intentEmbeddings[intent.Id] = batch.Select(e => e.Vector.ToArray()).ToArray();
+            }
+
+            _embeddingsReady = true;
+            logger.LogInformation(
+                "SemanticIntentRouter: embedded {New} new intent(s); cache now holds {Total} intent vectors",
+                missing.Count,
+                _intentEmbeddings.Count);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "SemanticIntentRouter: example embedding failed; router will degrade to fallback");
+            // Leave _embeddingsReady = false so a later call can retry.
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    private static float Cosine(float[] a, float[] b)
+    {
+        if (a.Length != b.Length) return 0f;
+
+        float dot = 0f, na = 0f, nb = 0f;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * b[i];
+            na  += a[i] * a[i];
+            nb  += b[i] * b[i];
+        }
+
+        if (na == 0f || nb == 0f) return 0f;
+        return dot / MathF.Sqrt(na * nb);
+    }
+}
+
+/// <summary>Result of a successful semantic intent match.</summary>
+public readonly record struct IntentMatch(
+    IIntent Intent,
+    float Confidence,
+    string MatchedExample);

--- a/Common/GA.Business.ML/Agents/Skills/ChordInfoSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ChordInfoSkill.cs
@@ -46,7 +46,20 @@ public sealed partial class ChordInfoSkill(ILogger<ChordInfoSkill> logger) : IOr
 
     public string Name => "ChordInfo";
 
-    public string Description => "Returns notes for common chord qualities from deterministic interval formulas";
+    public string Description =>
+        "Returns the notes that make up a named chord (e.g. C major chord = C, E, G; " +
+        "Dm7 = D, F, A, C). Also identifies which chord a set of notes spells. " +
+        "Pure domain computation, zero LLM calls.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What is a C major chord?",
+        "What notes are in Dm7?",
+        "Notes in an F minor chord",
+        "What chord contains C E G?",
+        "Spell a B7 chord",
+        "What notes are in a Cmaj7?",
+    ];
 
     public bool CanHandle(string message)
     {

--- a/Common/GA.Business.ML/Agents/Skills/IntervalSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/IntervalSkill.cs
@@ -17,7 +17,18 @@ using GA.Domain.Core.Primitives.Notes;
 public sealed class IntervalSkill(ILogger<IntervalSkill> logger) : IOrchestratorSkill
 {
     public string Name        => "Interval";
-    public string Description => "Returns the interval between two notes from the domain model";
+    public string Description =>
+        "Computes the interval between two notes (e.g. C to G is a perfect fifth). " +
+        "Pure domain computation, zero LLM calls.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What is the interval between C and G?",
+        "Distance from F# to D",
+        "Interval from C to E",
+        "How many semitones from A to E?",
+        "What's the interval between D and Bb?",
+    ];
 
     // Capture two note names with optional accidentals — order matters, "from X to Y"
     // is the natural reading direction; we treat the first as the lower note.

--- a/Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs
@@ -16,7 +16,17 @@ public sealed class KeyIdentificationSkill(IChatClient chatClient, ILogger<KeyId
     : AgentSkillBase(AgentIds.Theory, chatClient, logger), IOrchestratorSkill
 {
     public override string Name        => "KeyIdentification";
-    public override string Description => "Identifies the musical key of a chord progression using pitch-class arithmetic";
+    public override string Description =>
+        "Identifies the musical key of a chord progression using pitch-class arithmetic. " +
+        "Use when given a sequence of chords like 'C Am F G' or 'Dm G C' and asked what key it's in.";
+
+    public override IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What key is C Am F G in?",
+        "Identify the key of Dm G C",
+        "What key does Am F G E sound like?",
+        "Tell me the key of these chords: G D Em C",
+    ];
 
     public override bool CanHandle(string message) =>
         KeyIdentificationService.IsKeyIdentificationQuery(message);

--- a/Common/GA.Business.ML/Agents/Skills/ModesSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ModesSkill.cs
@@ -16,7 +16,20 @@ using GA.Domain.Core.Theory.Tonal.Modes.Diatonic;
 public sealed class ModesSkill(ILogger<ModesSkill> logger) : IOrchestratorSkill
 {
     public string Name        => "Modes";
-    public string Description => "Lists the modes of the major scale with formula and character";
+    public string Description =>
+        "Lists the seven modes of the major scale (Ionian, Dorian, Phrygian, Lydian, " +
+        "Mixolydian, Aeolian, Locrian) with degrees and character notes — pure music " +
+        "theory, no LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What are the modes of the major scale?",
+        "List the diatonic modes",
+        "Name the seven modes of the major scale",
+        "Tell me about the major scale modes",
+        "What is Lydian mode?",
+        "Explain Phrygian and Aeolian",
+    ];
 
     private static readonly Regex ModesPattern =
         new(@"\bmodes?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs
@@ -16,7 +16,18 @@ public sealed class ProgressionCompletionSkill(IChatClient chatClient, ILogger<P
     : AgentSkillBase(AgentIds.Theory, chatClient, logger), IOrchestratorSkill
 {
     public override string Name        => "ProgressionCompletion";
-    public override string Description => "Suggests diatonic chord completions for an in-progress progression";
+    public override string Description =>
+        "Suggests 2–3 diatonic chord completions for an in-progress progression — " +
+        "uses pitch-class arithmetic to detect the key, LLM only to phrase the cadence choice.";
+
+    public override IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What chord comes next after C G Am?",
+        "How do I finish this progression: Em D C",
+        "Help me end Am F G",
+        "What should follow Dm G C?",
+        "Continue this progression: F C G",
+    ];
 
     // ── Triggers ──────────────────────────────────────────────────────────────
 

--- a/Common/GA.Business.ML/Agents/Skills/ScaleInfoSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ScaleInfoSkill.cs
@@ -15,7 +15,18 @@ using GA.Domain.Core.Theory.Tonal;
 public sealed class ScaleInfoSkill(ILogger<ScaleInfoSkill> logger) : IOrchestratorSkill
 {
     public string Name        => "ScaleInfo";
-    public string Description => "Returns the notes of a major or minor key from the domain model";
+    public string Description =>
+        "Returns the notes of a major or minor key (e.g. C major has C D E F G A B). " +
+        "Pure domain computation, zero LLM calls.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What notes are in C major?",
+        "Show me the F# minor scale",
+        "List the notes in Bb major",
+        "What is D minor?",
+        "Tell me the notes of E major",
+    ];
 
     // Matches: "notes in C major", "what is Bb minor scale", "D# minor notes", etc.
     private static readonly Regex KeyPattern =

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
@@ -1,0 +1,241 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Intents;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+[TestFixture]
+public class SemanticIntentRouterTests
+{
+    private sealed class StubIntent(
+        string id,
+        string description,
+        IReadOnlyList<string> examples,
+        string answer = "stub answer") : IIntent
+    {
+        public string Id => id;
+        public string Description => description;
+        public IReadOnlyList<string> ExamplePrompts => examples;
+
+        public Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new IntentResult(answer));
+    }
+
+    /// <summary>
+    /// Returns an embedding generator that produces deterministic vectors
+    /// keyed by string identity — same string → same vector, different
+    /// strings → orthogonal-ish vectors. Lets us drive cosine similarity
+    /// without standing up a real embedder.
+    /// </summary>
+    private static IEmbeddingGenerator<string, Embedding<float>> StubEmbedder(
+        Dictionary<string, float[]> vectors)
+    {
+        var mock = new Mock<IEmbeddingGenerator<string, Embedding<float>>>();
+        mock.Setup(e => e.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<EmbeddingGenerationOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<string>, EmbeddingGenerationOptions?, CancellationToken>(
+                (inputs, _, _) =>
+                {
+                    var fallback = new float[] { 0f, 0f, 0f, 0f };
+                    var list = inputs.Select(input =>
+                        vectors.TryGetValue(input, out var v)
+                            ? new Embedding<float>(v)
+                            : new Embedding<float>(fallback))
+                        .ToList();
+                    return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(list));
+                });
+        return mock.Object;
+    }
+
+    private static IServiceProvider Services(params IIntent[] intents)
+    {
+        var sc = new ServiceCollection();
+        foreach (var intent in intents) sc.AddSingleton(intent);
+        return sc.BuildServiceProvider();
+    }
+
+    [Test]
+    public async Task RouteAsync_ExactMatch_ReturnsIntent()
+    {
+        var algebraIntent = new StubIntent(
+            id: "algebra",
+            description: "set theory",
+            examples: ["are 0146 and 0137 z-related"],
+            answer: "yes Z-related");
+
+        var vectors = new Dictionary<string, float[]>
+        {
+            ["are 0146 and 0137 z-related"] = [1f, 0f, 0f, 0f],
+            ["set theory"]                   = [0.5f, 0f, 0f, 0f],
+            // The query the user typed:
+            ["are 0146 and 0137 z-related?"] = [1f, 0f, 0f, 0f],
+        };
+
+        var router = new SemanticIntentRouter(
+            StubEmbedder(vectors),
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        var match = await router.RouteAsync("are 0146 and 0137 z-related?", Services(algebraIntent));
+
+        Assert.That(match, Is.Not.Null);
+        Assert.That(match!.Value.Intent.Id, Is.EqualTo("algebra"));
+        Assert.That(match.Value.Confidence, Is.GreaterThan(0.99f));
+    }
+
+    [Test]
+    public async Task RouteAsync_PicksHighestScorer_AcrossIntents()
+    {
+        var algebra = new StubIntent("algebra", "set theory",
+            ["are these z-related"]);
+        var modes = new StubIntent("skill.modes", "modes of major scale",
+            ["modes of the major scale"]);
+
+        var vectors = new Dictionary<string, float[]>
+        {
+            ["are these z-related"]        = [1f, 0f, 0f, 0f],
+            ["set theory"]                 = [0.9f, 0.1f, 0f, 0f],
+            ["modes of the major scale"]   = [0f, 1f, 0f, 0f],
+            ["modes of major scale"]       = [0.1f, 0.9f, 0f, 0f],
+            // Query: closer to modes than algebra
+            ["what are the modes"]         = [0f, 0.95f, 0f, 0f],
+        };
+
+        var router = new SemanticIntentRouter(
+            StubEmbedder(vectors),
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        var match = await router.RouteAsync("what are the modes", Services(algebra, modes));
+
+        Assert.That(match, Is.Not.Null);
+        Assert.That(match!.Value.Intent.Id, Is.EqualTo("skill.modes"));
+    }
+
+    [Test]
+    public async Task RouteAsync_BelowThreshold_ReturnsNull()
+    {
+        var algebra = new StubIntent("algebra", "set theory",
+            ["are these z-related"]);
+
+        var vectors = new Dictionary<string, float[]>
+        {
+            ["are these z-related"]   = [1f, 0f, 0f, 0f],
+            ["set theory"]            = [1f, 0f, 0f, 0f],
+            // Query: orthogonal — no match
+            ["what is for breakfast"] = [0f, 0f, 0f, 1f],
+        };
+
+        var router = new SemanticIntentRouter(
+            StubEmbedder(vectors),
+            NullLogger<SemanticIntentRouter>.Instance) { MinConfidence = 0.5f };
+
+        var match = await router.RouteAsync("what is for breakfast", Services(algebra));
+
+        Assert.That(match, Is.Null);
+    }
+
+    [Test]
+    public async Task RouteAsync_NoEmbedder_ReturnsNull()
+    {
+        var algebra = new StubIntent("algebra", "set theory", ["z-related"]);
+
+        var router = new SemanticIntentRouter(
+            textEmbeddings: null,
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        var match = await router.RouteAsync("anything", Services(algebra));
+
+        Assert.That(match, Is.Null);
+    }
+
+    [Test]
+    public async Task RouteAsync_NoIntentsWithExamples_ReturnsNull()
+    {
+        var bareIntent = new StubIntent("bare", "no examples", []);
+
+        var router = new SemanticIntentRouter(
+            StubEmbedder([]),
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        var match = await router.RouteAsync("anything", Services(bareIntent));
+
+        Assert.That(match, Is.Null);
+    }
+
+    [Test]
+    public async Task RouteAsync_NullOrWhitespaceQuery_ReturnsNull()
+    {
+        var algebra = new StubIntent("algebra", "set theory", ["z-related"]);
+        var router = new SemanticIntentRouter(
+            StubEmbedder([]),
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        Assert.That(await router.RouteAsync("",      Services(algebra)), Is.Null);
+        Assert.That(await router.RouteAsync("   ",   Services(algebra)), Is.Null);
+        Assert.That(await router.RouteAsync(null!,   Services(algebra)), Is.Null);
+    }
+
+    [Test]
+    public async Task RouteAsync_ExampleEmbeddingsAreCachedAcrossCalls()
+    {
+        var algebra = new StubIntent("algebra", "set theory", ["z-related"]);
+
+        var callCount = 0;
+        var mock = new Mock<IEmbeddingGenerator<string, Embedding<float>>>();
+        mock.Setup(e => e.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<EmbeddingGenerationOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<string>, EmbeddingGenerationOptions?, CancellationToken>(
+                (inputs, _, _) =>
+                {
+                    callCount++;
+                    var dummy = new float[] { 1f, 0f };
+                    var list = inputs.Select(_ => new Embedding<float>(dummy)).ToList();
+                    return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(list));
+                });
+
+        var router = new SemanticIntentRouter(
+            mock.Object,
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        var sp = Services(algebra);
+        await router.RouteAsync("first call",  sp);
+        await router.RouteAsync("second call", sp);
+        await router.RouteAsync("third call",  sp);
+
+        // Three queries → 3 query-embedding calls + 1 startup intent embedding.
+        Assert.That(callCount, Is.EqualTo(4),
+            "intent example embeddings must be cached across queries; only the per-query embedding repeats");
+    }
+
+    [Test]
+    public async Task IntentMatch_RecordsMatchedExample()
+    {
+        var modes = new StubIntent("skill.modes", "modes of major scale",
+            ["List the diatonic modes", "What are the modes of the major scale?"]);
+
+        var vectors = new Dictionary<string, float[]>
+        {
+            // Two examples with distinct vectors; description is orthogonal so
+            // it never wins. Query is exactly the first example so it scores 1.0
+            // there and < 1.0 elsewhere.
+            ["List the diatonic modes"]                 = [1f, 0f, 0f],
+            ["What are the modes of the major scale?"]  = [0f, 1f, 0f],
+            ["modes of major scale"]                    = [0f, 0f, 1f],
+            ["List the diatonic modes please"]          = [1f, 0f, 0f],
+        };
+
+        var router = new SemanticIntentRouter(
+            StubEmbedder(vectors),
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        var match = await router.RouteAsync("List the diatonic modes please", Services(modes));
+
+        Assert.That(match, Is.Not.Null);
+        Assert.That(match!.Value.MatchedExample, Is.EqualTo("List the diatonic modes"));
+    }
+}

--- a/docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md
+++ b/docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md
@@ -1,0 +1,522 @@
+---
+date: 2026-05-03
+status: recommendation
+reversibility: spike-first; no production migration should happen before measured parity
+owners: needs assignment
+audience: Claude Code / Codex / GA maintainers
+---
+
+# GA chatbot migration recommendation for Claude Code
+
+This document gives Claude Code a concrete migration brief for modernizing the
+GA chatbot without turning the codebase into a vendor-specific agent demo.
+
+The recommendation is to use **Microsoft Agent Framework** as the strategic
+agent/workflow layer, keep **Microsoft.Extensions.AI** as the provider-neutral
+model/tool contract, and use the official **Anthropic C# SDK** only as a Claude
+provider adapter.
+
+Do not replace the current orchestrator in one pass.
+
+## Current state
+
+The chatbot already has several important abstractions that should be preserved:
+
+- `Common/GA.Business.ML/Agents/IOrchestratorSkill.cs`
+  - deterministic pre-router skill contract
+  - `CanHandle(string)` fast path
+  - `ExecuteAsync(...)` returns GA's `AgentResponse`
+  - first match wins
+
+- `Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs`
+  - invokes `IOrchestratorSkill` before the full LLM route
+  - preserves low-latency answers for deterministic theory/voicing tasks
+  - owns hook/tracing integration around skill execution
+
+- `Common/GA.Business.ML/Agents/Plugins/InProcessMcpToolsProvider.cs`
+  - starts an in-process MCP server
+  - exposes MCP tools as `Microsoft.Extensions.AI.AIFunction`
+  - is already the right vendor-neutral bridge for LLM tool calling
+
+- `Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs`
+  - currently constructs `AnthropicClient`
+  - immediately converts it to `IChatClient`
+  - uses `UseFunctionInvocation()` and GA MCP tools
+  - this is directionally right, but construction should move behind a provider factory
+
+- `Apps/ga-server/GaApi/GaApi.csproj`
+  - already references `Microsoft.Agents.AI`
+  - this suggests Agent Framework has already been considered, but it is not yet the
+    canonical chatbot orchestration contract
+
+## Recommendation
+
+Adopt Microsoft Agent Framework gradually, using a compatibility spike first.
+
+The desired long-term shape is:
+
+```text
+UI / API / SignalR
+  -> GA chatbot application service
+    -> deterministic IOrchestratorSkill fast path
+    -> Microsoft Agent Framework agent/workflow path for multi-step work
+      -> AgentSkillsProvider for portable SKILL.md capabilities
+      -> Microsoft.Extensions.AI IChatClient
+        -> Anthropic / Ollama / OpenAI / Foundry provider adapters
+      -> AIFunction tools from GA MCP provider
+      -> A2A hosting/client only at the boundary
+```
+
+The boundary rule is strict:
+
+- GA application contracts must use `IChatClient`, `AIFunction`, `AgentResponse`,
+  GA trace DTOs, or Agent Framework abstractions.
+- Provider SDK DTOs must not leak into `IOrchestratorSkill`,
+  `ProductionOrchestrator`, API responses, trace payloads, or UI contracts.
+- Anthropic-specific types belong only in a provider adapter/factory.
+- Agent Framework should orchestrate agents/workflows, not replace simple
+  deterministic functions.
+
+## Why Microsoft Agent Framework
+
+Microsoft Agent Framework is the more modern Microsoft agent stack. It combines
+AutoGen-style agent abstractions with Semantic Kernel enterprise features and
+adds graph workflows, sessions, middleware, telemetry, MCP, A2A, and DevUI.
+
+Use it for:
+
+- multi-agent or multi-step chatbot behavior
+- QA architect / tribunal workflows
+- richer agentic traces
+- explicit graph workflows with checkpoints
+- A2A exposure and A2A clients
+- future DevUI-based local testing
+
+Do not use it for:
+
+- one-shot deterministic music theory answers
+- simple chord/scale parsing
+- LLM-as-classifier dispatch (per-call prompt to a model asking "which intent
+  is this?"). Routing decisions must not pay LLM round-trip latency.
+- making every GA domain operation an autonomous agent
+
+Microsoft's own guidance says: if a function can handle the task, use a function
+instead of an AI agent. That maps directly to GA's deterministic music logic.
+
+### Routing classifiers: embedding similarity is a function, not an agent
+
+The "no model-driven routing" rule above is about **LLM agents** doing per-call
+intent classification. **Embedding-based routing is in scope** and should
+replace ad-hoc keyword/regex classifiers (`KeywordAlgebraPromptClassifier`,
+`IsAskingForOptimization`, individual `IOrchestratorSkill.CanHandle` regexes).
+
+Why embedding routing counts as "function over agent":
+
+- Cosine similarity is a closed-form computation over fixed vectors.
+- Intent embeddings are computed **once at startup** from each intent's
+  `Description` + `ExamplePrompts`, then cached for the process lifetime.
+- Per query: one embedding (~5 ms locally with `nomic-embed-text`) + N dot
+  products. Deterministic, side-effect-free, fully auditable — the trace
+  records which example matched and at what score.
+- No LLM round-trip on the routing path.
+
+This pattern is the canonical replacement for string-matching dispatch in GA:
+
+- Each intent (algebra, voicing-search, modes, scale-info, transpose,
+  tab-optimize, tab-analyze, …) registers as an `IIntent { Id, Description,
+  ExamplePrompts }` in the DI container.
+- A single `SemanticIntentRouter` consumes all `IIntent` registrations plus an
+  `IEmbeddingGenerator<string, Embedding<float>>` and dispatches by cosine
+  similarity. Top match above threshold (≈ 0.65–0.75) wins; below threshold
+  falls through to the LLM agent path (which is still rare and bounded).
+- Skills keep their **deterministic execution** (`ExecuteAsync` stays as is).
+  Only **dispatch** moves from `CanHandle` regex → embedding similarity.
+
+Skills that previously held string-matching `CanHandle` should expose
+`ExamplePrompts` and stub `CanHandle` to `false` so they participate in
+semantic dispatch only. Legacy `CanHandle` paths can stay as fallback
+during migration but the goal is single-source-of-truth intent registration.
+
+## C# equivalent of Spring AI generic skills
+
+The C# equivalent of Spring AI's generic Agent Skills pattern is
+**Microsoft Agent Framework `AgentSkillsProvider`**.
+
+Use this instead of maintaining a long-term custom `SKILL.md` loader.
+
+Spring AI generic skills and Agent Framework skills line up almost directly:
+
+| Spring AI generic skills | C# / Microsoft Agent Framework |
+|---|---|
+| `SKILL.md` folders | `AgentSkillsProvider` file-based skills |
+| YAML frontmatter | `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` |
+| startup discovery | provider scans skill directories |
+| progressive disclosure | advertise skill, load body, read resources, run scripts |
+| `SkillsTool` | built-in `load_skill` tool |
+| `FileSystemTools.Read` | built-in `read_skill_resource` tool |
+| `ShellTools.Bash` | `run_skill_script` with an explicit script runner |
+| provider portability | Agent Framework + `Microsoft.Extensions.AI` providers |
+
+The important difference is operational: script execution must be explicitly
+enabled and treated as privileged. GA should start with read-only skills and
+resources, then add scripts only with approval, sandboxing, timeouts, and trace
+logging.
+
+Recommended GA skill layout:
+
+```text
+skills/
+  chord-voicing-review/
+    SKILL.md
+    references/
+      voicing-quality.md
+      fretboard-ergonomics.md
+    assets/
+      examples.json
+  qa-architect/
+    SKILL.md
+    references/
+      qa-verdict-contract.md
+```
+
+Example C# shape:
+
+```csharp
+using Microsoft.Agents.AI;
+
+var skillsProvider = new AgentSkillsProvider(
+    Path.Combine(AppContext.BaseDirectory, "skills"));
+
+AIAgent agent = chatClient.AsAIAgent(new ChatClientAgentOptions
+{
+    Name = "GaSkillsAgent",
+    ChatOptions = new()
+    {
+        Instructions = "You are the Guitar Alchemist assistant."
+    },
+    AIContextProviders = [skillsProvider],
+});
+```
+
+Only add script execution after the read-only path is proven:
+
+```csharp
+var skillsProvider = new AgentSkillsProvider(
+    Path.Combine(AppContext.BaseDirectory, "skills"),
+    SubprocessScriptRunner.RunAsync);
+```
+
+For production, do not use a raw subprocess runner without wrapping it in GA
+policy:
+
+- allow-list script names and extensions
+- reject scripts outside the skill directory
+- pass arguments as structured JSON only
+- set wall-clock timeout
+- set output size limits
+- redact secrets from logs and traces
+- record script name, arguments, exit code, duration, and output summary
+- require human approval for mutating scripts
+
+`Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs` is now best viewed
+as a bridge/prototype. It already proves the rough pattern: a `SKILL.md` body,
+an `IChatClient`, `UseFunctionInvocation()`, and GA MCP tools. The migration
+should move this onto `AgentSkillsProvider` where possible, while preserving the
+GA deterministic fast path.
+
+## Why keep Microsoft.Extensions.AI
+
+`Microsoft.Extensions.AI` is the right lowest common denominator for providers
+and tools in this repo.
+
+It gives GA:
+
+- provider-neutral `IChatClient`
+- provider-neutral `AIFunction`
+- `FunctionInvokingChatClient` / `UseFunctionInvocation`
+- compatibility with Ollama, OpenAI, Anthropic, and MCP tools
+- a stable testing seam for fake chat clients
+
+Claude Code should not introduce direct calls to Anthropic, OpenAI, Ollama, or
+Foundry throughout the agent code. Add provider-specific code only behind a
+factory that returns `IChatClient`.
+
+## Anthropic SDK guidance
+
+Use `https://github.com/anthropics/anthropic-sdk-csharp` when Claude-specific
+behavior is required. It is now the official C# SDK package under `Anthropic`
+version 10+.
+
+Allowed uses:
+
+- provider adapter construction
+- Claude model selection
+- Claude-specific timeouts/retries
+- Claude streaming behavior if `IChatClient` cannot express a required feature
+- Claude vision or prompt-caching experiments behind capability checks
+
+Not allowed:
+
+- Anthropic DTOs in API contracts
+- Anthropic DTOs in trace contracts
+- Anthropic DTOs in `AgentResponse`
+- Anthropic exceptions escaping user-facing endpoints
+- direct `new AnthropicClient` calls outside provider setup code
+
+Important risk: the Anthropic C# SDK is official but still documented as beta.
+Pin package versions and isolate usage so a minor SDK break does not ripple
+through GA.
+
+## Proposed migration phases
+
+### Phase 0 - freeze the baseline
+
+Before any migration:
+
+- run the chatbot smoke tests for deterministic skill queries
+- capture latency for deterministic skill answers vs full LLM answers
+- capture one detailed trace for a deterministic skill and one full-agent answer
+- identify current package versions for `Microsoft.Agents.AI`, `Anthropic`,
+  `Microsoft.Extensions.AI`, and `ModelContextProtocol`
+
+No new framework work should ship without this baseline.
+
+### Phase 1 - provider factory cleanup
+
+Goal: eliminate direct vendor construction from skills.
+
+Add a small provider-neutral factory, for example:
+
+```csharp
+public interface IChatClientFactory
+{
+    IChatClient Create(string purpose);
+}
+```
+
+Initial purposes can be:
+
+- `default`
+- `skill-md`
+- `qa-architect`
+- `fast-local`
+
+Move the `AnthropicClient.AsIChatClient(...).AsBuilder().UseFunctionInvocation().Build()`
+construction out of `SkillMdDrivenSkill` and into the factory.
+
+Acceptance criteria:
+
+- `SkillMdDrivenSkill` depends on `IChatClient` or `IChatClientFactory`, not
+  `AnthropicClient`
+- unit tests can inject a fake `IChatClient`
+- config can switch `skill-md` between Anthropic and local/Ollama where supported
+- no Anthropic DTO leaves the factory
+
+### Phase 2 - Agent Skills provider migration
+
+Goal: replace the custom long-term `SKILL.md` mechanism with Agent Framework's
+standard skills provider where it fits.
+
+Do this before migrating broader orchestration. Skills are the smallest useful
+place to validate the modern C# equivalent of Spring AI generic skills.
+
+Tasks:
+
+- create a `skills/` root for GA-owned portable skills
+- move or mirror one existing `SKILL.md` capability into that root
+- wire `AgentSkillsProvider` into an experimental Agent Framework agent
+- keep scripts disabled for the first pass
+- verify `load_skill` and `read_skill_resource` behavior
+- map skill output back into the existing chatbot response shape
+- keep `SkillMdDrivenSkill` available until parity is proven
+
+Acceptance criteria:
+
+- one file-based skill is discovered from disk
+- the agent advertises the skill without loading the full body upfront
+- the agent can load the skill body on demand
+- the agent can read a bundled reference file
+- no script execution is enabled by default
+- the same skill can run against at least two configured providers where tool
+  support allows it
+- tests cover malformed frontmatter, missing resource, and successful skill load
+
+### Phase 3 - Agent Framework spike
+
+Goal: prove Agent Framework improves orchestration without regressing the fast path.
+
+Create a small experimental adapter around the existing chatbot path:
+
+- wrap the full chatbot path as an Agent Framework `AIAgent`
+- attach `AgentSkillsProvider` for portable skills
+- expose one existing deterministic skill as an `AIFunction`
+- connect existing MCP tools
+- verify streaming behavior
+- verify trace richness
+- verify cancellation/timeout behavior
+- verify local provider support
+
+This spike should be isolated. Do not rewrite `ProductionOrchestrator` yet.
+
+Suggested location:
+
+- `Common/GA.Business.ML/Agents/AgentFramework/`
+- or `Apps/GaChatbot.AgentFrameworkSpike/` if the dependency graph gets messy
+
+Acceptance criteria:
+
+- deterministic fast-path answers remain faster than model/tool routing
+- Agent Framework can call GA MCP tools
+- Agent Framework output can be mapped back to existing chatbot response DTOs
+- no UI contract change is required
+- package versions are pinned
+- tests cover at least one success, one tool failure, and cancellation
+
+### Phase 4 - A2A boundary
+
+Goal: expose the chatbot as an A2A agent without changing internal contracts.
+
+Use Agent Framework A2A hosting at the edge:
+
+- expose one GA chatbot agent card
+- support streaming where possible
+- map A2A requests into the existing chatbot application service
+- map chatbot traces into A2A-visible task/run metadata where appropriate
+
+Acceptance criteria:
+
+- A2A client can discover the agent card
+- A2A client can run a basic query
+- A2A client can run a long-running query or receive a continuation/background
+  response if supported
+- local chatbot UI still works unchanged
+
+### Phase 5 - workflow migration for agentic work only
+
+Only after Phases 1-4 succeed, move multi-step agentic flows into Agent
+Framework workflows.
+
+Good candidates:
+
+- QA architect / tribunal
+- cross-repo review orchestration
+- multi-agent critique loops
+- long-running evaluation workflows
+- workflows requiring checkpointing or human approval
+
+Bad candidates:
+
+- chord info
+- scale info
+- modes
+- fret span
+- deterministic voicing lookups
+
+## Trace requirements
+
+The migration must improve, not weaken, agentic trace detail.
+
+Minimum trace fields:
+
+- trace id
+- run id
+- protocol tags
+- provider
+- model
+- agent/workflow id
+- selected skill or tool
+- routing method
+- tool call names
+- tool call arguments after secret redaction
+- tool call duration
+- tool result summary
+- retry count
+- token usage where available
+- cancellation/timeout reason
+- final response length
+
+Provider-specific details may be recorded, but only inside a provider metadata
+bag that the UI can safely ignore.
+
+## Test requirements
+
+Claude Code should add or preserve tests for:
+
+- provider factory selection by config
+- fake `IChatClient` injection
+- `SkillMdDrivenSkill` without Anthropic API key when a fake client is supplied
+- `AgentSkillsProvider` discovers one file-based GA skill
+- `AgentSkillsProvider` rejects malformed skill frontmatter
+- read-only skill resources can be loaded on demand
+- scripts are disabled by default
+- Anthropic provider config failure with a safe error
+- MCP tool list propagation into `ChatOptions`
+- cancellation propagation
+- deterministic skills bypassing Agent Framework
+- Agent Framework spike maps output into existing chatbot DTOs
+- A2A endpoint smoke test if Phase 3 is attempted
+
+Do not claim migration success unless these pass:
+
+```powershell
+dotnet build AllProjects.slnx -c Debug
+dotnet test AllProjects.slnx
+```
+
+For frontend-facing changes:
+
+```powershell
+Push-Location ReactComponents/ga-react-components
+npm run build
+npm run lint
+Pop-Location
+```
+
+## Non-goals
+
+- Do not replace every `IOrchestratorSkill` with an Agent Framework agent.
+- Do not make Claude the only supported provider.
+- Do not move music-domain computation into prompts.
+- Do not keep custom `SKILL.md` loading as the permanent path if
+  `AgentSkillsProvider` covers the use case.
+- Do not enable skill scripts in production without sandboxing, approval policy,
+  resource limits, and audit traces.
+- Do not introduce a second chatbot response contract.
+- Do not expose raw provider errors to users.
+- Do not make DevUI production infrastructure.
+
+## Decision summary
+
+Claude Code should proceed as follows:
+
+1. Preserve GA deterministic fast paths.
+2. Centralize model/provider construction behind `IChatClient`.
+3. Use Agent Framework `AgentSkillsProvider` for portable file-based skills.
+4. Use Anthropic SDK only inside the Anthropic provider adapter.
+5. Spike Microsoft Agent Framework for multi-step agentic orchestration.
+6. Use Agent Framework A2A at the boundary if the spike proves clean.
+7. Migrate only high-value multi-step workflows after parity and tests.
+
+This gives GA the modern Microsoft agent stack while preserving provider
+choice and keeping deterministic music logic fast, testable, and inspectable.
+
+## Official references checked
+
+- Microsoft Agent Framework overview:
+  `https://learn.microsoft.com/en-us/agent-framework/overview/`
+- Microsoft Agent Framework workflows:
+  `https://learn.microsoft.com/en-us/agent-framework/workflows/`
+- Microsoft Agent Framework Agent Skills:
+  `https://learn.microsoft.com/en-us/agent-framework/agents/skills`
+- Microsoft Agent Framework tools:
+  `https://learn.microsoft.com/en-us/agent-framework/agents/tools/`
+- Microsoft Agent Framework A2A:
+  `https://learn.microsoft.com/en-us/agent-framework/integrations/a2a`
+- Anthropic C# SDK:
+  `https://platform.claude.com/docs/en/api/sdks/csharp`
+- Anthropic SDK repository:
+  `https://github.com/anthropics/anthropic-sdk-csharp`
+- Microsoft.Extensions.AI tool calling:
+  `https://learn.microsoft.com/en-us/dotnet/ai/conceptual/ai-tools`
+- Spring AI generic Agent Skills comparison point:
+  `https://spring.io/blog/2026/01/13/spring-ai-generic-agent-skills/`


### PR DESCRIPTION
Replaces all ad-hoc string-matching classifiers in the chatbot routing layer with a single embedding-similarity dispatcher. Aligned with the clarified guidance now in `docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md` §"Routing classifiers".

## Why
The migration recommendation doc says "do not use Agent Framework for [...] replacing IOrchestratorSkill.CanHandle with model-driven routing." That prohibition was always specifically about LLM-as-classifier (per-call LLM round-trip) — embedding-similarity routing is a function, not an agent. The doc now says so explicitly.

## Killed
- `KeywordAlgebraPromptClassifier` (algebra keyword regex)
- `IsAskingForOptimization` — the bug routing "easy beginner chords" to tab optimize
- `foreach skill in _skills: if CanHandle` loop in `ProductionOrchestrator`
- Private `HandlePathOptimizationAsync` / `HandleTabAnalysisAsync` / `ExtractTabLines` / `TryAnswerWithAlgebraAsync`

## Replaced with
- `IIntent` { Id, Description, ExamplePrompts, ExecuteAsync }
- `SemanticIntentRouter` (Singleton, IServiceProvider-per-call so it sees Scoped intents)
- `AlgebraIntent`, `TabOptimizeIntent`, `TabAnalyzeIntent`, `OrchestratorSkillIntent` adapter
- `TabAnalysisOrchestrationService` (extracted from orchestrator privates)
- `AddOrchestratorSkillIntent<TSkill>` DI helper

8 existing skills now expose 3-6 `ExamplePrompts`. Hook lifecycle preserved.

## Test plan
- [x] 8 new `SemanticIntentRouterTests`
- [x] ML.Tests: 716 / 15 skip / 0 fail
- [x] Live smoke 5/7 route correctly via semantic; 2 fallback to graceful no-chord-symbols (better than the previous tab-optimize wall)

## Follow-up
Tune example prompts for "easy beginner chords" / "make progression darker" — they route to KeyIdentification / ProgressionCompletion respectively (close enough; they return graceful fallbacks, not crashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)