### PR TITLE
feat(readiness): orchestrator round-trip probe in /status

### DIFF
--- a/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
+++ b/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
@@ -245,5 +245,14 @@ public sealed class ChatbotStatus
     /// </summary>
     public bool ProviderReachable { get; set; }
 
+    /// <summary>
+    /// True iff a synthetic catalog-skill query round-trips through the
+    /// orchestrator within the probe's timeout. Catches process-level
+    /// wedges (DI registry empty, hosted services deadlocked, orchestrator
+    /// hung) that the provider-level probe cannot see. Independent of
+    /// <see cref="ProviderReachable"/>: catalog skills don't need Ollama.
+    /// </summary>
+    public bool? OrchestratorRoundTripOk { get; set; }
+
     public DateTime Timestamp { get; set; }
 }

--- a/Apps/GaChatbot.Api/Services/ChatProviderReadinessProbe.cs
+++ b/Apps/GaChatbot.Api/Services/ChatProviderReadinessProbe.cs
@@ -1,6 +1,8 @@
 namespace GaChatbot.Api.Services;
 
+using System.Diagnostics;
 using System.Text.Json;
+using GA.Business.ML.Agents.Intents;
 using GaChatbot.Api.Controllers;
 
 public interface IChatProviderReadinessProbe
@@ -17,13 +19,31 @@ public interface IChatProviderReadinessProbe
 /// </summary>
 public sealed class ChatProviderReadinessProbe(
     IConfiguration configuration,
-    IHttpClientFactory httpClientFactory) : IChatProviderReadinessProbe
+    IHttpClientFactory httpClientFactory,
+    IServiceProvider serviceProvider,
+    ILogger<ChatProviderReadinessProbe> logger) : IChatProviderReadinessProbe
 {
+    /// <summary>
+    /// Synthetic query for the orchestrator round-trip probe. Routes to a
+    /// catalog skill (no LLM call, no embedding call) so a wedged Ollama
+    /// can't false-positive nor false-negative the result.
+    /// </summary>
+    private const string RoundTripQuery = "show me beginner chords";
+
+    /// <summary>
+    /// Hard ceiling on the round-trip probe. /status callers expect a fast
+    /// response; a hung orchestrator must surface as a failed probe rather
+    /// than block the response. 3s is comfortably above any healthy
+    /// catalog-skill execution (<10ms in unit tests) but well under typical
+    /// HTTP-client timeouts.
+    /// </summary>
+    private static readonly TimeSpan RoundTripTimeout = TimeSpan.FromSeconds(3);
+
     public async Task<ChatbotStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
         var provider = (configuration["AI:ChatProvider"] ?? "ollama").ToLowerInvariant();
 
-        return provider switch
+        var providerStatus = provider switch
         {
             "github" => TokenBasedStatus("GITHUB_TOKEN", "GitHub Models", provider),
             "ollama" => await GetOllamaStatusAsync(cancellationToken),
@@ -36,6 +56,89 @@ public sealed class ChatProviderReadinessProbe(
                 Timestamp = DateTime.UtcNow,
             },
         };
+
+        // Round-trip probe: independent of the provider check above, so a
+        // wedged orchestrator process is caught even when the provider is
+        // healthy. Catalog-skill execution doesn't need Ollama, so this
+        // probe truly tests the chatbot pipeline without re-testing the
+        // upstream dep.
+        var roundTrip = await TryRoundTripAsync(cancellationToken);
+        providerStatus.OrchestratorRoundTripOk = roundTrip.Success;
+        if (!roundTrip.Success)
+        {
+            providerStatus.IsAvailable = false;
+            providerStatus.Message = string.IsNullOrEmpty(providerStatus.Message)
+                ? roundTrip.Diagnostic
+                : $"{providerStatus.Message} | Round-trip: {roundTrip.Diagnostic}";
+        }
+
+        return providerStatus;
+    }
+
+    /// <summary>
+    /// Issues a synthetic query through a catalog <see cref="IIntent"/> and
+    /// confirms the orchestrator pipeline returns a non-empty answer within
+    /// <see cref="RoundTripTimeout"/>. Catches process-level wedges (DI
+    /// resolution stuck, hosted services deadlocked, intent registry empty)
+    /// that the provider-level probe cannot see.
+    /// </summary>
+    private async Task<(bool Success, string Diagnostic)> TryRoundTripAsync(CancellationToken outerCt)
+    {
+        try
+        {
+            using var scope = serviceProvider.CreateScope();
+            var intents = scope.ServiceProvider.GetServices<IIntent>().ToList();
+            if (intents.Count == 0)
+            {
+                logger.LogWarning("Round-trip probe: no IIntent registrations resolved");
+                return (false, "no IIntent registrations — orchestrator registry empty");
+            }
+
+            // Prefer a catalog skill (no LLM, no embedding). Fall back to
+            // the first registration if none looks catalog-shaped.
+            var probe = intents.FirstOrDefault(IsCatalogIntent) ?? intents[0];
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(outerCt);
+            timeoutCts.CancelAfter(RoundTripTimeout);
+
+            var sw = Stopwatch.StartNew();
+            var result = await probe.ExecuteAsync(RoundTripQuery, timeoutCts.Token);
+            sw.Stop();
+
+            if (string.IsNullOrEmpty(result.Answer))
+            {
+                return (false, $"intent '{probe.Id}' returned empty answer in {sw.ElapsedMilliseconds}ms");
+            }
+
+            logger.LogDebug(
+                "Round-trip probe: intent={Intent} elapsed={Elapsed}ms",
+                probe.Id, sw.ElapsedMilliseconds);
+            return (true, $"ok via {probe.Id} in {sw.ElapsedMilliseconds}ms");
+        }
+        catch (OperationCanceledException) when (!outerCt.IsCancellationRequested)
+        {
+            return (false, $"timed out after {RoundTripTimeout.TotalSeconds}s — orchestrator likely wedged");
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Round-trip probe threw");
+            return (false, $"threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Heuristic for picking a catalog skill over a hybrid one. Catalog
+    /// skills don't make LLM/embedding calls, so they round-trip without
+    /// touching the upstream provider. Identified by the
+    /// <c>OrchestratorSkillIntent</c> ID prefix and a known set of catalog
+    /// skill names.
+    /// </summary>
+    private static bool IsCatalogIntent(IIntent intent)
+    {
+        var id = intent.Id ?? string.Empty;
+        return id.Contains("beginnerchords",   StringComparison.OrdinalIgnoreCase)
+            || id.Contains("progressionmood",  StringComparison.OrdinalIgnoreCase)
+            || id.Contains("modes",            StringComparison.OrdinalIgnoreCase);
     }
 
     private static ChatbotStatus TokenBasedStatus(string envVarName, string providerName, string providerKey)

--- a/Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj
+++ b/Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj
@@ -5,6 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <!-- IIntent / IntentResult / OrchestratorSkillIntent are tagged
+         [Experimental("SKEXP0001")] in GA.Business.ML; the production
+         GaChatbot.Api csproj suppresses the diagnostic, so the test
+         project must too. PR #103 added round-trip-probe tests that
+         construct these types directly. -->
+    <NoWarn>$(NoWarn);SKEXP0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Apps/GaChatbot.Api.Tests/Services/ChatProviderReadinessProbeTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Services/ChatProviderReadinessProbeTests.cs
@@ -2,8 +2,11 @@ namespace GaChatbot.Api.Tests.Services;
 
 using System.Net;
 using System.Text;
+using GA.Business.ML.Agents.Intents;
 using GaChatbot.Api.Services;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 [TestFixture]
 public class ChatProviderReadinessProbeTests
@@ -21,7 +24,10 @@ public class ChatProviderReadinessProbeTests
         Assert.Multiple(() =>
         {
             Assert.That(status.IsAvailable, Is.False);
-            Assert.That(status.Message, Is.EqualTo("Unsupported chat provider 'unknown-provider'."));
+            // PR #103: round-trip diagnostic is appended to Message — use Contain
+            // rather than equality so the original "Unsupported chat provider"
+            // signal is still pinned, but the new round-trip metadata can stack.
+            Assert.That(status.Message, Does.Contain("Unsupported chat provider 'unknown-provider'"));
             Assert.That(status.Provider, Is.EqualTo("unknown-provider"));
         });
     }
@@ -90,7 +96,11 @@ public class ChatProviderReadinessProbeTests
                 ["Ollama:ChatModel"]       = "llama3.2:3b",
                 ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
             },
-            JsonOk(tagsBody));
+            JsonOk(tagsBody),
+            // PR #103: round-trip probe is part of IsAvailable. Supply a working
+            // catalog intent so the orchestrator round-trip succeeds and
+            // IsAvailable stays true on this provider-healthy path.
+            intents: [new FakeCatalogIntent("skill.beginnerchords", "ok")]);
 
         var status = await probe.GetStatusAsync();
 
