### PR TITLE
feat(chatbot): FretSpanMcpTools — fourth MCP-tool-driven SKILL.md

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -69,5 +69,6 @@ public sealed class GaPlugin : IChatPlugin
         typeof(IntervalMcpTools),
         typeof(ScaleMcpTools),
         typeof(ChordMcpTools),
+        typeof(FretSpanMcpTools),
     ];
 }

--- a/Common/GA.Business.ML/Agents/Mcp/FretSpanMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/FretSpanMcpTools.cs
@@ -1,0 +1,152 @@
+namespace GA.Business.ML.Agents.Mcp;
+
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using ModelContextProtocol.Server;
+
+/// <summary>
+/// MCP tool surface for guitar chord-diagram playability analysis. Wraps the
+/// pure arithmetic in <see cref="Skills.FretSpanSkill"/> so an LLM-driven
+/// SKILL.md skill can compute fret span deterministically rather than
+/// recalling diagrams from training data (which it cannot reliably do for
+/// uncommon voicings).
+/// </summary>
+/// <remarks>
+/// Discovered by <see cref="Plugins.ChatPluginHost"/> via
+/// <see cref="Plugins.IChatPlugin.McpToolTypes"/>. Fourth tool in the MCP-
+/// tool-exposure workstream — same template as <see cref="IntervalMcpTools"/>,
+/// <see cref="ScaleMcpTools"/>, <see cref="ChordMcpTools"/>: length-guarded
+/// inputs, sanitized Error echo via <see cref="McpEchoSanitizer"/>, structured
+/// result with Error-branch invariant.
+/// </remarks>
+[McpServerToolType]
+public sealed partial class FretSpanMcpTools
+{
+    // Realistic chord diagrams: 6 tokens of 1-2 chars each + 5 separators =
+    // up to 17 chars. Compact form ("x02230") is 6 chars. Cap at 20 to admit
+    // both styles without inviting MB-sized abuse.
+    private const int MaxDiagramLength = 20;
+
+    /// <summary>
+    /// Parses a 6-string guitar chord diagram and returns its fret span,
+    /// difficulty description, and playability score.
+    /// </summary>
+    [McpServerTool(Name = "ga_fret_span"), Description(
+        "Compute fret span and playability for a 6-string guitar chord diagram. " +
+        "Accepts either dash-separated (e.g. 'x-3-2-0-1-0') or compact form starting with x (e.g. 'x32010'). " +
+        "Tokens are listed low-to-high (E A D G B e); 'x' = muted, '0' = open, otherwise the fret number. " +
+        "Use this whenever a user asks about a chord's stretch / reach / playability / difficulty.")]
+    public FretSpanResult ComputeSpan(
+        [Description("The chord diagram. Examples: 'x-3-2-0-1-0' (C major), 'x32010', '0-2-2-1-0-0' (E major). Six positions, low-to-high.")]
+        string diagram)
+    {
+        if (string.IsNullOrEmpty(diagram) || diagram.Length > MaxDiagramLength)
+            return FretSpanResult.Failure($"Could not parse '{McpEchoSanitizer.SanitizeEcho(diagram)}' as a chord diagram. Try 'x-3-2-0-1-0' or 'x32010'.");
+
+        var frets = TryParseFrets(diagram);
+        if (frets is null)
+            return FretSpanResult.Failure($"Could not parse '{McpEchoSanitizer.SanitizeEcho(diagram)}' as a chord diagram. Use 6 positions low-to-high (E A D G B e); 'x' = mute, '0' = open.");
+
+        var pressed = frets.Where(f => f > 0).ToList();
+        if (pressed.Count == 0)
+            return FretSpanResult.Failure("All strings are open or muted — no fret span to compute.");
+
+        var minFret = pressed.Min();
+        var maxFret = pressed.Max();
+        var span    = maxFret - minFret;
+
+        var difficulty = span switch
+        {
+            0 or 1 => "very easy — all fretted notes sit in adjacent positions",
+            2      => "easy — comfortable stretch for most players",
+            3      => "moderate — a normal left-hand extension",
+            4      => "challenging — requires a significant stretch; warm up first",
+            _      => $"very wide — span of {span} frets may be difficult for smaller hands",
+        };
+
+        var normalized = string.Join("-", frets.Select(f => f < 0 ? "x" : f.ToString()));
+        var playabilityScore = int.Clamp(1 + span * 2, 1, 10);
+
+        return new FretSpanResult
+        {
+            Diagram          = normalized,
+            Frets            = frets.ToArray(),
+            MinFret          = minFret,
+            MaxFret          = maxFret,
+            Span             = span,
+            Difficulty       = difficulty,
+            PlayabilityScore = playabilityScore,
+        };
+    }
+
+    /// <summary>
+    /// Returns 6 fret values (-1 = muted, 0 = open, &gt;0 = fret number) or
+    /// null if the input doesn't match a known diagram form. Lifted from
+    /// <c>FretSpanSkill.TryParseFrets</c>.
+    /// </summary>
+    private static List<int>? TryParseFrets(string message)
+    {
+        var dash = DashDiagramRegex().Match(message);
+        if (dash.Success)
+        {
+            return Enumerable.Range(1, 6)
+                .Select(i => ParseFretToken(dash.Groups[i].Value))
+                .ToList();
+        }
+
+        var compact = CompactDiagramRegex().Match(message);
+        if (!compact.Success) return null;
+
+        var val = compact.Value;
+        return val.Select(c => c is 'x' or 'X' ? -1 : c - '0').ToList();
+    }
+
+    private static int ParseFretToken(string s) =>
+        s.Equals("x", StringComparison.OrdinalIgnoreCase) ? -1 : int.Parse(s);
+
+    [GeneratedRegex(
+        @"\b([xX]|\d{1,2})-([xX]|\d{1,2})-([xX]|\d{1,2})-([xX]|\d{1,2})-([xX]|\d{1,2})-([xX]|\d{1,2})\b",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex DashDiagramRegex();
+
+    [GeneratedRegex(@"\b[xX]\d{5}\b", RegexOptions.CultureInvariant)]
+    private static partial Regex CompactDiagramRegex();
+}
+
+/// <summary>
+/// Structured result of <see cref="FretSpanMcpTools.ComputeSpan"/>.
+/// </summary>
+/// <remarks>
+/// <b>Invariant:</b> when <see cref="Error"/> is non-null, all string fields
+/// are <see cref="string.Empty"/>, <see cref="Frets"/> is empty, and the
+/// numeric fields are <c>0</c>. LLMs reading this record should branch on
+/// <see cref="Error"/> first.
+/// </remarks>
+public sealed record FretSpanResult
+{
+    /// <summary>Diagram normalized to dash-separated form, e.g. <c>"x-3-2-0-1-0"</c>.</summary>
+    public string Diagram { get; init; } = string.Empty;
+
+    /// <summary>Six fret values low-to-high. <c>-1</c> = muted, <c>0</c> = open, otherwise the fret number.</summary>
+    public int[] Frets { get; init; } = [];
+
+    /// <summary>Lowest fretted (non-zero, non-muted) position.</summary>
+    public int MinFret { get; init; }
+
+    /// <summary>Highest fretted position.</summary>
+    public int MaxFret { get; init; }
+
+    /// <summary>Difference between MaxFret and MinFret — the actual hand stretch required.</summary>
+    public int Span { get; init; }
+
+    /// <summary>Human-readable difficulty description.</summary>
+    public string Difficulty { get; init; } = string.Empty;
+
+    /// <summary>Coarse playability score 1 (easy) → 10 (very hard).</summary>
+    public int PlayabilityScore { get; init; }
+
+    /// <summary>Non-null when the input could not be parsed as a chord diagram.</summary>
+    public string? Error { get; init; }
+
+    public static FretSpanResult Failure(string message) => new() { Error = message };
+}

--- a/Common/GA.Business.ML/Agents/Mcp/FretSpanMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/FretSpanMcpTools.cs
@@ -109,7 +109,13 @@ public sealed partial class FretSpanMcpTools
         RegexOptions.CultureInvariant)]
     private static partial Regex DashDiagramRegex();
 
