### PR TITLE
feat(chatbot): port ProgressionCompletion — MIGRATION COMPLETE (10/10 skills)

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -201,6 +201,49 @@ public class FileBasedSkillsProviderTests
     }
 
     [Test]
+    public async Task InvokingAsync_LoadsProgressionCompletionSkillFromRepo()
+    {
+        // Seventh and final canary — completes the migration. Notable for
+        // REUSING ga_key_identify rather than introducing a new MCP tool;
+        // the deterministic detection is identical to KeyIdentification, only
+        // the SKILL.md instructions differ (cadence picking vs key naming).
+        var repoSkills = ResolveRepoSkillsDir();
+        if (repoSkills is null) Assert.Ignore("skills/ directory not reachable from test binary");
+
+        var provider = new FileBasedSkillsProvider(repoSkills!);
+
+        var pc = provider.Skills.SingleOrDefault(s => s.Name == "progression-completion");
+        Assert.That(pc, Is.Not.Null,
+            "skills/progression-completion/SKILL.md must be discovered with name 'progression-completion'");
+
+        Assert.That(pc!.Triggers.Any(t => t.Contains("what comes next")), Is.True);
+        Assert.That(pc.Triggers.Any(t => t.Contains("finish this")), Is.True);
+        Assert.That(pc.Triggers.Any(t => t.Contains("continue this")), Is.True);
+
+        // Body must reference the REUSED ga_key_identify tool.
+        Assert.That(pc.Body, Does.Contain("ga_key_identify"),
+            "progression-completion SKILL.md reuses ga_key_identify (no new tool needed)");
+
+        // The four-cadence catalog is load-bearing — every suggestion the LLM
+        // makes must come from this list. If a row is dropped or a Roman
+        // numeral typo'd, the LLM will silently teach wrong theory.
+        Assert.That(pc.Body, Does.Contain("Authentic").And.Contain("Half")
+                                  .And.Contain("Deceptive").And.Contain("Plagal"),
+            "all four cadence types must be named in the body");
+        Assert.That(pc.Body, Does.Contain("V → I").Or.Contain("V→I"),
+            "authentic cadence Roman numeral must be present");
+        Assert.That(pc.Body, Does.Contain("IV → I").Or.Contain("IV→I"),
+            "plagal cadence Roman numeral must be present");
+
+        // Hard constraints section guards the LLM against making up chords.
+        Assert.That(pc.Body, Does.Contain("DiatonicSet"),
+            "the 'every suggested chord must appear in DiatonicSet' constraint must survive");
+
+        var ctx = await provider.InvokingAsync(UserContext("what comes next after C G Am"));
+        Assert.That(ctx.Instructions, Does.Contain("ga_key_identify"));
+    }
+
+    [Test]
     public async Task InvokingAsync_LoadsKeyIdentificationSkillFromRepo()
     {
         // Sixth MCP-tool-driven canary, and the FIRST hybrid port (the C#

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderTests.cs
@@ -239,6 +239,19 @@ public class FileBasedSkillsProviderTests
         Assert.That(pc.Body, Does.Contain("DiatonicSet"),
             "the 'every suggested chord must appear in DiatonicSet' constraint must survive");
 
+        // Suggestion-count cap is load-bearing UX — too many overwhelms, too
+        // few is unhelpful. Lock the "max 3" copy so a future edit can't
+        // silently change the contract the LLM follows.
+        Assert.That(pc.Body, Does.Contain("at most 3").Or.Contain("max 3").Or.Contain("most 3"),
+            "the 'max 3 suggestions' constraint must survive in the body");
+
+        // Cross-reference to chord-substitution is the documented escape
+        // hatch for non-diatonic reharmonization queries. If the cross-ref
+        // breaks, users asking for diminished/borrowed chords get an
+        // unhelpful refusal instead of being routed to the right skill.
+        Assert.That(pc.Body, Does.Contain("chord-substitution"),
+            "deferral cross-reference to chord-substitution skill must survive");
+
         var ctx = await provider.InvokingAsync(UserContext("what comes next after C G Am"));
         Assert.That(ctx.Instructions, Does.Contain("ga_key_identify"));
     }

--- a/skills/progression-completion/SKILL.md
+++ b/skills/progression-completion/SKILL.md
@@ -45,6 +45,8 @@ The fields you'll use here:
 - `TopCandidates[0].DiatonicSet` — the seven chords you may pick from.
 - `RecognizedChords` — the chord symbols already in the progression (you typically want the NEXT chord to be different from the last one in this list).
 
