### PR TITLE
refactor(chord): extract Spell() to shared ChordSpelling helper

### DIFF
--- a/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
@@ -36,11 +36,7 @@ public sealed partial class ChordMcpTools
             ["B"] = 11, ["B#"] = 0, ["Cb"] = 11, ["E#"] = 5, ["Fb"] = 4,
         };
 
-    private static readonly char[] NaturalLetters = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
-    private static readonly IReadOnlyDictionary<char, int> NaturalPitchClasses = new Dictionary<char, int>
-    {
-        ['C'] = 0, ['D'] = 2, ['E'] = 4, ['F'] = 5, ['G'] = 7, ['A'] = 9, ['B'] = 11,
-    };
+    // NaturalLetters / NaturalPitchClasses live in ChordSpelling (PR #102).
 
     /// <summary>
     /// Parses a chord symbol (e.g. <c>"Cmaj7"</c>, <c>"F#m"</c>, <c>"Bbdim"</c>) and
@@ -71,7 +67,7 @@ public sealed partial class ChordMcpTools
 
         var formula = GetFormula(quality);
         var notes   = formula.Intervals
-            .Zip(formula.LetterSteps, (interval, letterSteps) => Spell(root, rootPc + interval, letterSteps))
+            .Zip(formula.LetterSteps, (interval, letterSteps) => ChordSpelling.Spell(root, rootPc + interval, letterSteps))
             .ToArray();
 
         return new ChordResult
@@ -134,31 +130,7 @@ public sealed partial class ChordMcpTools
         _            => new("major",      [0, 4, 7],     [0, 2, 4],    ["root", "major third", "perfect fifth"]),
     };
 
-    /// <summary>
-    /// Enharmonic-aware note spelling: given a root, target pitch class, and the
-    /// number of letter-steps from root to target, picks the right letter +
-    /// accidental so a Cmaj chord spells C-E-G (not C-E-Abb) and a Bbm chord
-    /// spells Bb-Db-F (not Bb-C#-F).
-    /// </summary>
-    private static string Spell(string root, int pitchClass, int letterSteps)
-    {
-        var rootLetter   = char.ToUpperInvariant(root[0]);
-        var rootIndex    = Array.IndexOf(NaturalLetters, rootLetter);
-        var targetLetter = NaturalLetters[(rootIndex + letterSteps) % NaturalLetters.Length];
-        var targetNatural = NaturalPitchClasses[targetLetter];
-        var normalized   = ((pitchClass % 12) + 12) % 12;
-        var accidental   = ((normalized - targetNatural) % 12 + 12) % 12;
-
-        return accidental switch
-        {
-            0  => targetLetter.ToString(),
-            1  => $"{targetLetter}#",
-            2  => $"{targetLetter}##",
-            10 => $"{targetLetter}bb",
-            11 => $"{targetLetter}b",
-            _  => $"{targetLetter}{(accidental < 6 ? new string('#', accidental) : new string('b', 12 - accidental))}",
-        };
-    }
+    // Spell() delegates to the shared helper (PR #102) — see ChordSpelling.
 
     [GeneratedRegex(@"^(?<root>[A-Ga-g][#b]?)(?<quality>maj7|min7|m7|maj|min|m|dim|aug|7|M7|M)?$",
         RegexOptions.CultureInvariant)]

