### PR TITLE
feat(chatbot): canary SKILL.md (beginner-chords) + canonical skills/ resolver

### DIFF
--- a/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
+++ b/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
@@ -28,10 +28,15 @@ public sealed class SkillMdPlugin : IChatPlugin
     /// requires a real directory tree on disk. A future <c>IHostedService</c>-based approach (see todo 040)
     /// would defer loading and allow full in-memory testing, but adds complexity not currently warranted.
     /// </remarks>
-    public void Register(IServiceCollection services)
-    {
-        var path = ResolveSkillsPath();
+    public void Register(IServiceCollection services) => Register(services, ResolveSkillsPath());
 
+    /// <summary>
+    /// Internal overload that takes an explicit skills path — used by unit
+    /// tests so they can register against an isolated temp directory rather
+    /// than mutating process env vars or the repo's real <c>skills/</c> tree.
+    /// </summary>
+    internal void Register(IServiceCollection services, string path)
+    {
         if (!Directory.Exists(path))
         {
             // Warning is emitted at runtime via ILogger — here we use Trace as fallback
@@ -67,8 +72,25 @@ public sealed class SkillMdPlugin : IChatPlugin
     /// <summary>MCP tool types contributed by this plugin (none — uses shared <see cref="IMcpToolsProvider"/>).</summary>
     public IReadOnlyList<Type> McpToolTypes => [];
 
-    private static string ResolveSkillsPath()
+    /// <summary>
+    /// Anchors at the repo root (<c>.git</c> marker), then prefers the canonical
+    /// <c>skills/</c> directory and falls back to the legacy <c>.agent/skills/</c>
+    /// directory when the canonical one is missing. <c>skills/</c> is the
+    /// one-way-door canonical home per
+    /// <c>docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md</c>;
+    /// the legacy probe stays until every SKILL.md migrates so unported skills
+    /// don't disappear from production at flip-time.
+    /// </summary>
+    /// <param name="startDir">
+    /// Anchor for repo-root discovery and env-var traversal validation.
+    /// Defaults to <see cref="AppContext.BaseDirectory"/>; tests pass a temp
+    /// path so they can exercise the resolver without touching the real repo.
+    /// </param>
+    /// <remarks>Internal so unit tests can re-anchor the search at a temp directory.</remarks>
+    internal static string ResolveSkillsPath(string? startDir = null)
     {
+        var anchor = startDir ?? AppContext.BaseDirectory;
+
         // 1. Explicit env var override — validated against the repo root to prevent
         //    path-traversal attacks (a compromised env var pointing to /etc/SKILL.md
         //    would otherwise inject arbitrary system prompts into every LLM call).
@@ -76,34 +98,33 @@ public sealed class SkillMdPlugin : IChatPlugin
         if (!string.IsNullOrWhiteSpace(env))
         {
             var resolved = Path.GetFullPath(env);
-            var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
-            if (repoRoot is not null &&
-                resolved.StartsWith(repoRoot, StringComparison.OrdinalIgnoreCase))
+            var rootForOverride = FindRepoRoot(anchor);
+            if (rootForOverride is not null &&
+                resolved.StartsWith(rootForOverride, StringComparison.OrdinalIgnoreCase))
                 return resolved;
 
             System.Diagnostics.Debug.WriteLine(
                 $"[SkillMdPlugin] SKILLMD_SKILLS_PATH '{env}' resolves to '{resolved}' " +
-                $"which is outside the repo root '{repoRoot}' — ignoring.");
+                $"which is outside the repo root '{rootForOverride}' — ignoring.");
         }
 
-        // 2. Crawl up from the binary directory to find the repo root (.git marker)
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
+        // 2. Anchor at the repo root, then probe canonical → legacy.
+        var repoRoot = FindRepoRoot(anchor);
+        if (repoRoot is not null)
         {
-            var candidate = Path.Combine(dir.FullName, ".agent", "skills");
-            if (Directory.Exists(candidate))
-                return candidate;
+            var canonical = Path.Combine(repoRoot, "skills");
+            if (Directory.Exists(canonical)) return canonical;
 
-            // Stop at repo root markers
-            if (File.Exists(Path.Combine(dir.FullName, ".git"))
-                || Directory.Exists(Path.Combine(dir.FullName, ".git")))
-                return candidate; // return even if missing — Register() will log warning
+            var legacy = Path.Combine(repoRoot, ".agent", "skills");
+            if (Directory.Exists(legacy)) return legacy;
 
-            dir = dir.Parent;
+            // Neither exists — return the canonical path so Register()'s
+            // missing-dir warning points at the right authoring location.
+            return canonical;
         }
 
-        // 3. Fallback relative to CWD
-        return Path.Combine(Directory.GetCurrentDirectory(), ".agent", "skills");
+        // 3. No .git anchor reachable — fall back to a CWD-relative canonical path.
+        return Path.Combine(Directory.GetCurrentDirectory(), "skills");
     }
 
     private static string? FindRepoRoot(string startDir)

--- a/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
+++ b/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
@@ -49,8 +49,28 @@ public sealed class SkillMdPlugin : IChatPlugin
         var skills = SkillMdLoader.LoadFromDirectory(path);
         if (skills.Count == 0)
         {
-            System.Diagnostics.Debug.WriteLine(
-                $"[SkillMdPlugin] No SKILL.md files with triggers found in {path}.");
+            // Migration footgun: an empty canonical `skills/` would silently
+            // shadow a populated `.agent/skills/` since the resolver returns
+            // the canonical path first. Detect that case and shout, so a fresh
+            // `mkdir skills` doesn't drop every unported skill from production.
+            var legacy = LegacyAgentSkillsPath(path);
+            var legacySkillCount = legacy is not null
+                ? SkillMdLoader.LoadFromDirectory(legacy).Count
+                : 0;
+
+            if (legacySkillCount > 0)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[SkillMdPlugin] Canonical '{path}' is empty but legacy '{legacy}' " +
+                    $"still has {legacySkillCount} SKILL.md file(s). Production will register ZERO " +
+                    $"skills. Either port them into the canonical directory or remove the empty " +
+                    $"canonical directory to fall through to legacy.");
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[SkillMdPlugin] No SKILL.md files with triggers found in {path}.");
+            }
             return;
         }
 
