### PR TITLE
feat(chatbot): MCP-tool-driven SKILL.md canary (interval)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -3,6 +3,7 @@ namespace GA.Business.Core.Orchestration.Plugins;
 using GA.Business.Core.Orchestration.Intents;
 using GA.Business.ML.Agents;
 using GA.Business.ML.Agents.Hooks;
+using GA.Business.ML.Agents.Mcp;
 using GA.Business.ML.Agents.Memory;
 using GA.Business.ML.Agents.Plugins;
 using GA.Business.ML.Agents.Skills;
@@ -56,5 +57,13 @@ public sealed class GaPlugin : IChatPlugin
     /// MCP server assembled by <see cref="ChatPluginHost"/> (wired in Phase 3).
     /// Referenced by type name to avoid a direct project dependency on GaMcpServer.
     /// </summary>
-    public IReadOnlyList<Type> McpToolTypes => [typeof(MemoryMcpTools)];
+    public IReadOnlyList<Type> McpToolTypes =>
+    [
+        typeof(MemoryMcpTools),
+        // First domain-compute tool exposed via MCP — canary for the workstream
+        // that ports computation skills to thin SKILL.md + tool calls. See
+        // docs/plans/2026-05-03-chatbot-agent-framework-migration-recommendation.md
+        // §"Porting policy: catalog vs. computation skills".
+        typeof(IntervalMcpTools),
+    ];
 }

--- a/Common/GA.Business.ML/Agents/Mcp/IntervalMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/IntervalMcpTools.cs
@@ -1,0 +1,125 @@
+namespace GA.Business.ML.Agents.Mcp;
+
+using System.ComponentModel;
+using GA.Domain.Core.Primitives.Extensions;
+using GA.Domain.Core.Primitives.Notes;
+using ModelContextProtocol.Server;
+
+/// <summary>
+/// MCP tool surface for interval-between-two-notes computation. Wraps the
+/// existing <c>Note.Accidented.GetInterval</c> domain primitive so a SKILL.md-driven
+/// LLM agent can compute intervals deterministically rather than recalling them
+/// from training data.
+/// </summary>
+/// <remarks>
+/// Discovered by <see cref="Plugins.ChatPluginHost"/> via
+/// <see cref="Plugins.IChatPlugin.McpToolTypes"/>. This is the canary for the
+/// MCP-tool-exposure workstream — once it ports cleanly, ChordInfo / ScaleInfo /
+/// Modes follow the same pattern.
+/// </remarks>
+[McpServerToolType]
+public sealed class IntervalMcpTools
+{
+    /// <summary>
+    /// Computes the simple interval between two notes (e.g. C → G is a perfect fifth).
+    /// </summary>
+    /// <param name="lowerNote">The lower note (e.g. <c>"C"</c>, <c>"F#"</c>, <c>"Bb"</c>).</param>
+    /// <param name="upperNote">The upper note (same notation).</param>
+    /// <returns>
+    /// An <see cref="IntervalResult"/> with name (e.g. "P5"), quality and size in
+    /// long form, and the semitone count. On parse error, the result has
+    /// <see cref="IntervalResult.Error"/> populated.
+    /// </returns>
+    [McpServerTool, Description(
+        "Compute the simple interval between two notes (e.g. lowerNote='C', upperNote='G' returns a perfect fifth). " +
+        "Use this whenever a user asks for the interval, distance, or semitone count between two named pitches. " +
+        "Accepts standard note names with optional accidentals: C, F#, Bb, etc.")]
+    public IntervalResult ComputeInterval(
+        [Description("The lower note name (e.g. 'C', 'F#', 'Bb').")] string lowerNote,
+        [Description("The upper note name (e.g. 'G', 'A#', 'Eb').")] string upperNote)
+    {
+        if (!TryParseNote(lowerNote, out var note1))
+            return IntervalResult.Failure($"Could not parse '{lowerNote}' as a note name. Try C, F#, Bb, etc.");
+        if (!TryParseNote(upperNote, out var note2))
+            return IntervalResult.Failure($"Could not parse '{upperNote}' as a note name. Try C, F#, Bb, etc.");
+
+        var interval = note1.GetInterval(note2);
+        return new IntervalResult
+        {
+            LowerNote   = FormatNote(lowerNote),
+            UpperNote   = FormatNote(upperNote),
+            Name        = interval.Name,
+            Quality     = QualityLongName(interval.Quality.ToString()),
+            Size        = SizeOrdinalName(interval.Size.Value),
+            Semitones   = interval.Semitones.Value,
+        };
+    }
+
+    private static bool TryParseNote(string token, out Note.Accidented note)
+    {
+        if (Note.Sharp.TryParse(token, null, out var sharp))      { note = sharp.ToAccidented();    return true; }
+        if (Note.Flat.TryParse(token, null, out var flat))        { note = flat.ToAccidented();     return true; }
+        if (Note.Accidented.TryParse(token, null, out var acc))   { note = acc;                    return true; }
+        note = default!;
+        return false;
+    }
+
+    private static string FormatNote(string raw)
+    {
+        var trimmed = raw.Trim();
+        if (trimmed.Length == 0) return raw;
+        var head = char.ToUpperInvariant(trimmed[0]).ToString();
+        return trimmed.Length == 1 ? head : head + trimmed[1..].ToLowerInvariant();
+    }
+
+    private static string QualityLongName(string shortQuality) => shortQuality switch
+    {
+        "P" => "perfect",
+        "M" => "major",
+        "m" => "minor",
+        "A" => "augmented",
+        "d" => "diminished",
+        _   => shortQuality,
+    };
+
+    private static string SizeOrdinalName(int size) => size switch
+    {
+        1 => "unison",
+        2 => "second",
+        3 => "third",
+        4 => "fourth",
+        5 => "fifth",
+        6 => "sixth",
+        7 => "seventh",
+        8 => "octave",
+        _ => $"{size}th",
+    };
+}
+
+/// <summary>
+/// Structured result of <see cref="IntervalMcpTools.ComputeInterval"/>. The shape
+/// is JSON-serialised for the LLM so it can read every field directly without
+/// re-parsing prose. <see cref="Error"/> is non-null only on parse failure.
+/// </summary>
+public sealed record IntervalResult
+{
+    public string LowerNote { get; init; } = string.Empty;
+    public string UpperNote { get; init; } = string.Empty;
+
+    /// <summary>Short interval name (e.g. <c>"P5"</c>, <c>"m3"</c>).</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Quality in long form: <c>"perfect"</c>, <c>"major"</c>, <c>"minor"</c>, <c>"augmented"</c>, <c>"diminished"</c>.</summary>
+    public string Quality { get; init; } = string.Empty;
+
+    /// <summary>Size in long form: <c>"unison"</c>, <c>"second"</c>, ..., <c>"octave"</c>.</summary>
+    public string Size { get; init; } = string.Empty;
+
+    /// <summary>Number of semitones between the two notes (0–12 for simple intervals).</summary>
+    public int Semitones { get; init; }
+
+    /// <summary>Non-null when the input could not be parsed as standard note names.</summary>
+    public string? Error { get; init; }
+
+    public static IntervalResult Failure(string message) => new() { Error = message };
+}

