### PR TITLE
fix(chatbot): /status verifies model presence — fixes "shallow readiness" bug

### DIFF
--- a/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
+++ b/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
@@ -1,0 +1,249 @@
+namespace GaChatbot.Api.Controllers;
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Text.Json;
+using GA.Business.Core.Orchestration.Models;
+using GaChatbot.Api.Helpers;
+using GaChatbot.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/chatbot")]
+public sealed class ChatbotController(
+    ILogger<ChatbotController> logger,
+    ILlmConcurrencyGate concurrencyGate,
+    IChatApplicationService chatApplicationService) : ControllerBase
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [HttpPost("chat/stream")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task ChatStream([FromBody] ChatRequest request, CancellationToken cancellationToken)
+    {
+        var message = request.Message?.Trim();
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            Response.StatusCode = StatusCodes.Status400BadRequest;
+            await WriteSseErrorAsync("Message cannot be empty.", cancellationToken);
+            return;
+        }
+
+        Response.StatusCode = StatusCodes.Status200OK;
+        Response.Headers.Append("Content-Type", "text/event-stream");
+        Response.Headers.Append("Cache-Control", "no-cache");
+        Response.Headers.Append("X-Accel-Buffering", "no");
+
+        await Response.StartAsync(cancellationToken);
+
+        if (!await concurrencyGate.TryEnterAsync(cancellationToken))
+        {
+            await WriteSseErrorAsync("Service is busy. Please try again in a few seconds.", cancellationToken);
+            return;
+        }
+
+        try
+        {
+            var chatRequest = new ChatExecutionRequest(message, ToConversationTurns(request.ConversationHistory));
+
+            await foreach (var update in chatApplicationService.ChatStreamAsync(chatRequest, cancellationToken))
+            {
+                if (update.Routing is not null)
+                {
+                    var routingPayload = JsonSerializer.Serialize(new
+                    {
+                        type = "routing",
+                        agentId = update.Routing.AgentId,
+                        confidence = update.Routing.Confidence,
+                        routingMethod = update.Routing.RoutingMethod,
+                        trace = update.Trace,
+                        grounding = update.Grounding is null
+                            ? null
+                            : new
+                            {
+                                source = update.Grounding.Source,
+                                revision = update.Grounding.Revision,
+                                queryType = update.Grounding.QueryType
+                            }
+                    }, JsonOptions);
+
+                    await WriteSseLineAsync(routingPayload, cancellationToken);
+                }
+
+                if (!string.IsNullOrWhiteSpace(update.Chunk))
+                {
+                    await WriteSseLineAsync(update.Chunk, cancellationToken);
+                }
+
+                if (update.IsCompleted)
+                {
+                    await Response.WriteAsync("data: [DONE]\n\n", cancellationToken);
+                    await Response.Body.FlushAsync(cancellationToken);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogWarning("Chat stream cancelled.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error streaming chatbot response");
+            await WriteSseErrorAsync("Failed to process message. Please try again.", cancellationToken);
+        }
+        finally
+        {
+            concurrencyGate.Release();
+        }
+    }
+
+    [HttpPost("chat")]
+    [ProducesResponseType(typeof(ChatJsonResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<ChatJsonResponse>> Chat(
+        [FromBody] ChatRequest request,
+        CancellationToken cancellationToken)
+    {
+        var message = request.Message?.Trim();
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return BadRequest(new { error = "Message cannot be empty." });
+        }
+
+        if (!await concurrencyGate.TryEnterAsync(cancellationToken))
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { error = "Service is busy. Please try again in a few seconds." });
+        }
+
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            var response = await chatApplicationService.ChatAsync(
+                new ChatExecutionRequest(message, ToConversationTurns(request.ConversationHistory)),
+                cancellationToken);
+            sw.Stop();
+
+            return Ok(new ChatJsonResponse(
+                response.NaturalLanguageAnswer,
+                response.Routing.AgentId,
+                response.Routing.Confidence,
+                response.Routing.RoutingMethod,
+                response.Grounding,
+                sw.ElapsedMilliseconds,
+                Activity.Current?.TraceId.ToString(),
+                response.Trace));
+        }
+        finally
+        {
+            concurrencyGate.Release();
+        }
+    }
+
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(ChatbotStatus), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ChatbotStatus>> GetStatus(CancellationToken cancellationToken)
+    {
+        var status = await chatApplicationService.GetStatusAsync(cancellationToken);
+        return Ok(status);
+    }
+
+    [HttpGet("examples")]
+    [ProducesResponseType(typeof(List<string>), StatusCodes.Status200OK)]
+    public ActionResult<List<string>> GetExamples() =>
+        Ok((List<string>)
+        [
+            "Show me some easy beginner chords",
+            "Explain voice leading in jazz",
+            "What are the modes of the major scale?",
+            "Generate a mellow ii-V-I in C",
+            "How do I make this progression sound darker?"
+        ]);
+
+    private async Task WriteSseLineAsync(string data, CancellationToken cancellationToken)
+    {
+        await Response.WriteAsync($"data: {data}\n\n", cancellationToken);
+        await Response.Body.FlushAsync(cancellationToken);
+    }
+
+    private Task WriteSseErrorAsync(string message, CancellationToken cancellationToken) =>
+        WriteSseLineAsync(JsonSerializer.Serialize(new { error = message }, JsonOptions), cancellationToken);
+
+    private static List<ConversationTurn>? ToConversationTurns(List<ChatMessage>? history) =>
+        history?
+            .Where(m => !string.IsNullOrWhiteSpace(m.Content))
+            .Select(m => new ConversationTurn(m.Role, m.Content, DateTimeOffset.UtcNow))
+            .ToList();
+}
+
+public sealed class ChatRequest
+{
+    [Required]
+    [MaxLength(2000)]
+    public string Message { get; set; } = string.Empty;
+
+    public List<ChatMessage>? ConversationHistory { get; set; }
+
+    public bool UseSemanticSearch { get; set; } = true;
+}
+
+public sealed record ChatJsonResponse(
+    string NaturalLanguageAnswer,
+    string AgentId,
+    float Confidence,
+    string RoutingMethod,
+    GroundingMetadata? Grounding = null,
+    long ElapsedMs = 0,
+    string? TraceId = null,
+    AgenticTrace? Trace = null);
+
+public sealed class ChatMessage
+{
+    public string Role { get; set; } = string.Empty;
+
+    public string Content { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Readiness probe response. <see cref="IsAvailable"/> requires the configured
+/// chat AND embedding models to be installed in the provider — was previously
+/// just "HTTP reachable", which silently reported healthy while live API was
+/// wedged. The new checks distinguish "Ollama process up" (transport-level)
+/// from "chatbot can actually serve a request" (path-level).
+/// </summary>
+public sealed class ChatbotStatus
+{
+    /// <summary>
+    /// True iff the chatbot can serve a request: provider HTTP reachable AND
+    /// configured chat model installed AND configured embedding model installed.
+    /// </summary>
+    public bool IsAvailable { get; set; }
+
+    /// <summary>Human-readable summary; surface this to operators directly.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>Provider name (<c>"ollama"</c>, <c>"github"</c>, <c>"docker"</c>).</summary>
+    public string Provider { get; set; } = string.Empty;
+
+    /// <summary>Configured chat model name (e.g. <c>"llama3.2:3b"</c>).</summary>
+    public string? ChatModel { get; set; }
+
+    /// <summary>True iff the chat model is installed in the provider.</summary>
+    public bool? ChatModelInstalled { get; set; }
+
+    /// <summary>Configured embedding model name (e.g. <c>"nomic-embed-text"</c>).</summary>
+    public string? EmbeddingModel { get; set; }
+
+    /// <summary>True iff the embedding model is installed in the provider.</summary>
+    public bool? EmbeddingModelInstalled { get; set; }
+
+    /// <summary>
+    /// True iff the provider HTTP endpoint responds. Distinct from
+    /// <see cref="IsAvailable"/>: we may be HTTP-reachable but missing models.
+    /// </summary>
+    public bool ProviderReachable { get; set; }
+
+    public DateTime Timestamp { get; set; }
+}

--- a/Apps/GaChatbot.Api/Services/ChatProviderReadinessProbe.cs
+++ b/Apps/GaChatbot.Api/Services/ChatProviderReadinessProbe.cs
@@ -55,7 +55,12 @@ public sealed class ChatProviderReadinessProbe(
 
     private async Task<ChatbotStatus> GetOllamaStatusAsync(CancellationToken cancellationToken)
     {
-        var chatModel      = configuration["Ollama:ChatModel"];
+        // Mirror OllamaChatService's precedence: `Chatbot:Model` wins over
+        // `Ollama:ChatModel` when set. Reading only the latter would
+        // green-light a misconfiguration where Chatbot:Model points at a
+        // non-installed model. Per PR #96 review.
+        var chatModel      = configuration["Chatbot:Model"]
+                             ?? configuration["Ollama:ChatModel"];
         var embeddingModel = configuration["Ollama:EmbeddingModel"];
         var status = new ChatbotStatus
         {
@@ -125,6 +130,11 @@ public sealed class ChatProviderReadinessProbe(
     /// </summary>
     private static List<string> ParseTagsResponse(string json)
     {
+        // Empty/null body would otherwise throw ArgumentNullException out of
+        // JsonDocument.Parse — bubble up to the outer catch and erroneously
+        // mark ProviderReachable=false despite the 200. Per PR #96 review.
+        if (string.IsNullOrWhiteSpace(json)) return [];
+
         try
         {
             using var doc = JsonDocument.Parse(json);

--- a/Apps/GaChatbot.Api/Services/ChatProviderReadinessProbe.cs
+++ b/Apps/GaChatbot.Api/Services/ChatProviderReadinessProbe.cs
@@ -1,0 +1,205 @@
+namespace GaChatbot.Api.Services;
+
+using System.Text.Json;
+using GaChatbot.Api.Controllers;
+
+public interface IChatProviderReadinessProbe
+{
+    Task<ChatbotStatus> GetStatusAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Readiness probe that distinguishes "provider reachable" from "chatbot can
+/// serve a request". Was previously shallow — just an HTTP GET to /api/tags —
+/// which let /status report healthy while live API was wedged because the
+/// configured chat / embedding models were not installed. Deepened in PR #96
+/// to verify model presence end-to-end via the provider's installed-model list.
+/// </summary>
+public sealed class ChatProviderReadinessProbe(
+    IConfiguration configuration,
+    IHttpClientFactory httpClientFactory) : IChatProviderReadinessProbe
+{
+    public async Task<ChatbotStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        var provider = (configuration["AI:ChatProvider"] ?? "ollama").ToLowerInvariant();
+
+        return provider switch
+        {
+            "github" => TokenBasedStatus("GITHUB_TOKEN", "GitHub Models", provider),
+            "ollama" => await GetOllamaStatusAsync(cancellationToken),
+            "docker" => await GetDockerStatusAsync(cancellationToken),
+            _ => new ChatbotStatus
+            {
+                IsAvailable = false,
+                Provider = provider,
+                Message = $"Unsupported chat provider '{provider}'.",
+                Timestamp = DateTime.UtcNow,
+            },
+        };
+    }
+
+    private static ChatbotStatus TokenBasedStatus(string envVarName, string providerName, string providerKey)
+    {
+        var configured = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(envVarName));
+        return new ChatbotStatus
+        {
+            IsAvailable = configured,
+            ProviderReachable = configured,
+            Provider = providerKey,
+            Message = configured
+                ? $"{providerName} is configured."
+                : $"{providerName} is not configured. Set {envVarName}.",
+            Timestamp = DateTime.UtcNow,
+        };
+    }
+
+    private async Task<ChatbotStatus> GetOllamaStatusAsync(CancellationToken cancellationToken)
+    {
+        var chatModel      = configuration["Ollama:ChatModel"];
+        var embeddingModel = configuration["Ollama:EmbeddingModel"];
+        var status = new ChatbotStatus
+        {
+            Provider       = "ollama",
+            ChatModel      = chatModel,
+            EmbeddingModel = embeddingModel,
+            Timestamp      = DateTime.UtcNow,
+        };
+
+        try
+        {
+            var client = httpClientFactory.CreateClient("Ollama");
+            var response = await client.GetAsync("/api/tags", cancellationToken);
+            status.ProviderReachable = response.IsSuccessStatusCode;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                status.IsAvailable = false;
+                status.Message     = $"Ollama returned {(int)response.StatusCode} from /api/tags.";
+                return status;
+            }
+
+            // Parse the installed-model list. Ollama returns:
+            //   { "models": [ { "name": "llama3.2:3b", ... }, ... ] }
+            // Names include the version tag; we accept either exact match or
+            // a base-name prefix match (so "llama3.2" matches "llama3.2:3b").
+            var json    = await response.Content.ReadAsStringAsync(cancellationToken);
+            var tagged  = ParseTagsResponse(json);
+
+            status.ChatModelInstalled      = chatModel is null      || ModelInstalled(tagged, chatModel);
+            status.EmbeddingModelInstalled = embeddingModel is null || ModelInstalled(tagged, embeddingModel);
+
+            var missing = new List<string>();
+            if (status.ChatModelInstalled == false)      missing.Add($"chat='{chatModel}'");
+            if (status.EmbeddingModelInstalled == false) missing.Add($"embedding='{embeddingModel}'");
+
+            if (missing.Count == 0)
+            {
+                status.IsAvailable = true;
+                status.Message     = chatModel is null && embeddingModel is null
+                    ? "Ollama reachable; no specific models configured."
+                    : $"Ollama ready: chat='{chatModel ?? "<unset>"}', embedding='{embeddingModel ?? "<unset>"}'.";
+            }
+            else
+            {
+                status.IsAvailable = false;
+                status.Message     =
+                    $"Ollama reachable but required model(s) missing: {string.Join(", ", missing)}. " +
+                    $"Pull with `ollama pull <model>`. Installed: [{string.Join(", ", tagged)}].";
+            }
+
+            return status;
+        }
+        catch (Exception ex)
+        {
+            status.IsAvailable       = false;
+            status.ProviderReachable = false;
+            status.Message           = $"Ollama is not reachable: {ex.Message}";
+            return status;
+        }
+    }
+
+    /// <summary>
+    /// Parses the model-name list out of an Ollama <c>/api/tags</c> response.
+    /// Robust to a missing or malformed body — returns empty rather than
+    /// throwing so the caller can still report "no models" cleanly.
+    /// </summary>
+    private static List<string> ParseTagsResponse(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("models", out var models)
+                || models.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var names = new List<string>();
+            foreach (var m in models.EnumerateArray())
+            {
+                if (m.TryGetProperty("name", out var n) && n.ValueKind == JsonValueKind.String)
+                {
+                    var name = n.GetString();
+                    if (!string.IsNullOrWhiteSpace(name)) names.Add(name);
+                }
+            }
+            return names;
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// True iff <paramref name="required"/> matches any installed model. Match
+    /// rules (in order): exact match, then base-name match (Ollama returns
+    /// versioned tags like <c>llama3.2:3b</c>; users may configure
+    /// <c>llama3.2</c> or vice versa, both should resolve).
+    /// </summary>
+    internal static bool ModelInstalled(IReadOnlyList<string> installed, string required)
+    {
+        foreach (var name in installed)
+        {
+            if (string.Equals(name, required, StringComparison.OrdinalIgnoreCase)) return true;
+
+            // Base-name match: "llama3.2" matches "llama3.2:3b" and vice versa.
+            var installedBase = name.Split(':', 2)[0];
+            var requiredBase  = required.Split(':', 2)[0];
+            if (string.Equals(installedBase, requiredBase, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    private async Task<ChatbotStatus> GetDockerStatusAsync(CancellationToken cancellationToken)
+    {
+        var baseUrl = configuration["DockerModelRunner:BaseUrl"] ?? "http://localhost:12434/v1";
+
+        try
+        {
+            using var client = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromSeconds(10) };
+            var response = await client.GetAsync("/models", cancellationToken);
+            return new ChatbotStatus
+            {
+                IsAvailable       = response.IsSuccessStatusCode,
+                ProviderReachable = response.IsSuccessStatusCode,
+                Provider          = "docker",
+                Message           = response.IsSuccessStatusCode
+                    ? "Docker Model Runner is reachable."
+                    : $"Docker Model Runner returned {(int)response.StatusCode}.",
+                Timestamp = DateTime.UtcNow,
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ChatbotStatus
+            {
+                IsAvailable       = false,
+                ProviderReachable = false,
+                Provider          = "docker",
+                Message           = $"Docker Model Runner is not reachable: {ex.Message}",
+                Timestamp         = DateTime.UtcNow,
+            };
+        }
+    }
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Services/ChatProviderReadinessProbeTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Services/ChatProviderReadinessProbeTests.cs
@@ -256,6 +256,61 @@ public class ChatProviderReadinessProbeTests
         Assert.That(status.ChatModelInstalled, Is.True);
     }
 
+    [Test]
+    public async Task GetStatusAsync_OllamaChatbotModelKey_TakesPrecedenceOverOllamaChatModel()
+    {
+        // OllamaChatService (sibling GaApi service) uses
+        // `Chatbot:Model ?? Ollama:ChatModel`. The probe must mirror that
+        // precedence to avoid green-lighting a misconfiguration where
+        // Chatbot:Model points at a model that isn't installed.
+        // Pinned by PR #96 review.
+        var tagsBody = """
+        {"models":[
+            {"name":"llama3.2:3b","size":1234},
+            {"name":"nomic-embed-text:latest","size":5678}
+        ]}
+        """;
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Chatbot:Model"]          = "phi-3:14b",     // wins; NOT installed
+                ["Ollama:ChatModel"]       = "llama3.2:3b",   // would otherwise pass
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk(tagsBody));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.That(status.IsAvailable, Is.False,
+            "Chatbot:Model precedence: phi-3:14b is the active chat model and is NOT installed");
+        Assert.That(status.ChatModel, Is.EqualTo("phi-3:14b"));
+        Assert.That(status.ChatModelInstalled, Is.False);
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaEmptyBody_DoesNotCrashAndReportsMissing()
+    {
+        // /api/tags returns 200 with empty/null body — guard added in PR #96
+        // so the probe doesn't bubble ArgumentNullException out and falsely
+        // mark ProviderReachable=false despite the successful HTTP response.
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk(""));   // 200 OK, empty body
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.That(status.ProviderReachable, Is.True,
+            "200 with empty body still means HTTP is up — should not flip to ProviderReachable=false");
+        Assert.That(status.IsAvailable, Is.False,
+            "but with no models parseable, the chat path can't serve");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static HttpResponseMessage JsonOk(string body) =>

--- a/Tests/Apps/GaChatbot.Api.Tests/Services/ChatProviderReadinessProbeTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Services/ChatProviderReadinessProbeTests.cs
@@ -1,0 +1,303 @@
+namespace GaChatbot.Api.Tests.Services;
+
+using System.Net;
+using System.Text;
+using GaChatbot.Api.Services;
+using Microsoft.Extensions.Configuration;
+
+[TestFixture]
+public class ChatProviderReadinessProbeTests
+{
+    [Test]
+    public async Task GetStatusAsync_UnsupportedProvider_ReturnsUnavailable()
+    {
+        var probe = CreateProbe(new Dictionary<string, string?>
+        {
+            ["AI:ChatProvider"] = "unknown-provider"
+        });
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.IsAvailable, Is.False);
+            Assert.That(status.Message, Is.EqualTo("Unsupported chat provider 'unknown-provider'."));
+            Assert.That(status.Provider, Is.EqualTo("unknown-provider"));
+        });
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaNonSuccess_ReturnsUnavailableWithStatusCode()
+    {
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"] = "ollama"
+            },
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.IsAvailable, Is.False);
+            Assert.That(status.ProviderReachable, Is.False);
+            Assert.That(status.Message, Does.Contain("503"));
+            Assert.That(status.Message, Does.Contain("/api/tags"));
+            Assert.That(status.Provider, Is.EqualTo("ollama"));
+        });
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaRequestFailure_ReturnsUnavailableWithReason()
+    {
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"] = "ollama"
+            },
+            exception: new HttpRequestException("connection refused"));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.IsAvailable, Is.False);
+            Assert.That(status.ProviderReachable, Is.False);
+            Assert.That(status.Message, Does.StartWith("Ollama is not reachable:"));
+            Assert.That(status.Message, Does.Contain("connection refused"));
+        });
+    }
+
+    // ── New tests for the deeper readiness probe (PR #96) ─────────────────────
+
+    [Test]
+    public async Task GetStatusAsync_OllamaModelsAllInstalled_ReturnsAvailable()
+    {
+        // Healthy case: /api/tags returns 200 with both chat AND embedding
+        // models present → IsAvailable=true. Pre-PR-#96 behaviour did NOT
+        // verify model presence, so this test pins the new contract.
+        var tagsBody = """
+        {"models":[
+            {"name":"llama3.2:3b","size":1234},
+            {"name":"nomic-embed-text:latest","size":5678}
+        ]}
+        """;
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk(tagsBody));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.IsAvailable, Is.True);
+            Assert.That(status.ProviderReachable, Is.True);
+            Assert.That(status.ChatModelInstalled, Is.True);
+            Assert.That(status.EmbeddingModelInstalled, Is.True);
+            Assert.That(status.Message, Does.Contain("ready"));
+        });
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaChatModelMissing_ReturnsUnavailable()
+    {
+        // The exact failure mode the user reported: Ollama HTTP-reachable
+        // (was reporting healthy), but the configured chat model is NOT
+        // installed → real chat request would have failed at first call.
+        var tagsBody = """
+        {"models":[
+            {"name":"nomic-embed-text:latest","size":5678}
+        ]}
+        """;
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk(tagsBody));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.IsAvailable, Is.False,
+                "missing chat model means we cannot serve a request — must report unavailable");
+            Assert.That(status.ProviderReachable, Is.True,
+                "Ollama HTTP is up; the new probe distinguishes provider-reachable from chatbot-ready");
+            Assert.That(status.ChatModelInstalled, Is.False);
+            Assert.That(status.EmbeddingModelInstalled, Is.True);
+            Assert.That(status.Message, Does.Contain("llama3.2:3b").And.Contain("missing"));
+        });
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaEmbeddingModelMissing_ReturnsUnavailable()
+    {
+        var tagsBody = """{"models":[{"name":"llama3.2:3b","size":1234}]}""";
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk(tagsBody));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.IsAvailable, Is.False);
+            Assert.That(status.ChatModelInstalled, Is.True);
+            Assert.That(status.EmbeddingModelInstalled, Is.False);
+            Assert.That(status.Message, Does.Contain("nomic-embed-text").And.Contain("missing"));
+        });
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaBothModelsMissing_ListsBothInMessage()
+    {
+        var tagsBody = """{"models":[{"name":"some-other-model","size":99}]}""";
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk(tagsBody));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.IsAvailable, Is.False);
+            Assert.That(status.Message, Does.Contain("llama3.2:3b"));
+            Assert.That(status.Message, Does.Contain("nomic-embed-text"));
+            Assert.That(status.Message, Does.Contain("some-other-model"),
+                "the message should list installed models so the operator knows what IS available");
+        });
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaMalformedTagsBody_ReportsAsModelsMissing()
+    {
+        // Robustness: if /api/tags returns 200 with garbage body, treat as
+        // "no models found" rather than crashing the probe.
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk("not valid json {"));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.That(status.IsAvailable, Is.False);
+        Assert.That(status.ProviderReachable, Is.True);
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaNoModelsConfigured_ReturnsAvailableOnReachable()
+    {
+        // Back-compat: when no specific models are configured (chat/embedding
+        // both null), fall back to the old "reachable = available" semantics.
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"] = "ollama",
+                // ChatModel + EmbeddingModel intentionally not set
+            },
+            JsonOk("""{"models":[]}"""));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.That(status.IsAvailable, Is.True,
+            "no models configured = no concrete check to fail; reachable counts as available");
+        Assert.That(status.Message, Does.Contain("no specific models"));
+    }
+
+    [Test]
+    public async Task GetStatusAsync_OllamaBaseNameMatch_ResolvesToInstalledTag()
+    {
+        // Operator pattern: configure base name "llama3.2", accept whichever
+        // tagged version Ollama happens to have. Probe should match by base
+        // name in either direction (config base → installed tag, OR config
+        // tag → installed base).
+        var tagsBody = """
+        {"models":[
+            {"name":"llama3.2:3b","size":1234},
+            {"name":"nomic-embed-text:latest","size":5678}
+        ]}
+        """;
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2",      // base name, no tag
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk(tagsBody));
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.That(status.IsAvailable, Is.True,
+            "configured 'llama3.2' should match installed 'llama3.2:3b' via base-name match");
+        Assert.That(status.ChatModelInstalled, Is.True);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static HttpResponseMessage JsonOk(string body) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+
+    private static ChatProviderReadinessProbe CreateProbe(
+        IReadOnlyDictionary<string, string?> values,
+        HttpResponseMessage? response = null,
+        Exception? exception = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var httpClient = new HttpClient(new StubHandler(response, exception))
+        {
+            BaseAddress = new Uri("http://localhost:11434")
+        };
+
+        return new ChatProviderReadinessProbe(configuration, new StubHttpClientFactory(httpClient));
+    }
+
+    private sealed class StubHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private sealed class StubHandler(HttpResponseMessage? response, Exception? exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (exception is not null)
+            {
+                throw exception;
+            }
+
+            return Task.FromResult(response ?? new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Quality fix #3 of 5 from your 2026-05-03 candid assessment: "/status was reporting healthy while live API was wedged".

The probe only called `/api/tags` for HTTP reachability — returned 200 even when the configured chat / embedding models weren't actually installed. Couldn't distinguish "Ollama is up and ready" from "Ollama is up but my call will fail at first chord parse".

## Fix

**`ChatProviderReadinessProbe.GetOllamaStatusAsync`** now:

1. Parses the `/api/tags` response and verifies configured chat AND embedding models are installed (exact match OR base-name match — `llama3.2` matches `llama3.2:3b` either direction).
2. `IsAvailable = providerReachable AND chatModelInstalled AND embeddingModelInstalled`. Previous semantics let healthy report through with missing models.
3. New diagnostic fields on `ChatbotStatus`: `Provider`, `ChatModel`, `ChatModelInstalled`, `EmbeddingModel`, `EmbeddingModelInstalled`, `ProviderReachable`. Operators see which check failed at a glance.
4. Message lists missing AND installed models so a hung deploy reads:
   ```
   Ollama reachable but required model(s) missing: chat='llama3.2:3b'.
   Pull with `ollama pull <model>`. Installed: [some-other-model].
   ```

## Tests (10 cases, all green)

- All-models-present → `IsAvailable=true` ✓
- **Chat model missing → `IsAvailable=false`, `ProviderReachable=true`** ← the regression
- Embedding model missing → `IsAvailable=false` ✓
- Both missing → message lists both + installed alternatives ✓
- Malformed `/api/tags` body → falls back to "missing" rather than crash ✓
- No models configured → falls back to old "reachable = available" ✓
- Base-name match → resolves correctly ✓
- 503 / connection refused / unknown provider → all unavailable ✓

Two unrelated pre-existing test failures (`Chat_AlgebraPrompt_*`) timeout on HTTP-integration tests that need a working Ollama (currently wedged in dev). NOT regressions from this PR.

## Scope note — pre-existing untracked files

This commit includes 3 files that were sitting **untracked in the working tree** for the whole session (visible as `?? Apps/GaChatbot.Api/...` in `git status`): `ChatbotController.cs`, `ChatProviderReadinessProbe.cs`, and the existing tests file. They were never committed to main but were needed for `Apps/GaChatbot.Api/GaChatbot.Api.csproj` to compile. The PR diff is 757 lines because of that — most of it is pre-existing content, my actual changes are:
- `ChatbotStatus`: added 5 structured fields
- `ChatProviderReadinessProbe`: deepened `GetOllamaStatusAsync` + added `ParseTagsResponse` + `ModelInstalled` helpers
- `ChatProviderReadinessProbeTests`: rewrote to cover the new contract (10 cases)

Happy to split into a "track existing files" commit + a "deepen probe" commit if you'd rather, but the alternative was leaving them untracked indefinitely.

## Latent gap

This fix addresses Ollama-only "shallow" `/status`. The user's complaint also covered "live API process was previously stale/wedged while /status still reported healthy" — i.e. process-level wedge in the chatbot service itself, not Ollama. A round-trip probe (synthetic request through the orchestrator) would catch that; deferred to a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)