### PR TITLE
feat(optick-sae): real-corpus local trainer + dead-feature finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,7 @@ Apps/GaChatbot.Api/.azure/
 # Playwright artifacts — regenerated on every test run
 Apps/ga-client/test-results/
 Apps/ga-client/playwright-report/
+
+# Local SAE training artifacts (per-developer-machine validation runs).
+# Real Phase 1 agent runs land at state/quality/optick-sae/<date>/ (no -local suffix).
+state/quality/optick-sae/*-local/

--- a/Scripts/optick_sae_smoke_read.py
+++ b/Scripts/optick_sae_smoke_read.py
@@ -1,0 +1,133 @@
+"""
+Smoke test: parse OPTK v4 header + first few vectors from state/voicings/optick.index.
+Validates that we can read the binary format from Python before committing to a full trainer.
+
+Format reference: Common/GA.Business.ML/Search/OptickIndexReader.cs lines 57-104.
+"""
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def read_header(path: Path) -> dict:
+    """Parse the OPTK v4 header. Returns offsets + dims + count."""
+    with path.open("rb") as f:
+        magic = f.read(4)
+        if magic != b"OPTK":
+            raise SystemExit(f"Not an OPTK file: magic={magic!r}")
+
+        version = struct.unpack("<I", f.read(4))[0]
+        if version != 4:
+            raise SystemExit(f"Unsupported version {version}")
+
+        header_size = struct.unpack("<I", f.read(4))[0]
+        schema_hash = struct.unpack("<I", f.read(4))[0]
+        endian = struct.unpack("<H", f.read(2))[0]
+        _r = f.read(2)  # padding
+
+        dim = struct.unpack("<I", f.read(4))[0]
+        count = struct.unpack("<Q", f.read(8))[0]
+
+        instruments = f.read(1)[0]
+        _pad = f.read(7)
+
+        # 3 instrument ranges of (byte_offset_u64, count_u64) — 16 bytes each
+        instr_ranges = []
+        for _ in range(3):
+            byte_off = struct.unpack("<Q", f.read(8))[0]
+            cnt = struct.unpack("<Q", f.read(8))[0]
+            instr_ranges.append((byte_off, cnt))
+
+        meta_offsets_off = struct.unpack("<Q", f.read(8))[0]
+        vectors_off = struct.unpack("<Q", f.read(8))[0]
+        meta_off = struct.unpack("<Q", f.read(8))[0]
+        meta_len = struct.unpack("<Q", f.read(8))[0]
+
+        return {
+            "version": version,
+            "header_size": header_size,
+            "schema_hash_hex": f"{schema_hash:08x}",
+            "endian_marker": f"0x{endian:04x}",
+            "instruments": instruments,
+            "dim": dim,
+            "count": count,
+            "instrument_ranges_byteoff_count": instr_ranges,
+            "meta_offsets_off": meta_offsets_off,
+            "vectors_off": vectors_off,
+            "meta_off": meta_off,
+            "meta_len": meta_len,
+        }
+
+
+def load_vectors_subset(path: Path, vectors_off: int, dim: int, count: int, n: int) -> np.ndarray:
+    """Memory-map and read first n vectors as float32."""
+    n = min(n, count)
+    bytes_per_vec = dim * 4
+    arr = np.memmap(
+        path,
+        dtype=np.float32,
+        mode="r",
+        offset=vectors_off,
+        shape=(count, dim),
+    )
+    return np.array(arr[:n])  # copy out of mmap
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parent.parent
+    index_path = repo / "state" / "voicings" / "optick.index"
+    if not index_path.exists():
+        print(f"FAIL: {index_path} not found", file=sys.stderr)
+        return 2
+
+    header = read_header(index_path)
+    print("=== OPTK v4 header ===")
+    for k, v in header.items():
+        print(f"  {k}: {v}")
+
+    expected_dim = 124  # v1.8 compact = STRUCTURE+MORPHOLOGY+CONTEXT+SYMBOLIC+MODAL+ROOT
+    if header["dim"] != expected_dim:
+        print(f"WARN: header dim={header['dim']} != expected {expected_dim} (v1.8 compact). Schema bumped?")
+
+    sample = load_vectors_subset(
+        index_path,
+        header["vectors_off"],
+        header["dim"],
+        header["count"],
+        n=10,
+    )
+    print(f"\n=== first 10 vectors ===")
+    print(f"  shape: {sample.shape}")
+    print(f"  dtype: {sample.dtype}")
+    print(f"  per-vector L2 norms (expect ≈ 1 since the index is L2-normalized):")
+    for i, v in enumerate(sample):
+        print(f"    [{i}] norm={np.linalg.norm(v):.6f}, mean={v.mean():.6f}, std={v.std():.6f}")
+
+    # Pull a representative slice across the full corpus to check distribution
+    full = np.memmap(
+        index_path,
+        dtype=np.float32,
+        mode="r",
+        offset=header["vectors_off"],
+        shape=(header["count"], header["dim"]),
+    )
+    n_sample = min(50_000, header["count"])
+    rng = np.random.default_rng(42)
+    idx = rng.choice(header["count"], size=n_sample, replace=False)
+    sub = np.array(full[idx])
+    print(f"\n=== {n_sample}-row random sample ===")
+    norms = np.linalg.norm(sub, axis=1)
+    print(f"  norm mean: {norms.mean():.6f}  std: {norms.std():.6f}")
+    print(f"  per-dim mean abs: {np.abs(sub).mean():.6f}")
+    nonzero_per_row = (sub != 0).sum(axis=1)
+    print(f"  nonzero entries per vector: p50={int(np.percentile(nonzero_per_row, 50))}  p95={int(np.percentile(nonzero_per_row, 95))}  max={nonzero_per_row.max()}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/optick_sae_train.py
+++ b/Scripts/optick_sae_train.py
@@ -1,0 +1,366 @@
+"""
+Local OPTIC-K Sparse Autoencoder trainer.
+
+Reads state/voicings/optick.index (OPTK v4 compact, 124-dim L2-normalized vectors),
+trains a top-k SAE, emits a contract-conforming artifact at
+state/quality/optick-sae/<date>-local/.
+
+Contract: docs/contracts/2026-05-02-optick-sae-artifact.contract.md
+Schema:   docs/contracts/optick-sae-artifact.schema.json
+
+WHY local: the cloud agent's checkout doesn't include optick.index (gitignored, 175 MB).
+This script runs natively on a machine that has the index, so we get real-data
+reconstruction MSE / partition_purity numbers instead of the synthetic-data smoke
+the cloud agent produces.
+
+USAGE:
+    python Scripts/optick_sae_train.py --epochs 5    # smoke
+    python Scripts/optick_sae_train.py --epochs 100  # real run
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import struct
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+# v1.8 compact layout (similarity partitions only). See
+# Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs : SimilarityPartitions.
+PARTITIONS_124 = [
+    ("STRUCTURE",   0,   24),
+    ("MORPHOLOGY",  24,  48),
+    ("CONTEXT",     48,  60),
+    ("SYMBOLIC",    60,  72),
+    ("MODAL",       72,  112),
+    ("ROOT",        112, 124),
+]
+
+
+# =============================================================================
+# OPTK v4 reader
+# =============================================================================
+
+def read_header(path: Path) -> dict:
+    with path.open("rb") as f:
+        if f.read(4) != b"OPTK":
+            raise SystemExit(f"Not an OPTK file: {path}")
+        version = struct.unpack("<I", f.read(4))[0]
+        if version != 4:
+            raise SystemExit(f"Unsupported version {version}")
+        f.read(4)  # header_size
+        f.read(4)  # schema_hash
+        f.read(2)  # endian
+        f.read(2)  # padding
+        dim = struct.unpack("<I", f.read(4))[0]
+        count = struct.unpack("<Q", f.read(8))[0]
+        f.read(8)  # instruments + pad
+        f.read(48)  # 3 * 16 bytes instr ranges
+        f.read(8)  # meta_offsets_off
+        vectors_off = struct.unpack("<Q", f.read(8))[0]
+        return {"dim": dim, "count": count, "vectors_off": vectors_off}
+
+
+def load_vectors(path: Path) -> np.ndarray:
+    h = read_header(path)
+    arr = np.memmap(
+        path,
+        dtype=np.float32,
+        mode="r",
+        offset=h["vectors_off"],
+        shape=(h["count"], h["dim"]),
+    )
+    return np.array(arr)  # copy out so we can drop the mmap
+
+
+def file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# =============================================================================
+# Top-k SAE
+# =============================================================================
+
+class TopKSAE(nn.Module):
+    def __init__(self, input_dim: int, dict_size: int, k: int):
+        super().__init__()
+        self.input_dim = input_dim
+        self.dict_size = dict_size
+        self.k = k
+        self.encoder = nn.Linear(input_dim, dict_size, bias=True)
+        self.decoder = nn.Linear(dict_size, input_dim, bias=True)
+        # Initialize decoder weights as transpose of encoder for tied-ish start.
+        with torch.no_grad():
+            self.decoder.weight.copy_(self.encoder.weight.T)
+
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.encoder(x)
+        h = torch.relu(h)
+        # Top-k mask: keep only the k largest activations per row.
+        topk_vals, topk_idx = torch.topk(h, k=self.k, dim=-1)
+        mask = torch.zeros_like(h)
+        mask.scatter_(-1, topk_idx, 1.0)
+        return h * mask
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        a = self.encode(x)
+        x_hat = self.decoder(a)
+        return x_hat, a
+
+
+# =============================================================================
+# Metrics
+# =============================================================================
+
+def compute_reconstruction(model: TopKSAE, X: torch.Tensor, batch: int = 8192) -> tuple[float, float]:
+    model.eval()
+    sse = 0.0
+    sst = 0.0
+    mean = X.mean(dim=0)
+    with torch.no_grad():
+        for i in range(0, len(X), batch):
+            xb = X[i:i + batch]
+            xh, _ = model(xb)
+            sse += float(((xh - xb) ** 2).sum())
+            sst += float(((xb - mean) ** 2).sum())
+    n_elem = X.numel()
+    mse = sse / n_elem
+    r2 = 1.0 - (sse / sst) if sst > 0 else 0.0
+    return mse, r2
+
+
+def compute_activation_stats(model: TopKSAE, X: torch.Tensor, batch: int = 8192) -> dict:
+    model.eval()
+    dict_size = model.dict_size
+    feature_active_count = torch.zeros(dict_size)
+    active_per_row = []
+    with torch.no_grad():
+        for i in range(0, len(X), batch):
+            a = model.encode(X[i:i + batch])
+            feature_active_count += (a > 0).float().sum(dim=0)
+            active_per_row.append((a > 0).sum(dim=-1).cpu().numpy())
+    active_per_row = np.concatenate(active_per_row)
+    n_rows = len(X)
+    frequency = (feature_active_count / n_rows).numpy()
+    dead = int((feature_active_count == 0).sum())
+    return {
+        "frequency": frequency,
+        "active_per_row_p50": int(np.percentile(active_per_row, 50)),
+        "active_per_row_p95": int(np.percentile(active_per_row, 95)),
+        "dead_features": dead,
+        "high_freq_count": int((frequency >= 0.10).sum()),
+        "low_freq_count": int((frequency < 0.001).sum()),
+    }
+
+
+def compute_partition_purity(model: TopKSAE) -> tuple[float, float]:
+    """For each feature, fraction of |decoder_weight| concentrated in its dominant partition."""
+    W = model.decoder.weight.detach().cpu().numpy()  # (input_dim, dict_size)
+    purities = []
+    for j in range(W.shape[1]):
+        col = np.abs(W[:, j])
+        total = col.sum() + 1e-12
+        partition_mass = []
+        for _, lo, hi in PARTITIONS_124:
+            partition_mass.append(col[lo:hi].sum())
+        purity = max(partition_mass) / total
+        purities.append(purity)
+    purities = np.array(purities)
+    return float(purities.mean()), float(np.percentile(purities, 10))
+
+
+# =============================================================================
+# Training
+# =============================================================================
+
+def train(args) -> dict:
+    repo = Path(__file__).resolve().parent.parent
+    index_path = repo / "state" / "voicings" / "optick.index"
+    if not index_path.exists():
+        raise SystemExit(f"Missing index: {index_path}")
+
+    print(f"[1/6] Loading {index_path}", flush=True)
+    t0 = time.time()
+    X_np = load_vectors(index_path)
+    sha = file_sha256(index_path)
+    print(f"    shape {X_np.shape}  sha256 {sha[:16]}...  load {time.time() - t0:.1f}s", flush=True)
+
+    rng = np.random.default_rng(args.seed)
+    perm = rng.permutation(len(X_np))
+    n_val = int(0.05 * len(X_np))
+    val_idx = perm[:n_val]
+    train_idx = perm[n_val:]
+    X_train = torch.from_numpy(X_np[train_idx]).float()
+    X_val = torch.from_numpy(X_np[val_idx]).float()
+    print(f"    train {len(X_train)}  val {len(X_val)}", flush=True)
+
+    print(f"[2/6] Building TopKSAE (dict={args.dict_size}, k={args.k_sparse})", flush=True)
+    torch.manual_seed(args.seed)
+    model = TopKSAE(input_dim=X_np.shape[1], dict_size=args.dict_size, k=args.k_sparse)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    print(f"[3/6] Training {args.epochs} epochs (batch={args.batch_size}, lr={args.lr})", flush=True)
+    n_train = len(X_train)
+    losses = []
+    train_t0 = time.time()
+    for epoch in range(args.epochs):
+        epoch_t0 = time.time()
+        model.train()
+        order = torch.randperm(n_train)
+        epoch_loss = 0.0
+        n_batches = 0
+        for i in range(0, n_train, args.batch_size):
+            batch_idx = order[i:i + args.batch_size]
+            xb = X_train[batch_idx]
+            xh, _ = model(xb)
+            loss = ((xh - xb) ** 2).mean()
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item()
+            n_batches += 1
+        avg = epoch_loss / max(1, n_batches)
+        losses.append(avg)
+        print(f"    epoch {epoch + 1:3d}/{args.epochs}  loss {avg:.6f}  {time.time() - epoch_t0:.1f}s", flush=True)
+    print(f"    total train time {time.time() - train_t0:.1f}s", flush=True)
+
+    print(f"[4/6] Computing metrics on val slice", flush=True)
+    mse, r2 = compute_reconstruction(model, X_val)
+    act = compute_activation_stats(model, X_val)
+    purity_mean, purity_p10 = compute_partition_purity(model)
+    print(f"    reconstruction_mse {mse:.6f}  r2 {r2:.4f}", flush=True)
+    print(f"    active_per_row p50 {act['active_per_row_p50']} p95 {act['active_per_row_p95']}", flush=True)
+    print(f"    dead {act['dead_features']}/{model.dict_size} ({100 * act['dead_features'] / model.dict_size:.1f}%)", flush=True)
+    print(f"    partition_purity mean {purity_mean:.3f}  p10 {purity_p10:.3f}", flush=True)
+
+    # ── Guardrail enforcement (contract §5) ──
+    dead_pct = 100.0 * act["dead_features"] / args.dict_size
+    guardrail_violations = []
+    if mse > 0.05:
+        guardrail_violations.append(f"reconstruction_mse {mse:.6f} > 0.05")
+    if dead_pct > 30.0:
+        guardrail_violations.append(f"dead_features_pct {dead_pct:.1f} > 30.0")
+    if guardrail_violations and not args.allow_guardrail_violation:
+        print("\n[FAIL] Contract §5 guardrail violation — NOT emitting artifact:", flush=True)
+        for v in guardrail_violations:
+            print(f"    {v}", flush=True)
+        print("    (rerun with --allow-guardrail-violation to emit anyway, or smaller --dict-size)", flush=True)
+        return None
+
+    # ── Build artifact ──
+    print(f"[5/6] Writing artifact", flush=True)
+    produced_at = datetime.now(timezone.utc)
+    artifact_id = (
+        f"optick-sae-{produced_at.strftime('%Y-%m-%dT%H-%M-%SZ')}"
+        f"-{uuid.uuid4().hex[:8]}-local-trainer"
+    )
+    out_dir = repo / "state" / "quality" / "optick-sae" / produced_at.strftime("%Y-%m-%d-local")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    artifact = {
+        "schema_version": 1,
+        "artifact_id": artifact_id,
+        "trained_at": produced_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "trainer": "manual",
+        "trainer_version": "0.1.0",
+        "input": {
+            "optick_index_path": "state/voicings/optick.index",
+            "optick_index_sha": f"sha256:{sha}",
+            "optick_dim": int(X_np.shape[1]),
+            "schema_version": "OPTIC-K-v1.8",
+            "corpus_size": int(len(X_np)),
+            "partitions_used": [name for name, _, _ in PARTITIONS_124],
+        },
+        "model": {
+            "kind": "topk_sae",
+            "dict_size": args.dict_size,
+            "k_sparse": args.k_sparse,
+            "training": {
+                "epochs": args.epochs,
+                "batch_size": args.batch_size,
+                "lr": args.lr,
+                "seed": args.seed,
+                "loss_final": losses[-1],
+                "sparsity_actual_mean": float(act["active_per_row_p50"]),
+            },
+        },
+        "metrics": {
+            "reconstruction_mse": mse,
+            "reconstruction_r2": r2,
+            "active_features_per_voicing_p50": act["active_per_row_p50"],
+            "active_features_per_voicing_p95": act["active_per_row_p95"],
+            "dead_features_pct": 100.0 * act["dead_features"] / args.dict_size,
+            "feature_partition_purity_mean": purity_mean,
+            "feature_partition_purity_p10": purity_p10,
+        },
+        "features_summary": {
+            "total": args.dict_size,
+            "alive": args.dict_size - act["dead_features"],
+            "high_frequency_count": act["high_freq_count"],
+            "low_frequency_count": act["low_freq_count"],
+        },
+        "links": {
+            "feature_activations_parquet": str((out_dir / "feature_activations.parquet").relative_to(repo)).replace("\\", "/"),
+            "feature_manifest_jsonl":      str((out_dir / "feature_manifest.jsonl").relative_to(repo)).replace("\\", "/"),
+            "training_log":                str((out_dir / "training.log").relative_to(repo)).replace("\\", "/"),
+            "model_weights":               str((out_dir / "sae_weights.pt").relative_to(repo)).replace("\\", "/"),
+            "supersedes": None,
+        },
+        "narrative": (
+            f"Local Phase 1 trainer run on real OPTIC-K v1.8 (124-dim compact, {len(X_np)} voicings). "
+            f"Reconstruction MSE {mse:.4f}, dead-features {100 * act['dead_features'] / args.dict_size:.1f}%, "
+            f"partition purity mean {purity_mean:.2f}. "
+            f"Pre-Phase-1-agent local validation."
+        )[:500],
+    }
+
+    artifact_path = out_dir / "optick-sae-artifact.json"
+    with artifact_path.open("w", encoding="utf-8") as f:
+        json.dump(artifact, f, indent=2, ensure_ascii=False)
+
+    # Save model weights (.pt; safetensors omitted to avoid extra dep)
+    torch.save(model.state_dict(), out_dir / "sae_weights.pt")
+
+    # Training log
+    with (out_dir / "training.log").open("w", encoding="utf-8") as f:
+        for i, l in enumerate(losses):
+            f.write(f"epoch {i + 1:3d}  loss {l:.6f}\n")
+        f.write(f"\nfinal: mse={mse:.6f} r2={r2:.4f} purity_mean={purity_mean:.3f}\n")
+
+    print(f"[6/6] {artifact_path}", flush=True)
+    print(f"    out dir: {out_dir}", flush=True)
+    return artifact
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="OPTIC-K SAE trainer")
+    p.add_argument("--dict-size", type=int, default=1024)
+    p.add_argument("--k-sparse", type=int, default=32)
+    p.add_argument("--epochs", type=int, default=5)
+    p.add_argument("--batch-size", type=int, default=4096)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--allow-guardrail-violation",
+        action="store_true",
+        help="Emit an artifact even when contract §5 guardrails are violated. "
+             "Use ONLY for diagnostic sweeps; production runs should leave this off.",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    sys.exit(0 if train(args) else 1)

--- a/docs/learnings/2026-05-03-optick-sae-vanilla-topk-dead-features.md
+++ b/docs/learnings/2026-05-03-optick-sae-vanilla-topk-dead-features.md
@@ -1,0 +1,106 @@
+---
+title: "Vanilla top-k SAE has structural dead-feature problem on OPTIC-K v1.8"
+date: 2026-05-03
+category: ml-engineering
+status: validated finding (real-corpus run)
+applies_to:
+  - docs/plans/2026-05-02-arch-optick-sae-plan.md
+  - docs/contracts/2026-05-02-optick-sae-artifact.contract.md
+  - state/voicings/optick.index (v1.8, 313047 voicings × 124-dim compact)
+---
+
+# Vanilla top-k SAE has a structural dead-feature problem on OPTIC-K v1.8
+
+## TL;DR
+
+A hand-rolled top-k SAE (no auxiliary loss, no ghost grads) trained on the real OPTIC-K v1.8 corpus achieves near-perfect reconstruction (r² ≥ 0.998 in 50 epochs) but **40-65% of dictionary atoms die regardless of `dict_size`**. The contract's `dead_features_pct ≤ 30` guardrail is unachievable with vanilla top-k — the rich-get-richer dynamic locks in the first-winning features and the rest never recover.
+
+## Methodology
+
+**Setup (run locally, 2026-05-03 EDT):**
+- Index: `state/voicings/optick.index` — OPTK v4 binary, 313,047 voicings × 124-dim compact (similarity partitions only; IDENTITY is NOT in the file)
+- Trainer: `Scripts/optick_sae_train.py` — top-k SAE, ReLU encoder + top-k mask + linear decoder, Adam, MSE loss
+- Corpus split: 95% train (297,395) / 5% val (15,652), seed 42
+- Hardware: CPU only (Python 3.14, torch 2.11.0+cpu)
+- Per-epoch wall time: ~0.5–1.1 s
+
+**Sweep:** held `k_sparse=32`, varied `dict_size`. 50 epochs each.
+
+## Results
+
+| `dict_size` | reconstruction_mse | r² | active_per_row p50 | dead features | partition_purity (mean) |
+|---:|---:|---:|---:|---:|---:|
+| 1024 | 0.000001 | 0.9997 | 32 | **662 (64.6%)** | 0.388 |
+| 512  | 0.000003 | 0.9992 | 32 | **332 (64.8%)** | 0.370 |
+| 384  | 0.000003 | 0.9992 | 32 | **211 (54.9%)** | 0.374 |
+| 200  | 0.000007 | 0.9980 | 32 | **81  (40.5%)** | 0.380 |
+
+Dead-feature rate is structurally ≥ 40% for vanilla top-k on this corpus. Reducing `dict_size` reduces absolute dead count but the proportional rate stays high. The corpus has roughly 180–360 distinct "patterns" the SAE finds useful at k=32; everything beyond that dies.
+
+## Why this happens (mechanism)
+
+Top-k masking is a hard winner-take-all step. Once a feature loses the top-k race for the first few epochs, gradients flow only through the winning features, the losing features never see updates, and they stay at near-zero activation forever. This is a known issue with vanilla top-k SAEs and is exactly what motivated:
+
+- **Ghost grads** (Anthropic, 2024) — auxiliary loss that flows gradient through dead features by reconstructing the residual via top-K-revival
+- **JumpReLU SAE** (DeepMind, 2024) — replaces top-k with a learned threshold; no hard mask
+- **Auxiliary L2 reconstruction loss** in `sae-lens` — same idea as ghost grads, different formulation
+
+## Implications
+
+### Contract §5 guardrail is `kind`-dependent, not universal
+
+The current contract says:
+> dead_features_pct > 30% triggers retrain with smaller dict
+
+For `kind: topk_sae` without auxiliary losses, this is unachievable on OPTIC-K. We have three options for the contract:
+
+1. **Make the guardrail `kind`-conditional** — `topk_sae: 0.65`, `gated_sae: 0.30`, `relu_sae: ...`. Most accurate but adds contract complexity.
+2. **Mandate `kind: gated_sae` or sae-lens with ghost grads** for production — keep the 30% guardrail, change which architecture producers must use.
+3. **Lower the universal guardrail to 0.65** — simplest, but loses the signal that "high dead rate = something's wrong" for architectures where 30% IS achievable.
+
+**Recommendation: option 2.** Vanilla top-k is a known-limited baseline. Phase 1 should use sae-lens proper (which has ghost grads built in) for production runs. The current hand-roll is fine for plumbing validation but not for emitting consumable artifacts.
+
+### Plan §Phase 1 needs an addendum
+
+- Specify `sae-lens` with `auxiliary_loss=ghost_grads` (or whatever the current sae-lens API name is)
+- Note the reasonable expected dead rate post-ghost-grads (literature says ~5–15%)
+- Add a fallback: if sae-lens has API drift, hand-rolled top-k MUST `--allow-guardrail-violation` to emit; the resulting artifact is informational, not consumable by `qa_score_quality_drift`.
+
+### Partition purity finding is preliminary but suggestive
+
+Mean partition_purity ~0.37–0.39 across all dict sizes. Random-baseline for 6 partitions of unequal size is roughly 0.32 (mass-weighted by partition fraction). So features ARE concentrating somewhat — but only weakly. Could be:
+- Genuine cross-partition correlations the schema doesn't separate (which would be the *interesting* finding)
+- Artifact of the L2-normalized + per-partition-pre-weighted compact format collapsing partition structure
+- Just a top-k SAE artifact — features that activate on similar voicings end up sharing patterns across partitions
+
+Phase 3 manual feature interpretation will tell the story. For now the SAE finds patterns, those patterns are mildly partition-respecting, and we shouldn't over-interpret 0.37.
+
+## What changes for the May 19 Phase 1 agent
+
+The agent's brief currently says:
+> Use sae-lens library (Joseph Bloom et al.) - field-standard PyTorch SAE tooling.
+
+Good — that's already pointing at the right tool. The new things the agent should know:
+
+1. **Don't fall back to hand-rolled top-k** without `--allow-guardrail-violation` — the artifact won't pass schema validation.
+2. **Expected dead-features rate with sae-lens + ghost grads on OPTIC-K v1.8** is ~5–15% (literature) but we haven't measured locally.
+3. **Reconstruction MSE will be much lower than 0.05** — this corpus is easy to reconstruct (r² ≥ 0.998 with even bad dead-rate). The MSE guardrail is loose; the dead-rate guardrail is the binding one.
+4. **Compact dim is 124, not 240** — the index file holds similarity partitions only (STRUCTURE 24, MORPHOLOGY 24, CONTEXT 12, SYMBOLIC 12, MODAL 40, ROOT 12). IDENTITY etc. are NOT in the file. Contract field `partitions_used` should reflect this — already did in PR #73.
+
+## Reproducibility
+
+```bash
+python -X utf8 Scripts/optick_sae_train.py --epochs 50 --dict-size 1024
+python -X utf8 Scripts/optick_sae_train.py --epochs 50 --dict-size 512
+python -X utf8 Scripts/optick_sae_train.py --epochs 50 --dict-size 384
+python -X utf8 Scripts/optick_sae_train.py --epochs 50 --dict-size 200
+```
+
+The trainer enforces guardrails by default — runs above will refuse to emit artifacts. Add `--allow-guardrail-violation` to emit anyway (for diagnostic sweeps).
+
+## References
+
+- `Scripts/optick_sae_train.py` — the trainer used here
+- `Scripts/optick_sae_smoke_read.py` — OPTK v4 binary reader (used to validate the format before writing the trainer)
+- `docs/contracts/2026-05-02-optick-sae-artifact.contract.md` — contract this finding affects
+- `docs/plans/2026-05-02-arch-optick-sae-plan.md` — plan that needs an addendum


### PR DESCRIPTION
## Summary

**Investigation deliverable**: validates that we can run Phase 1 SAE training on the real OPTIC-K v1.8 corpus (313,047 voicings × 124-dim compact) from Python, and surfaces a real engineering finding before the May 19 agent fires.

## What lands

| File | Purpose |
|---|---|
| `Scripts/optick_sae_smoke_read.py` | Pure-Python OPTK v4 binary reader; parsed format directly from `OptickIndexReader.cs` so no C# bridge needed |
| `Scripts/optick_sae_train.py` | Hand-rolled top-k SAE trainer in PyTorch. Enforces contract §5 guardrails by default (refuses to emit when `MSE > 0.05` or `dead_features_pct > 30`). `--allow-guardrail-violation` for diagnostic sweeps. |
| `docs/learnings/2026-05-03-optick-sae-vanilla-topk-dead-features.md` | The finding (below) |
| `.gitignore` | Adds `state/quality/optick-sae/*-local/` so per-machine validation runs don't pollute git status |

## The finding

Vanilla top-k SAE has structurally **40–65% dead features** on this corpus regardless of `dict_size`. Reconstruction is near-perfect (r² ≥ 0.998 in 50 epochs); dead-feature rate is the binding constraint.

| `dict_size` | recon MSE | r² | dead | purity (mean) |
|---:|---:|---:|---:|---:|
| 1024 | 0.000001 | 0.9997 | **64.6%** | 0.388 |
| 512  | 0.000003 | 0.9992 | **64.8%** | 0.370 |
| 384  | 0.000003 | 0.9992 | **54.9%** | 0.374 |
| 200  | 0.000007 | 0.9980 | **40.5%** | 0.380 |

Cause: top-k masking is winner-take-all; once a feature loses the race in the first epochs, gradients never flow through it. Solutions in the literature: ghost grads (Anthropic 2024), JumpReLU (DeepMind 2024), `sae-lens` auxiliary loss.

## Implication

The contract's 30% `dead_features_pct` guardrail is **unachievable with vanilla top-k**. Three options for the contract (tracked in the learning doc, not in this PR):

1. Make the guardrail `kind`-conditional (e.g. `topk_sae: 0.65`, `gated_sae: 0.30`)
2. Mandate sae-lens with ghost grads for production (keep 30% guardrail)
3. Lower the universal guardrail to 0.65 (loses signal where 30% IS achievable)

## What this PR does NOT do

- ❌ Does not update contract guardrail values (separate decision)
- ❌ Does not emit any local-run artifacts (all violated guardrails; per §5 MUST NOT emit)
- ❌ Does not modify the May 19 agent's brief

## Verification

- `python Scripts/optick_sae_smoke_read.py` → confirms dim=124, count=313047, format matches v1.8 schema
- `python Scripts/optick_sae_train.py --epochs 3 --dict-size 200` → guardrail violation correctly refused, no artifact emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)