### PR TITLE
fix(chatbot): route bare "What is X major/minor?" queries to scale-info

### DIFF
--- a/Common/GA.Business.ML/Agents/Skills/ScaleInfoSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ScaleInfoSkill.cs
@@ -24,7 +24,17 @@ public sealed class ScaleInfoSkill(ILogger<ScaleInfoSkill> logger) : IOrchestrat
         "What notes are in C major?",
         "Show me the F# minor scale",
         "List the notes in Bb major",
+        // Bare "What is X major/minor?" pattern — common phrasing that
+        // production was dropping into the LLM fallback because no example
+        // prompt was structurally close enough to it. The 0.65 cosine
+        // threshold + "What is a C major chord?" gap on the ChordInfo side
+        // pushed both candidates below threshold for the bare query.
+        // See docs/plans/2026-05-03-skill-routing-quality-fix.md for the
+        // diagnosis trail.
+        "What is C major?",
+        "What is A minor?",
         "What is D minor?",
+        "What is F# major?",
         "Tell me the notes of E major",
     ];
 

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ScaleInfoSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ScaleInfoSkillTests.cs
@@ -1,0 +1,56 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[TestFixture]
+public class ScaleInfoSkillTests
+{
+    private static ScaleInfoSkill MakeSkill() => new(NullLogger<ScaleInfoSkill>.Instance);
+
+    [Test]
+    public void ExamplePrompts_IncludeBareWhatIsXMajorPattern()
+    {
+        // Regression test for the user-reported routing failure:
+        // "What is C major?" was falling back to the LLM because no example
+        // prompt was structurally close enough to clear the 0.65 cosine
+        // threshold. The fix is to include the bare "What is X major/minor?"
+        // shape in ExamplePrompts so the SemanticIntentRouter scores it
+        // near-1.0 for that phrasing.
+        //
+        // If this test fails, "What is C major?" / "What is A minor?" /
+        // "What is F# major?" queries will likely fall back to the LLM in
+        // production. Re-add the patterns before removing them.
+        var skill = MakeSkill();
+
+        Assert.That(skill.ExamplePrompts, Has.Some.EqualTo("What is C major?"),
+            "bare major-key pattern must be in ExamplePrompts so the semantic router clears the confidence threshold");
+        Assert.That(skill.ExamplePrompts, Has.Some.EqualTo("What is A minor?"),
+            "bare minor-key pattern must be in ExamplePrompts");
+        Assert.That(skill.ExamplePrompts, Has.Some.EqualTo("What is F# major?"),
+            "accidental-key pattern must be in ExamplePrompts so accidentals don't drop below the threshold");
+    }
+
+    [Test]
+    public void ExamplePrompts_AlsoIncludeNotes_ResponsiblePhrasings()
+    {
+        // The bare "What is X major?" patterns coexist with the more explicit
+        // "What notes are in X major?" / "Show me the X scale" phrasings —
+        // the regression-fix added new prompts without removing existing ones.
+        var skill = MakeSkill();
+
+        Assert.That(skill.ExamplePrompts, Has.Some.Contain("notes are in"));
+        Assert.That(skill.ExamplePrompts, Has.Some.Contain("scale"));
+    }
+
+    [Test]
+    public void Description_DescribesKeyOrScaleLookup()
+    {
+        var skill = MakeSkill();
+
+        Assert.That(skill.Description, Does.Contain("major").IgnoreCase
+            .Or.Contain("minor").IgnoreCase
+            .Or.Contain("key").IgnoreCase
+            .Or.Contain("scale").IgnoreCase);
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
@@ -275,13 +275,20 @@ public class SemanticIntentRouterTests
             description: "Returns chord intervals.",
             examples: ["What is a C major chord?", "What notes are in Dm7?"]);
 
+        // Calibrated to mirror likely nomic-embed-text behaviour:
+        // - Literal-string ScaleInfo example matches at 1.0
+        // - ChordInfo's "What is a C major chord?" is a strong-but-not-literal
+        //   match at ~0.85 (realistic per PR #94 review — original 0.6 was
+        //   too pessimistic and didn't stress-test the close-competitor case).
+        // The test must still resolve to scale-info because the literal match
+        // dominates the close cousin, NOT because the cousin is far away.
         var queryVec       = new float[] { 1f, 0f, 0f, 0f };
-        var chordExampleV  = new float[] { 0.6f, 0.8f, 0f, 0f };  // close but not literal
+        var chordExampleV  = new float[] { 0.85f, 0.5267f, 0f, 0f };  // |v|=1.0, cos vs queryVec ≈ 0.85
         var vectors = new Dictionary<string, float[]>
         {
             ["What is C major?"]               = queryVec,         // literal match, score 1.0
-            ["What is A minor?"]               = [0.9f, 0.1f, 0f, 0f],
-            ["What notes are in C major?"]     = [0.7f, 0.7f, 0f, 0f],
+            ["What is A minor?"]               = [0.9f, 0.4359f, 0f, 0f],     // cos ≈ 0.9
+            ["What notes are in C major?"]     = [0.7f, 0.7141f, 0f, 0f],     // cos ≈ 0.7
             ["What is a C major chord?"]       = chordExampleV,
             ["What notes are in Dm7?"]         = [0f, 1f, 0f, 0f],
             ["Returns the notes of a major or minor key."] = [0f, 0f, 1f, 0f],

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
@@ -253,6 +253,58 @@ public class SemanticIntentRouterTests
     }
 
     [Test]
+    public async Task RouteAsync_BareWhatIsXMajor_RoutesToScaleInfoNotLLM()
+    {
+        // Regression for the user-reported bug: "What is C major?" was falling
+        // back to the LLM path because no example prompt was structurally
+        // close enough to score above the 0.65 threshold. Fix in PR-pending:
+        // ScaleInfoSkill.ExamplePrompts now includes the bare
+        // "What is C major?" / "What is A minor?" patterns.
+        //
+        // This test uses stub embeddings calibrated to mirror the real-world
+        // scenario: the bare query has high cosine similarity with the new
+        // ScaleInfo example (literal match → 1.0) and lower similarity with
+        // ChordInfo's "What is a C major chord?" (different vector → 0.6).
+        var scaleInfo = new StubIntent(
+            id: "skill.scaleinfo",
+            description: "Returns the notes of a major or minor key.",
+            examples: ["What is C major?", "What is A minor?", "What notes are in C major?"]);
+
+        var chordInfo = new StubIntent(
+            id: "skill.chordinfo",
+            description: "Returns chord intervals.",
+            examples: ["What is a C major chord?", "What notes are in Dm7?"]);
+
+        var queryVec       = new float[] { 1f, 0f, 0f, 0f };
+        var chordExampleV  = new float[] { 0.6f, 0.8f, 0f, 0f };  // close but not literal
+        var vectors = new Dictionary<string, float[]>
+        {
+            ["What is C major?"]               = queryVec,         // literal match, score 1.0
+            ["What is A minor?"]               = [0.9f, 0.1f, 0f, 0f],
+            ["What notes are in C major?"]     = [0.7f, 0.7f, 0f, 0f],
+            ["What is a C major chord?"]       = chordExampleV,
+            ["What notes are in Dm7?"]         = [0f, 1f, 0f, 0f],
+            ["Returns the notes of a major or minor key."] = [0f, 0f, 1f, 0f],
+            ["Returns chord intervals."]                   = [0f, 0f, 0f, 1f],
+        };
+
+        var router = new SemanticIntentRouter(
+            StubEmbedder(vectors),
+            NullLogger<SemanticIntentRouter>.Instance);
+
+        var match = await router.RouteAsync(
+            "What is C major?",
+            Services(scaleInfo, chordInfo));
+
+        Assert.That(match, Is.Not.Null,
+            "bare 'What is C major?' must route — the regression that drove this fix was LLM fallback at 0% confidence");
+        Assert.That(match!.Value.Intent.Id, Is.EqualTo("skill.scaleinfo"),
+            "bare 'What is X major' phrasing should route to scale-info (key/scale lookup), not chord-info");
+        Assert.That(match.Value.Confidence, Is.GreaterThanOrEqualTo(0.65f),
+            "must clear the MinConfidence threshold the production router applies");
+    }
+
+    [Test]
     public async Task IntentMatch_RecordsMatchedExample()
     {
         var modes = new StubIntent("skill.modes", "modes of major scale",


### PR DESCRIPTION
## Summary

User-reported regression: prompts like "What is C major?" / "What is A minor?" fall back to direct LLM instead of routing through skill dispatch.

## Diagnosis

`ProductionOrchestrator.cs:248` — production routing uses ONLY the `SemanticIntentRouter`; the legacy `_skills.foreach(CanHandle)` substring path was deleted in PR #70. Routing depends on cosine similarity vs `IIntent.ExamplePrompts`.

`ScaleInfoSkill.ExamplePrompts` had `"What notes are in C major?"` and `"What is D minor?"` but no example for the bare `"What is X major?"` shape. `ChordInfoSkill` had `"What is a C major chord?"` (extra "a" + "chord"). Both diverge from the bare query enough that real nomic-embed-text similarity drops below the 0.65 threshold → router returns null → LLM fallback.

## Fix

Added 4 bare-pattern examples to `ScaleInfoSkill.ExamplePrompts`:
- `"What is C major?"`
- `"What is A minor?"`
- `"What is F# major?"` (accidental coverage)
- `"What is D minor?"` (kept)

The `IntentEmbeddingWarmupService` re-embeds at chatbot startup; cosine similarity for "What is C major?" vs the literal example becomes ~1.0 (well above threshold).

## Tests

- **New `ScaleInfoSkillTests`** (3 cases) — contract test asserting the bare patterns exist in `ExamplePrompts`. Pins the fix at the source so removing a pattern fails locally before hitting prod.
- **New `SemanticIntentRouterTests` case** `RouteAsync_BareWhatIsXMajor_RoutesToScaleInfoNotLLM` — stub-embedding test verifying routing behavior given the new examples.
- 127/127 SkillMd / SemanticIntent / FileBasedSkill / ChordInfo / ScaleInfo tests pass.

## Live validation (deferred)

Requires chatbot service restart with the new ExamplePrompts so `IntentEmbeddingWarmupService` re-embeds. After restart, send `"What is C major?"` to `/api/chatbot/chat` and verify trace shows `agentId=skill.scaleinfo` (not direct LLM).

## Context

First of 5 quality fixes from the 2026-05-03 candid assessment. A2 modulation detection (PR #90's Phase 1 plan) is **paused** until routing / voicing scores / readiness probe / parity gate / retirement criteria are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)