### PR TITLE
fix(voicing): include MODAL + ROOT partitions in similarity scoring

### DIFF
--- a/Common/GA.Business.ML/Search/CpuVoicingSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/CpuVoicingSearchStrategy.cs
@@ -33,21 +33,37 @@ public class CpuVoicingSearchStrategy : IVoicingSearchStrategy
     private const int OpticKv131Dim = 109;
     private const int LegacyDim     = 96;
 
-    // Partition Config
-    private const int StructureOffset = 6;
-    private const int StructureDim = 24;
+    // Partition Config — must mirror EmbeddingSchema.Partitions exactly.
+    // SimilarityPartitions there mark which contribute to score; the
+    // similarity-role partitions are pulled in here with the same weights.
+    private const int StructureOffset  = 6;
+    private const int StructureDim     = 24;
     private const int MorphologyOffset = 30;
-    private const int MorphologyDim = 24;
-    private const int ContextOffset = 54;
-    private const int ContextDim = 12;
-    private const int SymbolicOffset = 66;
-    private const int SymbolicDim = 12;
+    private const int MorphologyDim    = 24;
+    private const int ContextOffset    = 54;
+    private const int ContextDim       = 12;
+    private const int SymbolicOffset   = 66;
+    private const int SymbolicDim      = 12;
+    // MODAL: introduced in OPTIC-K v1.6 (216-dim) — slots 109-148. Skipped on
+    // legacy / v1.3.1 vectors that don't have these slots.
+    private const int ModalOffset      = 109;
+    private const int ModalDim         = 40;
+    // ROOT: v1.8 only (240-dim) — slots 228-239. Pitch-class one-hot that
+    // closes the T-invariance gap STRUCTURE was over-loading in older
+    // schemas. Skipped on shorter vectors.
+    private const int RootOffset       = 228;
+    private const int RootDim          = 12;
 
-    // Weights
-    private const double StructureWeight = 0.45;
+    // Weights — mirror EmbeddingSchema.Partitions. Sum is 1.15 (not 1.0)
+    // when MODAL + ROOT both contribute; that's intentional. The score is
+    // monotonic for ranking and the residual mass beyond 1.0 is the v1.8
+    // discrimination signal that older schemas couldn't express.
+    private const double StructureWeight  = 0.45;
     private const double MorphologyWeight = 0.25;
-    private const double ContextWeight = 0.20;
-    private const double SymbolicWeight = 0.10;
+    private const double ContextWeight    = 0.20;
+    private const double SymbolicWeight   = 0.10;
+    private const double ModalWeight      = 0.10;
+    private const double RootWeight       = 0.05;
 
     public string Name => "CPU-Parallel";
     public bool IsAvailable => true;
