### PR TITLE
feat(chatbot): KeyIdentificationMcpTools — sixth MCP-tool canary (first hybrid port)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -71,5 +71,6 @@ public sealed class GaPlugin : IChatPlugin
         typeof(ChordMcpTools),
         typeof(FretSpanMcpTools),
         typeof(ChordSubstitutionMcpTools),
+        typeof(KeyIdentificationMcpTools),
     ];
 }

--- a/Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs
@@ -74,12 +74,18 @@ public sealed class KeyIdentificationMcpTools
             .Select(ToCandidate)
             .ToArray();
 
+        // Align top-level TotalChords with candidate-level TotalChords. The
+        // KeyIdentificationService internally calls .Distinct() before computing
+        // per-key match counts, so candidate.TotalChords reflects the de-duped
+        // count. Using `chords.Count` here would silently disagree with each
+        // candidate's `TotalChords` for inputs like "C Am F G C" (5 vs 4),
+        // confusing the LLM payload. Bug surfaced by PR #88 review.
         return new KeyIdentificationResult
         {
             RecognizedChords = [.. chords],
             TopCandidates    = topTied,
             PartialMatches   = partial,
-            TotalChords      = chords.Count,
+            TotalChords      = topTied[0].TotalChords,
         };
     }
 

--- a/Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs
@@ -1,0 +1,145 @@
+namespace GA.Business.ML.Agents.Mcp;
+
+using System.ComponentModel;
+using GA.Business.ML.Agents;
+using ModelContextProtocol.Server;
+
+/// <summary>
+/// MCP tool surface for chord-progression → key identification. Wraps
+/// <see cref="KeyIdentificationService"/> so an LLM-driven SKILL.md skill
+/// can call it deterministically and then phrase the answer in guitarist-
+/// friendly language.
+/// </summary>
+/// <remarks>
+/// Discovered by <see cref="Plugins.ChatPluginHost"/> via
+/// <see cref="Plugins.IChatPlugin.McpToolTypes"/>. Sixth tool in the MCP-
+/// tool-exposure workstream — same template as the prior five
+/// (<see cref="IntervalMcpTools"/> et al): length-guarded inputs, sanitized
+/// Error echo via <see cref="McpEchoSanitizer"/>, structured result with
+/// Error-branch invariant.
+///
+/// This is the FIRST hybrid-skill port: <see cref="Skills.KeyIdentificationSkill"/>
+/// did key detection deterministically and then asked the LLM to phrase
+/// the result. The C# path's prompt-building moves to the SKILL.md body;
+/// the deterministic detection becomes this tool.
+/// </remarks>
+[McpServerToolType]
+public sealed class KeyIdentificationMcpTools
+{
+    // The user message can be longer than a chord list — it might be
+    // "What key is C Am F G in?" with surrounding prose. Cap at 256 to
+    // accommodate that without inviting MB-sized abuse.
+    private const int MaxQueryLength = 256;
+
+    // Cap the candidate list — the LLM only needs the top tied + a couple
+    // of partials to phrase a comparison ("could also be Eb major").
+    private const int MaxPartialCandidates = 3;
+
+    /// <summary>
+    /// Identifies the most likely musical key(s) of a chord progression
+    /// extracted from <paramref name="query"/>. Returns the candidates ranked
+    /// by how many input chords are diatonic in each key.
+    /// </summary>
+    [McpServerTool(Name = "ga_key_identify"), Description(
+        "Identify the musical key of a chord progression. " +
+        "Pass either a bare chord list ('C Am F G') or the user's full question ('what key is C Am F G in?') — " +
+        "the tool extracts the chord symbols and returns the ranked candidate keys with their diatonic sets. " +
+        "Use whenever a user asks 'what key is X' / 'identify the key of X' / 'what key does X sound like'.")]
+    public KeyIdentificationResult IdentifyKey(
+        [Description("The user's question or a bare chord list. Examples: 'C Am F G', 'what key is Dm G C in?'.")]
+        string query)
+    {
+        if (string.IsNullOrEmpty(query) || query.Length > MaxQueryLength)
+            return KeyIdentificationResult.Failure(
+                $"Could not parse '{McpEchoSanitizer.SanitizeEcho(query)}' — pass a chord list or question (e.g. 'C Am F G').");
+
+        var chords = KeyIdentificationService.ExtractChords(query);
+        if (chords.Count == 0)
+            return KeyIdentificationResult.Failure(
+                "No recognisable chord symbols found. Write them as standard chord names — e.g. 'Am F C G'.");
+
+        var candidates = KeyIdentificationService.Identify(chords);
+        if (candidates.Count == 0)
+            return KeyIdentificationResult.Failure(
+                $"No candidate key matches the progression [{string.Join(", ", chords)}].");
+
+        var topScore = candidates[0].MatchCount;
+        var topTied  = candidates
+            .Where(c => c.MatchCount == topScore)
+            .Select(ToCandidate)
+            .ToArray();
+        var partial  = candidates
+            .Skip(topTied.Length)
+            .Take(MaxPartialCandidates)
+            .Select(ToCandidate)
+            .ToArray();
+
+        return new KeyIdentificationResult
+        {
+            RecognizedChords = [.. chords],
+            TopCandidates    = topTied,
+            PartialMatches   = partial,
+            TotalChords      = chords.Count,
+        };
+    }
+
+    private static KeyCandidateInfo ToCandidate(KeyIdentificationService.KeyCandidate c) => new()
+    {
+        Key            = c.Key,
+        RelativeKey    = c.RelativeKey,
+        MatchCount     = c.MatchCount,
+        TotalChords    = c.TotalChords,
+        DiatonicSet    = c.DiatonicSet,
+    };
+}
+
+/// <summary>One ranked candidate key.</summary>
+public sealed record KeyCandidateInfo
+{
+    /// <summary>Canonical key name, e.g. <c>"C major"</c>, <c>"A minor"</c>.</summary>
+    public string Key { get; init; } = string.Empty;
+
+    /// <summary>Name of the relative major/minor key.</summary>
+    public string RelativeKey { get; init; } = string.Empty;
+
+    /// <summary>Number of input chords that are diatonic in this key.</summary>
+    public int MatchCount { get; init; }
+
+    /// <summary>Total number of chords in the input.</summary>
+    public int TotalChords { get; init; }
+
+    /// <summary>The seven diatonic chords of this key, in order I…vii°.</summary>
+    public string[] DiatonicSet { get; init; } = [];
+}
+
+/// <summary>
+/// Structured result of <see cref="KeyIdentificationMcpTools.IdentifyKey"/>.
+/// </summary>
+/// <remarks>
+/// <b>Invariant:</b> when <see cref="Error"/> is non-null, all arrays are empty
+/// and <see cref="TotalChords"/> is <c>0</c>. LLMs reading this record should
+/// branch on <see cref="Error"/> first.
+///
+/// On success, <see cref="TopCandidates"/> is the set of keys tied at the
+/// highest match count (often 1 element; sometimes 2 — e.g. C major and A
+/// minor will tie because they share a diatonic set). <see cref="PartialMatches"/>
+/// is up to <c>3</c> partial-match keys ranked behind the top set.
+/// </remarks>
+public sealed record KeyIdentificationResult
+{
+    /// <summary>The chord symbols the parser actually recognised in the query.</summary>
+    public string[] RecognizedChords { get; init; } = [];
+
+    /// <summary>Keys tied at the highest match count.</summary>
+    public KeyCandidateInfo[] TopCandidates { get; init; } = [];
+
+    /// <summary>Up to 3 partial-match keys ranked behind the top set.</summary>
+    public KeyCandidateInfo[] PartialMatches { get; init; } = [];
+
+    public int TotalChords { get; init; }
+
+    /// <summary>Non-null when no chords could be parsed or no candidates matched.</summary>
+    public string? Error { get; init; }
+
+    public static KeyIdentificationResult Failure(string message) => new() { Error = message };
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -201,6 +201,41 @@ public class FileBasedSkillsProviderTests
     }
 
     [Test]
