### PR TITLE
feat(chatbot): port ModesSkill as catalog SKILL.md (re-classified)

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -201,6 +201,50 @@ public class FileBasedSkillsProviderTests
     }
 
     [Test]
+    public async Task InvokingAsync_LoadsModesSkillFromRepo()
+    {
+        // Third catalog SKILL.md (after beginner-chords and progression-mood).
+        // Confirms the catalog-style template works for the modes data — the
+        // 7-row mode table is load-bearing and a missing row would silently
+        // teach wrong theory.
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        var modes = provider.Skills.SingleOrDefault(s => s.Name == "modes");
+        Assert.That(modes, Is.Not.Null,
+            "skills/modes/SKILL.md must be discovered with name 'modes'");
+
+        // All seven mode names must appear in the body — a dropped row is
+        // the worst-case content drift.
+        var expectedModes = new[] { "Ionian", "Dorian", "Phrygian", "Lydian", "Mixolydian", "Aeolian", "Locrian" };
+        foreach (var modeName in expectedModes)
+        {
+            Assert.That(modes!.Body, Does.Contain(modeName),
+                $"modes SKILL.md body must include '{modeName}' row");
+        }
+
+        // Each mode's signature degree formula must be present (a missing 'b3'
+        // or '#4' would silently teach wrong theory).
+        Assert.That(modes!.Body, Does.Contain("1 2 3 4 5 6 7"),    "Ionian degrees");
+        Assert.That(modes.Body,  Does.Contain("1 2 b3 4 5 6 b7"),  "Dorian degrees");
+        Assert.That(modes.Body,  Does.Contain("1 b2 b3 4 5 b6 b7"), "Phrygian degrees");
+        Assert.That(modes.Body,  Does.Contain("1 2 3 #4 5 6 7"),   "Lydian degrees");
+        Assert.That(modes.Body,  Does.Contain("1 2 3 4 5 6 b7"),   "Mixolydian degrees");
+        Assert.That(modes.Body,  Does.Contain("1 b2 b3 4 b5 b6 b7"), "Locrian degrees");
+
+        // Trigger fires on common phrasings.
+        var ctx1 = await provider.InvokingAsync(UserContext("what are the modes of the major scale"));
+        Assert.That(ctx1.Instructions, Does.Contain("Lydian"),
+            "trigger 'modes of' / 'major scale modes' should inject the catalog body");
+
+        var ctx2 = await provider.InvokingAsync(UserContext("explain dorian"));
+        Assert.That(ctx2.Instructions, Does.Contain("Dorian"),
+            "single-mode trigger ('dorian') should also fire and surface the catalog");
+    }
+
+    [Test]
     public async Task InvokingAsync_LoadsChordInfoSkillFromRepo()
     {
         // Third MCP-tool-driven canary. Confirms the template scales to a

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -232,7 +232,13 @@ public class FileBasedSkillsProviderTests
         Assert.That(modes.Body,  Does.Contain("1 b2 b3 4 5 b6 b7"), "Phrygian degrees");
         Assert.That(modes.Body,  Does.Contain("1 2 3 #4 5 6 7"),   "Lydian degrees");
         Assert.That(modes.Body,  Does.Contain("1 2 3 4 5 6 b7"),   "Mixolydian degrees");
+        Assert.That(modes.Body,  Does.Contain("1 2 b3 4 5 b6 b7"), "Aeolian degrees");
         Assert.That(modes.Body,  Does.Contain("1 b2 b3 4 b5 b6 b7"), "Locrian degrees");
+
+        // The mnemonic is what makes the catalog memorable; if it gets dropped,
+        // the LLM loses the most useful single-line pedagogy in the skill.
+        Assert.That(modes.Body, Does.Contain("I Don't Particularly Like Modes A Lot"),
+            "the I-Don't-Particularly-Like-Modes-A-Lot mnemonic must survive into the catalog body");
 
         // Trigger fires on common phrasings.
         var ctx1 = await provider.InvokingAsync(UserContext("what are the modes of the major scale"));

--- a/skills/modes/SKILL.md
+++ b/skills/modes/SKILL.md
@@ -1,0 +1,68 @@
+---
+Name: "modes"
+Description: "Lists the seven modes of the major scale (Ionian, Dorian, Phrygian, Lydian, Mixolydian, Aeolian, Locrian) with their scale-degree formulas and characteristic sound. Pure catalog — same fixed pedagogy whether the user asks for the whole list or a single mode."
+Triggers:
+  - "modes of"
+  - "diatonic modes"
+  - "major scale modes"
+  - "seven modes"
+  - "what are the modes"
+  - "list the modes"
+  - "ionian"
+  - "dorian"
+  - "phrygian"
+  - "lydian"
+  - "mixolydian"
+  - "aeolian"
+  - "locrian"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "deterministic-catalog"
+  origin: "ported from Common/GA.Business.ML/Agents/Skills/ModesSkill.cs — third pure-catalog SKILL.md, joins beginner-chords and progression-mood"
+  evidence-kinds:
+    - catalog_lookup
+---
+
+# The Seven Modes of the Major Scale
+
+Reproduce the catalog below verbatim when the user asks for *the modes* / *the diatonic modes* / *the modes of the major scale*. When the user asks about a single mode (e.g. *"what is Lydian?"*, *"explain Phrygian"*), pull just that row from the table and lead with it before optionally offering the full list.
+
+## Setup
+
+The major scale has 7 modes. Each starts on a successive degree of the parent scale, rotating the same step pattern:
+
+> **Ionian formula: `W-W-H-W-W-W-H`** *(W = whole step, H = half step)*
+
+## The catalog
+
+| # | Mode | Degrees | Character |
+|---|---|---|---|
+| 1 | **Ionian** | `1 2 3 4 5 6 7` | Bright, the major scale itself |
+| 2 | **Dorian** | `1 2 b3 4 5 6 b7` | Minor with raised 6th — jazz/folk staple |
+| 3 | **Phrygian** | `1 b2 b3 4 5 b6 b7` | Dark minor with flat 2 — Spanish/flamenco |
+| 4 | **Lydian** | `1 2 3 #4 5 6 7` | Major with raised 4th — floating, dreamy |
+| 5 | **Mixolydian** | `1 2 3 4 5 6 b7` | Major with flat 7 — bluesy/rock |
+| 6 | **Aeolian** | `1 2 b3 4 5 b6 b7` | Natural minor |
+| 7 | **Locrian** | `1 b2 b3 4 b5 b6 b7` | Half-diminished — rare as a tonic |
+
+## Mnemonic
+
+*"I Don't Particularly Like Modes A Lot"* — Ionian, Dorian, Phrygian, Lydian, Mixolydian, Aeolian, Locrian.
+
+## Single-mode answer pattern
+
+When the user asks about one mode specifically, lead with: *"**\<Mode>** is mode \<n> of the major scale: degrees `\<formula>` — \<character note>."* Then optionally offer to compare with neighbouring modes (e.g. Dorian vs Aeolian for "minor flavour").
+
+## What this skill does NOT do
+
+- **Compute the notes of a specific key's mode** (e.g. *"give me the notes of D Dorian"*). That's a different operation — it needs to combine this catalog (Dorian's degree formula) with a root-and-scale lookup. Defer to the `scale-info` skill or the LLM agent path with this catalog as background context.
+- **Discuss non-diatonic modes** (harmonic minor modes, melodic minor modes, modes of limited transposition). This catalog covers only the seven modes of the major (a.k.a. diatonic) scale.
+- **Recommend mode for a specific musical situation** ("what mode should I use for X feel?"). The character notes here help, but composition advice belongs in the LLM agent path, not the catalog.
+
+## Cross-reference
+
+- C# implementation: `Common/GA.Business.ML/Agents/Skills/ModesSkill.cs` (regex-driven, kept as deterministic fast path)
+- Tests: `Tests/Common/GA.Business.ML.Tests/Unit/ModesSkillTests.cs`

--- a/skills/modes/SKILL.md
+++ b/skills/modes/SKILL.md
@@ -58,9 +58,11 @@ When the user asks about one mode specifically, lead with: *"**\<Mode>** is mode
 
 ## What this skill does NOT do
 
-- **Compute the notes of a specific key's mode** (e.g. *"give me the notes of D Dorian"*). That's a different operation — it needs to combine this catalog (Dorian's degree formula) with a root-and-scale lookup. Defer to the `scale-info` skill or the LLM agent path with this catalog as background context.
-- **Discuss non-diatonic modes** (harmonic minor modes, melodic minor modes, modes of limited transposition). This catalog covers only the seven modes of the major (a.k.a. diatonic) scale.
-- **Recommend mode for a specific musical situation** ("what mode should I use for X feel?"). The character notes here help, but composition advice belongs in the LLM agent path, not the catalog.
+These are hard constraints. **Do NOT** answer queries in these categories from this catalog alone.
+
+- **Specific-key note enumeration** (e.g. *"give me the notes of D Dorian"*). This catalog gives Dorian's degree formula but not the resulting notes for any particular root. Defer to the `scale-info` skill or the broader LLM agent path. Do NOT output specific-key note lists from this catalog alone.
+- **Non-diatonic modes** (harmonic minor modes, melodic minor modes, modes of limited transposition). This catalog covers only the seven modes of the major (a.k.a. diatonic) scale. If asked, decline cleanly: *"This catalog only covers the diatonic modes; harmonic-minor modes and others would need different tooling."*
+- **Composition recommendation** (*"what mode should I use for an angry feel?"*). The character notes here help an LLM phrase a recommendation, but the catalog itself does not prescribe — emit the catalog data, then let the broader agent path reason about fit.
 
 ## Cross-reference
 


### PR DESCRIPTION
## Summary

Re-classification + port of `ModesSkill`. Looking at the source closely, `_modeRows` is hardcoded pedagogy and the `MajorScaleMode.Items` domain check is purely defensive (count validation, not used for the answer). Same shape as `beginner-chords` and `progression-mood`: pure data, fixed pedagogy.

So this PR ports it via the **catalog** path (no MCP tool needed) rather than the MCP-tool-exposure workstream — keeps that workstream focused on actually computation-bound skills.

## What changed

| File | Role |
|---|---|
| `skills/modes/SKILL.md` | new catalog skill — 13 triggers (incl. each mode name like `"lydian"`, `"dorian"` for single-mode queries). Body reproduces the 7-mode table verbatim from the C# implementation, mnemonic, single-mode answer pattern, and explicit out-of-scope declines |
| `Tests/.../FileBasedSkillsProviderTests.cs` | new `InvokingAsync_LoadsModesSkillFromRepo` — asserts all 7 mode names + every signature degree formula present in body, trigger fires on both whole-list and single-mode phrasings |

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~FileBasedSkillsProvider"` — 16/16 pass
- [x] `dotnet build AllProjects.slnx -c Debug` clean
- [x] Body asserts every signature degree formula (`1 2 b3 4 5 6 b7` for Dorian, `1 b2 b3 4 b5 b6 b7` for Locrian, etc.) — a missing row or a typo'd flat would silently teach wrong theory; the test catches it.

## Reversibility

Two-way door — additive markdown + one test. C# `ModesSkill` stays in place as the deterministic fast path.

## Migration state

| Bucket | Count | Skills |
|---|---|---|
| Catalog SKILL.md | **3** | ✅ beginner-chords, ✅ progression-mood, ✅ modes |
| MCP-tool-driven SKILL.md | 3 | ✅ interval, ✅ scale, ✅ chord-info |
| Remaining computation skills | 4 | FretSpan, KeyIdentification, ProgressionCompletion, ChordSubstitution |

🤖 Generated with [Claude Code](https://claude.com/claude-code)