--- a/Common/GA.Business.ML/Agents/Mcp/ChordSpelling.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/ChordSpelling.cs
@@ -1,0 +1,71 @@
+namespace GA.Business.ML.Agents.Mcp;
+
+/// <summary>
+/// Enharmonic-aware chord-tone spelling shared between
+/// <see cref="Skills.ChordInfoSkill"/> (the deterministic fast path) and
+/// <see cref="ChordMcpTools"/> (the MCP-tool surface). Both call
+/// <see cref="Spell"/> with the same arguments and previously held byte-
+/// identical copies — drift between them would have caused the same chord
+/// query to return different note spellings depending on which path
+/// resolved it. Extracted per PR #80 review and shipped in PR #102.
+/// </summary>
+/// <remarks>
+/// The function picks the right letter+accidental combination so a Cmaj
+/// chord spells C-E-G (not C-E-Abb) and a Bbm chord spells Bb-Db-F
+/// (not Bb-C#-F). The choice is driven by <c>letterSteps</c> from the
+/// chord-formula table (e.g. triad steps [0, 2, 4]; seventh-chord steps
+/// [0, 2, 4, 6]) — the caller picks letterSteps based on the chord
+/// quality and this function does the enharmonic accounting.
+/// </remarks>
+internal static class ChordSpelling
+{
+    /// <summary>
+    /// Diatonic letters in C-major order. Used as a 7-position cycle so
+    /// "letter step N from C" = NaturalLetters[(0+N) % 7].
+    /// </summary>
+    public static readonly char[] NaturalLetters = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+
+    /// <summary>
+    /// Pitch class of each natural letter (no accidentals). Used to compute
+    /// the accidental needed to reach the target pitch class from the
+    /// chosen letter.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<char, int> NaturalPitchClasses =
+        new Dictionary<char, int>
+        {
+            ['C'] = 0, ['D'] = 2, ['E'] = 4, ['F'] = 5,
+            ['G'] = 7, ['A'] = 9, ['B'] = 11,
+        };
+
+    /// <summary>
+    /// Returns the enharmonic-aware spelling of a chord tone given its
+    /// <paramref name="root"/>, target <paramref name="pitchClass"/>, and
+    /// the number of <paramref name="letterSteps"/> from root to target
+    /// (per the chord formula).
+    /// </summary>
+    /// <example>
+    /// <c>Spell("C", 4, 2)</c> = <c>"E"</c> (root C, third = letter step 2,
+    /// pitch class 4 → letter E with no accidental).
+    /// <c>Spell("C", 3, 2)</c> = <c>"Eb"</c> (root C, third = letter step 2,
+    /// pitch class 3 → letter E flatted by one — the minor third of C).
+    /// </example>
+    public static string Spell(string root, int pitchClass, int letterSteps)
+    {
+        var rootLetter   = char.ToUpperInvariant(root[0]);
+        var rootIndex    = Array.IndexOf(NaturalLetters, rootLetter);
+        var targetLetter = NaturalLetters[(rootIndex + letterSteps) % NaturalLetters.Length];
+        var targetNatural = NaturalPitchClasses[targetLetter];
+        var normalized   = ((pitchClass % 12) + 12) % 12;
+        var accidental   = ((normalized - targetNatural) % 12 + 12) % 12;
+
+        return accidental switch
+        {
+            0  => targetLetter.ToString(),
+            1  => $"{targetLetter}#",
+            2  => $"{targetLetter}##",
+            10 => $"{targetLetter}bb",
+            11 => $"{targetLetter}b",
+            _  => $"{targetLetter}{(accidental < 6 ? new string('#', accidental) : new string('b', 12 - accidental))}",
+        };
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/ChordInfoSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ChordInfoSkill.cs
@@ -32,17 +32,9 @@ public sealed partial class ChordInfoSkill(ILogger<ChordInfoSkill> logger) : IOr
         ["Fb"] = 4,
     };
 
-    private static readonly char[] NaturalLetters = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
-    private static readonly IReadOnlyDictionary<char, int> NaturalPitchClasses = new Dictionary<char, int>
-    {
-        ['C'] = 0,
-        ['D'] = 2,
-        ['E'] = 4,
-        ['F'] = 5,
-        ['G'] = 7,
-        ['A'] = 9,
-        ['B'] = 11,
-    };
+    // NaturalLetters / NaturalPitchClasses moved to ChordSpelling (PR #102).
+    // Spell() below also delegates so this skill and ChordMcpTools share
+    // a single source of truth for enharmonic accounting.
 
     public string Name => "ChordInfo";
 
@@ -236,25 +228,10 @@ public sealed partial class ChordInfoSkill(ILogger<ChordInfoSkill> logger) : IOr
                normalized.Contains("note", StringComparison.Ordinal);
     }
 
