### PR TITLE
fix(voicing): recognize OPTIC-K v1.8 (240-dim) — fixes "scores at 0.000" bug

### DIFF
--- a/Common/GA.Business.ML/Search/CpuVoicingSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/CpuVoicingSearchStrategy.cs
@@ -23,11 +23,15 @@ public class CpuVoicingSearchStrategy : IVoicingSearchStrategy
     private TimeSpan _totalSearchTime = TimeSpan.Zero;
     private readonly object _statsLock = new();
 
-    // OPTIC-K Schema Constants
-    private const int OpticKv17Dim = 228;
-    private const int OpticKv16Dim = 216;
+    // OPTIC-K Schema Constants. Add new versions HERE when the schema changes.
+    // The partition-aware similarity below depends on slots 6-77 having a
+    // stable layout across versions (verified in EmbeddingSchema.cs); newer
+    // versions only ADD info partitions past slot 78.
+    private const int OpticKv18Dim  = 240;  // v1.8 — adds ROOT one-hot in raw slots 228-239
+    private const int OpticKv17Dim  = 228;
+    private const int OpticKv16Dim  = 216;
     private const int OpticKv131Dim = 109;
-    private const int LegacyDim = 96;
+    private const int LegacyDim     = 96;
 
     // Partition Config
     private const int StructureOffset = 6;
@@ -233,17 +237,28 @@ public class CpuVoicingSearchStrategy : IVoicingSearchStrategy
 
     private static double CosineSimilarity(double[] v1, double[] v2)
     {
-        if (v1.Length != v2.Length) return 0.0;
+        var v1Musical = IsKnownOpticKDim(v1.Length);
+        var v2Musical = IsKnownOpticKDim(v2.Length);
 
-        // Use weighted partition similarity for musical embeddings (v1.7, v1.6, v1.3.1, v1.2.1)
-        if (v1.Length == OpticKv17Dim || v1.Length == OpticKv16Dim || v1.Length == OpticKv131Dim || v1.Length == LegacyDim)
-        {
+        // Both vectors are OPTIC-K (possibly different versions): use partition-aware
+        // similarity. Partitions 6-77 (STRUCTURE / MORPHOLOGY / CONTEXT / SYMBOLIC)
+        // are layout-identical across v1.2.1 / v1.3.1 / v1.6 / v1.7 / v1.8 — newer
+        // versions only ADD info partitions past slot 78. The previous behaviour
+        // ("return 0.0 on length mismatch") was the user-reported "voicing scores
+        // at 0.000" bug after the schema bumped to v1.8 (240) while older indexed
+        // voicings remained at v1.7 (228).
+        if (v1Musical && v2Musical)
             return CalculateMusicalSimilarity(v1, v2);
-        }
 
-        // Fallback to standard Cosine Similarity
+        // Outside OPTIC-K: standard cosine, but require equal dim (no safe
+        // cross-dimension semantics for non-musical vectors).
+        if (v1.Length != v2.Length) return 0.0;
         return System.Numerics.Tensors.TensorPrimitives.CosineSimilarity(v1, v2);
     }