@@ -218,7 +228,8 @@ public class ChatProviderReadinessProbeTests
                 ["AI:ChatProvider"] = "ollama",
                 // ChatModel + EmbeddingModel intentionally not set
             },
-            JsonOk("""{"models":[]}"""));
+            JsonOk("""{"models":[]}"""),
+            intents: [new FakeCatalogIntent("skill.beginnerchords", "ok")]);
 
         var status = await probe.GetStatusAsync();
 
@@ -247,7 +258,8 @@ public class ChatProviderReadinessProbeTests
                 ["Ollama:ChatModel"]       = "llama3.2",      // base name, no tag
                 ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
             },
-            JsonOk(tagsBody));
+            JsonOk(tagsBody),
+            intents: [new FakeCatalogIntent("skill.beginnerchords", "ok")]);
 
         var status = await probe.GetStatusAsync();
 
@@ -311,6 +323,124 @@ public class ChatProviderReadinessProbeTests
             "but with no models parseable, the chat path can't serve");
     }
 
+    // ── Round-trip probe (PR #103) ────────────────────────────────────────────
+
+    [Test]
+    public async Task GetStatusAsync_RoundTripSucceeds_PopulatesOrchestratorRoundTripOk()
+    {
+        // Healthy case: a catalog IIntent is registered, executes, returns
+        // a non-empty answer within the probe's timeout. OrchestratorRoundTripOk = true.
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk("""{"models":[{"name":"llama3.2:3b"},{"name":"nomic-embed-text:latest"}]}"""),
+            intents: [new FakeCatalogIntent("skill.beginnerchords", "8 open-position chords...")]);
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.That(status.OrchestratorRoundTripOk, Is.True,
+            "registered IIntent that executes successfully → round-trip ok");
+        Assert.That(status.IsAvailable, Is.True);
+    }
+
+    [Test]
+    public async Task GetStatusAsync_NoIntentsRegistered_RoundTripFailsAndIsAvailableFalse()
+    {
+        // The user-perceived bug: orchestrator process is wedged (DI registry empty,
+        // intents not loaded). Provider-level probe is fine (Ollama HTTP up + models
+        // installed) but the chatbot literally cannot serve a query. Round-trip
+        // probe must catch this and flip IsAvailable to false.
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk("""{"models":[{"name":"llama3.2:3b"},{"name":"nomic-embed-text:latest"}]}"""),
+            intents: []);
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.OrchestratorRoundTripOk, Is.False);
+            Assert.That(status.IsAvailable, Is.False,
+                "round-trip failure must flip IsAvailable to false even when provider is healthy — exactly the bug the user reported");
+            Assert.That(status.Message, Does.Contain("registry empty").Or.Contain("no IIntent"));
+        });
+    }
+
+    [Test]
+    public async Task GetStatusAsync_IntentExecutionThrows_RoundTripFails()
+    {
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            JsonOk("""{"models":[{"name":"llama3.2:3b"},{"name":"nomic-embed-text:latest"}]}"""),
+            intents: [new ThrowingIntent("skill.beginnerchords", new InvalidOperationException("simulated wedge"))]);
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.That(status.OrchestratorRoundTripOk, Is.False);
+        Assert.That(status.IsAvailable, Is.False);
+        Assert.That(status.Message, Does.Contain("InvalidOperationException").Or.Contain("simulated wedge"));
+    }
+
+    [Test]
+    public async Task GetStatusAsync_RoundTripOkWhenProviderUnreachable_StillFlipsIsAvailable()
+    {
+        // Defense-in-depth: even if the round-trip probe succeeds (catalog
+        // skill works without Ollama), an unreachable provider should keep
+        // IsAvailable=false. Catalog round-trip alone isn't enough.
+        var probe = CreateProbe(
+            new Dictionary<string, string?>
+            {
+                ["AI:ChatProvider"]        = "ollama",
+                ["Ollama:ChatModel"]       = "llama3.2:3b",
+                ["Ollama:EmbeddingModel"]  = "nomic-embed-text",
+            },
+            exception: new HttpRequestException("connection refused"),
+            intents: [new FakeCatalogIntent("skill.beginnerchords", "ok")]);
+
+        var status = await probe.GetStatusAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.OrchestratorRoundTripOk, Is.True,
+                "catalog skill executes locally — round-trip succeeds");
+            Assert.That(status.ProviderReachable, Is.False);
+            Assert.That(status.IsAvailable, Is.False,
+                "but provider unreachable still flips IsAvailable; round-trip is necessary, not sufficient");
+        });
+    }
+
+    private sealed class FakeCatalogIntent(string id, string answer) : IIntent
+    {
+        public string Id => id;
+        public string Description => "fake catalog intent for tests";
+        public IReadOnlyList<string> ExamplePrompts => [];
+        public Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new IntentResult(answer));
+    }
+
+    private sealed class ThrowingIntent(string id, Exception toThrow) : IIntent
+    {
+        public string Id => id;
+        public string Description => "throwing intent for tests";
+        public IReadOnlyList<string> ExamplePrompts => [];
+        public Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default) =>
+            throw toThrow;
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static HttpResponseMessage JsonOk(string body) =>
@@ -322,7 +452,8 @@ public class ChatProviderReadinessProbeTests
     private static ChatProviderReadinessProbe CreateProbe(
         IReadOnlyDictionary<string, string?> values,
         HttpResponseMessage? response = null,
-        Exception? exception = null)
+        Exception? exception = null,
+        IIntent[]? intents = null)
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(values)
@@ -333,7 +464,22 @@ public class ChatProviderReadinessProbeTests
             BaseAddress = new Uri("http://localhost:11434")
         };
 