@@ -264,28 +280,46 @@ public class CpuVoicingSearchStrategy : IVoicingSearchStrategy
     {
         double score = 0;
 
-        // STRUCTURE
-        score += StructureWeight * ComputePartitionCosine(query, target, StructureOffset, StructureDim);
-
-        // MORPHOLOGY
+        // Partitions present in OPTIC-K v1.2.1 and later (slots 6-77).
+        score += StructureWeight  * ComputePartitionCosine(query, target, StructureOffset,  StructureDim);
         score += MorphologyWeight * ComputePartitionCosine(query, target, MorphologyOffset, MorphologyDim);
+        score += ContextWeight    * ComputePartitionCosine(query, target, ContextOffset,    ContextDim);
+        score += SymbolicWeight   * ComputePartitionCosine(query, target, SymbolicOffset,   SymbolicDim);
 
-        // CONTEXT
-        score += ContextWeight * ComputePartitionCosine(query, target, ContextOffset, ContextDim);
+        // MODAL partition: requires v1.6 (216-dim) or higher. Conditionally
+        // included so legacy/v1.3.1 vectors don't index past their length.
+        // Pre-fix (PR #99) silently dropped this even when both vectors had
+        // the slots — a real correctness gap that affected modal-flavor
+        // discrimination.
+        var minDim = Math.Min(query.Length, target.Length);
+        if (minDim >= ModalOffset + ModalDim)
+        {
+            score += ModalWeight * ComputePartitionCosine(query, target, ModalOffset, ModalDim);
+        }
 
-        // SYMBOLIC
-        score += SymbolicWeight * ComputePartitionCosine(query, target, SymbolicOffset, SymbolicDim);
+        // ROOT partition: v1.8 only (240-dim). Closes the T-invariance gap
+        // STRUCTURE was over-loading in older schemas. Pre-fix (PR #99)
+        // silently dropped this even on v1.8×v1.8 — meaning v1.8's whole
+        // point didn't reach scoring.
+        if (minDim >= RootOffset + RootDim)
+        {
+            score += RootWeight * ComputePartitionCosine(query, target, RootOffset, RootDim);
+        }
 
         return score;
     }
 
     private static double ComputePartitionCosine(double[] v1, double[] v2, int offset, int dim)
     {
-        // Using Span for performance to avoid allocations
         var span1 = new ReadOnlySpan<double>(v1, offset, dim);
         var span2 = new ReadOnlySpan<double>(v2, offset, dim);
-        
-        return System.Numerics.Tensors.TensorPrimitives.CosineSimilarity(span1, span2);
+        var raw = System.Numerics.Tensors.TensorPrimitives.CosineSimilarity(span1, span2);
+        // NaN protection: TensorPrimitives.CosineSimilarity returns NaN when
+        // one or both spans are all-zero (0/0 in the normalization). Treat
+        // that as "this partition contributes no signal" → score 0. Without
+        // this guard, the addition of MODAL/ROOT in PR #99 would propagate
+        // NaN through the total whenever those partitions were unpopulated.
+        return double.IsNaN(raw) ? 0.0 : raw;
     }
 
     private static VoicingSearchResult MapToSearchResult(VoicingEmbedding voicing, double score, string query)

--- a/Common/GA.Business.ML/Search/GpuVoicingSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/GpuVoicingSearchStrategy.cs
@@ -29,21 +29,31 @@ public class GpuVoicingSearchStrategy : IVoicingSearchStrategy, IDisposable
     private const int MusicalEmbeddingDim = 109; // v1.3.1
     private const int LegacyMusicalEmbeddingDim = 96; // v1.2.1
 
-    // Partition Offsets and Dimensions
-    private const int StructureOffset = 6;
-    private const int StructureDim = 24;
+    // Partition Offsets and Dimensions — must mirror EmbeddingSchema.Partitions.
+    private const int StructureOffset  = 6;
+    private const int StructureDim     = 24;
     private const int MorphologyOffset = 30;
-    private const int MorphologyDim = 24;
-    private const int ContextOffset = 54;
-    private const int ContextDim = 12;
-    private const int SymbolicOffset = 66;
-    private const int SymbolicDim = 12;
+    private const int MorphologyDim    = 24;
+    private const int ContextOffset    = 54;
+    private const int ContextDim       = 12;
+    private const int SymbolicOffset   = 66;
+    private const int SymbolicDim      = 12;
+    // MODAL (v1.6+, slots 109-148, 40 dims). Conditionally included so
+    // legacy/v1.3.1 vectors don't index past their length.
+    private const int ModalOffset      = 109;
+    private const int ModalDim         = 40;
+    // ROOT (v1.8 only, slots 228-239, 12 dims).
+    private const int RootOffset       = 228;
+    private const int RootDim          = 12;
 
-    // Similarity Weights
-    private const double StructureWeight = 0.45;
+    // Similarity Weights — sum is 1.15 (not 1.0) when MODAL+ROOT both fire.
+    // Intentional: residual mass beyond 1.0 is the v1.8 discrimination signal.
+    private const double StructureWeight  = 0.45;
     private const double MorphologyWeight = 0.25;
-    private const double ContextWeight = 0.20;
-    private const double SymbolicWeight = 0.10;
+    private const double ContextWeight    = 0.20;
+    private const double SymbolicWeight   = 0.10;
+    private const double ModalWeight      = 0.10;
+    private const double RootWeight       = 0.05;
     private readonly Lock _initLock = new();
     private readonly Dictionary<string, VoicingEmbedding> _voicings = [];
     private Accelerator? _accelerator;