+**Tied keys.** When `TopCandidates` has more than one entry (e.g. a progression that fits both C major and A minor), draw your suggestions from `TopCandidates[0].DiatonicSet`. Relative-pair ties share the same diatonic set so the choice is neutral; on the rare non-relative tie (very short progressions), defaulting to the first candidate keeps the answer concrete. Mention the alternative key in passing but only suggest chords from one set.
+
 If `Error` is non-null, surface the message verbatim and ask the user to clarify the chord names.
 
 ## Cadence catalog (the four you may name)

--- a/skills/progression-completion/SKILL.md
+++ b/skills/progression-completion/SKILL.md
@@ -1,0 +1,102 @@
+---
+Name: "progression-completion"
+Description: "Suggests 2-3 diatonic cadence completions for an in-progress chord progression. Reuses the `ga_key_identify` MCP tool for deterministic key detection, then names cadence types (authentic / half / deceptive / plagal) drawn from the detected key's diatonic set."
+Triggers:
+  - "what comes next"
+  - "next chord"
+  - "what should follow"
+  - "finish this"
+  - "complete this"
+  - "end this"
+  - "end it"
+  - "help me finish"
+  - "help me end"
+  - "how to end"
+  - "how do i end"
+  - "continue this"
+  - "extend this"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "tool-driven"
+  origin: "ported from Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs — seventh and final MCP-tool-driven canary; reuses ga_key_identify rather than introducing a new tool"
+  evidence-kinds:
+    - tool_call
+allowed-tools:
+  - ga_key_identify
+---
+
+# Progression Completion
+
+When a user asks how to finish, continue, or extend a chord progression, you must NOT invent chord suggestions from training knowledge. The LLM is unreliable at picking diatonic chords for unfamiliar keys. Instead:
+
+1. **First** — call `ga_key_identify` on the user query. It returns the detected key plus the seven diatonic chords (`I`–`vii°`) of that key.
+2. **Then** — pick 2-3 cadence candidates from that diatonic set (and ONLY from that set), name the cadence type, and give the Roman numeral.
+
+## Calling the tool
+
+The argument is a string — bare chord list (`"C G Am"`) or full question (`"what comes next after C G Am?"`). The tool's `KeyIdentificationResult` has the same shape as documented in the `key-identification` skill — see that for full field semantics.
+
+The fields you'll use here:
+
+- `TopCandidates[0].Key` — the detected key.
+- `TopCandidates[0].DiatonicSet` — the seven chords you may pick from.
+- `RecognizedChords` — the chord symbols already in the progression (you typically want the NEXT chord to be different from the last one in this list).
+
+If `Error` is non-null, surface the message verbatim and ask the user to clarify the chord names.
+
+## Cadence catalog (the four you may name)
+
+Every suggestion you make must be one of these four cadence types:
+
+| Cadence | Roman numerals | Effect |
+|---|---|---|
+| **Authentic** | V → I (V7→I is stronger) | Strong, conclusive resolution. The "home" feeling. |
+| **Half** | anything → V | Open, suspended; the progression "stops on a question". |
+| **Deceptive** | V → vi (instead of V → I) | Surprises the ear by avoiding tonic; useful when you want to extend. |
+| **Plagal** | IV → I | Soft, "amen" cadence; less assertive than authentic. |
+
+In a minor key, substitute as needed (V is often borrowed from the parallel major to get a leading tone — `V7` is fine even when only `v` appears in the natural-minor diatonic set).
+
+## How to phrase suggestions
+
+Lead with the key, then offer 2-3 numbered options. For each:
+
+- The chord(s) to play (1-2 chords drawn from `DiatonicSet`).
+- The cadence type from the catalog above.
+- The Roman numeral(s).
+- A one-sentence explanation in plain language.
+
+### Example
+
+User: *"What chord comes next after C G Am?"*
+
+After calling `ga_key_identify("C G Am")` → returns `TopCandidates: [{ Key: "C major", DiatonicSet: [C, Dm, Em, F, G, Am, B°] }, ...]` (also tied with A minor):
+
+> The progression `C G Am` is in **C major** (or its relative A minor — both fit). Here are three ways to continue:
+>
+> 1. **`F → G → C`** — *authentic cadence* (IV–V–I). Brings everything home cleanly. The classic 1960s-pop ending.
+> 2. **`F`** — *plagal cadence* (IV–I). Soft "amen" finish; less dramatic than the authentic resolution.
+> 3. **`Dm → G7`** — *half cadence* (ii–V7). Doesn't resolve — leaves the loop open if you're looping the progression.
+
+## Hard constraints (do NOT break these)
+
+- **Every suggested chord must appear in `DiatonicSet`.** No borrowed chords, no chromatic substitutions in this skill's output. If the user wants reharmonization with non-diatonic chords, defer to the `chord-substitution` skill.
+- **Pick at most 3 suggestions.** More is overwhelming; one is too few.
+- **Do not invent a key the tool didn't detect.** If the tool returns `Error`, surface the error — do not guess.
+- **Stay within the 4 cadence types.** Don't introduce "minor plagal" or "Phrygian half" — those are real but not in this catalog and would confuse the explanation.
+
+## What this skill does NOT do
+
+- **Reharmonization** — replacing existing chords with non-diatonic substitutes. Defer to `chord-substitution`.
+- **Modal cadences** (Phrygian half, Lydian II–I, etc.) — out of scope for this skill.
+- **Voice leading** — the tool returns chord symbols, not specific voicings or fingerings.
+- **Style-specific suggestions** ("what comes next in a jazz / metal / bluegrass tune?") — this skill is style-neutral; the cadence catalog is the universal harmonic vocabulary.
+
+## Cross-reference
+
+- Reused MCP tool: `Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs` — same tool the `key-identification` skill uses.
+- Legacy C# skill it replaces: `Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs` (regex-driven + LLM phrasing — kept for the deterministic fast path)
+- Sibling skill: `skills/key-identification/SKILL.md` for "what key is X" queries that don't ask for a continuation.