-    private static string Spell(string root, int pitchClass, int letterSteps)
-    {
-        var rootLetter = char.ToUpperInvariant(root[0]);
-        var rootIndex = Array.IndexOf(NaturalLetters, rootLetter);
-        var targetLetter = NaturalLetters[(rootIndex + letterSteps) % NaturalLetters.Length];
-        var targetNatural = NaturalPitchClasses[targetLetter];
-        var normalized = ((pitchClass % 12) + 12) % 12;
-        var accidental = ((normalized - targetNatural) % 12 + 12) % 12;
-
-        return accidental switch
-        {
-            0 => targetLetter.ToString(),
-            1 => $"{targetLetter}#",
-            2 => $"{targetLetter}##",
-            10 => $"{targetLetter}bb",
-            11 => $"{targetLetter}b",
-            _ => $"{targetLetter}{(accidental < 6 ? new string('#', accidental) : new string('b', 12 - accidental))}"
-        };
-    }
+    // Delegates to the shared helper (PR #102) so this skill and
+    // ChordMcpTools cannot drift on enharmonic accounting.
+    private static string Spell(string root, int pitchClass, int letterSteps) =>
+        GA.Business.ML.Agents.Mcp.ChordSpelling.Spell(root, pitchClass, letterSteps);
 
     private static string JoinNotes(IReadOnlyList<string> notes) =>
         notes.Count switch

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ChordSpellingTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ChordSpellingTests.cs
@@ -1,0 +1,59 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Mcp;
+
+/// <summary>
+/// Pins the shared <see cref="ChordSpelling.Spell"/> contract that
+/// <see cref="GA.Business.ML.Agents.Skills.ChordInfoSkill"/> and
+/// <see cref="ChordMcpTools"/> both depend on. Same input → same output;
+/// any future drift breaks here before the consumers diverge.
+/// </summary>
+[TestFixture]
+public class ChordSpellingTests
+{
+    // Triad letter-steps = [0, 2, 4]; seventh-chord letter-steps = [0, 2, 4, 6].
+    // Pitch classes are 0=C 1=C# 2=D 3=Eb 4=E 5=F 6=F# 7=G 8=Ab 9=A 10=Bb 11=B.
+
+    [TestCase("C", 0, 0,  "C")]   // root of C
+    [TestCase("C", 4, 2,  "E")]   // major third of C → E natural
+    [TestCase("C", 3, 2,  "Eb")]  // minor third of C → E flat (NOT D# — letter-step 2 forces E)
+    [TestCase("C", 7, 4,  "G")]   // perfect fifth
+    [TestCase("C", 6, 4,  "Gb")]  // diminished fifth → G flat (NOT F# — letter-step 4 forces G)
+    [TestCase("C", 11, 6, "B")]   // major seventh
+    [TestCase("C", 10, 6, "Bb")]  // minor seventh → B flat (NOT A# — letter-step 6 forces B)
+    public void Spell_TriadAndSeventhChordTones_HonourLetterSteps(
+        string root, int pitchClass, int letterSteps, string expected)
+    {
+        Assert.That(ChordSpelling.Spell(root, pitchClass, letterSteps), Is.EqualTo(expected));
+    }
+
+    [TestCase("F#", 6,  0, "F#")]
+    [TestCase("F#", 10, 2, "A#")]   // major third of F# → A# (NOT Bb — letter-step 2 from F# forces A)
+    [TestCase("Bb", 10, 0, "Bb")]
+    [TestCase("Bb", 1,  2, "Db")]   // minor third of Bb → Db (NOT C# — letter-step 2 from Bb forces D)
+    [TestCase("Bb", 5,  4, "F")]    // fifth of Bb
+    public void Spell_AccidentalRoots_PickRightLetterStep(
+        string root, int pitchClass, int letterSteps, string expected)
+    {
+        Assert.That(ChordSpelling.Spell(root, pitchClass, letterSteps), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Spell_BdimVoicing_SpellsAsBDF()
+    {
+        // The textbook diminished-triad case — F is the diminished fifth,
+        // NOT E# despite same pitch class. Letter-step 4 from B forces F.
+        Assert.That(ChordSpelling.Spell("B", 11, 0), Is.EqualTo("B"));
+        Assert.That(ChordSpelling.Spell("B", 2,  2), Is.EqualTo("D"));
+        Assert.That(ChordSpelling.Spell("B", 5,  4), Is.EqualTo("F"));
+    }
+
+    [Test]
+    public void Spell_DoubleAccidentals_RenderCorrectly()
+    {
+        // Edge case: Cdim7 has a doubly-diminished seventh = Bbb.
+        // Letter-step 6 from C → letter B; pitch class 9 (A) means
+        // accidental = (9-11) mod 12 = 10 → "bb".
+        Assert.That(ChordSpelling.Spell("C", 9, 6), Is.EqualTo("Bbb"));
+    }
+}


### PR DESCRIPTION
## Summary

Removes byte-identical duplication between `ChordInfoSkill` (deterministic fast path) and `ChordMcpTools` (MCP-tool surface). PR #80 review flagged this; same chord query producing different spellings depending on which path resolved it would be exactly the silent musical-correctness failure mode the migration was meant to retire.

## What changed

- **New** `Common/GA.Business.ML/Agents/Mcp/ChordSpelling.cs` — shared `Spell(root, pitchClass, letterSteps)` + `NaturalLetters` / `NaturalPitchClasses` tables.
- `ChordInfoSkill.Spell(...)` → 1-line delegate.
- `ChordMcpTools.GetChordInfo()` → calls `ChordSpelling.Spell` directly.
- **New** `ChordSpellingTests.cs` — 14 cases pinning the contract (triads, sevenths, accidental roots, Bdim, Cdim7's Bbb edge case).

## Test plan

- [x] 14/14 new `ChordSpellingTests` cases
- [x] 54/54 existing `ChordInfo` + `ChordMcp` consumer tests still pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)