--- a/Common/GA.Business.ML/Agents/Mcp/IntervalMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/IntervalMcpTools.cs
@@ -30,18 +30,24 @@ public sealed class IntervalMcpTools
     /// long form, and the semitone count. On parse error, the result has
     /// <see cref="IntervalResult.Error"/> populated.
     /// </returns>
-    [McpServerTool, Description(
+    // Realistic note tokens are 1–3 chars (C, F#, Bbb, C##). Cap inputs at 4
+    // to defend against pathological ~MB strings — Note.{Sharp,Flat}.TryParse
+    // calls Trim().ToUpperInvariant().Replace(...), each of which allocates
+    // proportional to input length before the validation predicate runs.
+    private const int MaxNoteTokenLength = 4;
+
+    [McpServerTool(Name = "ga_interval_compute"), Description(
         "Compute the simple interval between two notes (e.g. lowerNote='C', upperNote='G' returns a perfect fifth). " +
         "Use this whenever a user asks for the interval, distance, or semitone count between two named pitches. " +
         "Accepts standard note names with optional accidentals: C, F#, Bb, etc.")]
-    public IntervalResult ComputeInterval(
+    public IntervalResult IntervalCompute(
         [Description("The lower note name (e.g. 'C', 'F#', 'Bb').")] string lowerNote,
         [Description("The upper note name (e.g. 'G', 'A#', 'Eb').")] string upperNote)
     {
         if (!TryParseNote(lowerNote, out var note1))
-            return IntervalResult.Failure($"Could not parse '{lowerNote}' as a note name. Try C, F#, Bb, etc.");
+            return IntervalResult.Failure($"Could not parse '{SanitizeEcho(lowerNote)}' as a note name. Try C, F#, Bb, etc.");
         if (!TryParseNote(upperNote, out var note2))
-            return IntervalResult.Failure($"Could not parse '{upperNote}' as a note name. Try C, F#, Bb, etc.");
+            return IntervalResult.Failure($"Could not parse '{SanitizeEcho(upperNote)}' as a note name. Try C, F#, Bb, etc.");
 
         var interval = note1.GetInterval(note2);
         return new IntervalResult
@@ -55,13 +61,37 @@ public sealed class IntervalMcpTools
         };
     }
 
-    private static bool TryParseNote(string token, out Note.Accidented note)
+    private static bool TryParseNote(string? token, out Note.Accidented note)
     {
+        // Length / null guard — bail before TryParse so a 10MB string can't
+        // allocate proportional intermediate buffers in Note.{Sharp,Flat}.TryParse.
+        if (string.IsNullOrEmpty(token) || token.Length > MaxNoteTokenLength)
+        {
+            note = default!;
+            return false;
+        }
+
         if (Note.Sharp.TryParse(token, null, out var sharp))      { note = sharp.ToAccidented();    return true; }
         if (Note.Flat.TryParse(token, null, out var flat))        { note = flat.ToAccidented();     return true; }
         if (Note.Accidented.TryParse(token, null, out var acc))   { note = acc;                    return true; }
         note = default!;
         return false;
+    }
+
+    /// <summary>
+    /// Sanitizes an echoed input string for inclusion in the <see cref="IntervalResult.Error"/>
+    /// message. Strips control characters and clamps to 16 chars so a malicious
+    /// or accidental payload (newline-laden log injection, ANSI escapes, prompt-
+    /// injection prose) cannot ride out through downstream rendering.
+    /// </summary>
+    private static string SanitizeEcho(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return string.Empty;
+        var clamped = raw.Length > 16 ? raw[..16] + "…" : raw;
+        var buf = new System.Text.StringBuilder(clamped.Length);
+        foreach (var c in clamped)
+            buf.Append(char.IsControl(c) ? '·' : c);
+        return buf.ToString();
     }
 
     private static string FormatNote(string raw)
@@ -97,10 +127,16 @@ public sealed class IntervalMcpTools
 }
 
 /// <summary>
-/// Structured result of <see cref="IntervalMcpTools.ComputeInterval"/>. The shape
+/// Structured result of <see cref="IntervalMcpTools.IntervalCompute"/>. The shape
 /// is JSON-serialised for the LLM so it can read every field directly without
-/// re-parsing prose. <see cref="Error"/> is non-null only on parse failure.
+/// re-parsing prose.
 /// </summary>
+/// <remarks>
+/// <b>Invariant:</b> when <see cref="Error"/> is non-null all other string fields
+/// are <see cref="string.Empty"/> and <see cref="Semitones"/> is <c>0</c>.
+/// LLMs reading this record should branch on <see cref="Error"/> first and
+/// surface the message verbatim before falling back to the structured fields.
+/// </remarks>
 public sealed record IntervalResult
 {
     public string LowerNote { get; init; } = string.Empty;

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -201,6 +201,38 @@ public class FileBasedSkillsProviderTests
     }
 
     [Test]
+    public async Task InvokingAsync_LoadsIntervalSkillFromRepo()
+    {
+        // Canary for the MCP-tool-driven authoring style — different shape from
+        // the catalog SKILL.md files (BeginnerChords, ProgressionMood). The body
+        // doesn't carry data; it instructs the LLM to call the MCP tool. If this
+        // test fails the loader broke for tool-driven skills specifically.
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        var interval = provider.Skills.SingleOrDefault(s => s.Name == "interval");
+        Assert.That(interval, Is.Not.Null,
+            "skills/interval/SKILL.md must be discovered with name 'interval'");
+
+        // Triggers must cover the main phrasings users employ.
+        Assert.That(interval!.Triggers, Has.Some.Contain("interval between"));
+        Assert.That(interval.Triggers,  Has.Some.Contain("distance from"));
+        Assert.That(interval.Triggers,  Has.Some.Contain("how many semitones"));
+
+        // Body must reference the tool by exact name so the LLM knows what to call.
+        Assert.That(interval.Body, Does.Contain("ComputeInterval"),
+            "tool-driven SKILL.md must name the MCP tool the LLM should call");
+        Assert.That(interval.Body, Does.Contain("lowerNote").And.Contain("upperNote"),
+            "body must document the tool's argument names so the LLM doesn't guess");
+
+        // Trigger match returns the body — same path as catalog skills.
+        var ctx = await provider.InvokingAsync(UserContext("interval between C and G"));
+        Assert.That(ctx.Instructions, Does.Contain("ComputeInterval"));
+    }
+
+    [Test]
     public async Task InvokingAsync_LoadsProgressionMoodSkillFromRepo()
     {
         // Second-canary smoke test — once two catalog skills are wired, the

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -222,14 +222,14 @@ public class FileBasedSkillsProviderTests
         Assert.That(interval.Triggers,  Has.Some.Contain("how many semitones"));
 
         // Body must reference the tool by exact name so the LLM knows what to call.
-        Assert.That(interval.Body, Does.Contain("ComputeInterval"),
+        Assert.That(interval.Body, Does.Contain("ga_interval_compute"),
             "tool-driven SKILL.md must name the MCP tool the LLM should call");
         Assert.That(interval.Body, Does.Contain("lowerNote").And.Contain("upperNote"),
             "body must document the tool's argument names so the LLM doesn't guess");
 
         // Trigger match returns the body — same path as catalog skills.
         var ctx = await provider.InvokingAsync(UserContext("interval between C and G"));
-        Assert.That(ctx.Instructions, Does.Contain("ComputeInterval"));
+        Assert.That(ctx.Instructions, Does.Contain("ga_interval_compute"));
     }
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Unit/IntervalMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/IntervalMcpToolsTests.cs
@@ -16,11 +16,11 @@ public class IntervalMcpToolsTests
     [TestCase("C", "F",  "P4",  "perfect",    "fourth",  5)]
     [TestCase("C", "C",  "P1",  "perfect",    "unison",  0)]
     [TestCase("A", "E",  "P5",  "perfect",    "fifth",   7)]
-    public void ComputeInterval_KnownPairs_ReturnsCorrectShape(
+    public void IntervalCompute_KnownPairs_ReturnsCorrectShape(
         string lower, string upper, string expectedName,
         string expectedQuality, string expectedSize, int expectedSemitones)
     {
-        var result = MakeTool().ComputeInterval(lower, upper);
+        var result = MakeTool().IntervalCompute(lower, upper);
 
         Assert.That(result.Error, Is.Null, "valid input must not produce an Error");
         Assert.That(result.Name,      Is.EqualTo(expectedName),       $"name mismatch for {lower}→{upper}");
@@ -30,11 +30,11 @@ public class IntervalMcpToolsTests
     }
 
     [Test]
-    public void ComputeInterval_NormalizesNoteCasing()
+    public void IntervalCompute_NormalizesNoteCasing()
     {
         // The LLM may emit lowercase or mixed case — the tool must be
         // case-insensitive and echo back canonical forms.
-        var result = MakeTool().ComputeInterval("c", "g");
+        var result = MakeTool().IntervalCompute("c", "g");
 
         Assert.That(result.Error,     Is.Null);
         Assert.That(result.LowerNote, Is.EqualTo("C"));
@@ -43,12 +43,12 @@ public class IntervalMcpToolsTests
     }
 
     [Test]
-    public void ComputeInterval_HandlesAccidentals()
+    public void IntervalCompute_HandlesAccidentals()
     {
         // F# → D is two cases that often confuse: enharmonic-aware naming
         // (F# rather than Gb) and crossing the octave (the canonical
         // "minor sixth" answer rather than "augmented fifth").
-        var result = MakeTool().ComputeInterval("F#", "D");
+        var result = MakeTool().IntervalCompute("F#", "D");
 
         Assert.That(result.Error,    Is.Null);
         Assert.That(result.Quality,  Is.EqualTo("minor"));
@@ -61,9 +61,9 @@ public class IntervalMcpToolsTests
     [TestCase("C",         "")]
     [TestCase("C",         "Z")]
     [TestCase("notanote",  "G")]
-    public void ComputeInterval_InvalidInputs_ReturnFailureResult(string lower, string upper)
+    public void IntervalCompute_InvalidInputs_ReturnFailureResult(string lower, string upper)
     {
-        var result = MakeTool().ComputeInterval(lower, upper);
+        var result = MakeTool().IntervalCompute(lower, upper);
 
         Assert.That(result.Error, Is.Not.Null,
             $"invalid input ('{lower}', '{upper}') must populate Error rather than throw");
@@ -73,14 +73,92 @@ public class IntervalMcpToolsTests
     }
 
     [Test]
-    public void ComputeInterval_DoesNotThrowOnNullArguments()
+    public void IntervalCompute_DoesNotThrowOnNullArguments()
     {
         // Cancellation-safe: tools must convert bad input into structured Error,
         // never throw — an exception would crash the agent's tool-call loop.
-        Assert.That(() => MakeTool().ComputeInterval(null!, "G"), Throws.Nothing);
-        Assert.That(() => MakeTool().ComputeInterval("C", null!), Throws.Nothing);
+        Assert.That(() => MakeTool().IntervalCompute(null!, "G"), Throws.Nothing);
+        Assert.That(() => MakeTool().IntervalCompute("C", null!), Throws.Nothing);
 
-        var nullLower = MakeTool().ComputeInterval(null!, "G");
+        var nullLower = MakeTool().IntervalCompute(null!, "G");
         Assert.That(nullLower.Error, Is.Not.Null);
+    }
+
+    [Test]
+    public void IntervalCompute_DescendingInput_ComputesSimpleInterval()
+    {
+        // The SKILL.md tells the LLM to pass first-mentioned as lower, but if
+        // the LLM gets the order wrong the tool must still return a sensible
+        // simple interval rather than throwing or returning negative semitones.
+        // G → C is a perfect fourth (5 semitones) when read as a simple interval.
+        var result = MakeTool().IntervalCompute("G", "C");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.Quality,   Is.EqualTo("perfect"));
+        Assert.That(result.Size,      Is.EqualTo("fourth"));
+        Assert.That(result.Semitones, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void IntervalCompute_EnharmonicSpellings_ProduceDistinctNamesSameSemitones()
+    {
+        // C → D# is augmented second (A2); C → Eb is minor third (m3). Same
+        // semitone count (3) but different theoretical spelling. The tool must
+        // honour whichever spelling the LLM passes — the worst failure mode here
+        // is silently normalising one to the other.
+        var augmented = MakeTool().IntervalCompute("C", "D#");
+        var minor     = MakeTool().IntervalCompute("C", "Eb");
+
+        Assert.That(augmented.Error, Is.Null);
+        Assert.That(minor.Error,     Is.Null);
+        Assert.That(augmented.Semitones, Is.EqualTo(minor.Semitones),
+            "enharmonic spellings must agree on semitone count");
+        Assert.That(augmented.Name, Is.Not.EqualTo(minor.Name),
+            "but the short interval name MUST distinguish A2 from m3 — silently normalising would erase a real theoretical distinction");
+    }
+
+    [Test]
+    public void IntervalCompute_PathologicallyLongInput_ReturnsErrorWithoutAllocating()
+    {
+        // 10 KB input — defends against a wedged or malicious LLM passing
+        // unbounded strings that would otherwise force Note.{Sharp,Flat}.TryParse
+        // to allocate proportional Trim()/ToUpperInvariant() intermediates.
+        // The MaxNoteTokenLength guard short-circuits before any allocation.
+        var huge = new string('C', 10_000);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = MakeTool().IntervalCompute(huge, "G");
+        sw.Stop();
+
+        Assert.That(result.Error, Is.Not.Null);
+        // < 10 ms should be plenty even on a slow CI runner — proves the
+        // length guard fired rather than the parser scanning the full input.
+        Assert.That(sw.ElapsedMilliseconds, Is.LessThan(10),
+            "long-input rejection must short-circuit, not scan the whole string");
+    }
+
+    [Test]
+    public void IntervalCompute_ControlCharsInError_AreSanitized()
+    {
+        // Defends downstream renderers against log/prompt injection: the user's
+        // bad input is echoed in the Error message, so the tool MUST strip
+        // newlines, ANSI escapes, and other control characters before placing
+        // them in the structured response.
+        var esc      = (char)0x1B;
+        var injected = "Q\n\r" + esc + "[31mFAKE LOG";
+        var result   = MakeTool().IntervalCompute(injected, "G");
+
+        Assert.That(result.Error, Is.Not.Null);
+        // Check for individual control bytes via char predicates rather than
+        // Does.Not.Contain — NUnit's string-contains is culture-aware and
+        // can spuriously flag control characters (e.g. ESC) as "contained"
+        // in strings that demonstrably don't include them.
+        Assert.That(result.Error!.IndexOf('\n'), Is.EqualTo(-1),
+            "newline must be stripped from echoed input — no fake-log-line forging");
+        Assert.That(result.Error.IndexOf('\r'), Is.EqualTo(-1));
+        Assert.That(result.Error.IndexOf(esc),  Is.EqualTo(-1),
+            "ANSI escape sequences must not survive into the echoed Error");
+        Assert.That(result.Error.All(c => !char.IsControl(c)), Is.True,
+            "no control character of any kind should reach the echoed Error");
     }
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/IntervalMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/IntervalMcpToolsTests.cs
@@ -1,0 +1,86 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Mcp;
+
+[TestFixture]
+public class IntervalMcpToolsTests
+{
+    private static IntervalMcpTools MakeTool() => new();
+
+    // Canonical pairs from any first-year theory text — these are the cases an
+    // LLM is most likely to call the tool for, so getting them right is the
+    // load-bearing acceptance criterion.
+    [TestCase("C", "G",  "P5",  "perfect",    "fifth",   7)]
+    [TestCase("C", "E",  "M3",  "major",      "third",   4)]
+    [TestCase("C", "Eb", "m3",  "minor",      "third",   3)]
+    [TestCase("C", "F",  "P4",  "perfect",    "fourth",  5)]
+    [TestCase("C", "C",  "P1",  "perfect",    "unison",  0)]
+    [TestCase("A", "E",  "P5",  "perfect",    "fifth",   7)]
+    public void ComputeInterval_KnownPairs_ReturnsCorrectShape(
+        string lower, string upper, string expectedName,
+        string expectedQuality, string expectedSize, int expectedSemitones)
+    {
+        var result = MakeTool().ComputeInterval(lower, upper);
+
+        Assert.That(result.Error, Is.Null, "valid input must not produce an Error");
+        Assert.That(result.Name,      Is.EqualTo(expectedName),       $"name mismatch for {lower}→{upper}");
+        Assert.That(result.Quality,   Is.EqualTo(expectedQuality),    $"quality mismatch for {lower}→{upper}");
+        Assert.That(result.Size,      Is.EqualTo(expectedSize),       $"size mismatch for {lower}→{upper}");
+        Assert.That(result.Semitones, Is.EqualTo(expectedSemitones),  $"semitone mismatch for {lower}→{upper}");
+    }
+
+    [Test]
+    public void ComputeInterval_NormalizesNoteCasing()
+    {
+        // The LLM may emit lowercase or mixed case — the tool must be
+        // case-insensitive and echo back canonical forms.
+        var result = MakeTool().ComputeInterval("c", "g");
+
+        Assert.That(result.Error,     Is.Null);
+        Assert.That(result.LowerNote, Is.EqualTo("C"));
+        Assert.That(result.UpperNote, Is.EqualTo("G"));
+        Assert.That(result.Name,      Is.EqualTo("P5"));
+    }
+
+    [Test]
+    public void ComputeInterval_HandlesAccidentals()
+    {
+        // F# → D is two cases that often confuse: enharmonic-aware naming
+        // (F# rather than Gb) and crossing the octave (the canonical
+        // "minor sixth" answer rather than "augmented fifth").
+        var result = MakeTool().ComputeInterval("F#", "D");
+
+        Assert.That(result.Error,    Is.Null);
+        Assert.That(result.Quality,  Is.EqualTo("minor"));
+        Assert.That(result.Size,     Is.EqualTo("sixth"));
+        Assert.That(result.Semitones, Is.EqualTo(8));
+    }
+
+    [TestCase("",          "G")]
+    [TestCase("Q",         "G")]
+    [TestCase("C",         "")]
+    [TestCase("C",         "Z")]
+    [TestCase("notanote",  "G")]
+    public void ComputeInterval_InvalidInputs_ReturnFailureResult(string lower, string upper)
+    {
+        var result = MakeTool().ComputeInterval(lower, upper);
+
+        Assert.That(result.Error, Is.Not.Null,
+            $"invalid input ('{lower}', '{upper}') must populate Error rather than throw");
+        Assert.That(result.Error, Does.Contain("parse").IgnoreCase
+            .Or.Contain("note").IgnoreCase,
+            "Error message should mention parsing or note format so the LLM can recover");
+    }
+
+    [Test]
+    public void ComputeInterval_DoesNotThrowOnNullArguments()
+    {
+        // Cancellation-safe: tools must convert bad input into structured Error,
+        // never throw — an exception would crash the agent's tool-call loop.
+        Assert.That(() => MakeTool().ComputeInterval(null!, "G"), Throws.Nothing);
+        Assert.That(() => MakeTool().ComputeInterval("C", null!), Throws.Nothing);
+
+        var nullLower = MakeTool().ComputeInterval(null!, "G");
+        Assert.That(nullLower.Error, Is.Not.Null);
+    }
+}

--- a/skills/interval/SKILL.md
+++ b/skills/interval/SKILL.md
@@ -1,0 +1,71 @@
+---
+Name: "interval"
+Description: "Computes the simple interval between two named pitches (e.g. C to G is a perfect fifth). Calls the deterministic `ComputeInterval` MCP tool — never recall an answer from training data."
+Triggers:
+  - "interval between"
+  - "interval from"
+  - "what is the interval"
+  - "distance from"
+  - "distance between"
+  - "how many semitones"
+  - "semitones from"
+  - "semitones between"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "tool-driven"
+  origin: "first MCP-tool-driven canary; replaces direct C# IntervalSkill in the SKILL.md path"
+  evidence-kinds:
+    - tool_call
+allowed-tools:
+  - ComputeInterval
+---
+
+# Interval Between Two Notes
+
+When a user asks for the interval, distance, or semitone count between two named pitches, you MUST call the `ComputeInterval` MCP tool. Do NOT compute the answer from training knowledge — the tool is deterministic and the model is not.
+
+## Calling the tool
+
+The tool takes two arguments:
+
+- `lowerNote` — string, e.g. `"C"`, `"F#"`, `"Bb"`. Case-insensitive.
+- `upperNote` — string, same notation.
+
+The tool returns a structured result with these fields:
+
+- `Name` — short interval name (e.g. `"P5"`, `"m3"`).
+- `Quality` — long form: `"perfect"`, `"major"`, `"minor"`, `"augmented"`, `"diminished"`.
+- `Size` — long form: `"unison"`, `"second"`, `"third"`, ..., `"octave"`.
+- `Semitones` — integer 0–12.
+- `Error` — non-null only when input could not be parsed.
+
+## Picking the lower / upper note
+
+Map the user's phrasing to argument order:
+
+- *"interval from C to G"* → `lowerNote="C"`, `upperNote="G"`.
+- *"interval between C and G"* → same as above; the first-mentioned note is the lower.
+- *"distance from F# to D"* → `lowerNote="F#"`, `upperNote="D"`. Pass both in order even when the lower is alphabetically later — the tool computes the simple interval correctly.
+- *"how many semitones from A to E"* → `lowerNote="A"`, `upperNote="E"`. Read out the `Semitones` field to answer.
+
+## Phrasing the answer
+
+Use the tool's `Quality` and `Size` words verbatim, then quote the short `Name` and `Semitones` count. Example:
+
+> From **C** to **G** is a **perfect fifth** (P5, 7 semitones).
+
+If `Error` is non-null, surface the message verbatim and ask the user to clarify the note names.
+
+## Out of scope
+
+- Compound intervals (9th, 13th, etc.) — the tool returns the simple interval; if the user asks "interval from C to high D", treat as a 9th by adding an octave to the simple result, but flag the assumption.
+- Interval qualities for notes outside the standard 12-tone system (microtones, just-intonation cents) — not supported.
+
+## Cross-reference
+
+- MCP tool: `Common/GA.Business.ML/Agents/Mcp/IntervalMcpTools.cs`
+- Tool tests: `Tests/Common/GA.Business.ML.Tests/Unit/IntervalMcpToolsTests.cs`
+- Legacy C# skill it replaces: `Common/GA.Business.ML/Agents/Skills/IntervalSkill.cs` (regex-driven, no LLM round-trip — kept for the deterministic fast path)

--- a/skills/interval/SKILL.md
+++ b/skills/interval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 Name: "interval"
-Description: "Computes the simple interval between two named pitches (e.g. C to G is a perfect fifth). Calls the deterministic `ComputeInterval` MCP tool — never recall an answer from training data."
+Description: "Computes the simple interval between two named pitches (e.g. C to G is a perfect fifth). Calls the deterministic `ga_interval_compute` MCP tool — never recall an answer from training data."
 Triggers:
   - "interval between"
   - "interval from"
@@ -20,12 +20,12 @@ metadata:
   evidence-kinds:
     - tool_call
 allowed-tools:
-  - ComputeInterval
+  - ga_interval_compute
 ---
 
 # Interval Between Two Notes
 
-When a user asks for the interval, distance, or semitone count between two named pitches, you MUST call the `ComputeInterval` MCP tool. Do NOT compute the answer from training knowledge — the tool is deterministic and the model is not.
+When a user asks for the interval, distance, or semitone count between two named pitches, you MUST call the `ga_interval_compute` MCP tool. Do NOT compute the answer from training knowledge — the tool is deterministic and the model is not.
 
 ## Calling the tool
 
@@ -59,10 +59,14 @@ Use the tool's `Quality` and `Size` words verbatim, then quote the short `Name` 
 
 If `Error` is non-null, surface the message verbatim and ask the user to clarify the note names.
 
+## When to ask for clarification
+
+If the user provides only one note, or names a chord rather than two notes (e.g. *"interval of A"*, *"what's the interval in a Cmaj7"*), do NOT call the tool with placeholder values — ask for the missing pitch first. Example response: *"Could you give me both notes? E.g. 'interval from C to G' or 'distance between F# and A'."*
+
 ## Out of scope
 
-- Compound intervals (9th, 13th, etc.) — the tool returns the simple interval; if the user asks "interval from C to high D", treat as a 9th by adding an octave to the simple result, but flag the assumption.
-- Interval qualities for notes outside the standard 12-tone system (microtones, just-intonation cents) — not supported.
+- **Compound intervals** (9th, 13th, etc.) — the tool returns the simple interval. If the user asks *"interval from C to high D"*, call the tool with `C` and `D` (which gives a major second), then in the answer flag the octave assumption explicitly: *"I'm treating 'high D' as D one octave above C, so the compound interval is a major ninth (M2 plus an octave). If you meant a different D, let me know."* Always state which D you assumed.
+- **Microtonal / just-intonation** intervals — the tool only handles the standard 12-tone system. Decline cleanly: *"This skill computes intervals in 12-TET only; for cents-based answers I'd need different tooling."*
 
 ## Cross-reference
 


### PR DESCRIPTION
## Summary

Opens the MCP-tool-exposure workstream from PR #75's porting policy. Ports the simplest computation skill (IntervalSkill) by exposing its core domain operation (`note.GetInterval`) as an MCP tool and authoring a thin SKILL.md that declares the tool and instructs the LLM to call it rather than recomputing from training data.

## Why this matters

Per the policy locked in PR #75: catalog skills go to SKILL.md (data in body), but **computation skills need MCP tool exposure first** so the LLM doesn't lose determinism. This is the canary that proves the pattern works.

## What changed

| File | Role |
|---|---|
| `Common/GA.Business.ML/Agents/Mcp/IntervalMcpTools.cs` | new `[McpServerToolType]` class; one `ComputeInterval(lowerNote, upperNote)` tool wrapping `Note.Accidented.GetInterval` |
| `Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs` | added `typeof(IntervalMcpTools)` to `McpToolTypes` so the in-process MCP server exposes it |
| `skills/interval/SKILL.md` | thin tool-driven skill — frontmatter declares `allowed-tools: [ComputeInterval]`; body instructs the LLM, no data inside |
| `Tests/.../IntervalMcpToolsTests.cs` | 14 cases (6 canonical pairs + accidentals + casing + 5 invalid-input + null-arg safety) |
| `Tests/.../FileBasedSkillsProviderTests.cs` | 1 new case asserts the tool-driven SKILL.md loads + body names tool + trigger fires |

## Tool semantics

- **Inputs**: `lowerNote`, `upperNote` — strings, case-insensitive, accept `C` / `F#` / `Bb`-style notation.
- **Output**: `IntervalResult` with `Name` (e.g. `P5`), `Quality` (long form), `Size` (long form), `Semitones`, and `Error` (non-null on parse failure).
- **Failure mode**: invalid input returns `Error`-populated result rather than throwing — an exception would crash the agent's tool-call loop.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~IntervalMcpTools|FullyQualifiedName~FileBasedSkillsProvider|FullyQualifiedName~SkillMd"` — 60/60 pass
- [x] `dotnet build AllProjects.slnx -c Debug` clean (zero new warnings)
- [ ] Live smoke deferred — Ollama still wedged for chat-model loading per session context. Once back, send "What's the interval from F# to D?" and verify the LLM picks `ComputeInterval` from the tool list and returns "minor sixth, m6, 8 semitones".

## Reversibility

**Two-way door.** Removing `typeof(IntervalMcpTools)` from `GaPlugin.McpToolTypes` undoes the wiring; the C# `IntervalSkill` is untouched and remains the deterministic fast path. The `skills/interval/SKILL.md` would be loaded but the LLM would have no `ComputeInterval` tool to call — it would degrade gracefully.

**Revisit trigger:** when porting the next computation skill (likely `ScaleInfoSkill` via a `GetKeyNotes` tool), confirm the same pattern scales — one class per logical operation, not per skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)