### PR DESCRIPTION
## Summary

Final skill port. **All 10 `IOrchestratorSkill` implementations now have SKILL.md equivalents.**

`ProgressionCompletionSkill` is hybrid like `KeyIdentificationSkill` — and crucially uses **the same deterministic detection** (key + diatonic set). So this port doesn't introduce a new MCP tool: it reuses `ga_key_identify` and just gives the LLM different SKILL.md instructions (cadence-picking instead of key-naming).

## What changed

| File | Role |
|---|---|
| `skills/progression-completion/SKILL.md` | new tool-driven skill; `allowed-tools: [ga_key_identify]` (reused, no new tool) |
| `Tests/.../FileBasedSkillsProviderTests.cs` | new `InvokingAsync_LoadsProgressionCompletionSkillFromRepo` |

## SKILL.md body highlights

- **4-cadence catalog** (Authentic / Half / Deceptive / Plagal) with Roman numerals — every suggestion the LLM makes must come from this list.
- **Worked example** for "what comes next after C G Am?" walking through the tool call → 3 suggestion options.
- **Hard constraints** section explicitly tells the LLM: every suggested chord must appear in `DiatonicSet`, max 3 suggestions, no inventing keys, only the 4 catalog cadence types.
- **Out-of-scope** declines reharmonization, modal cadences, voice leading, style-specific suggestions.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~FileBasedSkillsProvider"` — 20/20 pass (was 19 before)
- [x] Body asserts the four cadence type names + Roman numerals (typo guard)
- [x] Body asserts DiatonicSet hard constraint survives
- [x] `dotnet build AllProjects.slnx -c Debug` clean

## Reversibility

Two-way door — additive markdown + one test. C# `ProgressionCompletionSkill` stays in place as the deterministic fast path.

## Migration state — COMPLETE

All 10 `IOrchestratorSkill` implementations migrated.

| Bucket | Count | Skills |
|---|---|---|
| **Catalog SKILL.md** | 4 | qa-architect, beginner-chords, progression-mood, modes |
| **MCP-tool-driven SKILL.md** (own tool) | 6 | interval, scale, chord-info, fret-span, chord-substitution, key-identification |
| **MCP-tool-driven SKILL.md** (reuses tool) | 1 | progression-completion (reuses `ga_key_identify`) |

7 MCP tools total exposed under `ga_*` prefix. C# skills coexist as the deterministic fast path until parity is proven in production.

## What's next (separate workstreams)

- **Live smoke tests** once Ollama unwedges — verify each SKILL.md actually fires correctly through the LLM path
- **Decide retirement** — when do C# skills stop being kept around as the fast path? Migration recommendation says "until parity is proven"; we now have unit-test parity but not prod-telemetry parity
- **Extract `Spell()` helper** shared between `ChordInfoSkill` and `ChordMcpTools` (deferred from PR #80 review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)