### PR TITLE
feat(chatbot): BeginnerChordsSkill + ProgressionMoodSkill + cache warmup

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
+++ b/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
@@ -80,6 +80,7 @@ public static class ChatbotOrchestrationExtensions
         // KeywordAlgebraPromptClassifier, IsAskingForOptimization, the per-skill
         // CanHandle foreach, and the tab-analysis branch.
         services.AddSingleton<SemanticIntentRouter>();
+        services.AddHostedService<IntentEmbeddingWarmupService>();
         services.AddScoped<TabAnalysisOrchestrationService>();
 
         services.AddSingleton<AlgebraIntent>();

--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -35,6 +35,8 @@ public sealed class GaPlugin : IChatPlugin
         services.AddOrchestratorSkillIntent<IntervalSkill>();
         services.AddOrchestratorSkillIntent<FretSpanSkill>();
         services.AddOrchestratorSkillIntent<ChordSubstitutionSkill>();
+        services.AddOrchestratorSkillIntent<BeginnerChordsSkill>();
+        services.AddOrchestratorSkillIntent<ProgressionMoodSkill>();
 
         // Skills using IChatClient are Scoped (IChatClient lifetime is Scoped).
         services.AddOrchestratorSkillIntent<KeyIdentificationSkill>(ServiceLifetime.Scoped);

--- a/Common/GA.Business.Core.Orchestration/Services/IntentEmbeddingWarmupService.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/IntentEmbeddingWarmupService.cs
@@ -1,0 +1,68 @@
+namespace GA.Business.Core.Orchestration.Services;
+
+using GA.Business.ML.Agents.Intents;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Pre-warms the <see cref="SemanticIntentRouter"/> embedding cache at startup
+/// so the first real user request doesn't pay the cold-cache cost (~80 embedding
+/// calls for the current intent set × CPU-mode latency = &gt;60s on a slow box,
+/// which is well past any reasonable HTTP timeout).
+/// </summary>
+/// <remarks>
+/// <para>Fires a single dummy <see cref="SemanticIntentRouter.RouteAsync"/>
+/// call after the host starts. The router computes intent embeddings on first
+/// query; this just makes that "first query" happen in the background.</para>
+/// <para>Failures are logged but never thrown — embedding service might not be
+/// reachable at startup (Ollama warming up, network blip), and we'd rather the
+/// first user request retry warmup than crash the host.</para>
+/// </remarks>
+public sealed class IntentEmbeddingWarmupService(
+    IServiceProvider services,
+    SemanticIntentRouter router,
+    ILogger<IntentEmbeddingWarmupService> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Fire-and-forget — host startup must not block on this.
+        _ = Task.Run(() => WarmAsync(cancellationToken), cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task WarmAsync(CancellationToken cancellationToken)
+    {
+        if (!router.IsAvailable)
+        {
+            logger.LogDebug("IntentEmbeddingWarmupService: router has no embedder; skipping warmup");
+            return;
+        }
+
+        try
+        {
+            using var scope = services.CreateScope();
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
+            // The query content doesn't matter — we just want the router to
+            // populate its example-embedding cache during this call.
+            await router.RouteAsync("warmup", scope.ServiceProvider, cancellationToken);
+
+            sw.Stop();
+            logger.LogInformation(
+                "IntentEmbeddingWarmupService: cache warmed in {ElapsedMs}ms",
+                sw.ElapsedMilliseconds);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host is shutting down — fine.
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "IntentEmbeddingWarmupService: warmup failed; first user request will retry");
+        }
+    }
+}

