### PR TITLE
fix(voicing): VoicingAgent passes filters to search instead of null

### DIFF
--- a/Common/GA.Business.ML/Agents/VoicingAgent.cs
+++ b/Common/GA.Business.ML/Agents/VoicingAgent.cs
@@ -77,10 +77,11 @@ public sealed class VoicingAgent(
             : 10;
 
         var queryVector = encoder.Encode(structured);
+        var filters = BuildSearchFilters(structured);
 
         Task<double[]> Generator(string _) => Task.FromResult(queryVector);
         var results = await voicingSearch.SearchAsync(
-            request.Query, Generator, limit, filters: null, cancellationToken);
+            request.Query, Generator, limit, filters, cancellationToken);
 
         if (results.Count == 0)
         {
@@ -144,5 +145,24 @@ public sealed class VoicingAgent(
         if (q.ModeName is not null) parts.Add($"mode {q.ModeName}");
         if (q.Tags is { Count: > 0 }) parts.Add($"tags [{string.Join(", ", q.Tags)}]");
         return parts.Count == 0 ? "your query" : string.Join(" + ", parts);
+    }
+
+    internal static VoicingSearchFilters? BuildSearchFilters(StructuredQuery q)
+    {
+        var hasFilter = q.ChordSymbol is not null
+                        || q.ModeName is not null
+                        || q.Instrument is not null
+                        || q.Tags is { Count: > 0 };
+
+        if (!hasFilter)
+        {
+            return null;
+        }
+
+        return new VoicingSearchFilters(
+            VoicingType: q.Instrument,
+            ModeName: q.ModeName,
+            Tags: q.Tags is { Count: > 0 } ? [.. q.Tags] : null,
+            ChordName: q.ChordSymbol);
     }
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/VoicingAgentFilterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/VoicingAgentFilterTests.cs
@@ -1,0 +1,105 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Search;
+
+/// <summary>
+/// Contract tests for <see cref="VoicingAgent.BuildSearchFilters"/>. The
+/// agent extracts filters from a structured query and forwards them to
+/// the voicing search instead of passing <c>null</c>; pre-fix code was
+/// over-fetching from the entire voicing space and relying on score
+/// ordering alone for relevance.
+/// </summary>
+[TestFixture]
+public class VoicingAgentFilterTests
+{
+    [Test]
+    public void BuildSearchFilters_AllFieldsNull_ReturnsNullForCheapPath()
+    {
+        // No filter signals → return null. Important: passing an empty
+        // VoicingSearchFilters (rather than null) might still narrow
+        // the search behind the scenes; the explicit null preserves the
+        // original "no filter" semantics for downstream callers.
+        var query = new StructuredQuery(
+            ChordSymbol: null,
+            RootPitchClass: null,
+            PitchClasses: null,
+            ModeName: null,
+            Tags: null);
+
+        Assert.That(VoicingAgent.BuildSearchFilters(query), Is.Null);
+    }
+
+    [Test]
+    public void BuildSearchFilters_ChordSymbolOnly_ReturnsFiltersWithChord()
+    {
+        var query = new StructuredQuery(
+            ChordSymbol: "Cmaj7",
+            RootPitchClass: null,
+            PitchClasses: null,
+            ModeName: null,
+            Tags: null);
+
+        var filters = VoicingAgent.BuildSearchFilters(query);
+
+        Assert.That(filters,           Is.Not.Null);
+        Assert.That(filters!.ChordName, Is.EqualTo("Cmaj7"));
+        Assert.That(filters.ModeName,   Is.Null);
+        Assert.That(filters.VoicingType, Is.Null);
+        Assert.That(filters.Tags,       Is.Null);
+    }
+
+    [Test]
+    public void BuildSearchFilters_InstrumentMapsToVoicingType()
+    {
+        var query = new StructuredQuery(
+            ChordSymbol: null,
+            RootPitchClass: null,
+            PitchClasses: null,
+            ModeName: null,
+            Tags: null) { Instrument = "bass" };
+
+        var filters = VoicingAgent.BuildSearchFilters(query);
+
+        Assert.That(filters,             Is.Not.Null);
+        Assert.That(filters!.VoicingType, Is.EqualTo("bass"),
+            "the Instrument property maps to VoicingType on the filter so the search filters by voicing-type column");
+    }
+
+    [Test]
+    public void BuildSearchFilters_AllFieldsSet_PopulatesAllFilterFields()
+    {
+        var query = new StructuredQuery(
+            ChordSymbol: "Cmaj7",
+            RootPitchClass: 0,
+            PitchClasses: [0, 4, 7, 11],
+            ModeName: "Lydian",
+            Tags: ["jazz", "smooth"]) { Instrument = "guitar" };
+
+        var filters = VoicingAgent.BuildSearchFilters(query);
+
+        Assert.That(filters,               Is.Not.Null);
+        Assert.That(filters!.ChordName,     Is.EqualTo("Cmaj7"));
+        Assert.That(filters.ModeName,       Is.EqualTo("Lydian"));
+        Assert.That(filters.VoicingType,    Is.EqualTo("guitar"));
+        Assert.That(filters.Tags,           Is.EquivalentTo(new[] { "jazz", "smooth" }));
+    }
+
+    [Test]
+    public void BuildSearchFilters_EmptyTagsList_TreatedAsNull()
+    {
+        // Empty tags should not trigger filter creation — that signal
+        // means "the user did not specify tags", not "the user specified
+        // an empty tag set". Pinned to prevent a future refactor from
+        // flipping the semantics.
+        var query = new StructuredQuery(
+            ChordSymbol: null,
+            RootPitchClass: null,
+            PitchClasses: null,
+            ModeName: null,
+            Tags: []);
+
+        Assert.That(VoicingAgent.BuildSearchFilters(query), Is.Null,
+            "empty tag list is the same as no tags — no filter created");
+    }
+}


### PR DESCRIPTION
## Summary

Pre-existing fix from stash@{0}, evaluated against current main and shipped with a contract test.

`VoicingAgent.HandleAsync` was calling `voicingSearch.SearchAsync(..., filters: null, ...)` — over-fetching from the entire voicing space regardless of user intent. The `StructuredQuery` already carried `ChordSymbol` / `ModeName` / `Instrument` / `Tags` signals; they were never propagated.

`BuildSearchFilters` extracts those into `VoicingSearchFilters` (or `null` when no signal is present, preserving the explicit "no filter" semantics).

## Tests (5 cases)

- All-null query → null filters
- ChordSymbol-only populates `ChordName`
- Instrument → VoicingType (column-name mismatch pinned to prevent a quiet refactor)
- All fields set populate all filter fields
- Empty tag list treated as "no tags"

## Pairs with PR #95

PR #95 fixed OPTIC-K v1.8 dim recognition (cosine returning 0.000 for cross-version pairs). This PR ensures the *correct subset* is searched. Together: voicings now score correctly AND search the relevant slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)