-    [GeneratedRegex(@"\b[xX]\d{5}\b", RegexOptions.CultureInvariant)]
+    // Compact form is 6 characters, each being a fret digit (0-9), 'x', or 'X'.
+    // The C# FretSpanSkill regex required a leading 'x' which silently rejected
+    // very common voicings: 032010 (G major), 355463 (Ab barre), 577655 (B
+    // major barre), 133211 (F major barre). Fixed here per PR #83 review.
+    // Two-digit frets (e.g. position 12) are not expressible in compact form —
+    // those must use the dash-separated diagram instead.
+    [GeneratedRegex(@"\b[xX0-9]{6}\b", RegexOptions.CultureInvariant)]
     private static partial Regex CompactDiagramRegex();
 }
 

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -201,6 +201,33 @@ public class FileBasedSkillsProviderTests
     }
 
     [Test]
+    public async Task InvokingAsync_LoadsFretSpanSkillFromRepo()
+    {
+        // Fourth MCP-tool-driven canary. Confirms the template covers chord-
+        // diagram-shaped inputs (different from interval/scale/chord which
+        // take note-name strings).
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        var fretSpan = provider.Skills.SingleOrDefault(s => s.Name == "fret-span");
+        Assert.That(fretSpan, Is.Not.Null,
+            "skills/fret-span/SKILL.md must be discovered with name 'fret-span'");
+
+        Assert.That(fretSpan!.Triggers.Any(t => t.Contains("fret span")), Is.True);
+        Assert.That(fretSpan.Triggers.Any(t => t.Contains("playability")), Is.True);
+
+        Assert.That(fretSpan.Body, Does.Contain("ga_fret_span"),
+            "tool-driven SKILL.md must name the MCP tool the LLM should call");
+        Assert.That(fretSpan.Body, Does.Contain("diagram"),
+            "body must document the tool's argument name");
+
+        var ctx = await provider.InvokingAsync(UserContext("what's the fret span on x-3-2-0-1-0"));
+        Assert.That(ctx.Instructions, Does.Contain("ga_fret_span"));
+    }
+
+    [Test]
     public async Task InvokingAsync_LoadsModesSkillFromRepo()
     {
         // Third catalog SKILL.md (after beginner-chords and progression-mood).

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FretSpanMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FretSpanMcpToolsTests.cs
@@ -1,0 +1,147 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Mcp;
+
+[TestFixture]
+public class FretSpanMcpToolsTests
+{
+    private static FretSpanMcpTools MakeTool() => new();
+
+    // The eight first-position open chords every beginner learns. The skill
+    // computes Min/Max/Span over PRESSED frets only (excludes open strings = 0
+    // and muted = -1), which is what matters for hand stretch.
+    [TestCase("x-3-2-0-1-0", 1, 3, 2, 5, "easy")]       // C major: pressed [3,2,1]
+    [TestCase("3-2-0-0-0-3", 2, 3, 1, 3, "very easy")]  // G major: pressed [3,2,3]
+    [TestCase("x-x-0-2-3-2", 2, 3, 1, 3, "very easy")]  // D major: pressed [2,3,2]
+    [TestCase("x-0-2-2-2-0", 2, 2, 0, 1, "very easy")]  // A major: pressed [2,2,2]
+    [TestCase("0-2-2-1-0-0", 1, 2, 1, 3, "very easy")]  // E major: pressed [2,2,1]
+    [TestCase("x-0-2-2-1-0", 1, 2, 1, 3, "very easy")]  // A minor: pressed [2,2,1]
+    [TestCase("0-2-2-0-0-0", 2, 2, 0, 1, "very easy")]  // E minor: pressed [2,2]
+    [TestCase("x-x-0-2-3-1", 1, 3, 2, 5, "easy")]       // D minor: pressed [2,3,1]
+    public void ComputeSpan_OpenChords_ReturnCorrectShape(
+        string diagram, int expectedMin, int expectedMax, int expectedSpan,
+        int expectedScore, string expectedDifficultyKeyword)
+    {
+        var result = MakeTool().ComputeSpan(diagram);
+
+        Assert.That(result.Error,            Is.Null,                  $"valid diagram must not produce an Error for {diagram}");
+        Assert.That(result.MinFret,          Is.EqualTo(expectedMin),  $"MinFret mismatch for {diagram}");
+        Assert.That(result.MaxFret,          Is.EqualTo(expectedMax),  $"MaxFret mismatch for {diagram}");
+        Assert.That(result.Span,             Is.EqualTo(expectedSpan), $"Span mismatch for {diagram}");
+        Assert.That(result.PlayabilityScore, Is.EqualTo(expectedScore));
+        Assert.That(result.Difficulty,       Does.Contain(expectedDifficultyKeyword));
+    }
+
+    [Test]
+    public void ComputeSpan_AcceptsCompactForm()
+    {
+        // x32010 is the compact form of x-3-2-0-1-0 (C major).
+        var compact = MakeTool().ComputeSpan("x32010");
+        var dashed  = MakeTool().ComputeSpan("x-3-2-0-1-0");
+
+        Assert.That(compact.Error, Is.Null);
+        Assert.That(compact.Diagram,          Is.EqualTo(dashed.Diagram),
+            "compact form must normalize to dashed form for echo consistency");
+        Assert.That(compact.Frets,            Is.EqualTo(dashed.Frets));
+        Assert.That(compact.Span,             Is.EqualTo(dashed.Span));
+        Assert.That(compact.PlayabilityScore, Is.EqualTo(dashed.PlayabilityScore));
+    }
+
+    [Test]
+    public void ComputeSpan_FourFretStretch_FlagsAsChallenging()
+    {
+        // 4-fret stretch — barre chords with a 5-fret range live here. The
+        // skill's difficulty switch maps span=4 to "challenging".
+        // x-3-2-x-3-7: pressed [3,2,3,7] → span 5 (very wide).
+        // x-3-2-x-3-6: pressed [3,2,3,6] → span 4 (challenging).
+        var result = MakeTool().ComputeSpan("x-3-2-x-3-6");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.Span, Is.EqualTo(4));
+        Assert.That(result.Difficulty, Does.Contain("challenging"));
+        Assert.That(result.PlayabilityScore, Is.GreaterThanOrEqualTo(7));
+    }
+
+    [Test]
+    public void ComputeSpan_VeryWideStretch_DescribedAsWide()
+    {
+        // 5+ fret span goes into the catch-all "very wide" branch.
+        // x-3-x-2-3-9: pressed [3,2,3,9] → span 7.
+        var result = MakeTool().ComputeSpan("x-3-x-2-3-9");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.Span, Is.EqualTo(7));
+        Assert.That(result.Difficulty, Does.Contain("wide"),
+            "spans of 5+ frets fall into the 'very wide' difficulty branch");
+    }
+
+    [Test]
+    public void ComputeSpan_MutedAndOpenOnly_ReturnsError()
+    {
+        // Diagram has no fretted notes — span is undefined.
+        var result = MakeTool().ComputeSpan("x-0-0-0-0-x");
+
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(result.Error, Does.Contain("open").Or.Contain("muted"));
+    }
+
+    [TestCase("")]
+    [TestCase("not a diagram")]
+    [TestCase("x-3-2-0-1")]      // 5 positions instead of 6
+    [TestCase("x-y-2-0-1-0")]    // invalid token 'y'
+    public void ComputeSpan_InvalidInputs_ReturnFailureResult(string diagram)
+    {
+        var result = MakeTool().ComputeSpan(diagram);
+
+        Assert.That(result.Error, Is.Not.Null,
+            $"invalid input '{diagram}' must populate Error rather than throw");
+        Assert.That(result.Frets, Is.Empty);
+    }
+
+    [Test]
+    public void ComputeSpan_DoesNotThrowOnNullArgument()
+    {
+        Assert.That(() => MakeTool().ComputeSpan(null!), Throws.Nothing);
+        var result = MakeTool().ComputeSpan(null!);
+        Assert.That(result.Error, Is.Not.Null);
+    }
+
+    [Test]
+    public void ComputeSpan_PathologicallyLongInput_ReturnsErrorWithoutScanning()
+    {
+        var huge = new string('3', 10_000);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = MakeTool().ComputeSpan(huge);
+        sw.Stop();
+
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(sw.ElapsedMilliseconds, Is.LessThan(10),
+            "long-input rejection must short-circuit, not scan the whole string");
+    }
+
+    [Test]
+    public void ComputeSpan_ControlCharsInError_AreSanitized()
+    {
+        var esc      = (char)0x1B;
+        var injected = "Q\n\r" + esc + "[31m";
+        var result   = MakeTool().ComputeSpan(injected);
+
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(result.Error!.IndexOf('\n'), Is.EqualTo(-1));
+        Assert.That(result.Error.IndexOf('\r'), Is.EqualTo(-1));
+        Assert.That(result.Error.IndexOf(esc),  Is.EqualTo(-1));
+        Assert.That(result.Error.All(c => !char.IsControl(c)), Is.True);
+    }
+
+    [Test]
+    public void ComputeSpan_NormalizesDiagram_WithMutedTokensAsLowercaseX()
+    {
+        // The skill emits the canonical 'x' (lowercase) regardless of input case.
+        var result = MakeTool().ComputeSpan("X-3-2-0-1-0");
+
+        Assert.That(result.Error,   Is.Null);
+        Assert.That(result.Diagram, Does.StartWith("x-"),
+            "mute tokens normalize to lowercase 'x' in the echoed diagram");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FretSpanMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FretSpanMcpToolsTests.cs
@@ -47,6 +47,39 @@ public class FretSpanMcpToolsTests
         Assert.That(compact.PlayabilityScore, Is.EqualTo(dashed.PlayabilityScore));
     }
 