@@ -411,21 +421,29 @@ public class GpuVoicingSearchStrategy : IVoicingSearchStrategy, IDisposable
         {
             var score = 0.0;
 
-            // STRUCTURE
-            score += StructureWeight * ComputePartitionCosineGpu(
-                queryVector, StructureOffset, voicingEmbeddings, voicingOffset + StructureOffset, StructureDim);
-
-            // MORPHOLOGY
+            // Partitions present in v1.2.1 and later (slots 6-77).
+            score += StructureWeight  * ComputePartitionCosineGpu(
+                queryVector, StructureOffset,  voicingEmbeddings, voicingOffset + StructureOffset,  StructureDim);
             score += MorphologyWeight * ComputePartitionCosineGpu(
                 queryVector, MorphologyOffset, voicingEmbeddings, voicingOffset + MorphologyOffset, MorphologyDim);
+            score += ContextWeight    * ComputePartitionCosineGpu(
+                queryVector, ContextOffset,    voicingEmbeddings, voicingOffset + ContextOffset,    ContextDim);
+            score += SymbolicWeight   * ComputePartitionCosineGpu(
+                queryVector, SymbolicOffset,   voicingEmbeddings, voicingOffset + SymbolicOffset,   SymbolicDim);
 
-            // CONTEXT
-            score += ContextWeight * ComputePartitionCosineGpu(
-                queryVector, ContextOffset, voicingEmbeddings, voicingOffset + ContextOffset, ContextDim);
-
-            // SYMBOLIC
-            score += SymbolicWeight * ComputePartitionCosineGpu(
-                queryVector, SymbolicOffset, voicingEmbeddings, voicingOffset + SymbolicOffset, SymbolicDim);
+            // MODAL (v1.6+) and ROOT (v1.8). embeddingDim is the per-voicing
+            // length; gate each partition against it. Pre-PR-#99 these were
+            // silently dropped even when both vectors had the slots.
+            if (embeddingDim >= ModalOffset + ModalDim)
+            {
+                score += ModalWeight * ComputePartitionCosineGpu(
+                    queryVector, ModalOffset, voicingEmbeddings, voicingOffset + ModalOffset, ModalDim);
+            }
+            if (embeddingDim >= RootOffset + RootDim)
+            {
+                score += RootWeight * ComputePartitionCosineGpu(
+                    queryVector, RootOffset, voicingEmbeddings, voicingOffset + RootOffset, RootDim);
+            }
 
             similarities[index] = score;
         }
@@ -471,21 +489,29 @@ public class GpuVoicingSearchStrategy : IVoicingSearchStrategy, IDisposable
         {
             var score = 0.0;
 
-            // STRUCTURE
-            score += StructureWeight * ComputePartitionCosineGpu(
-                queryVector, StructureOffset, voicingEmbeddings, voicingOffset + StructureOffset, StructureDim);
-
-            // MORPHOLOGY
+            // Partitions present in v1.2.1 and later (slots 6-77).
+            score += StructureWeight  * ComputePartitionCosineGpu(
+                queryVector, StructureOffset,  voicingEmbeddings, voicingOffset + StructureOffset,  StructureDim);
             score += MorphologyWeight * ComputePartitionCosineGpu(
                 queryVector, MorphologyOffset, voicingEmbeddings, voicingOffset + MorphologyOffset, MorphologyDim);
+            score += ContextWeight    * ComputePartitionCosineGpu(
+                queryVector, ContextOffset,    voicingEmbeddings, voicingOffset + ContextOffset,    ContextDim);
+            score += SymbolicWeight   * ComputePartitionCosineGpu(
+                queryVector, SymbolicOffset,   voicingEmbeddings, voicingOffset + SymbolicOffset,   SymbolicDim);
 
-            // CONTEXT
-            score += ContextWeight * ComputePartitionCosineGpu(
-                queryVector, ContextOffset, voicingEmbeddings, voicingOffset + ContextOffset, ContextDim);
-
-            // SYMBOLIC
-            score += SymbolicWeight * ComputePartitionCosineGpu(
-                queryVector, SymbolicOffset, voicingEmbeddings, voicingOffset + SymbolicOffset, SymbolicDim);
+            // MODAL (v1.6+) and ROOT (v1.8). embeddingDim is the per-voicing
+            // length; gate each partition against it. Pre-PR-#99 these were
+            // silently dropped even when both vectors had the slots.
+            if (embeddingDim >= ModalOffset + ModalDim)
+            {
+                score += ModalWeight * ComputePartitionCosineGpu(
+                    queryVector, ModalOffset, voicingEmbeddings, voicingOffset + ModalOffset, ModalDim);
+            }
+            if (embeddingDim >= RootOffset + RootDim)
+            {
+                score += RootWeight * ComputePartitionCosineGpu(
+                    queryVector, RootOffset, voicingEmbeddings, voicingOffset + RootOffset, RootDim);
+            }
 
             similarities[index] = score;
         }