+    public async Task InvokingAsync_LoadsKeyIdentificationSkillFromRepo()
+    {
+        // Sixth MCP-tool-driven canary, and the FIRST hybrid port (the C#
+        // skill combined deterministic detection with LLM phrasing). The
+        // SKILL.md body now carries the phrasing rules; the tool carries
+        // the deterministic match.
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        var keyId = provider.Skills.SingleOrDefault(s => s.Name == "key-identification");
+        Assert.That(keyId, Is.Not.Null,
+            "skills/key-identification/SKILL.md must be discovered with name 'key-identification'");
+
+        Assert.That(keyId!.Triggers.Any(t => t.Contains("what key is")), Is.True);
+        Assert.That(keyId.Triggers.Any(t => t.Contains("identify the key")), Is.True);
+
+        Assert.That(keyId.Body, Does.Contain("ga_key_identify"),
+            "tool-driven SKILL.md must name the MCP tool the LLM should call");
+        Assert.That(keyId.Body, Does.Contain("DiatonicSet").And.Contain("TopCandidates"),
+            "body must document the structured result fields the LLM consumes");
+
+        // Both phrasing paths must be documented (single candidate vs tied
+        // relative pair) — the relative-pair ambiguity is the most common
+        // case (any I-vi-IV-V progression), and missing the tie-handling
+        // would make the LLM emit confidently-wrong single-key answers.
+        Assert.That(keyId.Body, Does.Contain("Tied").Or.Contain("relative"),
+            "body must explain how to handle relative-pair ties");
+
+        var ctx = await provider.InvokingAsync(UserContext("what key is C Am F G in"));
+        Assert.That(ctx.Instructions, Does.Contain("ga_key_identify"));
+    }
+
+    [Test]
     public async Task InvokingAsync_LoadsChordSubstitutionSkillFromRepo()
     {
         // Fifth MCP-tool-driven canary, and first SKILL.md to expose TWO

--- a/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationMcpToolsTests.cs
@@ -94,6 +94,43 @@ public class KeyIdentificationMcpToolsTests
         Assert.That(result.PartialMatches, Has.Length.LessThanOrEqualTo(3));
     }
 
