### PR TITLE
docs: align OPTIC-K canonical references with v1.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Apps live in `Apps/`: `ga-server/GaApi` (ASP.NET + SignalR + GraphQL), `GaChatbo
 
 ## OPTIC-K
 
-228-dim musical embedding (v1.7). Canonical schema: `Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs`. Never change dimension without coordinated re-index.
+240-dim musical embedding (`OPTIC-K-v1.8`). Canonical schema: `Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs` — read `TotalDimension` and `Version` constants, do not hardcode. v1.8 (2026-04-19) added a 12-dim `ROOT` partition at slots 228–239 to carry root pitch class outside `STRUCTURE`, closing the T-invariance gap that 91% of same-PC-set cross-instrument voicings exposed in invariant test #25. Never change dimension without coordinated re-index.
 
 ## Planning & Commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Apps live in `Apps/`: `ga-server/GaApi` (ASP.NET + SignalR + GraphQL), `GaChatbo
 
 ## OPTIC-K
 
-228-dim musical embedding (v1.7). Canonical schema: `Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs`. Never change dimension without coordinated re-index.
+240-dim musical embedding (`OPTIC-K-v1.8`). Canonical schema: `Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs` — read `TotalDimension` and `Version` constants, do not hardcode. v1.8 (2026-04-19) added a 12-dim `ROOT` partition at slots 228–239 to carry root pitch class outside `STRUCTURE`, closing the T-invariance gap that 91% of same-PC-set cross-instrument voicings exposed in invariant test #25. Never change dimension without coordinated re-index.
 
 ## Planning & Commits
 

--- a/docs/contracts/2026-05-02-qa-verdict.contract.md
+++ b/docs/contracts/2026-05-02-qa-verdict.contract.md
@@ -45,7 +45,7 @@ The contract is a **one-way door**: every consumer encodes the field names, enum
   "blast_radius": {
     "layers_touched": ["domain", "analysis", "ai_ml"],
     "one_way_doors_crossed": [],
-    "invariants_at_risk": ["optick.dim=228", "five-layer.bottom-up"],
+    "invariants_at_risk": ["optick.dim=240", "five-layer.bottom-up"],
     "components_reached": [
       "Common/GA.Business.Core/Analysis/...",
       "Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs"
@@ -161,7 +161,7 @@ A verdict's `risk_tier` is the **maximum** severity across its `followups`. A ve
 |---|---|---|
 | `layers_touched` | array<enum> | Subset of `core`, `domain`, `analysis`, `ai_ml`, `orchestration`, `apps`, `frontend`, `infra`, `docs`. |
 | `one_way_doors_crossed` | array<string> | Doors crossed *without* documented sign-off. Empty array is fine; presence forces `P0`. |
-| `invariants_at_risk` | array<string> | Stable IDs from `docs/contracts/` and CLAUDE.md. Examples: `optick.dim=228`, `five-layer.bottom-up`, `optick.weights.simplex`. |
+| `invariants_at_risk` | array<string> | Stable IDs from `docs/contracts/` and CLAUDE.md. Examples: `optick.dim=240`, `optick.schema=OPTIC-K-v1.8`, `five-layer.bottom-up`, `optick.weights.simplex`. |
 | `components_reached` | array<string> | Repo-relative paths or namespaces. |
 | `estimated_blast_score` | float [0..1] | Producer's heuristic. Score ≥ 0.7 means "wide-reach diff" — used for sampling and prioritization. Score is **advisory**, not gating. |
 


### PR DESCRIPTION
## Summary

Yesterday's PR #73 aligned the SAE Phase 0 docs with the v1.8 schema (228→240, ROOT partition added 2026-04-19). The other canonical references still said v1.7 / 228-dim, which would re-introduce the drift on the next agent that reads them.

## Updates

- **`CLAUDE.md` §OPTIC-K**: 228→240, `v1.7`→`OPTIC-K-v1.8`. Adds the ROOT partition note and "read `EmbeddingSchema.TotalDimension` and `Version` constants, do not hardcode" guidance.
- **`AGENTS.md` §OPTIC-K**: same content as CLAUDE.md (parallel canonical reference for non-Claude agents like Codex, Conductor).
- **`docs/contracts/2026-05-02-qa-verdict.contract.md`**: the example `invariants_at_risk` array used `"optick.dim=228"` as an illustrative invariant id → updated to `"optick.dim=240"` and added `"optick.schema=OPTIC-K-v1.8"` to the field-reference example list.

## Why now

The May 18 QA Architect Phase 1 agent and the May 19 OPTIC-K SAE Phase 1 agent both read CLAUDE.md and the QA verdict contract for invariant ids. With CLAUDE.md saying 228 and the (already-corrected) SAE contract saying 240, the agents would emit verdicts pointing at an invariant id that no longer exists.

## What this PR does NOT do

- ❌ Does not touch docs/architecture/audit-2026-04-25.md or other point-in-time snapshots that mention 228. Those are historical artifacts, not canonical references.
- ❌ Does not modify user memory or `.agent/skills/` — out of repo scope or maintained separately.

## Test plan

- [x] 4-line diff across 3 docs files
- [x] No code changes
- [ ] CI: standard build (no impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)