--- a/Tests/Common/GA.Business.ML.Tests/Search/CpuVoicingSearchStrategyDimensionTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/CpuVoicingSearchStrategyDimensionTests.cs
@@ -177,6 +177,91 @@ public class CpuVoicingSearchStrategyDimensionTests
     }
 
     [Test]
+    public async Task SemanticSearchAsync_RootPartitionDifference_AffectsScoreOnV18()
+    {
+        // PR #99 regression: ROOT (slots 228-239, weight 0.05) was silently
+        // ignored by CalculateMusicalSimilarity even though
+        // EmbeddingSchema.Partitions declared it Similarity. v1.8's whole
+        // point was to add ROOT for T-invariance discrimination — without
+        // this fix, that signal never reached scoring.
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = MakeV18Vector(1.0);
+
+        // Two voicings with IDENTICAL slots 6-77 (so STRUCTURE/MORPHOLOGY/
+        // CONTEXT/SYMBOLIC scores are equal) but DIFFERENT ROOT one-hot.
+        var matchingRoot = MakeV18Vector(1.0);
+        matchingRoot[228] = 1.0;   // root pitch class 0 (C)
+        var differentRoot = MakeV18Vector(1.0);
+        differentRoot[233] = 1.0;  // root pitch class 5 (F)
+        // Match query's root to the first voicing
+        query[228] = 1.0;
+
+        await strategy.InitializeAsync(
+        [
+            MakeVoicing("matching-root",  matchingRoot),
+            MakeVoicing("different-root", differentRoot),
+        ]);
+
+        var results = await strategy.SemanticSearchAsync(query, limit: 2);
+
+        Assert.That(results, Has.Count.EqualTo(2));
+        Assert.That(results[0].Document.Id, Is.EqualTo("matching-root"),
+            "ROOT partition must affect scoring — matching root must outrank different root");
+        Assert.That(results[0].Score, Is.GreaterThan(results[1].Score),
+            "scores must differ; if they're equal, ROOT was ignored (the pre-PR-#99 bug)");
+    }
+
+    [Test]
+    public async Task SemanticSearchAsync_ModalPartitionDifference_AffectsScoreOnV17()
+    {
+        // MODAL (slots 109-148, weight 0.10) was likewise ignored. Test on
+        // v1.7 (228-dim) to prove MODAL contribution lands without ROOT
+        // (which only exists in v1.8).
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = MakeV17Vector(1.0);
+        // Set MODAL bits in query
+        for (var i = 109; i < 149; i++) query[i] = 0.1 * (i - 109);
+
+        var matchingModal  = MakeV17Vector(1.0);
+        var differentModal = MakeV17Vector(1.0);
+        for (var i = 109; i < 149; i++) matchingModal[i]  = 0.1 * (i - 109);  // identical to query
+        for (var i = 109; i < 149; i++) differentModal[i] = 0.5;              // diverges
+
+        await strategy.InitializeAsync(
+        [
+            MakeVoicing("matching-modal",  matchingModal),
+            MakeVoicing("different-modal", differentModal),
+        ]);
+
+        var results = await strategy.SemanticSearchAsync(query, limit: 2);
+
+        Assert.That(results[0].Document.Id, Is.EqualTo("matching-modal"),
+            "MODAL partition must affect scoring on v1.7+ — matching MODAL must outrank diverging MODAL");
+        Assert.That(results[0].Score, Is.GreaterThan(results[1].Score));
+    }
+
+    [Test]
+    public async Task SemanticSearchAsync_LegacyDim_StillWorksWithoutModalOrRoot()
+    {
+        // Legacy 96-dim has no MODAL (would start at 109) and no ROOT.
+        // Must not crash trying to read past the end of the array; the
+        // min-dim guards in CalculateMusicalSimilarity handle this.
+        var strategy = new CpuVoicingSearchStrategy();
+        var query    = MakeV18Vector(1.0);
+        var legacy   = new double[96];
+        for (var i = 6;  i < 30; i++) legacy[i] = 1.0 * 0.1 + i * 0.01;
+        for (var i = 30; i < 54; i++) legacy[i] = 1.0 * 0.2 + i * 0.01;
+        for (var i = 54; i < 66; i++) legacy[i] = 1.0 * 0.3 + i * 0.01;
+        for (var i = 66; i < 78; i++) legacy[i] = 1.0 * 0.4 + i * 0.01;
+
+        await strategy.InitializeAsync([MakeVoicing("legacy", legacy)]);
+
+        Assert.That(async () => await strategy.SemanticSearchAsync(query, limit: 1),
+            Throws.Nothing,
+            "legacy 96-dim must not crash on the new MODAL/ROOT path — min-dim guards handle it");
+    }
+
+    [Test]
     public async Task SemanticSearchAsync_QueryWithUnknownDim_DoesNotCrashAndReturnsResults()
     {
         // Unknown query dim (e.g. some future schema). When the query is NOT


### PR DESCRIPTION
## Summary

Latent bug surfaced by the PR #95 review. `CalculateMusicalSimilarity` was summing only STRUCTURE (0.45) + MORPHOLOGY (0.25) + CONTEXT (0.20) + SYMBOLIC (0.10) — but `EmbeddingSchema.Partitions` also marks **MODAL** (0.10) and v1.8's **ROOT** (0.05) as `PartitionRole.Similarity`. Both silently dropped.

Most damaging case: v1.8's entire purpose is closing the T-invariance gap via the 12-dim ROOT one-hot at slots 228-239. Without it in scoring, two voicings of the same set-class but different roots scored **identically** — exactly the gap PR #95's dim-recognition fix was supposed to enable closing.

## Fix

`CpuVoicingSearchStrategy` + `GpuVoicingSearchStrategy`:

1. Added `MODAL` (offset 109, dim 40, weight 0.10) and `ROOT` (offset 228, dim 12, weight 0.05) constants mirroring `EmbeddingSchema`.
2. `CalculateMusicalSimilarity` (CPU) + GPU kernel now conditionally include each partition gated by `minDim ≥ offset+dim`. Legacy 96-dim and v1.3.1 109-dim vectors still work (don't have those slots; partitions skipped). v1.6+ gets MODAL. v1.8 gets both.
3. **NaN guard** in `ComputePartitionCosine` — `TensorPrimitives.CosineSimilarity` returns NaN for all-zero spans. Without this, adding MODAL/ROOT would propagate NaN through the total when those partitions were unpopulated.

## Score range

When MODAL+ROOT both fire, the total exceeds 1.0 (sum of weights = 1.15). **Intentional** — score is monotonic for ranking; the residual mass beyond 1.0 is the v1.8 discrimination signal older schemas couldn't express. Documented in the constants block.

## Tests (3 new + 5 existing, 8/8 green; 119/119 voicing+search sweep)

- `SemanticSearchAsync_RootPartitionDifference_AffectsScoreOnV18` — two voicings identical in 6-77 but different in ROOT; matching root must outrank.
- `SemanticSearchAsync_ModalPartitionDifference_AffectsScoreOnV17` — same logic for MODAL on v1.7.
- `SemanticSearchAsync_LegacyDim_StillWorksWithoutModalOrRoot` — 96-dim legacy must not crash; min-dim guards handle.

## Trio with PRs #95 and #98

- **PR #95**: voicings score (vs returning 0.000 on dim mismatch)
- **PR #99 (this)**: voicings score with the right signals (MODAL + ROOT included)
- **PR #98**: voicings searched against the relevant filter subset

🤖 Generated with [Claude Code](https://claude.com/claude-code)