+    [Test]
+    public void IdentifyKey_PartialMatches_AreRankedByDescendingMatchCount()
+    {
+        // The SKILL.md instructs the LLM to "optionally mention 1-2 partial
+        // matches" — that's only useful if they're ordered best-first. Pin
+        // the contract so a future refactor can't silently flip the order.
+        var result = MakeTool().IdentifyKey("C Am F G");
+
+        Assert.That(result.Error, Is.Null);
+        for (var i = 1; i < result.PartialMatches.Length; i++)
+        {
+            Assert.That(result.PartialMatches[i].MatchCount,
+                Is.LessThanOrEqualTo(result.PartialMatches[i - 1].MatchCount),
+                $"PartialMatches[{i}] must be ranked behind PartialMatches[{i-1}]");
+        }
+    }
+
+    [Test]
+    public void IdentifyKey_TopLevelTotalChordsAlignsWithCandidate()
+    {
+        // Bug surfaced by PR #88 review.
+        // ExtractChords does string-level dedup (so "C Am F G C" comes out
+        // as 4 strings). But Identify ALSO dedups at the parsed-tuple level
+        // (RootPc + Quality), so an enharmonic-equivalent input like
+        // "C Am F# Gb" returns 4 RecognizedChords from ExtractChords but
+        // candidate.TotalChords = 3 (F# and Gb collapse to the same tuple).
+        //
+        // The result-level TotalChords MUST equal candidate-level — otherwise
+        // the LLM payload contains two contradictory totals.
+        var result = MakeTool().IdentifyKey("C Am F# Gb");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.TopCandidates, Is.Not.Empty);
+        Assert.That(result.TotalChords, Is.EqualTo(result.TopCandidates[0].TotalChords),
+            "Top-level TotalChords MUST equal candidate-level TotalChords (post tuple-dedup); the LLM payload must not contain two disagreeing totals");
+    }
+
     // ── Error paths ───────────────────────────────────────────────────────────
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationMcpToolsTests.cs
@@ -1,0 +1,163 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Mcp;
+
+[TestFixture]
+public class KeyIdentificationMcpToolsTests
+{
+    private static KeyIdentificationMcpTools MakeTool() => new();
+
+    // ── Common-key progressions ───────────────────────────────────────────────
+
+    [Test]
+    public void IdentifyKey_CAmFG_BareList_FindsCMajorAndAMinorTied()
+    {
+        // I vi IV V in C major. C major and A minor share the same diatonic
+        // set (relative pair), so they tie at the top score. This is exactly
+        // the kind of ambiguity the LLM-phrasing layer in the SKILL.md is
+        // meant to disambiguate.
+        var result = MakeTool().IdentifyKey("C Am F G");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.RecognizedChords, Is.EqualTo(new[] { "C", "Am", "F", "G" }));
+        Assert.That(result.TotalChords, Is.EqualTo(4));
+
+        var topKeys = result.TopCandidates.Select(c => c.Key).ToArray();
+        Assert.That(topKeys, Has.Member("C major"),
+            "C Am F G must include C major in the top tied set");
+        Assert.That(topKeys, Has.Member("A minor"),
+            "C Am F G must also include A minor (relative pair tied at the top score)");
+
+        // All top candidates should report 4/4 diatonic.
+        Assert.That(result.TopCandidates.All(c => c.MatchCount == 4 && c.TotalChords == 4), Is.True);
+    }
+
+    [Test]
+    public void IdentifyKey_DmGC_FindsCMajorOrAMinor()
+    {
+        // ii V I in C major (or iv VII III in A minor). All three diatonic
+        // in both relative-pair keys.
+        var result = MakeTool().IdentifyKey("Dm G C");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.TopCandidates.Select(c => c.Key), Has.Some.Contain("C major"));
+    }
+
+    [Test]
+    public void IdentifyKey_DiatonicSetSurfacedForLlmExplanation()
+    {
+        // The LLM phrases its answer using the DiatonicSet — verify the tool
+        // exposes a 7-element ordered list (I, ii, iii, IV, V, vi, vii°).
+        var result = MakeTool().IdentifyKey("C F G");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.TopCandidates, Is.Not.Empty);
+
+        var top = result.TopCandidates[0];
+        Assert.That(top.DiatonicSet, Has.Length.EqualTo(7),
+            "DiatonicSet must always have exactly 7 chords (I…vii°)");
+    }
+
+    // ── Query parsing variants ────────────────────────────────────────────────
+
+    [Test]
+    public void IdentifyKey_AcceptsFullQuestionWithSurroundingProse()
+    {
+        // The LLM may pass the user's whole question rather than just the
+        // chord list — the tool must extract chords correctly either way.
+        var result = MakeTool().IdentifyKey("what key is C Am F G in?");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.RecognizedChords, Is.EqualTo(new[] { "C", "Am", "F", "G" }),
+            "extraction must drop surrounding prose and return only chord symbols");
+    }
+
+    [Test]
+    public void IdentifyKey_AcceptsCommaSeparatedChords()
+    {
+        var result = MakeTool().IdentifyKey("Tell me the key of: G, D, Em, C");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.RecognizedChords.Length, Is.EqualTo(4));
+    }
+
+    // ── Partial match ranking ─────────────────────────────────────────────────
+
+    [Test]
+    public void IdentifyKey_PartialMatchesCappedAt3()
+    {
+        // Whatever progression we pass, PartialMatches must never exceed
+        // MaxPartialCandidates = 3. The tool's responsibility, not the LLM's.
+        var result = MakeTool().IdentifyKey("C Am F G");
+
+        Assert.That(result.Error, Is.Null);
+        Assert.That(result.PartialMatches, Has.Length.LessThanOrEqualTo(3));
+    }
+
+    // ── Error paths ───────────────────────────────────────────────────────────
+
+    [Test]
+    public void IdentifyKey_NoChords_ReturnsErrorAboutSymbols()
+    {
+        var result = MakeTool().IdentifyKey("what key is this in?");
+
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(result.Error, Does.Contain("chord").IgnoreCase
+            .Or.Contain("symbol").IgnoreCase);
+        Assert.That(result.RecognizedChords, Is.Empty);
+        Assert.That(result.TopCandidates,    Is.Empty);
+    }
+
+    [Test]
+    public void IdentifyKey_EmptyOrNullInput_ReturnsError()
+    {
+        Assert.That(MakeTool().IdentifyKey("").Error,    Is.Not.Null);
+        Assert.That(MakeTool().IdentifyKey(null!).Error, Is.Not.Null);
+    }
+
+    [Test]
+    public void IdentifyKey_PathologicallyLongInput_ReturnsErrorWithoutScanning()
+    {
+        var huge = new string('C', 10_000);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = MakeTool().IdentifyKey(huge);
+        sw.Stop();
+
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(sw.ElapsedMilliseconds, Is.LessThan(10),
+            "long-input rejection must short-circuit before extraction");
+    }
+
+    [Test]
+    public void IdentifyKey_ControlCharsInError_AreSanitized()
+    {
+        var esc      = (char)0x1B;
+        var injected = "Q\n\r" + esc + "[31m";
+        var result   = MakeTool().IdentifyKey(injected);
+
+        // Either the input is too short to extract chords (Error about chord
+        // symbols) or it triggers the long-input length guard. Both paths use
+        // McpEchoSanitizer, so either way Error must be control-char free.
+        if (result.Error is not null)
+        {
+            Assert.That(result.Error.IndexOf('\n'), Is.EqualTo(-1));
+            Assert.That(result.Error.IndexOf('\r'), Is.EqualTo(-1));
+            Assert.That(result.Error.IndexOf(esc),  Is.EqualTo(-1));
+            Assert.That(result.Error.All(c => !char.IsControl(c)), Is.True);
+        }
+    }
+
+    // ── Result invariant ──────────────────────────────────────────────────────
+
+    [Test]
+    public void Failure_LeavesAllOtherFieldsAtDefault()
+    {
+        var fail = KeyIdentificationResult.Failure("test");
+
+        Assert.That(fail.RecognizedChords, Is.Empty);
+        Assert.That(fail.TopCandidates,    Is.Empty);
+        Assert.That(fail.PartialMatches,   Is.Empty);
+        Assert.That(fail.TotalChords,      Is.EqualTo(0));
+    }
+}

