### PR TITLE
feat(chatbot): ChordMcpTools — third MCP-tool-driven SKILL.md (chord-info)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -68,5 +68,6 @@ public sealed class GaPlugin : IChatPlugin
         // §"Porting policy: catalog vs. computation skills".
         typeof(IntervalMcpTools),
         typeof(ScaleMcpTools),
+        typeof(ChordMcpTools),
     ];
 }

--- a/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
@@ -95,19 +95,33 @@ public sealed partial class ChordMcpTools
         };
     }
 
-    private static string NormalizeQuality(string raw) =>
-        raw.Trim().ToLowerInvariant() switch
+    private static string NormalizeQuality(string raw)
+    {
+        var trimmed = raw.Trim();
+        // Case-sensitive arms FIRST — uppercase "M" and "M7" mean major and
+        // major 7 respectively in chord notation, and they cannot be folded
+        // through ToLowerInvariant because "M".ToLowerInvariant() == "m"
+        // which is the minor abbreviation. Lower-case fallbacks come AFTER.
+        // Bug fix from PR #80 review: previously `CM` and `CM7` silently
+        // resolved to C minor / C minor 7 because the lowercase arms ran first.
+        return trimmed switch
         {
-            ""                              => "major",
-            "maj" or "major" or "M"         => "major",
-            "m" or "min" or "minor"         => "minor",
-            "dim" or "diminished"           => "diminished",
-            "aug" or "augmented"            => "augmented",
-            "7" or "dominant" or "dom7"     => "dominant 7",
-            "maj7" or "major 7" or "M7"     => "major 7",
-            "m7" or "min7" or "minor 7"     => "minor 7",
-            var other                       => other,
+            "M"  => "major",
+            "M7" => "major 7",
+            _    => trimmed.ToLowerInvariant() switch
+            {
+                ""                              => "major",
+                "maj" or "major"                => "major",
+                "m" or "min" or "minor"         => "minor",
+                "dim" or "diminished"           => "diminished",
+                "aug" or "augmented"            => "augmented",
+                "7" or "dominant" or "dom7"     => "dominant 7",
+                "maj7" or "major 7"             => "major 7",
+                "m7" or "min7" or "minor 7"     => "minor 7",
+                var other                       => other,
+            },
         };
+    }
 
     private static ChordFormula GetFormula(string quality) => quality switch
     {

--- a/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
@@ -1,0 +1,186 @@
+namespace GA.Business.ML.Agents.Mcp;
+
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using ModelContextProtocol.Server;
+
+/// <summary>
+/// MCP tool surface for chord-symbol → notes/intervals computation. Wraps the
+/// pitch-class arithmetic and enharmonic-respelling logic that <see cref="Skills.ChordInfoSkill"/>
+/// also uses, so an LLM-driven SKILL.md skill can call it deterministically rather
+/// than recalling the notes from training data (the failure mode there is silently
+/// flipping enharmonics — Db vs C#, Ab vs G# — depending on the source the model saw).
+/// </summary>
+/// <remarks>
+/// Discovered by <see cref="Plugins.ChatPluginHost"/> via
+/// <see cref="Plugins.IChatPlugin.McpToolTypes"/>. Third tool in the MCP-tool-
+/// exposure workstream — same template as <see cref="IntervalMcpTools"/> /
+/// <see cref="ScaleMcpTools"/>: length-guarded inputs, sanitized Error echo via
+/// <see cref="McpEchoSanitizer"/>, structured result with Error-branch invariant.
+/// </remarks>
+[McpServerToolType]
+public sealed partial class ChordMcpTools
+{
+    // Realistic chord symbols are <= 8 chars: "F#dim7", "Cmaj7#5", "Bbm7b5".
+    // Cap at 12 to admit edge cases without inviting MB-sized abuse.
+    private const int MaxChordSymbolLength = 12;
+
+    private static readonly IReadOnlyDictionary<string, int> PitchClasses =
+        new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["C"] = 0,  ["C#"] = 1, ["Db"] = 1,
+            ["D"] = 2,  ["D#"] = 3, ["Eb"] = 3,
+            ["E"] = 4,  ["F"] = 5,  ["F#"] = 6, ["Gb"] = 6,
+            ["G"] = 7,  ["G#"] = 8, ["Ab"] = 8,
+            ["A"] = 9,  ["A#"] = 10, ["Bb"] = 10,
+            ["B"] = 11, ["B#"] = 0, ["Cb"] = 11, ["E#"] = 5, ["Fb"] = 4,
+        };
+
+    private static readonly char[] NaturalLetters = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+    private static readonly IReadOnlyDictionary<char, int> NaturalPitchClasses = new Dictionary<char, int>
+    {
+        ['C'] = 0, ['D'] = 2, ['E'] = 4, ['F'] = 5, ['G'] = 7, ['A'] = 9, ['B'] = 11,
+    };
+
+    /// <summary>
+    /// Parses a chord symbol (e.g. <c>"Cmaj7"</c>, <c>"F#m"</c>, <c>"Bbdim"</c>) and
+    /// returns its constituent notes, intervals, and quality.
+    /// </summary>
+    [McpServerTool(Name = "ga_chord_info"), Description(
+        "Parse a chord symbol and return its notes, intervals, and quality. " +
+        "Examples: 'Cmaj7' returns C E G B; 'F#m' returns F# A C#; 'Bbdim' returns Bb Db Fb. " +
+        "Use this whenever a user asks for the notes / intervals / construction of a named chord. " +
+        "Supports major, minor (m/min), diminished (dim), augmented (aug), dominant 7 (just '7'), " +
+        "major 7 (maj7/M7), and minor 7 (m7/min7).")]
+    public ChordResult GetChordInfo(
+        [Description("The chord symbol — root note plus optional quality suffix. Examples: 'C', 'Cm', 'Cmaj7', 'F#dim', 'Bbm7', 'Aaug'.")]
+        string chordSymbol)
+    {
+        if (string.IsNullOrEmpty(chordSymbol) || chordSymbol.Length > MaxChordSymbolLength)
+            return ChordResult.Failure($"Could not parse '{McpEchoSanitizer.SanitizeEcho(chordSymbol)}' as a chord symbol. Try C, Cm, Cmaj7, F#dim, Bbm7, etc.");
+
+        var match = ChordSymbolRegex().Match(chordSymbol);
+        if (!match.Success)
+            return ChordResult.Failure($"Could not parse '{McpEchoSanitizer.SanitizeEcho(chordSymbol)}' as a chord symbol. Try C, Cm, Cmaj7, F#dim, Bbm7, etc.");
+
+        var root    = NormalizeRoot(match.Groups["root"].Value);
+        var quality = NormalizeQuality(match.Groups["quality"].Value);
+
+        if (!PitchClasses.TryGetValue(root, out var rootPc))
+            return ChordResult.Failure($"'{McpEchoSanitizer.SanitizeEcho(root)}' is not a recognised chord root. Try C, F#, Bb, etc.");
+
+        var formula = GetFormula(quality);
+        var notes   = formula.Intervals
+            .Zip(formula.LetterSteps, (interval, letterSteps) => Spell(root, rootPc + interval, letterSteps))
+            .ToArray();
+
+        return new ChordResult
+        {
+            Symbol    = chordSymbol.Trim(),
+            Root      = root,
+            Quality   = formula.DisplayName,
+            Notes     = notes,
+            Intervals = formula.IntervalNames.ToArray(),
+        };
+    }
+
+    private static string NormalizeRoot(string raw)
+    {
+        var trimmed = raw.Trim();
+        return trimmed.Length switch
+        {
+            0 => string.Empty,
+            1 => trimmed.ToUpperInvariant(),
+            _ => char.ToUpperInvariant(trimmed[0]) + trimmed[1..].ToLowerInvariant(),
+        };
+    }
+
+    private static string NormalizeQuality(string raw) =>
+        raw.Trim().ToLowerInvariant() switch
+        {
+            ""                              => "major",
+            "maj" or "major" or "M"         => "major",
+            "m" or "min" or "minor"         => "minor",
+            "dim" or "diminished"           => "diminished",
+            "aug" or "augmented"            => "augmented",
+            "7" or "dominant" or "dom7"     => "dominant 7",
+            "maj7" or "major 7" or "M7"     => "major 7",
+            "m7" or "min7" or "minor 7"     => "minor 7",
+            var other                       => other,
+        };
+
+    private static ChordFormula GetFormula(string quality) => quality switch
+    {
+        "minor"      => new("minor",      [0, 3, 7],     [0, 2, 4],    ["root", "minor third", "perfect fifth"]),
+        "diminished" => new("diminished", [0, 3, 6],     [0, 2, 4],    ["root", "minor third", "diminished fifth"]),
+        "augmented"  => new("augmented",  [0, 4, 8],     [0, 2, 4],    ["root", "major third", "augmented fifth"]),
+        "dominant 7" => new("dominant 7", [0, 4, 7, 10], [0, 2, 4, 6], ["root", "major third", "perfect fifth", "minor seventh"]),
+        "major 7"    => new("major 7",    [0, 4, 7, 11], [0, 2, 4, 6], ["root", "major third", "perfect fifth", "major seventh"]),
+        "minor 7"    => new("minor 7",    [0, 3, 7, 10], [0, 2, 4, 6], ["root", "minor third", "perfect fifth", "minor seventh"]),
+        _            => new("major",      [0, 4, 7],     [0, 2, 4],    ["root", "major third", "perfect fifth"]),
+    };
+
+    /// <summary>
+    /// Enharmonic-aware note spelling: given a root, target pitch class, and the
+    /// number of letter-steps from root to target, picks the right letter +
+    /// accidental so a Cmaj chord spells C-E-G (not C-E-Abb) and a Bbm chord
+    /// spells Bb-Db-F (not Bb-C#-F).
+    /// </summary>
+    private static string Spell(string root, int pitchClass, int letterSteps)
+    {
+        var rootLetter   = char.ToUpperInvariant(root[0]);
+        var rootIndex    = Array.IndexOf(NaturalLetters, rootLetter);
+        var targetLetter = NaturalLetters[(rootIndex + letterSteps) % NaturalLetters.Length];
+        var targetNatural = NaturalPitchClasses[targetLetter];
+        var normalized   = ((pitchClass % 12) + 12) % 12;
+        var accidental   = ((normalized - targetNatural) % 12 + 12) % 12;
+
+        return accidental switch
+        {
+            0  => targetLetter.ToString(),
+            1  => $"{targetLetter}#",
+            2  => $"{targetLetter}##",
+            10 => $"{targetLetter}bb",
+            11 => $"{targetLetter}b",
+            _  => $"{targetLetter}{(accidental < 6 ? new string('#', accidental) : new string('b', 12 - accidental))}",
+        };
+    }
+
+    [GeneratedRegex(@"^(?<root>[A-Ga-g][#b]?)(?<quality>maj7|min7|m7|maj|min|m|dim|aug|7|M7|M)?$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex ChordSymbolRegex();
+
+    private sealed record ChordFormula(
+        string DisplayName,
+        IReadOnlyList<int> Intervals,
+        IReadOnlyList<int> LetterSteps,
+        IReadOnlyList<string> IntervalNames);
+}
+
+/// <summary>
+/// Structured result of <see cref="ChordMcpTools.GetChordInfo"/>.
+/// </summary>
+/// <remarks>
+/// <b>Invariant:</b> when <see cref="Error"/> is non-null, all string fields
+/// are <see cref="string.Empty"/> and <see cref="Notes"/> / <see cref="Intervals"/>
+/// are empty. LLMs reading this record should branch on <see cref="Error"/> first.
+/// </remarks>
+public sealed record ChordResult
+{
+    /// <summary>The chord symbol as parsed (echoed back, trimmed).</summary>
+    public string Symbol { get; init; } = string.Empty;
+
+    public string Root    { get; init; } = string.Empty;
+    public string Quality { get; init; } = string.Empty;
+
+    /// <summary>Chord tones in ascending order, e.g. <c>["C","E","G","B"]</c> for Cmaj7.</summary>
+    public string[] Notes { get; init; } = [];
+
+    /// <summary>Interval names, e.g. <c>["root","major third","perfect fifth","major seventh"]</c>.</summary>
+    public string[] Intervals { get; init; } = [];
+
+    /// <summary>Non-null when the input could not be parsed as a chord symbol.</summary>
+    public string? Error { get; init; }
+
+    public static ChordResult Failure(string message) => new() { Error = message };
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs
@@ -138,6 +138,44 @@ public class ChordMcpToolsTests
         Assert.That(result.Notes,   Is.EqualTo(new[] { "C", "E", "G" }));
     }
 
+    // Regression suite for the PR #80 review's BLOCK finding: the case-sensitive
+    // "M" / "M7" alternates were unreachable because NormalizeQuality lowercased
+    // the input first, so `CM` silently resolved to C minor and `CM7` to C minor 7.
+    // The SKILL.md advertises CM=major / CM7=major 7 — these tests pin the
+    // documented contract so the regression cannot recur.
+    [TestCase("CM",   "C", "major",   new[] { "C", "E",  "G"        })]
+    [TestCase("CM7",  "C", "major 7", new[] { "C", "E",  "G",  "B"  })]
+    [TestCase("FM7",  "F", "major 7", new[] { "F", "A",  "C",  "E"  })]
+    [TestCase("BbM7", "Bb", "major 7", new[] { "Bb", "D", "F",  "A"  })]
+    public void GetChordInfo_UppercaseMQualifier_ResolvesToMajor(
+        string symbol, string expectedRoot, string expectedQuality, string[] expectedNotes)
+    {
+        var result = MakeTool().GetChordInfo(symbol);
+
+        Assert.That(result.Error,   Is.Null,                 $"valid input must not produce an Error for {symbol}");
+        Assert.That(result.Root,    Is.EqualTo(expectedRoot));
+        Assert.That(result.Quality, Is.EqualTo(expectedQuality),
+            $"'{symbol}' must resolve to {expectedQuality}, NOT minor (regression from PR #80 review)");
+        Assert.That(result.Notes,   Is.EqualTo(expectedNotes), $"notes mismatch for {symbol}");
+    }
+
+    [TestCase("Csus4")]
+    [TestCase("C9")]
+    [TestCase("Am7b5")]
+    [TestCase("Cadd9")]
+    [TestCase("C/E")]
+    public void GetChordInfo_OutOfScopeSymbols_ReturnError(string symbol)
+    {
+        // SKILL.md explicitly declines extended / altered / sus / slash chords.
+        // Tool must reject cleanly rather than fabricating notes — this is the
+        // failure mode the LLM is most likely to expose.
+        var result = MakeTool().GetChordInfo(symbol);
+
+        Assert.That(result.Error, Is.Not.Null,
+            $"out-of-scope chord symbol '{symbol}' must populate Error rather than return fabricated notes");
+        Assert.That(result.Notes, Is.Empty);
+    }
+
     [Test]
     public void GetChordInfo_IntervalsSurfacedAsHumanReadable()
     {

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs
@@ -1,0 +1,150 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Mcp;
+
+[TestFixture]
+public class ChordMcpToolsTests
+{
+    private static ChordMcpTools MakeTool() => new();
+
+    // Canonical triads — what an LLM is most likely to call the tool for.
+    [TestCase("C",      "C", "major",      new[] { "C", "E",  "G"  })]
+    [TestCase("Cm",     "C", "minor",      new[] { "C", "Eb", "G"  })]
+    [TestCase("Cdim",   "C", "diminished", new[] { "C", "Eb", "Gb" })]
+    [TestCase("Caug",   "C", "augmented",  new[] { "C", "E",  "G#" })]
+    [TestCase("F#",     "F#", "major",     new[] { "F#", "A#", "C#" })]
+    [TestCase("Bbm",    "Bb", "minor",     new[] { "Bb", "Db", "F"  })]
+    public void GetChordInfo_KnownTriads_ReturnsCorrectNotes(
+        string symbol, string expectedRoot, string expectedQuality, string[] expectedNotes)
+    {
+        var result = MakeTool().GetChordInfo(symbol);
+
+        Assert.That(result.Error,   Is.Null,                 $"valid input must not produce an Error for {symbol}");
+        Assert.That(result.Root,    Is.EqualTo(expectedRoot));
+        Assert.That(result.Quality, Is.EqualTo(expectedQuality));
+        Assert.That(result.Notes,   Is.EqualTo(expectedNotes), $"notes mismatch for {symbol}");
+    }
+
+    [TestCase("C7",     "C", "dominant 7", new[] { "C", "E",  "G", "Bb" })]
+    [TestCase("Cmaj7",  "C", "major 7",    new[] { "C", "E",  "G", "B"  })]
+    [TestCase("Cm7",    "C", "minor 7",    new[] { "C", "Eb", "G", "Bb" })]
+    [TestCase("Bbmaj7", "Bb", "major 7",   new[] { "Bb", "D",  "F", "A"  })]
+    [TestCase("F#m7",   "F#", "minor 7",   new[] { "F#", "A",  "C#", "E" })]
+    public void GetChordInfo_SeventhChords_ReturnsCorrectNotes(
+        string symbol, string expectedRoot, string expectedQuality, string[] expectedNotes)
+    {
+        var result = MakeTool().GetChordInfo(symbol);
+
+        Assert.That(result.Error,   Is.Null);
+        Assert.That(result.Root,    Is.EqualTo(expectedRoot));
+        Assert.That(result.Quality, Is.EqualTo(expectedQuality));
+        Assert.That(result.Notes,   Is.EqualTo(expectedNotes));
+    }
+
+    [Test]
+    public void GetChordInfo_EnharmonicSpelling_PrefersLetterStepsOverPitchClass()
+    {
+        // C minor must spell as C-Eb-G, NOT C-D#-G. The pitch classes are
+        // identical but the letter-steps math forces the right enharmonic
+        // (D# would be a doubled letter — root is C, third must be E-letter).
+        var result = MakeTool().GetChordInfo("Cm");
+
+        Assert.That(result.Notes[1], Is.EqualTo("Eb"),
+            "minor third of C must spell as Eb (E with flat), not D# — letter-steps math drives enharmonics");
+    }
+
+    [Test]
+    public void GetChordInfo_DiminishedSpelling_HandlesUnusualLetters()
+    {
+        // Bdim → B-D-F is the textbook spelling. The diminished fifth is F,
+        // not E# (same pitch class but wrong letter step).
+        var result = MakeTool().GetChordInfo("Bdim");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.Notes, Is.EqualTo(new[] { "B", "D", "F" }));
+    }
+
+    [Test]
+    public void GetChordInfo_NormalizesSymbolCasing()
+    {
+        // Lowercase root and short minor — common LLM emission patterns.
+        var result = MakeTool().GetChordInfo("cm7");
+
+        Assert.That(result.Error,   Is.Null);
+        Assert.That(result.Root,    Is.EqualTo("C"));
+        Assert.That(result.Quality, Is.EqualTo("minor 7"));
+    }
+
+    [TestCase("")]
+    [TestCase("Q")]
+    [TestCase("Qmaj7")]
+    [TestCase("Cnotaquality")]
+    [TestCase("not a chord")]
+    public void GetChordInfo_InvalidInputs_ReturnFailureResult(string symbol)
+    {
+        var result = MakeTool().GetChordInfo(symbol);
+
+        Assert.That(result.Error, Is.Not.Null,
+            $"invalid input '{symbol}' must populate Error rather than throw");
+        Assert.That(result.Notes, Is.Empty);
+    }
+
+    [Test]
+    public void GetChordInfo_DoesNotThrowOnNullArgument()
+    {
+        Assert.That(() => MakeTool().GetChordInfo(null!), Throws.Nothing);
+        var result = MakeTool().GetChordInfo(null!);
+        Assert.That(result.Error, Is.Not.Null);
+    }
+
+    [Test]
+    public void GetChordInfo_PathologicallyLongInput_ReturnsErrorWithoutScanning()
+    {
+        // Length guard short-circuits before regex, avoiding a multi-MB scan.
+        var huge = new string('C', 10_000);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = MakeTool().GetChordInfo(huge);
+        sw.Stop();
+
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(sw.ElapsedMilliseconds, Is.LessThan(10),
+            "long-input rejection must short-circuit, not scan the whole string");
+    }
+
+    [Test]
+    public void GetChordInfo_ControlCharsInError_AreSanitized()
+    {
+        var esc      = (char)0x1B;
+        var injected = "Q\n\r" + esc + "[31mFAKE";
+        var result   = MakeTool().GetChordInfo(injected);
+
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(result.Error!.IndexOf('\n'), Is.EqualTo(-1));
+        Assert.That(result.Error.IndexOf('\r'), Is.EqualTo(-1));
+        Assert.That(result.Error.IndexOf(esc),  Is.EqualTo(-1));
+        Assert.That(result.Error.All(c => !char.IsControl(c)), Is.True);
+    }
+
+    [Test]
+    public void GetChordInfo_DefaultsToMajorWhenNoQualitySuffix()
+    {
+        // Bare "C" without any quality suffix should yield C major. This is
+        // the most common shorthand and the LLM will emit it constantly.
+        var result = MakeTool().GetChordInfo("C");
+
+        Assert.That(result.Error,   Is.Null);
+        Assert.That(result.Quality, Is.EqualTo("major"));
+        Assert.That(result.Notes,   Is.EqualTo(new[] { "C", "E", "G" }));
+    }
+
+    [Test]
+    public void GetChordInfo_IntervalsSurfacedAsHumanReadable()
+    {
+        // Major chord intervals are the load-bearing label — root, major 3rd,
+        // perfect 5th — these are what the LLM phrases the answer with.
+        var result = MakeTool().GetChordInfo("C");
+
+        Assert.That(result.Intervals, Is.EqualTo(new[] { "root", "major third", "perfect fifth" }));
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -201,6 +201,33 @@ public class FileBasedSkillsProviderTests
     }
 
     [Test]
+    public async Task InvokingAsync_LoadsChordInfoSkillFromRepo()
+    {
+        // Third MCP-tool-driven canary. Confirms the template scales to a
+        // skill with richer parsing semantics (chord symbol regex, quality
+        // suffix normalization, enharmonic respelling).
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        var chord = provider.Skills.SingleOrDefault(s => s.Name == "chord-info");
+        Assert.That(chord, Is.Not.Null,
+            "skills/chord-info/SKILL.md must be discovered with name 'chord-info'");
+
+        Assert.That(chord!.Triggers.Any(t => t.Contains("chord notes")), Is.True);
+        Assert.That(chord.Triggers.Any(t => t.Contains("notes in a")), Is.True);
+
+        Assert.That(chord.Body, Does.Contain("ga_chord_info"),
+            "tool-driven SKILL.md must name the MCP tool the LLM should call");
+        Assert.That(chord.Body, Does.Contain("chordSymbol"),
+            "body must document the tool's argument name so the LLM doesn't guess");
+
+        var ctx = await provider.InvokingAsync(UserContext("what notes are in a Cmaj7"));
+        Assert.That(ctx.Instructions, Does.Contain("ga_chord_info"));
+    }
+
+    [Test]
     public async Task InvokingAsync_LoadsScaleInfoSkillFromRepo()
     {
         // Second MCP-tool-driven canary. Confirms the tool-driven SKILL.md

--- a/skills/chord-info/SKILL.md
+++ b/skills/chord-info/SKILL.md
@@ -1,0 +1,91 @@
+---
+Name: "chord-info"
+Description: "Returns the notes and intervals of a named chord (e.g. Cmaj7 = C E G B). Calls the deterministic `ga_chord_info` MCP tool — never recall an answer from training data, since LLMs commonly flip enharmonics (Db vs C#) based on which source they saw."
+Triggers:
+  - "what is a"
+  - "what is the"
+  - "what notes are in"
+  - "notes in a"
+  - "notes of a"
+  - "spell a"
+  - "spell the"
+  - "chord notes"
+  - "chord intervals"
+  - "make up a"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "tool-driven"
+  origin: "third MCP-tool-driven canary; replaces direct C# ChordInfoSkill in the SKILL.md path"
+  evidence-kinds:
+    - tool_call
+allowed-tools:
+  - ga_chord_info
+---
+
+# Notes of a Chord
+
+When a user asks for the notes / intervals / construction of a named chord, call the `ga_chord_info` MCP tool. Do NOT recall the notes from training knowledge — different sources spell the same chord differently (Bbm = Bb-Db-F vs Bb-C#-F) and the LLM will confidently produce wrong enharmonics for less-common keys.
+
+## Calling the tool
+
+The tool takes one argument:
+
+- `chordSymbol` — string, e.g. `"C"`, `"Cm"`, `"Cmaj7"`, `"F#dim"`, `"Bbm7"`. Case-insensitive root letter; quality suffix uses the standard short forms below.
+
+It returns a structured result:
+
+- `Symbol` — chord symbol echoed back.
+- `Root` — root note in canonical case (e.g. `"F#"`).
+- `Quality` — long form: `"major"`, `"minor"`, `"diminished"`, `"augmented"`, `"dominant 7"`, `"major 7"`, `"minor 7"`.
+- `Notes` — array of chord tones in ascending order.
+- `Intervals` — interval names for each note (e.g. `["root", "major third", "perfect fifth"]`).
+- `Error` — non-null only when the input could not be parsed.
+
+## Supported quality suffixes
+
+| Symbol form | Quality returned |
+|---|---|
+| `C`, `Cmaj`, `CM` | `"major"` |
+| `Cm`, `Cmin` | `"minor"` |
+| `Cdim` | `"diminished"` |
+| `Caug` | `"augmented"` |
+| `C7`, `Cdom7` | `"dominant 7"` |
+| `Cmaj7`, `CM7` | `"major 7"` |
+| `Cm7`, `Cmin7` | `"minor 7"` |
+
+## Mapping user phrasings to arguments
+
+- *"What is a C major chord?"* → `chordSymbol="C"` (or `"Cmaj"`).
+- *"What notes are in Dm7?"* → `chordSymbol="Dm7"`.
+- *"Spell a B7 chord"* → `chordSymbol="B7"`.
+- *"Notes in an F minor chord"* → `chordSymbol="Fm"`.
+- *"What's in a Cmaj7?"* → `chordSymbol="Cmaj7"`.
+
+## Phrasing the answer
+
+Use the `Notes` array verbatim, joined with `–` (en-dash) or commas. Mention the `Quality` and the `Intervals` for educational color. Example:
+
+> A **Cmaj7** chord contains **C – E – G – B** (root, major third, perfect fifth, major seventh).
+
+If `Error` is non-null, surface the message verbatim and ask the user to clarify.
+
+## When to ask for clarification
+
+- User names a key rather than a chord (e.g. *"what notes are in C major key"* — vs *"C major chord"*) → that's a scale-info question; defer to the scale-info skill, do NOT call `ga_chord_info`.
+- User asks for a chord quality this tool doesn't support (sus2, sus4, 9th, 11th, 13th, slash chords, altered dominants like 7b5 or 7#9) — the tool will return an Error. Decline cleanly: *"I can spell major / minor / diminished / augmented triads and major/minor/dominant sevenths. For altered or extended chords I'd need different tooling."*
+
+## Out of scope
+
+- **Extended chords** (9, 11, 13) — not yet supported.
+- **Altered / suspended / add chords** (sus2, sus4, add9, 7b5, 7#9, m7b5, etc.) — not supported.
+- **Slash chords** (C/E, Am/G) — not supported; pass just the upper chord and explain the bass note in prose.
+- **Chord identification from a note set** (*"what chord is C E G?"*) — not yet exposed; that would be a separate `ga_chord_identify(notes)` tool.
+
+## Cross-reference
+
+- MCP tool: `Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs`
+- Tool tests: `Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs`
+- Legacy C# skill it replaces: `Common/GA.Business.ML/Agents/Skills/ChordInfoSkill.cs` (regex-driven, no LLM round-trip — kept for the deterministic fast path)


### PR DESCRIPTION
## Summary

Third MCP-tool-driven canary, applying the now-mature template (PRs #76, #78, #79) to the most complex computation skill in the queue: `ChordInfoSkill` → `ga_chord_info`. Chord symbols have richer parsing than note pairs or scale roots, and enharmonic spelling matters (Cm = C-Eb-G, NOT C-D#-G), so this is the real "does the template scale" test.

## What changed

| File | Role |
|---|---|
| `Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs` | new `[McpServerToolType]`; `GetChordInfo(chordSymbol) → ChordResult` |
| `Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs` | registered `typeof(ChordMcpTools)` |
| `skills/chord-info/SKILL.md` | thin tool-driven skill with quality-suffix table, call-mapping, explicit clarification cases for unsupported qualities |
| `Tests/.../ChordMcpToolsTests.cs` | 24 cases (6 triads + 5 sevenths + enharmonic + diminished + casing + 5 invalid + length guard + control-char sanitization + default-major + intervals shape) |
| `Tests/.../FileBasedSkillsProviderTests.cs` | new canary `InvokingAsync_LoadsChordInfoSkillFromRepo` |

## Tool semantics

- **Input**: `chordSymbol` (string, case-insensitive root + optional quality suffix; max 12 chars)
- **Supported qualities**: major / minor / diminished / augmented / dominant 7 / major 7 / minor 7
- **Output**: `ChordResult` with `Symbol`, `Root`, `Quality`, `Notes[]`, `Intervals[]`, `Error` branch
- **Failure mode**: invalid input → `Error`-populated result, never throws

## Notable correctness moments tested

- **Enharmonic spelling**: `Cm` returns `[C, Eb, G]`, NOT `[C, D#, G]` — the letter-steps math forces the right enharmonic. This is exactly the failure mode where the LLM-from-training-data path was unreliable.
- **Diminished spelling**: `Bdim` returns `[B, D, F]` — the diminished fifth must spell as F (letter step from B is F-letter), not E# despite same pitch class.
- **Default quality**: bare `"C"` → major chord with `[C, E, G]`, since LLMs constantly emit unadorned chord symbols.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~Mcp|FullyQualifiedName~SkillMd|FullyQualifiedName~FileBasedSkill"` — 118/118 pass (was 94 before this PR; +24 chord tests)
- [x] `dotnet build AllProjects.slnx -c Debug` clean
- [ ] Live smoke deferred (Ollama still wedged)

## Reversibility

**Two-way door.** Removing `typeof(ChordMcpTools)` from `GaPlugin.McpToolTypes` undoes the wiring; `ChordInfoSkill` (C#) is untouched and remains the deterministic fast path.

## Workstream progress

- Computation skills migrated via MCP tool: **3 of 8** (✅ interval, ✅ scale, ✅ chord-info; remaining: Modes, FretSpan, KeyIdentification, ProgressionCompletion, ChordSubstitution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)