@@ -100,7 +120,7 @@ public sealed class SkillMdPlugin : IChatPlugin
             var resolved = Path.GetFullPath(env);
             var rootForOverride = FindRepoRoot(anchor);
             if (rootForOverride is not null &&
-                resolved.StartsWith(rootForOverride, StringComparison.OrdinalIgnoreCase))
+                IsPathInsideDirectory(resolved, rootForOverride))
                 return resolved;
 
             System.Diagnostics.Debug.WriteLine(
@@ -125,6 +145,44 @@ public sealed class SkillMdPlugin : IChatPlugin
 
         // 3. No .git anchor reachable — fall back to a CWD-relative canonical path.
         return Path.Combine(Directory.GetCurrentDirectory(), "skills");
+    }
+
+    /// <summary>
+    /// Returns the legacy <c>.agent/skills</c> directory that pairs with the
+    /// canonical <paramref name="canonicalPath"/>, or <c>null</c> if it can't
+    /// be derived. Used to detect the empty-canonical / populated-legacy footgun
+    /// during migration.
+    /// </summary>
+    private static string? LegacyAgentSkillsPath(string canonicalPath)
+    {
+        var parent = Path.GetDirectoryName(canonicalPath);
+        if (string.IsNullOrEmpty(parent)) return null;
+        var legacy = Path.Combine(parent, ".agent", "skills");
+        return Directory.Exists(legacy) ? legacy : null;
+    }
+
+    /// <summary>
+    /// Path-prefix check that defends against prefix-collision attacks on
+    /// <c>StartsWith</c> — e.g. <c>C:\repo</c> matching <c>C:\repo-evil</c>.
+    /// Both arguments are normalized via <see cref="Path.GetFullPath(string)"/>
+    /// and the directory side is suffixed with the platform separator before
+    /// the case-insensitive prefix check.
+    /// </summary>
+    /// <remarks>
+    /// Note: this is a lexical check. It does NOT dereference NTFS junctions /
+    /// reparse points / symlinks — that's a separate hardening pass tracked in
+    /// the migration recommendation's followups.
+    /// </remarks>
+    private static bool IsPathInsideDirectory(string candidatePath, string directory)
+    {
+        var candidateFull = Path.GetFullPath(candidatePath);
+        var dirFull       = Path.GetFullPath(directory);
+        if (!dirFull.EndsWith(Path.DirectorySeparatorChar) &&
+            !dirFull.EndsWith(Path.AltDirectorySeparatorChar))
+        {
+            dirFull += Path.DirectorySeparatorChar;
+        }
+        return candidateFull.StartsWith(dirFull, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? FindRepoRoot(string startDir)

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -200,6 +200,45 @@ public class FileBasedSkillsProviderTests
         Assert.That(ctx.Instructions, Does.Contain("QA Architect Skill"));
     }
 
+    [Test]
+    public async Task InvokingAsync_LoadsBeginnerChordsSkillFromRepo()
+    {
+        // Canary for SKILL.md authoring: the beginner-chords skill is the first
+        // deterministic-catalog skill to be ported from C# to a markdown spec.
+        // If this test fails, SKILL.md authoring is broken — block the migration
+        // before porting more skills.
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        var beginner = provider.Skills.SingleOrDefault(s => s.Name == "beginner-chords");
+        Assert.That(beginner, Is.Not.Null,
+            "skills/beginner-chords/SKILL.md must be discovered with name 'beginner-chords'");
+        Assert.That(beginner!.Description, Does.Contain("first-position open"),
+            "Description should describe the catalog scope");
+        Assert.That(beginner.Triggers, Has.Some.Contain("beginner chord"));
+        Assert.That(beginner.Triggers, Has.Some.Contain("first chord"));
+
+        // Body must contain every diagram so the LLM cannot drop one.
+        var expectedDiagrams = new[]
+        {
+            "x-3-2-0-1-0", "3-2-0-0-0-3", "x-x-0-2-3-2", "x-0-2-2-2-0",
+            "0-2-2-1-0-0", "x-0-2-2-1-0", "0-2-2-0-0-0", "x-x-0-2-3-1",
+        };
+        foreach (var diagram in expectedDiagrams)
+        {
+            Assert.That(beginner.Body, Does.Contain(diagram),
+                $"beginner-chords SKILL.md body must include diagram '{diagram}'");
+        }
+
+        // Provider hands the body back as Instructions when a trigger fires.
+        var ctx = await provider.InvokingAsync(UserContext("show me some beginner chord shapes"));
+        Assert.That(ctx.Instructions, Does.Contain("beginner-chords"));
+        Assert.That(ctx.Instructions, Does.Contain("x-3-2-0-1-0"),
+            "trigger match should inject the catalog body verbatim");
+    }
+
     private static string? ResolveRepoSkillsDir()
     {
         var dir = new DirectoryInfo(Environment.GetEnvironmentVariable("GA_REPO_ROOT")

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdPluginResolverTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdPluginResolverTests.cs
@@ -1,6 +1,8 @@
 namespace GA.Business.ML.Tests.Unit;
 
+using System.Diagnostics;
 using GA.Business.ML.Agents.Plugins;
+using Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Tests for <see cref="SkillMdPlugin.ResolveSkillsPath"/> — verifies the
@@ -111,6 +113,79 @@ public class SkillMdPluginResolverTests
         {
             try { Directory.Delete(outside, recursive: true); } catch { /* best-effort */ }
         }
+    }
+
+    [Test]
+    public void ResolveSkillsPath_RejectsPrefixCollisionEnvOverride()
+    {
+        // Defends against `<repo>/skills` matching the prefix of a sibling
+        // directory like `<repo>-evil/skills`. Without the trailing separator
+        // in the prefix check, ordinal-ignore-case StartsWith would accept it.
+        var canonical = Path.Combine(_tmpRoot, "skills");
+        Directory.CreateDirectory(canonical);
+
+        // Create an "evil sibling" whose path starts with the same prefix as
+        // _tmpRoot but is outside it.
+        var siblingRoot = _tmpRoot + "-evil";
+        Directory.CreateDirectory(siblingRoot);
+        var siblingSkills = Path.Combine(siblingRoot, "skills");
+        Directory.CreateDirectory(siblingSkills);
+        try
+        {
+            Environment.SetEnvironmentVariable("SKILLMD_SKILLS_PATH", siblingSkills);
+
+            var resolved = SkillMdPlugin.ResolveSkillsPath(_tmpRoot);
+
+            Assert.That(resolved, Is.EqualTo(canonical),
+                "Prefix-collision sibling path must be rejected — the prefix check has to require a directory boundary, not just a string prefix.");
+        }
+        finally
+        {
+            try { Directory.Delete(siblingRoot, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
+    public void Register_CanonicalEmptyButLegacyPopulated_WarnsAboutSilentSkillLoss()
+    {
+        // The migration footgun: someone runs `mkdir skills` while authoring
+        // the canonical home, and the resolver immediately starts returning
+        // the empty canonical path — silently shadowing the legacy directory
+        // so production registers ZERO skills. Register() must shout in that
+        // exact configuration so the migration doesn't silently brick prod.
+        var canonical = Path.Combine(_tmpRoot, "skills");
+        var legacyDir = Path.Combine(_tmpRoot, ".agent", "skills", "alpha");
+        Directory.CreateDirectory(canonical);    // empty canonical
+        Directory.CreateDirectory(legacyDir);
+        File.WriteAllText(
+            Path.Combine(legacyDir, "SKILL.md"),
+            "---\nName: \"alpha\"\nDescription: \"Test\"\nTriggers:\n  - \"alpha\"\n---\n\nBody.");
+
+        var debugListener = new TestTraceListener();
+        Trace.Listeners.Add(debugListener);
+        try
+        {
+            new SkillMdPlugin().Register(new ServiceCollection(), canonical);
+        }
+        finally
+        {
+            Trace.Listeners.Remove(debugListener);
+        }
+
+        var output = debugListener.Output;
+        Assert.That(output, Does.Contain("Canonical").And.Contain("empty"),
+            "Register() must warn when canonical is empty and legacy still has skills, otherwise the migration silently bricks production.");
+        Assert.That(output, Does.Contain("1 SKILL.md"),
+            "warning must include the legacy skill count so the operator knows what's being shadowed");
+    }
+
+    /// <summary>Captures Debug.WriteLine output for inspection.</summary>
+    private sealed class TestTraceListener : TraceListener
+    {
+        private readonly System.Text.StringBuilder _buf = new();
+        public string Output => _buf.ToString();
+        public override void Write(string? message)     => _buf.Append(message);
+        public override void WriteLine(string? message) => _buf.AppendLine(message);
     }
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdPluginResolverTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdPluginResolverTests.cs
@@ -1,0 +1,129 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Plugins;
+
+/// <summary>
+/// Tests for <see cref="SkillMdPlugin.ResolveSkillsPath"/> — verifies the
+/// canonical-first lookup order documented in the 2026-05-03 migration
+/// recommendation. Uses internal access via InternalsVisibleTo.
+/// </summary>
+[TestFixture]
+public class SkillMdPluginResolverTests
+{
+    private string _tmpRoot = string.Empty;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tmpRoot = Path.Combine(Path.GetTempPath(), "ga-resolver-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tmpRoot);
+        // .git marker so FindRepoRoot anchors here rather than the real repo
+        File.WriteAllText(Path.Combine(_tmpRoot, ".git"), "gitdir: fake\n");
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        Environment.SetEnvironmentVariable("SKILLMD_SKILLS_PATH", null);
+        if (Directory.Exists(_tmpRoot))
+        {
+            try { Directory.Delete(_tmpRoot, recursive: true); }
+            catch { /* best-effort under Windows file locks */ }
+        }
+    }
+
+    [Test]
+    public void ResolveSkillsPath_PrefersCanonicalSkillsDir()
+    {
+        // Both directories exist — canonical must win.
+        var canonical = Path.Combine(_tmpRoot, "skills");
+        var legacy    = Path.Combine(_tmpRoot, ".agent", "skills");
+        Directory.CreateDirectory(canonical);
+        Directory.CreateDirectory(legacy);
+
+        var resolved = SkillMdPlugin.ResolveSkillsPath(_tmpRoot);
+
+        Assert.That(resolved, Is.EqualTo(canonical),
+            "When both 'skills/' and '.agent/skills/' exist, the canonical path wins per the migration recommendation.");
+    }
+
+    [Test]
+    public void ResolveSkillsPath_FallsBackToLegacyWhenCanonicalMissing()
+    {
+        // Only .agent/skills exists — back-compat path so unported skills
+        // don't disappear at flip-time.
+        var legacy = Path.Combine(_tmpRoot, ".agent", "skills");
+        Directory.CreateDirectory(legacy);
+
+        var resolved = SkillMdPlugin.ResolveSkillsPath(_tmpRoot);
+
+        Assert.That(resolved, Is.EqualTo(legacy),
+            "When only legacy '.agent/skills/' exists, it should still be picked up so unported skills load.");
+    }
+
+    [Test]
+    public void ResolveSkillsPath_ReturnsCanonicalWhenNeitherExists()
+    {
+        // Neither exists — return the canonical path so the Register() warning
+        // points users at the right place to author new skills.
+        var resolved = SkillMdPlugin.ResolveSkillsPath(_tmpRoot);
+
+        Assert.That(resolved, Is.EqualTo(Path.Combine(_tmpRoot, "skills")),
+            "When neither directory exists, the resolver should return the canonical path so the missing-dir warning points at the right authoring location.");
+    }
+
+    [Test]
+    public void ResolveSkillsPath_EnvVarOverrideWinsWhenInsideRepoRoot()
+    {
+        var canonical = Path.Combine(_tmpRoot, "skills");
+        var override_ = Path.Combine(_tmpRoot, "custom-skills");
+        Directory.CreateDirectory(canonical);
+        Directory.CreateDirectory(override_);
+
+        Environment.SetEnvironmentVariable("SKILLMD_SKILLS_PATH", override_);
+
+        var resolved = SkillMdPlugin.ResolveSkillsPath(_tmpRoot);
+
+        Assert.That(resolved, Is.EqualTo(override_),
+            "Env var override that resolves inside the repo root must win over canonical/legacy probing.");
+    }
+
+    [Test]
+    public void ResolveSkillsPath_EnvVarOverrideRejectedWhenOutsideRepoRoot()
+    {
+        // Path-traversal defense: an env var pointing outside the repo root
+        // must be ignored to prevent injection of arbitrary system prompts.
+        var canonical = Path.Combine(_tmpRoot, "skills");
+        Directory.CreateDirectory(canonical);
+
+        var outside = Path.Combine(Path.GetTempPath(), "ga-outside-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outside);
+        try
+        {
+            Environment.SetEnvironmentVariable("SKILLMD_SKILLS_PATH", outside);
+
+            var resolved = SkillMdPlugin.ResolveSkillsPath(_tmpRoot);
+
+            Assert.That(resolved, Is.EqualTo(canonical),
+                "Env var pointing outside the repo root must be ignored, falling back to canonical path resolution.");
+        }
+        finally
+        {
+            try { Directory.Delete(outside, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
+    public void ResolveSkillsPath_NoGitMarker_FallsBackToCwd()
+    {
+        // Strip the .git marker to simulate "not in a repo" — should fall back
+        // to the CWD-relative canonical path.
+        File.Delete(Path.Combine(_tmpRoot, ".git"));
+
+        var resolved = SkillMdPlugin.ResolveSkillsPath(_tmpRoot);
+
+        Assert.That(resolved, Does.EndWith(Path.Combine(string.Empty, "skills"))
+            .Or.EndWith(Path.DirectorySeparatorChar + "skills"),
+            "Without a .git anchor the resolver falls back to <cwd>/skills.");
+    }
+}

--- a/skills/beginner-chords/SKILL.md
+++ b/skills/beginner-chords/SKILL.md
@@ -1,0 +1,55 @@
+---
+Name: "beginner-chords"
+Description: "Returns the eight first-position open guitar chords every curriculum starts with — C, G, D, A, E, Am, Em, Dm — with diagrams and short fingering tips. Use when a learner asks 'what are the easy chords' / 'beginner chords' / 'first chords I should learn'."
+Triggers:
+  - "beginner chord"
+  - "easy chord"
+  - "first chord"
+  - "open chord"
+  - "starter chord"
+  - "basic open chord"
+  - "simple guitar chord"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "deterministic-catalog"
+  origin: "ported from Common/GA.Business.ML/Agents/Skills/BeginnerChordsSkill.cs (PR #71) — canary for SKILL.md authoring (PR-pending)"
+  evidence-kinds:
+    - catalog_lookup
+---
+
+# Beginner Open-Position Guitar Chords
+
+Use this catalog when a learner asks for the first chords to learn. Reproduce the eight diagrams verbatim and end with the practice tip in the final paragraph. Do not invent additional chord shapes or alter the fingering notes — those are pedagogically chosen and pre-validated.
+
+## Diagram conventions
+
+Each diagram is six tokens, low-to-high (E A D G B e). `0` = open string, `x` = mute, otherwise the integer is the fret number. Tokens are separated by `-`.
+
+## The eight chords
+
+1. **C major** — `x-3-2-0-1-0` — First-position major. Watch the muted low E.
+2. **G major** — `3-2-0-0-0-3` — Use ring/middle/pinky on E-A-e for cleaner switching to D.
+3. **D major** — `x-x-0-2-3-2` — Compact triad — handy for "D shape" barre training later.
+4. **A major** — `x-0-2-2-2-0` — Index/middle/ring on D-G-B; or barre with one finger across the 2nd fret.
+5. **E major** — `0-2-2-1-0-0` — Strongest, fullest open chord — every string rings.
+6. **A minor** — `x-0-2-2-1-0` — Same shape as E, moved one string up; bedrock minor sound.
+7. **E minor** — `0-2-2-0-0-0` — Easiest chord on the guitar — two fingers, six strings ringing.
+8. **D minor** — `x-x-0-2-3-1` — Compact like D major; good for swapping with C and G in folk songs.
+
+## Practice tip
+
+Drill C ↔ G ↔ D ↔ Am ↔ Em as a smooth loop. Those five cover most folk, pop, and country songs in major keys. Add A, E, and Dm next.
+
+## Out of scope
+
+- Barre chords (F, B, Bm) — these are second-pass, not first-pass material.
+- Power chords / palm-muted shapes — those serve a different pedagogical track.
+- Tunings other than standard EADGBe — convert from this catalog rather than re-deriving.
+
+## Cross-reference
+
+- C# implementation: `Common/GA.Business.ML/Agents/Skills/BeginnerChordsSkill.cs`
+- Tests: `Tests/Common/GA.Business.ML.Tests/Unit/BeginnerChordsSkillTests.cs`


### PR DESCRIPTION
## Summary

Two related commits that together complete Phase 2 of the [agent-framework migration](docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md) for the **production** chatbot path (not just the Agent Framework spike).

### Commit 1 — `skills/beginner-chords/SKILL.md` (canary)

First deterministic-catalog skill ported from C# to a markdown spec. Body reproduces the eight first-position open chords with diagrams, fingering tips, and a practice loop — copied verbatim from `BeginnerChordsSkill.cs` so behavior matches exactly.

Test: `InvokingAsync_LoadsBeginnerChordsSkillFromRepo` asserts the loader discovers the skill, exposes its frontmatter, and reproduces every diagram in the body. Trigger match injects body as `Instructions` verbatim. Skipped if `skills/` is unreachable from the test binary (mirrors the qa-architect smoke test).

### Commit 2 — `SkillMdPlugin` resolves canonical `skills/` first

`SkillMdPlugin` (the production orchestrator wiring) used to resolve only `.agent/skills/`, so the canary above wouldn't auto-register. Refactored to:
1. Honour `SKILLMD_SKILLS_PATH` env var (with the existing path-traversal defense).
2. Anchor at the `.git` repo root, prefer canonical `skills/`, fall back to legacy `.agent/skills/` until every skill migrates.
3. Fall back to `<cwd>/skills` when no `.git` anchor is reachable.

Refactored `ResolveSkillsPath` to `internal static` with an optional `startDir` so tests can re-anchor at a temp dir.

Tests: 6 new `SkillMdPluginResolverTests` cases covering canonical-wins, legacy-fallback, missing-both, env-override, env-traversal-rejection, no-git-fallback.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~SkillMd|FullyQualifiedName~FileBasedSkill"` — 42/42 pass
- [x] `dotnet build AllProjects.slnx -c Debug` clean (zero new warnings on this PR's files)
- [ ] Live smoke: with the chatbot service restarted, send a "show me beginner chords" prompt and verify it routes through `skill.md.beginner-chords` (deferred — Ollama still wedged for chat-model loading per session context)

## Reversibility

Both commits are **two-way doors**:
- The SKILL.md is purely additive — deleting it leaves the C# skill intact.
- The resolver still honours `.agent/skills/` so unported skills keep working in production.

**Revisit trigger:** when every C# `IOrchestratorSkill` has a SKILL.md equivalent, drop the `.agent/skills/` legacy probe and (separately) decide whether to remove the C# implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)