--- a/skills/key-identification/SKILL.md
+++ b/skills/key-identification/SKILL.md
@@ -1,0 +1,89 @@
+---
+Name: "key-identification"
+Description: "Identifies the most likely musical key of a chord progression and explains why. Calls the deterministic `ga_key_identify` MCP tool — never recall the analysis from training data, since the diatonic-set match is pitch-class arithmetic and the LLM is unreliable at it."
+Triggers:
+  - "what key is"
+  - "what key does"
+  - "what key are"
+  - "identify the key"
+  - "key of these"
+  - "key of the"
+  - "key is this"
+  - "what key am i"
+  - "diatonic to"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "tool-driven"
+  origin: "ported from Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs — sixth MCP-tool-driven canary; first hybrid port (deterministic detection + LLM phrasing)"
+  evidence-kinds:
+    - tool_call
+allowed-tools:
+  - ga_key_identify
+---
+
+# Key Identification
+
+When a user asks what key a chord progression is in, call `ga_key_identify`. Do NOT analyze the progression from training knowledge — the diatonic-set match is pitch-class arithmetic and the LLM is unreliable at it.
+
+## Calling the tool
+
+The tool takes one argument:
+
+- `query` — string. Either a bare chord list (`"C Am F G"`) or the user's full question (`"what key is C Am F G in?"`). The tool extracts chord symbols from prose.
+
+It returns a structured result:
+
+- `RecognizedChords` — string array, what the parser actually saw (useful for catching typos).
+- `TopCandidates` — array of `KeyCandidateInfo`. Keys tied at the highest match count.
+- `PartialMatches` — up to 3 partial-match keys ranked behind the top set.
+- `TotalChords` — total chords parsed.
+- `Error` — non-null when no chords parsed or no candidates matched.
+
+Each `KeyCandidateInfo` has:
+
+- `Key` — canonical key name (e.g. `"C major"`, `"A minor"`).
+- `RelativeKey` — name of the relative pair.
+- `MatchCount` / `TotalChords` — N of M chords are diatonic in this key.
+- `DiatonicSet` — the seven diatonic chords (`I` through `vii°`) in order.
+
+## Phrasing the answer
+
+Your job is to explain the key choice in guitarist-friendly language. Use the structured tool result; do NOT add analysis the tool didn't compute.
+
+### Single top candidate
+
+When `TopCandidates` has exactly one entry: lead with the key name and the match score, give the Roman numeral function of each input chord, and mention the diatonic set.
+
+> The progression `Dm G C` is in **C major** (3/3 chords diatonic). In C major: Dm = ii, G = V, C = I — a classic ii-V-I cadence. The diatonic chords of C major are C – Dm – Em – F – G – Am – B°.
+
+### Tied candidates (relative-pair ambiguity)
+
+When `TopCandidates` has multiple entries (almost always 2 — the relative major/minor pair share a diatonic set): name both, then explain how to distinguish them by ear.
+
+> The progression `C Am F G` fits **C major** AND **A minor** equally — both contain all four chords. To tell them apart, listen for the tonic: if the progression keeps resolving to **C** as home, it's C major; if **Am** feels like home, it's A minor. The relative-key pair shares the diatonic set C – Dm – Em – F – G – Am – B°.
+
+### Partial matches
+
+When `PartialMatches` has entries, optionally mention 1–2 of them with their match score: *"Could also be partly heard as G major (3/4 diatonic — the F is the borrowed chord)."*
+
+### Error path
+
+If `Error` is non-null, surface the message verbatim and ask the user to write the chords as standard symbols.
+
+## What this skill does NOT do
+
+These are hard constraints. Do NOT compute these from this catalog alone.
+
+- **Modal analysis** — modes (Dorian, Phrygian, etc.) are out of scope. The tool only ranks major/minor keys. If the user asks about modal context, defer.
+- **Chord-quality details beyond major/minor/7ths** — the tool's diatonic match doesn't distinguish a `Cmaj7` from a `C` for the purposes of key fitting.
+- **Recommend chords to ADD to the progression** — the tool detects a key from existing chords; it does not suggest continuations. For "what comes next?" defer to the progression-completion skill (when implemented).
+
+## Cross-reference
+
+- MCP tool: `Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs`
+- Tool tests: `Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationMcpToolsTests.cs`
+- Domain service: `Common/GA.Business.ML/Agents/KeyIdentificationService.cs`
+- Legacy C# skill it replaces: `Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs` (regex-driven + LLM phrasing — kept for the deterministic fast path)