+
+    private static bool IsKnownOpticKDim(int n) =>
+        n == OpticKv18Dim || n == OpticKv17Dim || n == OpticKv16Dim
+        || n == OpticKv131Dim || n == LegacyDim;
 
     private static double CalculateMusicalSimilarity(double[] query, double[] target)
     {

--- a/Common/GA.Business.ML/Search/GpuVoicingSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/GpuVoicingSearchStrategy.cs
@@ -716,7 +716,7 @@ public class GpuVoicingSearchStrategy : IVoicingSearchStrategy, IDisposable
         var embeddingStartIdx = voicingIndex * _embeddingDimensions;
 
         // Use weighted partition similarity for musical embeddings (v1.7, v1.6, v1.3.1, v1.2.1)
-        if (_embeddingDimensions == OpticKv17Dim || _embeddingDimensions == OpticKv16Dim || _embeddingDimensions == MusicalEmbeddingDim || _embeddingDimensions == LegacyMusicalEmbeddingDim)
+        if (_embeddingDimensions == OpticKv18Dim || _embeddingDimensions == OpticKv17Dim || _embeddingDimensions == OpticKv16Dim || _embeddingDimensions == MusicalEmbeddingDim || _embeddingDimensions == LegacyMusicalEmbeddingDim)
         {
             return CalculateMusicalSimilarity(queryEmbedding, _hostEmbeddings, embeddingStartIdx);
         }

--- a/Common/GA.Business.ML/Search/GpuVoicingSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/GpuVoicingSearchStrategy.cs
@@ -20,7 +20,10 @@ using ILGPU.Runtime;
 /// </summary>
 public class GpuVoicingSearchStrategy : IVoicingSearchStrategy, IDisposable
 {
-    // OPTIC-K Musical Embedding Schema Constants
+    // OPTIC-K Musical Embedding Schema Constants. Add new versions HERE.
+    // Partition-aware similarity reads slots 6-77 only — layout stable across
+    // versions, newer ones only add info partitions past slot 78.
+    private const int OpticKv18Dim = 240; // v1.8 — adds ROOT one-hot in raw slots 228-239
     private const int OpticKv17Dim = 228; // v1.7
     private const int OpticKv16Dim = 216; // v1.6
     private const int MusicalEmbeddingDim = 109; // v1.3.1
@@ -404,7 +407,7 @@ public class GpuVoicingSearchStrategy : IVoicingSearchStrategy, IDisposable
 
         var voicingOffset = index * embeddingDim;
 
-        if (embeddingDim == OpticKv17Dim || embeddingDim == OpticKv16Dim || embeddingDim == MusicalEmbeddingDim || embeddingDim == LegacyMusicalEmbeddingDim)
+        if (embeddingDim == OpticKv18Dim || embeddingDim == OpticKv17Dim || embeddingDim == OpticKv16Dim || embeddingDim == MusicalEmbeddingDim || embeddingDim == LegacyMusicalEmbeddingDim)
         {
             var score = 0.0;
 
@@ -464,7 +467,7 @@ public class GpuVoicingSearchStrategy : IVoicingSearchStrategy, IDisposable
         var voicingIdx = allowedIndices[index];
         var voicingOffset = voicingIdx * embeddingDim;
 
-        if (embeddingDim == OpticKv17Dim || embeddingDim == OpticKv16Dim || embeddingDim == MusicalEmbeddingDim || embeddingDim == LegacyMusicalEmbeddingDim)
+        if (embeddingDim == OpticKv18Dim || embeddingDim == OpticKv17Dim || embeddingDim == OpticKv16Dim || embeddingDim == MusicalEmbeddingDim || embeddingDim == LegacyMusicalEmbeddingDim)
         {
             var score = 0.0;
 

--- a/Tests/Common/GA.Business.ML.Tests/Search/CpuVoicingSearchStrategyDimensionTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/CpuVoicingSearchStrategyDimensionTests.cs
@@ -152,6 +152,31 @@ public class CpuVoicingSearchStrategyDimensionTests
     }
 
     [Test]
+    public async Task SemanticSearchAsync_V18QueryAgainstLegacyVoicing_ScoresNonZero()
+    {
+        // Cross-version with the OLDEST recognized dim (v1.2.1 = 96).
+        // Slots 6..77 still exist in legacy (96 ≥ 78), so partition-aware
+        // similarity is safe. Reviewer (octo-code-reviewer on PR #95)
+        // requested explicit coverage so future schema changes don't
+        // silently regress the legacy compatibility surface.
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = MakeV18Vector(1.0);
+        var legacy   = new double[96];
+        for (var i = 6;  i < 30; i++) legacy[i] = 1.0 * 0.1 + i * 0.01;
+        for (var i = 30; i < 54; i++) legacy[i] = 1.0 * 0.2 + i * 0.01;
+        for (var i = 54; i < 66; i++) legacy[i] = 1.0 * 0.3 + i * 0.01;
+        for (var i = 66; i < 78; i++) legacy[i] = 1.0 * 0.4 + i * 0.01;
+
+        await strategy.InitializeAsync([MakeVoicing("legacy-target", legacy)]);
+
+        var results = await strategy.SemanticSearchAsync(query, limit: 1);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Score, Is.GreaterThan(0.0),
+            "v1.8 query against legacy (96-dim) voicing must produce a non-zero score");
+    }
+
+    [Test]
     public async Task SemanticSearchAsync_QueryWithUnknownDim_DoesNotCrashAndReturnsResults()
     {
         // Unknown query dim (e.g. some future schema). When the query is NOT

--- a/Tests/Common/GA.Business.ML.Tests/Search/CpuVoicingSearchStrategyDimensionTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/CpuVoicingSearchStrategyDimensionTests.cs
@@ -1,0 +1,171 @@
+namespace GA.Business.ML.Tests.Search;
+
+using GA.Business.ML.Search;
+using GA.Domain.Services.Fretboard.Voicings.Core;
+
+/// <summary>
+/// Regression tests for the user-reported "voicing scores at 0.000" bug.
+/// Cause: <see cref="CpuVoicingSearchStrategy.CosineSimilarity"/> previously
+/// returned <c>0.0</c> when query and target had different lengths AND only
+/// recognised dimensions 96 / 109 / 216 / 228 — but the schema bumped to
+/// v1.8 (240) without updating the dim recognition list, so any v1.8 query
+/// against v1.7 indexed voicings (or vice versa) hit the "return 0.0"
+/// short-circuit.
+/// </summary>
+[TestFixture]
+public class CpuVoicingSearchStrategyDimensionTests
+{
+    /// <summary>
+    /// Build a v1.8-shaped (240-dim) embedding with deterministic values in
+    /// the similarity partitions (slots 6-77) and zeros in the info slots.
+    /// </summary>
+    private static double[] MakeV18Vector(double seed)
+    {
+        var v = new double[240];
+        // STRUCTURE 6..29
+        for (var i = 6;  i < 30; i++) v[i] = seed * 0.1 + i * 0.01;
+        // MORPHOLOGY 30..53
+        for (var i = 30; i < 54; i++) v[i] = seed * 0.2 + i * 0.01;
+        // CONTEXT 54..65
+        for (var i = 54; i < 66; i++) v[i] = seed * 0.3 + i * 0.01;
+        // SYMBOLIC 66..77
+        for (var i = 66; i < 78; i++) v[i] = seed * 0.4 + i * 0.01;
+        // ROOT one-hot at 228..239 (v1.8-specific) — keep at 0 for the test
+        return v;
+    }
+
+    /// <summary>
+    /// Build a v1.7-shaped (228-dim) embedding with the SAME similarity-partition
+    /// values as <see cref="MakeV18Vector"/> for the same seed. Slot 228+ doesn't
+    /// exist for v1.7 (no ROOT partition).
+    /// </summary>
+    private static double[] MakeV17Vector(double seed)
+    {
+        var v = new double[228];
+        for (var i = 6;  i < 30; i++) v[i] = seed * 0.1 + i * 0.01;
+        for (var i = 30; i < 54; i++) v[i] = seed * 0.2 + i * 0.01;
+        for (var i = 54; i < 66; i++) v[i] = seed * 0.3 + i * 0.01;
+        for (var i = 66; i < 78; i++) v[i] = seed * 0.4 + i * 0.01;
+        return v;
+    }
+
+    private static VoicingEmbedding MakeVoicing(string id, double[] embedding) =>
+        new(
+            Id:                  id,
+            ChordName:           "Test",
+            VoicingType:         null,
+            Position:            null,
+            Difficulty:          null,
+            ModeName:            null,
+            ModalFamily:         null,
+            PossibleKeys:        [],
+            SemanticTags:        [],
+            PrimeFormId:         "",
+            TranslationOffset:   0,
+            Diagram:             "",
+            MidiNotes:           [],
+            PitchClassSet:       "",
+            IntervalClassVector: "",
+            MinFret:             0,
+            MaxFret:             0,
+            BarreRequired:       false,
+            HandStretch:         0,
+            StackingType:        null,
+            RootPitchClass:      null,
+            MidiBassNote:        0,
+            HarmonicFunction:    null,
+            IsNaturallyOccurring: false,
+            ConsonanceScore:     0,
+            BrightnessScore:     0,
+            IsRootless:          false,
+            HasGuideTones:       false,
+            Inversion:           0,
+            TopPitchClass:       null,
+            TexturalDescription: null,
+            DoubledTones:        null,
+            AlternateNames:      null,
+            OmittedTones:        null,
+            CagedShape:          null,
+            Description:         id,
+            Embedding:           embedding,
+            TextEmbedding:       null);
+
+    [Test]
+    public async Task SemanticSearchAsync_V18QueryAgainstV18Voicing_ScoresNonZero()
+    {
+        // Identical seed for query and voicing → similarity should be near 1.0.
+        // The pre-fix code would have FAILED line 239's dim-recognition
+        // (240 not in the list) and fallen back to TensorPrimitives.CosineSimilarity
+        // which works — but it would've SKIPPED the partition-aware path.
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = MakeV18Vector(1.0);
+        await strategy.InitializeAsync([MakeVoicing("v18-target", MakeV18Vector(1.0))]);
+
+        var results = await strategy.SemanticSearchAsync(query, limit: 1);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Score, Is.GreaterThan(0.0),
+            "v1.8 query against v1.8 voicing must produce a non-zero score");
+    }
+
+    [Test]
+    public async Task SemanticSearchAsync_V18QueryAgainstV17Voicing_NoLongerReturnsZero()
+    {
+        // The user-reported regression: v1.8 query (240) × v1.7 indexed voicing
+        // (228) → length mismatch → 0.0 score. The fix recognizes both as
+        // OPTIC-K dims and routes to partition-aware similarity, which reads
+        // slots 6-77 (layout-stable across versions) — so a non-zero score
+        // emerges from genuinely-similar voicings even cross-version.
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = MakeV18Vector(1.0);
+        await strategy.InitializeAsync([MakeVoicing("v17-target", MakeV17Vector(1.0))]);
+
+        var results = await strategy.SemanticSearchAsync(query, limit: 1);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Score, Is.GreaterThan(0.0),
+            "v1.8 query against v1.7 voicing MUST produce a non-zero score — " +
+            "the regression was returning 0.0 for every cross-version pair.");
+    }
+
+    [Test]
+    public async Task SemanticSearchAsync_V18QueryRanksMatchAboveMismatch()
+    {
+        // Two voicings with different similarity-partition values; the
+        // matching-seed voicing must outrank the dissimilar one. This pins
+        // that the fix didn't accidentally make all scores collapse to a
+        // single value (e.g. by returning a constant on the cross-version
+        // path).
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = MakeV18Vector(1.0);
+        await strategy.InitializeAsync(
+        [
+            MakeVoicing("good-match",   MakeV17Vector(1.0)),
+            MakeVoicing("poor-match",   MakeV17Vector(7.0)),
+        ]);
+
+        var results = await strategy.SemanticSearchAsync(query, limit: 2);
+
+        Assert.That(results, Has.Count.EqualTo(2));
+        Assert.That(results[0].Document.Id, Is.EqualTo("good-match"),
+            "the seed-matching voicing must rank first; cross-version comparison must still be discriminating");
+    }
+
+    [Test]
+    public async Task SemanticSearchAsync_QueryWithUnknownDim_DoesNotCrashAndReturnsResults()
+    {
+        // Unknown query dim (e.g. some future schema). When the query is NOT
+        // a known OPTIC-K dim and the target IS, the fallback is
+        // (1) length mismatch with v1.7/v1.8 → 0.0 (correct: cross-version
+        // semantics are only safe when BOTH sides are OPTIC-K)
+        // (2) length match → standard cosine similarity
+        // The test asserts no crash and returns the expected number of results.
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = new double[300]; // not a known OPTIC-K dim
+        for (var i = 0; i < 300; i++) query[i] = 0.1 * i;
+        await strategy.InitializeAsync([MakeVoicing("v17", MakeV17Vector(1.0))]);
+
+        Assert.That(async () => await strategy.SemanticSearchAsync(query, limit: 1),
+            Throws.Nothing);
+    }
+}


### PR DESCRIPTION
## Summary

User reported voicing scores stuck at **0.000** in production. Root cause traced to `CpuVoicingSearchStrategy.CosineSimilarity` (line 236):

```csharp
if (v1.Length != v2.Length) return 0.0;
```

`EmbeddingSchema` bumped to **OPTIC-K v1.8 (240 dims)** — added a 12-dim ROOT one-hot at slots 228-239. `MusicalEmbeddingGenerator.Dimension` returns 240. But indexed voicings were still v1.7 (228). Every query × voicing pair hit the length-mismatch short-circuit → 0.000 score.

Even when both sides match at 240, the dim-recognition list at line 239 only knew v1.7/v1.6/v1.3.1/legacy — so v1.8 silently bypassed the partition-aware similarity and used standard cosine (works, but bypasses the carefully-tuned 0.45/0.25/0.20/0.10 partition weights).

## Fix

1. **Add `OpticKv18Dim = 240` constant** to both `CpuVoicingSearchStrategy` and `GpuVoicingSearchStrategy`.

2. **Replace the equal-length short-circuit with a smarter check**: if BOTH sides are recognized OPTIC-K dims, use partition-aware similarity even if dimensions differ. Slots 6-77 (STRUCTURE / MORPHOLOGY / CONTEXT / SYMBOLIC) are layout-identical across versions; newer versions only ADD info partitions past slot 78. Cross-version comparison is safe.

3. **Update GPU strategy's 3 dim-recognition sites** (kernel scoring + post-processing + accelerator-init guard) to include v1.8.

## Tests

New `CpuVoicingSearchStrategyDimensionTests` (4 cases):

- ✅ v1.8 query × v1.8 voicing → non-zero score
- ✅ v1.8 query × v1.7 voicing → non-zero score (**the regression**)
- ✅ v1.8 query ranks matching v1.7 voicing ABOVE dissimilar v1.7 voicing (proves cross-version comparison stays discriminating)
- ✅ Unknown query dim doesn't crash, falls back gracefully

155/155 broader Voicing / Search / OpticK / Embedding tests still pass.

## Live validation deferred

Math-level fix — dim mismatch can no longer return 0.000 for OPTIC-K vectors. Real-world ranking quality needs a separate eval against the live voicing index.

## Context

Fix #2 of 5 from your 2026-05-03 candid assessment. Junie's earlier unsolicited GPU/CPU-mode-forcing edits (stashed) were NOT this fix — they targeted a different problem (GPU stability) and would have been a one-way door away from production GPU acceleration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)