### PR TITLE
fix(chatbot): handoff doc inconsistencies + junie wrapper for Windows

### DIFF
--- a/Scripts/junie-review.ps1
+++ b/Scripts/junie-review.ps1
@@ -1,0 +1,69 @@
+# junie-review.ps1 — Windows-friendly junie invocation that survives multi-line prompts.
+#
+# The bare `junie --task "$multiline"` invocation breaks on Windows because
+# cmd.exe re-quotes embedded newlines and quotes inside the --task string.
+# This wrapper reads the prompt from a file (or pipeline) into a PowerShell
+# variable and passes it as a single argument array element to junie. Native
+# PowerShell variable passing bypasses the cmd-layer rewrite.
+#
+# Usage:
+#   pwsh Scripts/junie-review.ps1 -PromptFile path/to/prompt.txt [-Project repo-root]
+#   Get-Content prompt.txt -Raw | pwsh Scripts/junie-review.ps1 [-Project repo-root]
+#
+# Why this exists: PR #90's review attempted to run junie three times and
+# all three failed with "The syntax of the command is incorrect." until we
+# switched to file-based prompt passing.
+
+[CmdletBinding()]
+param(
+    [string]$PromptFile,
+    [string]$Project = (Get-Location).Path,
+
+    # Pipeline input. ValueFromPipeline accepts both `Get-Content -Raw`
+    # (single string) and `Get-Content` (string array of lines).
+    [Parameter(ValueFromPipeline = $true)]
+    [string[]]$StdinLines
+)
+
+begin {
+    $ErrorActionPreference = 'Stop'
+    $bufferedLines = New-Object System.Collections.Generic.List[string]
+}
+
+process {
+    if ($StdinLines) { $bufferedLines.AddRange([string[]]$StdinLines) }
+}
+
+end {
+    if ($PromptFile) {
+        if (-not (Test-Path $PromptFile)) {
+            Write-Error "Prompt file not found: $PromptFile"
+            exit 2
+        }
+        $promptText = Get-Content -Raw -Path $PromptFile
+    }
+    elseif ($bufferedLines.Count -gt 0) {
+        $promptText = $bufferedLines -join "`n"
+    }
+    else {
+        Write-Error "Empty prompt — pass -PromptFile or pipe content via stdin."
+        exit 2
+    }
+
+    if ([string]::IsNullOrWhiteSpace($promptText)) {
+        Write-Error "Empty prompt — pass -PromptFile or pipe content via stdin."
+        exit 2
+    }
+
+    if (-not (Test-Path $Project)) {
+        Write-Error "Project directory not found: $Project"
+        exit 2
+    }
+
+    # Pass the prompt as a single array argument. PowerShell's native exec
+    # path (& with @args) preserves the string verbatim — no cmd.exe rewrite,
+    # no quote re-interpretation, no newline mangling.
+    $junieArgs = @('--task', $promptText, '--project', $Project)
+    & junie @junieArgs
+    exit $LASTEXITCODE
+}

--- a/docs/plans/2026-05-03-chatbot-skill-md-migration-completion.md
+++ b/docs/plans/2026-05-03-chatbot-skill-md-migration-completion.md
@@ -6,7 +6,7 @@
 
 ## What landed
 
-13 PRs merged to `main` on 2026-05-03:
+12 PRs merged to `main` on 2026-05-03 (this workstream):
 
 | PR | Type | Topic |
 |---|---|---|
@@ -25,9 +25,11 @@
 
 ## Migration map (final state)
 
+> **Note**: `qa-architect/` was authored separately in PR #66 (Phase 2 of the migration recommendation, before this workstream's 12 PRs); it's listed in the layout for completeness but did not ship in any of the 12 PRs above.
+
 ```
 skills/
-├── qa-architect/              SKILL.md   (catalog — instructions for QA Architect agent)
+├── qa-architect/              SKILL.md   (catalog — pre-existing, PR #66; instructions for QA Architect agent)
 ├── beginner-chords/           SKILL.md   (catalog — 8 open-position chord diagrams)
 ├── progression-mood/          SKILL.md   (catalog — darken/brighten technique catalog)
 ├── modes/                     SKILL.md   (catalog — 7-mode major-scale catalog)


### PR DESCRIPTION
## Summary

Retroactive PR #91 review (ce-coherence-reviewer) flagged two real inconsistencies in the merged handoff doc; fixing them. Also adds the junie wrapper that PR #90's review surfaced as needed.

## Changes

**`docs/plans/2026-05-03-chatbot-skill-md-migration-completion.md`** — two fixes:
1. Header off-by-one: said "13 PRs" but table lists 12. Corrected to "12 PRs (this workstream)".
2. `qa-architect/` was listed in the migration map as a catalog skill but no PR in the table ported it — it was authored separately in PR #66 (the original Phase 2 migration recommendation work, before this workstream began). Added a note + annotation so future readers don't read it as orphaned.

**`Scripts/junie-review.ps1`** — new Windows-friendly wrapper for the junie CLI:
- PR #90's review tried to run junie three times; all three failed with "The syntax of the command is incorrect." because cmd.exe re-quotes embedded newlines and quotes inside the `--task` string.
- The wrapper reads the prompt from a file or pipeline into a PowerShell variable and passes it via PowerShell's native exec path (`& with @args`), bypassing the cmd-layer rewrite.
- Usage: `pwsh Scripts/junie-review.ps1 -PromptFile prompt.txt -Project repo` OR `Get-Content prompt.txt -Raw | pwsh Scripts/junie-review.ps1 -Project repo`

## Test plan

- [x] Doc renders correctly (visual diff)
- [x] Wrapper accepts both file-input and stdin paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)