### PR TITLE
docs(optick-sae): producer SHOULD use auxiliary loss + measure dead on full train

### DIFF
--- a/docs/contracts/2026-05-02-optick-sae-artifact.contract.md
+++ b/docs/contracts/2026-05-02-optick-sae-artifact.contract.md
@@ -169,7 +169,11 @@ The contract is a **two-way door** until Phase 4 freeze (target 2026-Q3). Field 
 1. Pin `input.optick_index_sha` from the actual file at training time.
 2. Fail the run (do NOT emit an artifact) if `reconstruction_mse > 0.05` or `dead_features_pct > 30`.
 3. Set `links.supersedes` when re-training over a prior artifact in the same lineage.
-4. Validate against `optick-sae-artifact.schema.json` (generated from this contract in Phase 1) before persisting.
+4. Validate against `optick-sae-artifact.schema.json` before persisting.
+5. Compute `dead_features_pct` over the **full training set**, not a held-out validation slice. A feature active on 0.1% of voicings is real but a 5% val sample reports it "dead" by chance — this consistently overstates the rate by ~2× on OPTIC-K v1.8 ([2026-05-03 finding](../learnings/2026-05-03-optick-sae-vanilla-topk-dead-features.md)).
+
+**Producer (`ix-optick-sae`) SHOULD:**
+1. **Enable AuxK / ghost-grads or equivalent auxiliary loss.** Vanilla top-k without auxiliary loss has structural ~40–65% dead-feature rate on OPTIC-K v1.8 and will fail the §5 MUST #2 guardrail. `sae-lens` enables this by default; the hand-rolled trainer at `Scripts/optick_sae_train.py` supports it via `--use-ghost-grads`. Empirically `aux_alpha = 0.1` (3× the Anthropic 2024 default) and `aux_k ≈ 2 × k_sparse` satisfy the guardrail on this corpus.
 
 **Consumers SHOULD:**
 1. Treat unknown `model.kind` values as "skip" rather than "fail."


### PR DESCRIPTION
## Summary

Codifies the two findings from PR #86 into the contract:

1. **New MUST #5** — `dead_features_pct` must be computed over the **full training set**, not a held-out val slice. The val-slice measurement consistently overstates by ~2× on OPTIC-K v1.8 (a feature active on 0.1% of voicings is real but a 5% val sample reports it dead by chance).

2. **New SHOULD #1** — enable AuxK / ghost-grads or equivalent auxiliary loss. Vanilla top-k without aux loss has 40–65% dead and will fail the existing §5 MUST guardrail. `sae-lens` enables this by default; the hand-rolled trainer supports it via `--use-ghost-grads`. Empirically `aux_alpha=0.1` (3× the Anthropic 2024 default) satisfies the guardrail on this corpus.

Both items link to [`docs/learnings/2026-05-03-optick-sae-vanilla-topk-dead-features.md`](docs/learnings/2026-05-03-optick-sae-vanilla-topk-dead-features.md) so future readers find the empirical justification.

## Why these are MUST vs SHOULD

- **Full-train measurement is MUST** — without it the dead_features_pct number is wrong by 2× and a producer could think it's passing the guardrail when it's actually failing. Methodology, not preference.
- **Auxiliary loss is SHOULD** — multiple ways to achieve `dead_features_pct ≤ 30`: AuxK, ghost-grads, gated SAE, JumpReLU, sae-lens defaults. SHOULD lets producers pick their mechanism while making the practical reality clear (vanilla top-k won't work).

## What this PR does NOT do

- ❌ Does not add a corresponding constraint to `optick-sae-artifact.schema.json` — both items are procedural (about how training is done), not JSON shape constraints (about what the artifact says).
- ❌ Does not change the v0.1 draft state or trigger a v0.2 bump — these are additive clarifications in the existing producer/consumer section.

## Diff

5 lines added to `docs/contracts/2026-05-02-optick-sae-artifact.contract.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)