### PR DESCRIPTION
## Summary

Sixth MCP-tool canary, and the **first hybrid port**. `KeyIdentificationSkill` was the first skill in the queue that combined deterministic detection (pitch-class arithmetic over diatonic chord-set match) with LLM phrasing. The C# version did both inline; the MCP-tool path keeps the deterministic detection in the tool, and the LLM-phrasing rules move to the SKILL.md body.

## What changed

| File | Role |
|---|---|
| `Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs` | new `[McpServerToolType]`; `IdentifyKey(query) → KeyIdentificationResult` wrapping `KeyIdentificationService` |
| `Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs` | registered `typeof(KeyIdentificationMcpTools)` |
| `skills/key-identification/SKILL.md` | thin tool-driven skill with phrasing rules for single-candidate, tied-relative-pair, partial-match, and error paths |
| `Tests/.../KeyIdentificationMcpToolsTests.cs` | 11 cases |
| `Tests/.../FileBasedSkillsProviderTests.cs` | new canary `InvokingAsync_LoadsKeyIdentificationSkillFromRepo` |

## Tool semantics

- **Input**: `query` (string, max 256 chars). Either bare chord list or full question with surrounding prose; the tool extracts chord symbols.
- **Output**: `KeyIdentificationResult` with `RecognizedChords`, `TopCandidates` (keys tied at the highest match count — usually 1, sometimes 2 for relative pairs), `PartialMatches` (up to 3), `TotalChords`, `Error` branch.