+    [TestCase("032010", new[] { 0, 3, 2, 0, 1, 0 })]   // G major (no leading x — was a regex hole)
+    [TestCase("133211", new[] { 1, 3, 3, 2, 1, 1 })]   // F major barre
+    [TestCase("577655", new[] { 5, 7, 7, 6, 5, 5 })]   // B major barre
+    public void ComputeSpan_CompactWithoutLeadingX_NowParses(string diagram, int[] expectedFrets)
+    {
+        // Regression for PR #83 review: the original C# regex required a
+        // leading 'x' for compact form, silently rejecting common voicings.
+        // The fixed regex accepts any combination of digits and x's in any
+        // of the 6 positions.
+        var result = MakeTool().ComputeSpan(diagram);
+
+        Assert.That(result.Error, Is.Null,
+            $"compact diagram '{diagram}' must parse — was a regression in the original C# regex");
+        Assert.That(result.Frets, Is.EqualTo(expectedFrets));
+    }
+
+    [TestCase("1-3-3-2-1-1", 1, 3, 2, 5, "easy")]      // F major barre
+    [TestCase("x-2-4-4-3-2", 2, 4, 2, 5, "easy")]      // Bm barre (compact xx4432-style)
+    [TestCase("x-x-0-2-3-0", 2, 3, 1, 3, "very easy")] // Dadd9 (open) — pressed-only span semantics
+    public void ComputeSpan_CommonBarreAndOpenVoicings_ReturnExpectedShape(
+        string diagram, int expectedMin, int expectedMax, int expectedSpan,
+        int expectedScore, string expectedDifficultyKeyword)
+    {
+        var result = MakeTool().ComputeSpan(diagram);
+
+        Assert.That(result.Error,            Is.Null,                  $"valid diagram must not produce an Error for {diagram}");
+        Assert.That(result.MinFret,          Is.EqualTo(expectedMin));
+        Assert.That(result.MaxFret,          Is.EqualTo(expectedMax));
+        Assert.That(result.Span,             Is.EqualTo(expectedSpan));
+        Assert.That(result.PlayabilityScore, Is.EqualTo(expectedScore));
+        Assert.That(result.Difficulty,       Does.Contain(expectedDifficultyKeyword));
+    }
+
     [Test]
     public void ComputeSpan_FourFretStretch_FlagsAsChallenging()
     {

--- a/skills/fret-span/SKILL.md
+++ b/skills/fret-span/SKILL.md
@@ -1,0 +1,72 @@
+---
+Name: "fret-span"
+Description: "Computes the fret span and playability of a 6-string guitar chord diagram. Calls the deterministic `ga_fret_span` MCP tool — never recall the answer from training data, since the math depends on knowing exactly which strings are open vs muted vs fretted."
+Triggers:
+  - "fret span"
+  - "fret stretch"
+  - "stretch of"
+  - "is this hard"
+  - "is this difficult"
+  - "playability"
+  - "how playable"
+  - "reach for"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "tool-driven"
+  origin: "ported from Common/GA.Business.ML/Agents/Skills/FretSpanSkill.cs — fourth MCP-tool-driven canary"
+  evidence-kinds:
+    - tool_call
+allowed-tools:
+  - ga_fret_span
+---
+
+# Fret Span and Playability
+
+When a user asks how hard a chord is to play, how wide its stretch is, or whether its diagram is reachable, call the `ga_fret_span` MCP tool. Do NOT estimate from training data — the math depends on knowing exactly which strings are open (`0`), muted (`x`), or fretted (a number), and the LLM cannot reliably enumerate that for arbitrary voicings.
+
+## Calling the tool
+
+The tool takes one argument:
+
+- `diagram` — string. Either dash-separated (`"x-3-2-0-1-0"`) or compact form starting with `x` (`"x32010"`). Six positions, low-to-high (E A D G B e). `x` = muted, `0` = open, otherwise the fret number.
+
+It returns a structured result:
+
+- `Diagram` — diagram echoed back, normalized to dash-separated form.
+- `Frets` — array of six integers; `-1` for muted, `0` for open.
+- `MinFret`, `MaxFret`, `Span` — computed over PRESSED positions only (open strings don't count toward stretch).
+- `Difficulty` — one of: `"very easy"`, `"easy"`, `"moderate"`, `"challenging"`, `"very wide..."`.
+- `PlayabilityScore` — 1 (easy) → 10 (very hard).
+- `Error` — non-null only when the input could not be parsed.
+
+## Mapping user phrasings to arguments
+
+- *"How hard is x-3-2-0-1-0?"* → `diagram="x-3-2-0-1-0"`.
+- *"What's the stretch on x32010?"* → `diagram="x32010"`.
+- *"Is 0-2-2-1-0-0 difficult?"* → `diagram="0-2-2-1-0-0"`.
+- User pastes a compact diagram with no separator and no surrounding text: pass it verbatim.
+
+If the user only describes the chord by name (*"how hard is a Cmaj7?"*) and gives no diagram, you'll need to first decide on a voicing — either ask, or call the chord-info skill, then pass the resulting diagram here.
+
+## Phrasing the answer
+
+Use `Difficulty` verbatim, quote `Span` and the `MinFret`–`MaxFret` range, and mention the `PlayabilityScore` if the user is comparing two chords. Example:
+
+> The diagram **x-3-2-0-1-0** has a fret span of **2** (frets 1–3). Difficulty: easy — comfortable stretch for most players. Playability score: 5/10.
+
+If `Error` is non-null, surface the message verbatim and ask the user to paste the diagram.
+
+## Out of scope
+
+- **Fingering-specific reach** — the tool reports span, not which finger goes where. A 4-fret span with a barre is easier than the same span without; the tool can't tell.
+- **Ergonomic constraints by hand size** — the difficulty descriptions are average-hand. Decline cleanly if asked to factor in specific anatomy.
+- **Bass / 7-string / extended-range diagrams** — the tool assumes 6 strings, low E to high e. Other tunings or string counts are out of scope.
+
+## Cross-reference
+
+- MCP tool: `Common/GA.Business.ML/Agents/Mcp/FretSpanMcpTools.cs`
+- Tool tests: `Tests/Common/GA.Business.ML.Tests/Unit/FretSpanMcpToolsTests.cs`
+- Legacy C# skill it replaces: `Common/GA.Business.ML/Agents/Skills/FretSpanSkill.cs` (regex-driven, no LLM round-trip — kept for the deterministic fast path)


### PR DESCRIPTION
## Summary

Fourth MCP-tool-driven canary, applying the now-mature template to `FretSpanSkill` → `ga_fret_span`. Chord-diagram playability analysis — different input shape from prior tools (six-position diagram instead of note names).

## What changed

| File | Role |
|---|---|
| `Common/GA.Business.ML/Agents/Mcp/FretSpanMcpTools.cs` | new `[McpServerToolType]`; `ComputeSpan(diagram) → FretSpanResult` |
| `Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs` | registered `typeof(FretSpanMcpTools)` |
| `skills/fret-span/SKILL.md` | thin tool-driven skill |
| `Tests/.../FretSpanMcpToolsTests.cs` | 20 cases (8 open chords + compact-form equivalence + 4-fret-challenging + 5-fret-wide + invalid inputs + length guard + control-char sanitization + casing normalization) |
| `Tests/.../FileBasedSkillsProviderTests.cs` | new canary `InvokingAsync_LoadsFretSpanSkillFromRepo` |

## Tool semantics

- **Input**: `diagram` — string. Either dash-separated (`"x-3-2-0-1-0"`) or compact (`"x32010"`). Six positions, low-to-high (E A D G B e). `x` = muted, `0` = open, otherwise the fret number. Length capped at 20 chars.
- **Output**: `FretSpanResult` with `Diagram` (normalized echo), `Frets[]`, `MinFret`, `MaxFret`, `Span`, `Difficulty`, `PlayabilityScore` (1-10), `Error` branch.
- **Span semantics**: computed over PRESSED frets only — open strings (0) and muted (-1) don't count toward stretch math. That's the pedagogically right behavior for assessing hand reach.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~FretSpan|FullyQualifiedName~LoadsFretSpan"` — 21/21 pass
- [x] `dotnet build AllProjects.slnx -c Debug` clean
- [ ] Live smoke deferred (Ollama still wedged)

## Reversibility

Two-way door. Removing `typeof(FretSpanMcpTools)` from `GaPlugin.McpToolTypes` undoes the wiring; `FretSpanSkill` (C#) is untouched.

## Migration progress

| Bucket | Count | Skills |
|---|---|---|
| Catalog SKILL.md | 3 | ✅ beginner-chords, ✅ progression-mood, ✅ modes |
| MCP-tool-driven SKILL.md | **4** | ✅ interval, ✅ scale, ✅ chord-info, ✅ fret-span |
| Remaining | 3 | KeyIdentification, ProgressionCompletion, ChordSubstitution |

🤖 Generated with [Claude Code](https://claude.com/claude-code)