-        return new ChatProviderReadinessProbe(configuration, new StubHttpClientFactory(httpClient));
+        // Build an IServiceProvider with the supplied intents so the probe
+        // can resolve IEnumerable<IIntent> for the round-trip check. Empty
+        // array (default) simulates a wedged orchestrator with no
+        // registrations — the user-perceived failure mode.
+        var services = new ServiceCollection();
+        foreach (var intent in intents ?? [])
+        {
+            services.AddSingleton(intent);
+        }
+        var sp = services.BuildServiceProvider();
+
+        return new ChatProviderReadinessProbe(
+            configuration,
+            new StubHttpClientFactory(httpClient),
+            sp,
+            NullLogger<ChatProviderReadinessProbe>.Instance);
     }
 
     private sealed class StubHttpClientFactory(HttpClient client) : IHttpClientFactory


### PR DESCRIPTION
## Summary
- Provider-level probe (#96) only checks Ollama HTTP + installed models; orchestrator-level wedges (empty IIntent registry, hung hosted services, deadlocked skills) still report healthy. This PR closes that gap.
- New round-trip probe executes a synthetic query through a **catalog** `IIntent` (no LLM, no embedding call) with a 3s hard timeout. Fails fast on a wedged orchestrator, can't be false-positived by a wedged Ollama.
- `ChatbotStatus.OrchestratorRoundTripOk` surfaced to `/status` callers, distinct from `ProviderReachable`. Round-trip failure flips `IsAvailable=false` even when the provider is healthy.

## Why now
Local Ollama has been wedged on chat-model loading for the past 24h while embeddings are fine — the kind of partial failure the shallow probe is bad at. The new probe rounds-trips a catalog skill so we don't have to re-test the upstream provider to learn whether the chatbot pipeline can serve.

## Failure modes pinned by tests
| Scenario | OrchestratorRoundTripOk | IsAvailable |
| --- | --- | --- |
| Provider healthy + catalog intent registered + executes | true | true |
| Provider healthy + **no IIntent registrations** | false | **false** ← the user-perceived bug |
| Provider healthy + intent throws | false | false |
| Provider **unreachable** + catalog intent works | true | **false** (round-trip is necessary, not sufficient) |

## Test plan
- [x] `dotnet test Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj --filter "FullyQualifiedName~ChatProviderReadinessProbeTests"` → 16/16 pass (12 prior + 4 new)
- [x] `dotnet build AllProjects.slnx -c Debug` clean
- [ ] Manual smoke: hit `GET /api/chatbot/status` with the chatbot running, confirm new field surfaces. (Deferred — local Ollama is wedged, see `state/quality/chatbot-baseline-2026-05-03-postfix.json`.)

## One-way / two-way door
**Two-way door.** Adding a nullable response field + a probe leg is reversible — flip it off via DI registration if it ever becomes flaky. Revisit trigger: any `/status` regression where round-trip flips `IsAvailable=false` for a transient cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)