## SKILL.md phrasing rules

Three explicit branches in the body:

1. **Single top candidate** → lead with key name + match score, give Roman numeral function of each chord, mention diatonic set.
2. **Tied relative pair** (the most common ambiguous case — `C Am F G` ties C major and A minor at 4/4) → name both, explain how to distinguish by listening for the tonic.
3. **Partial matches** → optionally mention 1–2 with their match score (e.g. "could also be heard partly as G major — 3/4 diatonic, F is borrowed").

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~KeyIdentification"` — 31/31 pass (11 new MCP tool + existing C# skill suite still green)
- [x] `dotnet build AllProjects.slnx -c Debug` clean
- [ ] Live smoke deferred (Ollama)

## Reversibility

Two-way door. Removing `typeof(KeyIdentificationMcpTools)` from `GaPlugin.McpToolTypes` undoes the wiring; `KeyIdentificationSkill` (C#) is untouched.

## Migration progress

| Bucket | Count | Skills |
|---|---|---|
| Catalog SKILL.md | 3 | ✅ beginner-chords, ✅ progression-mood, ✅ modes |
| MCP-tool-driven SKILL.md | **6** | ✅ interval, ✅ scale, ✅ chord-info, ✅ fret-span, ✅ chord-substitution, ✅ key-identification |
| Remaining | **1** | ProgressionCompletion |

🤖 Generated with [Claude Code](https://claude.com/claude-code)