--- a/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
+++ b/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
@@ -44,6 +44,10 @@ public sealed class SemanticIntentRouter(
     /// <summary>Cosine-similarity threshold above which an intent claims the query.</summary>
     public float MinConfidence { get; init; } = DefaultMinConfidence;
 
+    /// <summary>True iff embedding infrastructure is wired. Used by the warmup
+    /// hosted service to skip when there's no embedder to call.</summary>
+    public bool IsAvailable => textEmbeddings is not null;
+
     /// <summary>
     /// Selects the best intent for the query, or <c>null</c> if no intent
     /// scores above <see cref="MinConfidence"/>.

--- a/Common/GA.Business.ML/Agents/Skills/BeginnerChordsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/BeginnerChordsSkill.cs
@@ -1,0 +1,82 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using System.Text;
+
+/// <summary>
+/// Returns a curated catalogue of open-position guitar chords for beginners —
+/// zero LLM calls. Replies to "easy chords", "beginner chords", "first chords
+/// to learn" etc. with the chord name, diagram, and a one-line note about
+/// fingering or common usage.
+/// </summary>
+/// <remarks>
+/// Chord diagrams use the standard 6-string format <c>E A D G B e</c>
+/// (low-to-high), where each token is the fret to play (0 = open string,
+/// x = muted). The eight chords here are the standard "first eight" most
+/// guitar curricula start with.
+/// </remarks>
+public sealed class BeginnerChordsSkill(ILogger<BeginnerChordsSkill> logger) : IOrchestratorSkill
+{
+    public string Name        => "BeginnerChords";
+    public string Description =>
+        "Returns a curated list of open-position guitar chords for beginners — " +
+        "C, G, D, A, E, Am, Em, Dm — with diagrams and a one-line tip per chord. " +
+        "Pure catalog lookup, no LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "Show me some easy beginner chords",
+        "What are the first chords I should learn?",
+        "Give me some simple guitar chords for a beginner",
+        "I'm just starting out — what chords should I practice?",
+        "List basic open chords",
+        "Easy chords for a new guitarist",
+        "What are the most common beginner chords?",
+    ];
+
+    /// <summary>
+    /// Frets are listed low-to-high (E A D G B e). 'x' = mute, '0' = open.
+    /// </summary>
+    private static readonly (string Name, string Diagram, string Note)[] _chords =
+    [
+        ("C major",  "x-3-2-0-1-0", "First-position major. Watch the muted low E."),
+        ("G major",  "3-2-0-0-0-3", "Use ring/middle/pinky on E-A-e for cleaner switching to D."),
+        ("D major",  "x-x-0-2-3-2", "Compact triad — handy for 'D shape' barre training later."),
+        ("A major",  "x-0-2-2-2-0", "Index/middle/ring on D-G-B; or barre with one finger across the 2nd fret."),
+        ("E major",  "0-2-2-1-0-0", "Strongest, fullest open chord — every string rings."),
+        ("A minor",  "x-0-2-2-1-0", "Same shape as E, moved one string up; bedrock minor sound."),
+        ("E minor",  "0-2-2-0-0-0", "Easiest chord on the guitar — two fingers, six strings ringing."),
+        ("D minor",  "x-x-0-2-3-1", "Compact like D major; good for swapping with C and G in folk songs."),
+    ];
+
+    public bool CanHandle(string message) => false; // semantic-routing only — see ExamplePrompts
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Here are eight open-position chords every beginner should learn first. Diagrams are low-to-high (E A D G B e); `0` = open string, `x` = mute.");
+        sb.AppendLine();
+
+        for (var i = 0; i < _chords.Length; i++)
+        {
+            var (name, diagram, note) = _chords[i];
+            sb.AppendLine($"{i + 1}. **{name}** — `{diagram}` — {note}");
+        }
+
+        sb.AppendLine();
+        sb.Append("Practice tip: drill C ↔ G ↔ D ↔ Am ↔ Em as a smooth loop. Those five cover most folk, pop, and country songs in major keys. Add A, E, and Dm next.");
+
+        var evidence = _chords.Select(c => $"{c.Name}: {c.Diagram}").ToList();
+        evidence.Add($"Catalog size: {_chords.Length} chords");
+
+        logger.LogDebug("BeginnerChordsSkill: returned {Count} catalog entries", _chords.Length);
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId     = AgentIds.Theory,
+            Result      = sb.ToString(),
+            Confidence  = 1.0f,
+            Evidence    = evidence,
+            Assumptions = ["Standard tuning EADGBe, open position"],
+        });
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/ProgressionMoodSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ProgressionMoodSkill.cs
@@ -1,0 +1,106 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using System.Text;
+
+/// <summary>
+/// Explains how to make a chord progression sound <b>darker</b> (or brighter) —
+/// zero LLM calls, returns a curated set of harmonic-mood techniques.
+/// </summary>
+/// <remarks>
+/// Triggers on queries like "how do I make this progression sound darker",
+/// "make it sadder", "moodier chords", etc. The skill returns techniques
+/// (parallel minor, modal interchange from Phrygian / Aeolian / Dorian,
+/// borrowed bVII / bVI / bIII / iv) rather than computing a transformation
+/// on a specific progression — that level of analysis would need the LLM
+/// path. The deterministic answer is grounded music-theory pedagogy.
+/// </remarks>
+public sealed class ProgressionMoodSkill(ILogger<ProgressionMoodSkill> logger) : IOrchestratorSkill
+{
+    public string Name        => "ProgressionMood";
+    public string Description =>
+        "Explains how to darken or brighten a chord progression via parallel-minor " +
+        "swaps, modal interchange (Phrygian / Aeolian / Dorian), and borrowed bVII / " +
+        "bVI / bIII / iv chords. Educational, no LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "How do I make this progression sound darker?",
+        "Make this progression sound moodier",
+        "How can I make my chords sound sadder?",
+        "What can I do to make a song sound more melancholy?",
+        "How to add a darker feel to a chord progression",
+        "Techniques to make a major progression minor-sounding",
+        "Make my song sound brighter",
+        "How to make a progression more uplifting",
+    ];
+
+    public bool CanHandle(string message) => false; // semantic-routing only
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var lower = message.ToLowerInvariant();
+        var brighten = lower.Contains("brighter") || lower.Contains("uplift") || lower.Contains("happier");
+
+        return Task.FromResult(brighten
+            ? BrightenAnswer()
+            : DarkenAnswer());
+    }
+
+    private AgentResponse DarkenAnswer()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Here are five reliable ways to darken a progression. Pick one or stack them — each shifts the harmonic mood without abandoning the underlying key.");
+        sb.AppendLine();
+        sb.AppendLine("1. **Swap to parallel minor** — replace the tonic's major chord with its parallel minor (C → Cm). Pulls everything that follows toward minor-mode resolution.");
+        sb.AppendLine("2. **Borrow from Aeolian (natural minor)** — substitute IV → iv, vi → bVI, V → v. So `C F G` → `C Fm G` or `C bA G`. Standard pop-ballad move.");
+        sb.AppendLine("3. **Borrow from Phrygian** — drop in bII (Db in C major) or use bII–I as a final resolution. The half-step approach gives a Spanish/cinematic colour.");
+        sb.AppendLine("4. **Borrow from Dorian** — keep the i minor but swap iv → IV (Dorian's natural 6) for the bittersweet, modal-folk feel of Scarborough Fair.");
+        sb.AppendLine("5. **Replace V with bVII** — `C bB F` instead of `C G F`. Common in rock; the lack of a leading tone weakens the pull home and reads as moodier.");
+        sb.AppendLine();
+        sb.Append("Combine 1 + 2 for a strong sad-pop transformation; 3 alone for film-score gravity; 4 alone for folk melancholy.");
+
+        return new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = sb.ToString(),
+            Confidence = 1.0f,
+            Evidence   =
+            [
+                "Technique 1: parallel minor (I → i)",
+                "Technique 2: Aeolian modal interchange (IV → iv, vi → bVI, V → v)",
+                "Technique 3: Phrygian modal interchange (bII)",
+                "Technique 4: Dorian modal interchange (iv → IV)",
+                "Technique 5: bVII substitution for V (drop the leading tone)",
+            ],
+            Assumptions = ["Caller wants a general technique catalog, not a transformation of a specific named progression"],
+        };
+    }
+
+    private AgentResponse BrightenAnswer()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Here are four reliable ways to brighten a progression that feels too dark or static.");
+        sb.AppendLine();
+        sb.AppendLine("1. **Swap to parallel major** — flip a minor tonic to its parallel major (Am → A). Strongest mood-flip available.");
+        sb.AppendLine("2. **Borrow from Lydian** — raise IV → #IV (#iv° actually), or hold a IV with a #11 colour. Floating, dreamy lift.");
+        sb.AppendLine("3. **Borrow from Mixolydian** — add bVII as a passing chord that doesn't resolve down (`I bVII IV I`); rock-anthem brightness.");
+        sb.AppendLine("4. **Reinforce V → I** — make sure the dominant resolves cleanly back to tonic. Add a V7 or V/V to strengthen pull.");
+        sb.AppendLine();
+        sb.Append("Combine 1 + 4 for a definitive lift from minor to major; 2 alone for ethereal/cinematic brightness.");
+
+        return new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = sb.ToString(),
+            Confidence = 1.0f,
+            Evidence   =
+            [
+                "Technique 1: parallel major (i → I)",
+                "Technique 2: Lydian modal interchange (#IV / IV#11)",
+                "Technique 3: Mixolydian bVII passing chord",
+                "Technique 4: strengthen V → I cadence",
+            ],
+            Assumptions = ["Caller wants a general technique catalog, not a transformation of a specific named progression"],
+        };
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/BeginnerChordsSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/BeginnerChordsSkillTests.cs
@@ -1,0 +1,73 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[TestFixture]
+public class BeginnerChordsSkillTests
+{
+    private static BeginnerChordsSkill MakeSkill() => new(NullLogger<BeginnerChordsSkill>.Instance);
+
+    [Test]
+    public void Metadata_ExposesExamplePrompts()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.ExamplePrompts, Has.Count.GreaterThanOrEqualTo(3),
+            "skill must expose enough example prompts for the SemanticIntentRouter");
+        Assert.That(skill.Description, Does.Contain("beginner").IgnoreCase
+            .Or.Contain("open").IgnoreCase);
+    }
+
+    [Test]
+    public void CanHandle_AlwaysFalse_DispatchedSemantically()
+    {
+        // The skill is registered for SemanticIntentRouter dispatch only —
+        // CanHandle stays false so it doesn't fire on incidental keyword matches
+        // in the legacy fallback path.
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle("show me some easy beginner chords"), Is.False);
+        Assert.That(skill.CanHandle("anything"), Is.False);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ReturnsAllEightChords()
+    {
+        var skill = MakeSkill();
+        var response = await skill.ExecuteAsync("show me some easy beginner chords");
+
+        Assert.That(response.Confidence, Is.EqualTo(1.0f));
+        // The eight chords every curriculum lists first.
+        var expected = new[] { "C major", "G major", "D major", "A major", "E major", "A minor", "E minor", "D minor" };
+        foreach (var chord in expected)
+        {
+            Assert.That(response.Result, Does.Contain(chord),
+                $"expected '{chord}' in the result");
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DiagramFormatIsValidLowToHigh()
+    {
+        var skill = MakeSkill();
+        var response = await skill.ExecuteAsync("show me some easy beginner chords");
+
+        // Spot-check a few canonical diagrams. Format: low-E A D G B high-e.
+        // C major: x-3-2-0-1-0
+        Assert.That(response.Result, Does.Contain("x-3-2-0-1-0"));
+        // E major: 0-2-2-1-0-0 — the fullest open chord
+        Assert.That(response.Result, Does.Contain("0-2-2-1-0-0"));
+        // E minor: 0-2-2-0-0-0 — the easiest chord
+        Assert.That(response.Result, Does.Contain("0-2-2-0-0-0"));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_EvidenceListsEveryChord()
+    {
+        var skill = MakeSkill();
+        var response = await skill.ExecuteAsync("show me some easy beginner chords");
+
+        Assert.That(response.Evidence, Has.Count.GreaterThanOrEqualTo(8),
+            "evidence should include one entry per catalog chord plus the catalog-size summary");
+        Assert.That(response.Evidence, Has.Some.Contains("C major: x-3-2-0-1-0"));
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ProgressionMoodSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ProgressionMoodSkillTests.cs
@@ -1,0 +1,67 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[TestFixture]
+public class ProgressionMoodSkillTests
+{
+    private static ProgressionMoodSkill MakeSkill() => new(NullLogger<ProgressionMoodSkill>.Instance);
+
+    [Test]
+    public void Metadata_ExposesExamplePrompts()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.ExamplePrompts, Has.Count.GreaterThanOrEqualTo(4));
+        Assert.That(skill.Description, Does.Contain("darken").IgnoreCase
+            .Or.Contain("brighten").IgnoreCase
+            .Or.Contain("modal interchange").IgnoreCase);
+    }
+
+    [Test]
+    public void CanHandle_AlwaysFalse_DispatchedSemantically()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle("how do I make this progression sound darker"), Is.False);
+    }
+
+    [TestCase("How do I make this progression sound darker?")]
+    [TestCase("Make this progression sound moodier")]
+    [TestCase("How can I make my chords sound sadder?")]
+    public async Task ExecuteAsync_DarkenQueries_ReturnDarkenTechniques(string prompt)
+    {
+        var skill = MakeSkill();
+        var response = await skill.ExecuteAsync(prompt);
+
+        Assert.That(response.Confidence, Is.EqualTo(1.0f));
+        Assert.That(response.Result, Does.Contain("parallel minor").IgnoreCase);
+        Assert.That(response.Result, Does.Contain("Phrygian").Or.Contain("Aeolian"));
+        Assert.That(response.Evidence, Has.Some.Contains("parallel minor"));
+    }
+
+    [TestCase("Make my song sound brighter")]
+    [TestCase("How to make a progression more uplifting")]
+    public async Task ExecuteAsync_BrightenQueries_ReturnBrightenTechniques(string prompt)
+    {
+        var skill = MakeSkill();
+        var response = await skill.ExecuteAsync(prompt);
+
+        Assert.That(response.Confidence, Is.EqualTo(1.0f));
+        Assert.That(response.Result, Does.Contain("parallel major").IgnoreCase);
+        Assert.That(response.Result, Does.Contain("Lydian").Or.Contain("Mixolydian"));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DarkenAnswerListsAtLeastFiveTechniques()
+    {
+        var skill = MakeSkill();
+        var response = await skill.ExecuteAsync("how do I darken my progression");
+
+        // The answer numbers techniques 1. 2. 3. 4. 5. — verify all five render.
+        for (var i = 1; i <= 5; i++)
+        {
+            Assert.That(response.Result, Does.Contain($"{i}."),
+                $"darken answer should number technique {i}");
+        }
+    }
+}


### PR DESCRIPTION
Closes the two paraphrase edge cases left from #70.

## Skills
- **BeginnerChordsSkill** — curated catalog of 8 open-position guitar chords (C, G, D, A, E, Am, Em, Dm) with diagrams + tips. 7 example prompts.
- **ProgressionMoodSkill** — explains darken (parallel minor / Aeolian / Phrygian / Dorian / bVII) vs brighten (parallel major / Lydian / Mixolydian / V→I) techniques. 8 example prompts.

Both deterministic, zero LLM calls, registered via `AddOrchestratorSkillIntent`.

## Cold-cache fix
`IntentEmbeddingWarmupService` (IHostedService) pre-warms `SemanticIntentRouter` in background. Without it, first user query had to embed all 80+ intent examples on a CPU-mode Ollama, hitting >60s timeouts. Warmup completes in ~10s in background.

## Live smoke (after warmup, 11/12 green)
```
OK skill.beginnerchords  Show me some easy beginner chords      95ms
OK skill.beginnerchords  What are the first chords I should learn? 82ms
OK skill.beginnerchords  Easy chords for a new guitarist        67ms
OK skill.progressionmood How do I make this progression sound darker? 76ms
OK skill.progressionmood Make this progression sound moodier    62ms
OK skill.progressionmood How can I make my chords sound sadder? 82ms
OK skill.progressionmood Make my song sound brighter            56ms
OK skill.modes / .scaleinfo / .interval / algebra (regressions check)
KO skill.chordinfo       What is a C major chord?               TIMEOUT
```

## Known follow-up
`What is a C major chord?` routes to `skill.keyidentification` instead of `skill.chordinfo` despite ChordInfo having the literal query as an example prompt. Likely a ranking-tie quirk or over-broad KeyIdentification description. Tracked as: investigate router score logging + tighten KeyIdentification example prompts.

## Tests
- 6 `BeginnerChordsSkillTests` + 7 `ProgressionMoodSkillTests` = 13 new, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)