### PR TITLE
chore(repo): track chatbot Scripts + GaApi GuitarPlayingController

### DIFF
--- a/Apps/ga-server/GaApi/Controllers/GuitarPlayingController.cs
+++ b/Apps/ga-server/GaApi/Controllers/GuitarPlayingController.cs
@@ -1,0 +1,66 @@
+namespace GaApi.Controllers;
+
+using System.Net.Http;
+using GA.Business.AI.HandPose;
+
+/// <summary>
+///     Hand pose detection endpoints used by the Hand Pose demo (/demos/hand-pose).
+///     Wraps <see cref="HandPoseClient"/> so the demo works with only GaApi + the
+///     Python hand-pose-service running (no full Aspire microservice mesh required).
+/// </summary>
+[ApiController]
+[Route("api/guitarplaying")]
+[Produces("application/json")]
+public class GuitarPlayingController(
+    HandPoseClient handPoseClient,
+    ILogger<GuitarPlayingController> logger)
+    : ControllerBase
+{
+    /// <summary>
+    ///     Detect hand pose keypoints in an uploaded image.
+    /// </summary>
+    [HttpPost("detect-hands")]
+    [ProducesResponseType(typeof(HandPoseResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> DetectHands(IFormFile image, CancellationToken ct)
+    {
+        if (image is null || image.Length == 0)
+        {
+            return BadRequest(new { error = "No image provided. Upload a file under the 'image' form field." });
+        }
+
+        try
+        {
+            await using var stream = image.OpenReadStream();
+            var result = await handPoseClient.InferAsync(stream, image.FileName, ct);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex) when (ex.InnerException is HttpRequestException)
+        {
+            // HandPoseClient wraps transport failures this way when the Python service is unreachable.
+            logger.LogWarning(ex, "hand-pose-service unreachable");
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "Hand pose service is not running",
+                details = "Start the Python service under Apps/hand-pose-service (uvicorn on :8080), " +
+                          "or set HandPoseService:BaseUrl to a reachable endpoint."
+            });
+        }
+    }
+
+    /// <summary>
+    ///     Lightweight health probe for the downstream Python hand-pose service.
+    /// </summary>
+    [HttpGet("health")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Health(CancellationToken ct)
+    {
+        var up = await handPoseClient.HealthCheckAsync(ct);
+        return Ok(new
+        {
+            handPoseService = up ? "healthy" : "unavailable",
+            overall = up ? "healthy" : "degraded"
+        });
+    }
+}

--- a/Scripts/chatbot-status.ps1
+++ b/Scripts/chatbot-status.ps1
@@ -1,0 +1,39 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Check local thin-chatbot API and optional frontend availability.
+.PARAMETER ApiUrl
+    Base URL of the chatbot API.
+.PARAMETER FrontendUrl
+    Optional frontend URL to test.
+#>
+
+param(
+    [string]$ApiUrl = "http://localhost:5252",
+    [string]$FrontendUrl = "http://localhost:5173"
+)
+
+$ErrorActionPreference = "Continue"
+
+Write-Host "Chatbot status" -ForegroundColor Cyan
+Write-Host "  API:      $ApiUrl" -ForegroundColor White
+Write-Host "  Frontend: $FrontendUrl" -ForegroundColor White
+Write-Host ""
+
+$apiStatus = try { Invoke-RestMethod "$ApiUrl/api/chatbot/status" } catch { $null }
+if ($apiStatus) {
+    $availability = if ($apiStatus.isAvailable) { "AVAILABLE" } else { "UNAVAILABLE" }
+    Write-Host "API: $availability" -ForegroundColor $(if ($apiStatus.isAvailable) { "Green" } else { "Yellow" })
+    Write-Host "  Message: $($apiStatus.message)" -ForegroundColor Gray
+} else {
+    Write-Host "API: DOWN" -ForegroundColor Red
+}
+
+$frontendStatus = try { (Invoke-WebRequest $FrontendUrl -TimeoutSec 5).StatusCode } catch { $null }
+if ($frontendStatus -eq 200) {
+    Write-Host "Frontend: UP" -ForegroundColor Green
+} elseif ($frontendStatus) {
+    Write-Host "Frontend: HTTP $frontendStatus" -ForegroundColor Yellow
+} else {
+    Write-Host "Frontend: DOWN" -ForegroundColor Red
+}

--- a/Scripts/measure-qa-architect-baseline.ps1
+++ b/Scripts/measure-qa-architect-baseline.ps1
@@ -1,0 +1,323 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Measure Phase 0 QA Architect baseline runtimes.
+
+.DESCRIPTION
+    Runs a small set of local probes and writes an additive JSON snapshot to
+    state/quality/qa-architect/baseline.json. Probes are intentionally recorded
+    independently: a failed or timed-out probe is baseline data, not a reason to
+    discard the whole run.
+
+.PARAMETER OutputPath
+    JSON baseline output path.
+
+.PARAMETER SkipOllama
+    Skip local Ollama HTTP probes.
+
+.PARAMETER OllamaUrl
+    Base URL for local Ollama.
+
+.PARAMETER OllamaModel
+    Model to use for the guarded generation probe. If omitted, the script
+    prefers qwen2.5-coder:7b when available, then the first local model.
+
+.PARAMETER OllamaTimeoutSeconds
+    Timeout for each Ollama HTTP request.
+#>
+
+param(
+    [string]$OutputPath,
+    [switch]$SkipOllama,
+    [string]$OllamaUrl = "http://localhost:11434",
+    [string]$OllamaModel,
+    [int]$OllamaTimeoutSeconds = 60
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $repoRoot "state/quality/qa-architect/baseline.json"
+}
+
+function ConvertTo-OutputTail {
+    param([string]$Text, [int]$MaxLength = 6000)
+
+    if ([string]::IsNullOrEmpty($Text)) {
+        return ""
+    }
+
+    if ($Text.Length -le $MaxLength) {
+        return $Text.Trim()
+    }
+
+    return $Text.Substring($Text.Length - $MaxLength).Trim()
+}
+
+function Invoke-BaselineCommand {
+    param(
+        [string]$Name,
+        [string]$Category,
+        [string]$Command,
+        [scriptblock]$Script
+    )
+
+    Write-Host ""
+    Write-Host "== $Name ==" -ForegroundColor Cyan
+
+    $started = (Get-Date).ToUniversalTime()
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $exitCode = 0
+    $status = "passed"
+    $output = ""
+    $errorMessage = $null
+
+    try {
+        $global:LASTEXITCODE = 0
+        $output = (& $Script 2>&1 | Out-String)
+        $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+        if ($exitCode -ne 0) {
+            $status = "failed"
+        }
+    }
+    catch {
+        $status = "failed"
+        $exitCode = 1
+        $errorMessage = $_.Exception.Message
+        $output = $_ | Out-String
+    }
+    finally {
+        $stopwatch.Stop()
+    }
+
+    Write-Host "$status in $($stopwatch.Elapsed.TotalSeconds.ToString('F1'))s" -ForegroundColor $(if ($status -eq "passed") { "Green" } else { "Yellow" })
+
+    [ordered]@{
+        name = $Name
+        category = $Category
+        command = $Command
+        status = $status
+        exit_code = $exitCode
+        started_at = $started.ToString("O")
+        elapsed_seconds = [Math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+        error = $errorMessage
+        output_tail = ConvertTo-OutputTail $output
+    }
+}
+
+function Invoke-OllamaHttpProbe {
+    param(
+        [string]$Name,
+        [string]$Category,
+        [string]$Command,
+        [scriptblock]$Script
+    )
+
+    Write-Host ""
+    Write-Host "== $Name ==" -ForegroundColor Cyan
+
+    $started = (Get-Date).ToUniversalTime()
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $status = "passed"
+    $errorMessage = $null
+    $payload = $null
+
+    try {
+        $payload = & $Script
+    }
+    catch {
+        $status = if ($_.Exception.Message -match "timed out|timeout|operation was canceled") { "timed_out" } else { "failed" }
+        $errorMessage = $_.Exception.Message
+    }
+    finally {
+        $stopwatch.Stop()
+    }
+
+    Write-Host "$status in $($stopwatch.Elapsed.TotalSeconds.ToString('F1'))s" -ForegroundColor $(if ($status -eq "passed") { "Green" } else { "Yellow" })
+
+    [ordered]@{
+        name = $Name
+        category = $Category
+        command = $Command
+        status = $status
+        exit_code = if ($status -eq "passed") { 0 } else { 1 }
+        started_at = $started.ToString("O")
+        elapsed_seconds = [Math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+        error = $errorMessage
+        output_tail = if ($null -eq $payload) { "" } else { ConvertTo-OutputTail (($payload | ConvertTo-Json -Depth 12 -Compress)) }
+    }
+}
+
+function Get-GitValue {
+    param([string[]]$GitArgs)
+
+    try {
+        return ((& git @GitArgs 2>$null) | Out-String).Trim()
+    }
+    catch {
+        return $null
+    }
+}
+
+Set-Location $repoRoot
+$env:GA_REPO_ROOT = $repoRoot
+$runStarted = (Get-Date).ToUniversalTime()
+$runStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$probes = @()
+$runId = $runStarted.ToString("yyyyMMddTHHmmssZ")
+$outRoot = Join-Path ([System.IO.Path]::GetTempPath()) "ga-qa-architect-baseline-$runId"
+New-Item -ItemType Directory -Force -Path $outRoot | Out-Null
+$contractOut = Join-Path $outRoot "qa-verdict-contract"
+$backendSchemaOut = Join-Path $outRoot "backend-schema"
+$opticKOut = Join-Path $outRoot "optick-search"
+
+$probes += Invoke-BaselineCommand `
+    -Name "qa_verdict_contract_tests" `
+    -Category "contract" `
+    -Command 'dotnet test Tests\Common\GA.Business.ML.Tests\GA.Business.ML.Tests.csproj --filter "FullyQualifiedName~QaArchitectAgentTests" -p:OutDir=<temp>\qa-verdict-contract\' `
+    -Script {
+        dotnet test Tests\Common\GA.Business.ML.Tests\GA.Business.ML.Tests.csproj --filter "FullyQualifiedName~QaArchitectAgentTests" --logger "console;verbosity=minimal" -p:OutDir="$contractOut\"
+    }
+
+$probes += Invoke-BaselineCommand `
+    -Name "backend_schema_smoke_tests" `
+    -Category "backend_tests" `
+    -Command 'dotnet test Tests\Common\GA.Business.Core.Tests\GA.Business.Core.Tests.csproj --filter "FullyQualifiedName~SchemaContractTests" -p:OutDir=<temp>\backend-schema\' `
+    -Script {
+        dotnet test Tests\Common\GA.Business.Core.Tests\GA.Business.Core.Tests.csproj --filter "FullyQualifiedName~SchemaContractTests" --logger "console;verbosity=minimal" -p:OutDir="$backendSchemaOut\"
+    }
+
+$probes += Invoke-BaselineCommand `
+    -Name "optick_search_smoke_tests" `
+    -Category "optic_k" `
+    -Command 'dotnet test Tests\Common\GA.Business.ML.Tests\GA.Business.ML.Tests.csproj --filter "FullyQualifiedName~MusicalQueryEncoderTests" -p:OutDir=<temp>\optick-search\' `
+    -Script {
+        dotnet test Tests\Common\GA.Business.ML.Tests\GA.Business.ML.Tests.csproj --filter "FullyQualifiedName~MusicalQueryEncoderTests" --logger "console;verbosity=minimal" -p:OutDir="$opticKOut\"
+    }
+
+if ($SkipOllama) {
+    $probes += [ordered]@{
+        name = "ollama_tags_probe"
+        category = "semantic_judge"
+        command = "GET $OllamaUrl/api/tags"
+        status = "skipped"
+        exit_code = 0
+        started_at = (Get-Date).ToUniversalTime().ToString("O")
+        elapsed_seconds = 0
+        error = $null
+        output_tail = "Skipped by -SkipOllama."
+    }
+}
+else {
+    $tagsPayload = $null
+    $tagsProbe = Invoke-OllamaHttpProbe `
+        -Name "ollama_tags_probe" `
+        -Category "semantic_judge" `
+        -Command "GET $OllamaUrl/api/tags" `
+        -Script {
+            $script:tagsPayload = Invoke-RestMethod -Method Get -Uri "$OllamaUrl/api/tags" -TimeoutSec $OllamaTimeoutSeconds
+            $script:tagsPayload
+        }
+    $probes += $tagsProbe
+
+    if ($tagsProbe.status -eq "passed") {
+        $modelNames = @($script:tagsPayload.models | ForEach-Object { $_.name })
+        if ([string]::IsNullOrWhiteSpace($OllamaModel)) {
+            $preferred = $modelNames | Where-Object { $_ -eq "qwen2.5-coder:7b" } | Select-Object -First 1
+            $OllamaModel = if ($preferred) { $preferred } else { $modelNames | Select-Object -First 1 }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($OllamaModel)) {
+            $probes += [ordered]@{
+                name = "ollama_generation_probe"
+                category = "semantic_judge"
+                command = "POST $OllamaUrl/api/generate"
+                status = "skipped"
+                exit_code = 0
+                started_at = (Get-Date).ToUniversalTime().ToString("O")
+                elapsed_seconds = 0
+                error = $null
+                output_tail = "No local Ollama models were listed."
+            }
+        }
+        else {
+            $body = @{
+                model = $OllamaModel
+                stream = $false
+                prompt = "Return exactly one JSON object: {`"verdict`":`"informational`",`"risk_tier`":`"P3`"}. No prose."
+                options = @{
+                    num_predict = 64
+                    temperature = 0
+                }
+            } | ConvertTo-Json -Depth 8
+
+            $probes += Invoke-OllamaHttpProbe `
+                -Name "ollama_generation_probe" `
+                -Category "semantic_judge" `
+                -Command "POST $OllamaUrl/api/generate model=$OllamaModel timeout=${OllamaTimeoutSeconds}s" `
+                -Script {
+                    Invoke-RestMethod -Method Post -Uri "$OllamaUrl/api/generate" -Body $body -ContentType "application/json" -TimeoutSec $OllamaTimeoutSeconds
+                }
+        }
+    }
+}
+
+$runStopwatch.Stop()
+$passed = @($probes | Where-Object { $_.status -eq "passed" }).Count
+$failed = @($probes | Where-Object { $_.status -eq "failed" }).Count
+$timedOut = @($probes | Where-Object { $_.status -eq "timed_out" }).Count
+$skipped = @($probes | Where-Object { $_.status -eq "skipped" }).Count
+$ollamaGeneration = $probes | Where-Object { $_.name -eq "ollama_generation_probe" } | Select-Object -First 1
+$latencyFeasibility = if ($null -eq $ollamaGeneration) {
+    "unknown"
+}
+elseif ($ollamaGeneration.status -ne "passed") {
+    "not_established"
+}
+elseif ($ollamaGeneration.elapsed_seconds -le 480) {
+    "needs_more_samples"
+}
+else {
+    "not_established"
+}
+
+$baseline = [ordered]@{
+    schema_version = 1
+    produced_at = (Get-Date).ToUniversalTime().ToString("O")
+    repo_root = $repoRoot
+    temp_output_root = $outRoot
+    git = [ordered]@{
+        branch = Get-GitValue -GitArgs @("branch", "--show-current")
+        sha = Get-GitValue -GitArgs @("rev-parse", "HEAD")
+        dirty = -not [string]::IsNullOrWhiteSpace((Get-GitValue -GitArgs @("status", "--porcelain")))
+    }
+    thresholds = [ordered]@{
+        provisional_local_tribunal_p95_seconds = 480
+        hard_stop_seconds = 900
+        ollama_probe_timeout_seconds = $OllamaTimeoutSeconds
+    }
+    summary = [ordered]@{
+        started_at = $runStarted.ToString("O")
+        elapsed_seconds = [Math]::Round($runStopwatch.Elapsed.TotalSeconds, 3)
+        probe_count = $probes.Count
+        passed = $passed
+        failed = $failed
+        timed_out = $timedOut
+        skipped = $skipped
+        local_tribunal_p95_feasibility = $latencyFeasibility
+        notes = @(
+            "This is a Phase 0 local baseline, not a statistical P95.",
+            "Failed or timed-out probes are preserved as evidence."
+        )
+    }
+    probes = $probes
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+$baseline | ConvertTo-Json -Depth 16 | Set-Content -Path $OutputPath -Encoding utf8
+
+Write-Host ""
+Write-Host "Baseline written to $OutputPath" -ForegroundColor Green
+Write-Host "Summary: passed=$passed failed=$failed timed_out=$timedOut skipped=$skipped elapsed=$($runStopwatch.Elapsed.TotalSeconds.ToString('F1'))s"

--- a/Scripts/start-chatbot-api.ps1
+++ b/Scripts/start-chatbot-api.ps1
@@ -1,0 +1,40 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Start the thin Guitar Alchemist chatbot API host.
+.PARAMETER SkipBuild
+    Skip the initial dotnet build step.
+.PARAMETER Port
+    Local HTTP port for the chatbot API.
+#>
+
+param(
+    [switch]$SkipBuild = $false,
+    [int]$Port = 5252
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$projectPath = Join-Path $repoRoot "Apps/GaChatbot.Api/GaChatbot.Api.csproj"
+$apiUrl = "http://localhost:$Port"
+
+Write-Host "Starting GaChatbot.Api..." -ForegroundColor Cyan
+Write-Host "  API URL: $apiUrl" -ForegroundColor White
+
+if (-not $SkipBuild) {
+    Write-Host "  Building chatbot API..." -ForegroundColor Yellow
+    Push-Location $repoRoot
+    dotnet build $projectPath -c Debug
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Host "  Build failed." -ForegroundColor Red
+        exit 1
+    }
+    Pop-Location
+}
+
+$env:ASPNETCORE_URLS = $apiUrl
+Push-Location $repoRoot
+dotnet run --project $projectPath --no-launch-profile
+Pop-Location

--- a/Scripts/start-chatbot-dev.ps1
+++ b/Scripts/start-chatbot-dev.ps1
@@ -1,0 +1,109 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Start the thin chatbot API and ga-client together for local development.
+.PARAMETER SkipBuild
+    Skip the initial chatbot API build step.
+.PARAMETER ApiPort
+    Local HTTP port for the chatbot API.
+.PARAMETER FrontendPort
+    Local port for the Vite frontend.
+#>
+
+param(
+    [switch]$SkipBuild = $false,
+    [int]$ApiPort = 5252,
+    [int]$FrontendPort = 5173
+)
+
+$ErrorActionPreference = "Continue"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$apiProject = Join-Path $repoRoot "Apps/GaChatbot.Api/GaChatbot.Api.csproj"
+$frontendDir = Join-Path $repoRoot "Apps/ga-client"
+$apiUrl = "http://localhost:$ApiPort"
+$frontendUrl = "http://localhost:$FrontendPort"
+
+Write-Host "Starting chatbot dev stack..." -ForegroundColor Cyan
+Write-Host "  API:      $apiUrl" -ForegroundColor White
+Write-Host "  Frontend: $frontendUrl" -ForegroundColor White
+
+if (-not $SkipBuild) {
+    Write-Host "  Building chatbot API..." -ForegroundColor Yellow
+    Push-Location $repoRoot
+    dotnet build $apiProject -c Debug | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Host "  Build failed." -ForegroundColor Red
+        exit 1
+    }
+    Pop-Location
+}
+
+$apiJob = Start-Job -ScriptBlock {
+    Set-Location $using:repoRoot
+    $env:ASPNETCORE_ENVIRONMENT = "Development"
+    $env:ASPNETCORE_URLS = $using:apiUrl
+    dotnet run --project $using:apiProject --no-build --no-launch-profile 2>&1
+}
+Write-Host "  Chatbot API starting (Job $($apiJob.Id))..." -ForegroundColor Green
+
+$frontendJob = Start-Job -ScriptBlock {
+    Set-Location $using:frontendDir
+    $env:VITE_GA_API_URL = $using:apiUrl
+    npm run dev -- --host --port $using:FrontendPort 2>&1
+}
+Write-Host "  Frontend starting (Job $($frontendJob.Id))..." -ForegroundColor Green
+
+Start-Sleep 8
+$apiHealthy = try { (Invoke-RestMethod "$apiUrl/api/chatbot/status").isAvailable } catch { $false }
+if ($apiHealthy) {
+    Write-Host "  Chatbot API: READY" -ForegroundColor Green
+} else {
+    Write-Host "  Chatbot API: Still starting..." -ForegroundColor Yellow
+}
+
+$frontendHealthy = try { (Invoke-WebRequest $frontendUrl -TimeoutSec 5).StatusCode -eq 200 } catch { $false }
+if ($frontendHealthy) {
+    Write-Host "  Frontend: READY" -ForegroundColor Green
+} else {
+    Write-Host "  Frontend: Still starting..." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Dev stack running. Press Ctrl+C to stop both jobs." -ForegroundColor Cyan
+Write-Host "  API status: $apiUrl/api/chatbot/status" -ForegroundColor White
+Write-Host "  Frontend:   $frontendUrl" -ForegroundColor White
+Write-Host ""
+
+try {
+    while ($true) {
+        Start-Sleep 30
+
+        if ($apiJob.State -ne "Running") {
+            Write-Host "  [!] Chatbot API stopped, restarting..." -ForegroundColor Red
+            $apiJob = Start-Job -ScriptBlock {
+                Set-Location $using:repoRoot
+                $env:ASPNETCORE_ENVIRONMENT = "Development"
+                $env:ASPNETCORE_URLS = $using:apiUrl
+                dotnet run --project $using:apiProject --no-build --no-launch-profile 2>&1
+            }
+        }
+
+        if ($frontendJob.State -ne "Running") {
+            Write-Host "  [!] Frontend stopped, restarting..." -ForegroundColor Red
+            $frontendJob = Start-Job -ScriptBlock {
+                Set-Location $using:frontendDir
+                $env:VITE_GA_API_URL = $using:apiUrl
+                npm run dev -- --host --port $using:FrontendPort 2>&1
+            }
+        }
+    }
+}
+finally {
+    Write-Host "Stopping chatbot dev stack..." -ForegroundColor Yellow
+    Stop-Job $apiJob -ErrorAction SilentlyContinue
+    Stop-Job $frontendJob -ErrorAction SilentlyContinue
+    Remove-Job $apiJob -ErrorAction SilentlyContinue
+    Remove-Job $frontendJob -ErrorAction SilentlyContinue
+}

--- a/Scripts/test-chatbot-a2a.ps1
+++ b/Scripts/test-chatbot-a2a.ps1
@@ -1,0 +1,184 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Smoke-test the GA chatbot A2A endpoint.
+.DESCRIPTION
+    Verifies the live A2A discovery card, synchronous message/send,
+    streaming message/stream, and JSON-RPC error behavior against a running
+    chatbot API.
+.PARAMETER ApiUrl
+    Base URL of the chatbot API.
+.PARAMETER TimeoutSeconds
+    Per-request timeout in seconds.
+.EXAMPLE
+    pwsh Scripts/test-chatbot-a2a.ps1
+.EXAMPLE
+    pwsh Scripts/test-chatbot-a2a.ps1 -ApiUrl http://localhost:5252 -TimeoutSeconds 120
+#>
+
+param(
+    [string]$ApiUrl = "http://localhost:5252",
+    [int]$TimeoutSeconds = 120
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "== $Message ==" -ForegroundColor Cyan
+}
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Invoke-JsonRpc {
+    param(
+        [string]$Method,
+        [object]$Params,
+        [string]$Id = "a2a-smoke"
+    )
+
+    $body = @{
+        jsonrpc = "2.0"
+        id = $Id
+        method = $Method
+        params = $Params
+    } | ConvertTo-Json -Depth 20
+
+    Invoke-RestMethod `
+        -Uri "$ApiUrl/a2a" `
+        -Method Post `
+        -Body $body `
+        -ContentType "application/json" `
+        -TimeoutSec $TimeoutSeconds
+}
+
+function Invoke-A2AStream {
+    param(
+        [object]$Params,
+        [string]$Id = "a2a-stream-smoke"
+    )
+
+    $body = @{
+        jsonrpc = "2.0"
+        id = $Id
+        method = "message/stream"
+        params = $Params
+    } | ConvertTo-Json -Depth 20
+
+    $response = Invoke-WebRequest `
+        -Uri "$ApiUrl/a2a" `
+        -Method Post `
+        -Body $body `
+        -ContentType "application/json" `
+        -TimeoutSec $TimeoutSeconds
+
+    Assert-True ($response.StatusCode -eq 200) "Expected message/stream HTTP 200."
+    $contentType = [string]::Join(";", @($response.Headers["Content-Type"]))
+    Assert-True ($contentType -like "text/event-stream*") "Expected text/event-stream content type."
+
+    $response.Content `
+        -split "`n" `
+        | Where-Object { $_.StartsWith("data: ", [StringComparison]::Ordinal) } `
+        | ForEach-Object { $_.Substring("data: ".Length).Trim() } `
+        | Where-Object { $_ }
+}
+
+function New-MessageParams {
+    param(
+        [string]$Text,
+        [string]$ContextId = "ctx-a2a-smoke"
+    )
+
+    @{
+        message = @{
+            role = "user"
+            contextId = $ContextId
+            parts = @(
+                @{
+                    kind = "text"
+                    text = $Text
+                }
+            )
+        }
+    }
+}
+
+Write-Host "GA chatbot A2A smoke test" -ForegroundColor Cyan
+Write-Host "API: $ApiUrl"
+
+Write-Step "API metadata"
+$metadata = Invoke-RestMethod -Uri "$ApiUrl/api" -Method Get -TimeoutSec 10
+Assert-True ($metadata.service -eq "ga-chatbot-api") "Unexpected /api service value."
+Write-Host "OK: $($metadata.service) $($metadata.version)" -ForegroundColor Green
+
+Write-Step "Agent card"
+$card = Invoke-RestMethod -Uri "$ApiUrl/.well-known/agent-card.json" -Method Get -TimeoutSec 10
+Assert-True ($card.name -eq "Guitar Alchemist Chatbot") "Unexpected agent card name."
+Assert-True ($card.url -eq "$ApiUrl/a2a") "Unexpected A2A URL '$($card.url)'."
+Assert-True ($card.preferredTransport -eq "JSONRPC") "Agent card does not advertise JSONRPC."
+Assert-True ([bool]$card.capabilities.streaming) "Agent card does not advertise streaming."
+Assert-True ($card.skills.Count -gt 0) "Agent card has no skills."
+Write-Host "OK: discovery card advertises JSON-RPC streaming" -ForegroundColor Green
+
+Write-Step "message/send"
+$send = Invoke-JsonRpc `
+    -Method "message/send" `
+    -Params (New-MessageParams "What notes are in C major?")
+Assert-True ($send.jsonrpc -eq "2.0") "message/send did not return JSON-RPC 2.0."
+Assert-True ($null -ne $send.result) "message/send did not return a result."
+Assert-True ($send.result.kind -eq "message") "message/send did not return a message result."
+Assert-True ($send.result.role -eq "agent") "message/send result role is not agent."
+Assert-True ($send.result.parts.Count -gt 0) "message/send result has no parts."
+Assert-True (($send.result.parts[0].text -match "C") -and ($send.result.parts[0].text -match "D")) "message/send answer did not mention expected C major notes."
+Assert-True ($null -ne $send.result.metadata.trace) "message/send result has no agentic trace."
+Assert-True ($send.result.metadata.trace.protocol -match "otel-genai") "message/send trace does not advertise OTel GenAI semantics."
+Assert-True ($send.result.metadata.trace.steps.Count -gt 0) "message/send trace has no steps."
+Assert-True ($send.result.metadata.trace.steps[0].name -eq "chat.request") "message/send trace does not start with chat.request."
+Write-Host "OK: message/send returned an agent message" -ForegroundColor Green
+
+Write-Step "message/send conversation context"
+$context = Invoke-JsonRpc `
+    -Method "message/send" `
+    -Params (New-MessageParams "In my previous A2A message, which scale did I ask about? Reply with the scale name only.")
+Assert-True ($context.result.parts.Count -gt 0) "Context follow-up returned no text parts."
+Assert-True ($context.result.contextId -eq "ctx-a2a-smoke") "Context follow-up did not preserve contextId."
+Assert-True ($context.result.metadata.historyTurnCount -ge 2) "Context follow-up did not receive prior conversation turns."
+Write-Host "Answer: $($context.result.parts[0].text)"
+Write-Host "OK: message/send preserved same-context conversation history" -ForegroundColor Green
+
+Write-Step "message/stream"
+$events = @(Invoke-A2AStream -Params (New-MessageParams "What notes are in C major?" "ctx-a2a-stream-smoke"))
+Assert-True ($events.Count -ge 3) "Expected at least task, artifact, and final status events."
+
+$jsonEvents = @($events | ForEach-Object { $_ | ConvertFrom-Json })
+$results = @($jsonEvents | ForEach-Object { $_.result } | Where-Object { $null -ne $_ })
+$task = $results | Where-Object { $_.kind -eq "task" } | Select-Object -First 1
+$artifact = $results | Where-Object { $_.kind -eq "artifact-update" } | Select-Object -First 1
+$final = $results | Where-Object { $_.kind -eq "status-update" -and $_.final -eq $true } | Select-Object -First 1
+
+Assert-True ($null -ne $task) "message/stream did not emit an initial task."
+Assert-True ($task.status.state -eq "working") "Initial task status was not working."
+Assert-True ($null -ne $artifact) "message/stream did not emit an artifact update."
+Assert-True ($artifact.artifact.parts.Count -gt 0) "Artifact update had no text parts."
+Assert-True ($null -ne $final) "message/stream did not emit a final status update."
+Assert-True ($final.status.state -eq "completed") "Final stream status was not completed."
+Write-Host "OK: message/stream returned task, artifact, and completed status" -ForegroundColor Green
+
+Write-Step "JSON-RPC invalid method"
+$invalid = Invoke-JsonRpc -Method "tasks/get" -Params @{ id = "missing-task" } -Id "a2a-invalid-method"
+Assert-True ($null -ne $invalid.error) "Invalid method did not return an error."
+Assert-True ($invalid.error.code -eq -32601) "Invalid method did not return JSON-RPC -32601."
+Write-Host "OK: invalid method returns JSON-RPC -32601" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "A2A smoke test passed." -ForegroundColor Green

--- a/Scripts/test-chatbot-live-qa.ps1
+++ b/Scripts/test-chatbot-live-qa.ps1
@@ -1,0 +1,105 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Live QA smoke test for the local GA chatbot.
+.DESCRIPTION
+    Exercises the same HTTP surface as the mini UI and asserts the behavior that
+    matters for interactive QA: readiness, a fast simple response, renderable
+    VexTab for known voicings, and useful agentic trace steps.
+#>
+
+param(
+    [string]$ApiUrl = "http://localhost:5252",
+    [int]$SimpleTimeoutSeconds = 20,
+    [int]$VoicingTimeoutSeconds = 240,
+    [int]$MaxSimpleElapsedMs = 10000,
+    [int]$MaxVoicingElapsedMs = 10000
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-ChatbotPost {
+    param(
+        [string]$Message,
+        [int]$TimeoutSeconds
+    )
+
+    $body = @{ message = $Message } | ConvertTo-Json
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $response = Invoke-RestMethod `
+        -Uri "$ApiUrl/api/chatbot/chat" `
+        -Method Post `
+        -ContentType "application/json" `
+        -Body $body `
+        -TimeoutSec $TimeoutSeconds
+    $stopwatch.Stop()
+
+    [pscustomobject]@{
+        Response = $response
+        WallClockMs = [int]$stopwatch.ElapsedMilliseconds
+    }
+}
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+Write-Host "GA chatbot live QA" -ForegroundColor Cyan
+Write-Host "API: $ApiUrl"
+
+$status = Invoke-RestMethod -Uri "$ApiUrl/api/chatbot/status" -TimeoutSec 10
+Assert-True $status.isAvailable "Chatbot status is not available: $($status | ConvertTo-Json -Compress)"
+Write-Host "OK: status available ($($status.message))" -ForegroundColor Green
+
+$simple = Invoke-ChatbotPost -Message "What is C major?" -TimeoutSeconds $SimpleTimeoutSeconds
+Assert-True ($simple.Response.naturalLanguageAnswer -match "C") "Simple answer did not mention C."
+Assert-True ($simple.Response.elapsedMs -le $MaxSimpleElapsedMs) "Simple answer too slow: $($simple.Response.elapsedMs)ms."
+Write-Host "OK: simple prompt $($simple.Response.elapsedMs)ms, route $($simple.Response.agentId)/$($simple.Response.routingMethod)" -ForegroundColor Green
+
+$voicing = Invoke-ChatbotPost -Message "Show me Dm7 shell voicings" -TimeoutSeconds $VoicingTimeoutSeconds
+$answer = [string]$voicing.Response.naturalLanguageAnswer
+$traceSteps = @($voicing.Response.trace.steps)
+$traceStepNames = @($traceSteps | ForEach-Object { $_.name })
+$notationStep = @($traceSteps | Where-Object { $_.name -eq "notation.vextab" }) | Select-Object -First 1
+
+Assert-True ($answer -match '```vextab') "Voicing answer did not include a fenced vextab block."
+Assert-True ($answer -match "\d+/\d+") "Voicing answer did not include string/fret notation tokens."
+Assert-True ($voicing.Response.routingMethod -eq "deterministic-voicing") "Voicing prompt did not use deterministic routing: $($voicing.Response.routingMethod)."
+Assert-True ($voicing.Response.elapsedMs -le $MaxVoicingElapsedMs) "Voicing answer too slow: $($voicing.Response.elapsedMs)ms."
+Assert-True ($traceStepNames -contains "orchestration.route") "Trace missing orchestration.route."
+Assert-True ($traceStepNames -contains "agent.semantic_result") "Trace missing agent.semantic_result."
+Assert-True ($traceStepNames -contains "notation.vextab") "Trace missing notation.vextab."
+Assert-True ($traceStepNames -contains "response.emit") "Trace missing response.emit."
+Assert-True ($null -ne $notationStep) "Trace notation step was not found."
+Assert-True ([int]$notationStep.attributes.'notation.diagram.count' -ge 1) "Trace did not report detected chord diagrams."
+
+Write-Host "OK: voicing prompt $($voicing.Response.elapsedMs)ms, vextab generated, trace steps=$($traceSteps.Count)" -ForegroundColor Green
+
+[pscustomobject]@{
+    Status = "passed"
+    ApiUrl = $ApiUrl
+    Simple = [pscustomobject]@{
+        AgentId = $simple.Response.agentId
+        RoutingMethod = $simple.Response.routingMethod
+        ElapsedMs = $simple.Response.elapsedMs
+        WallClockMs = $simple.WallClockMs
+    }
+    Voicing = [pscustomobject]@{
+        AgentId = $voicing.Response.agentId
+        RoutingMethod = $voicing.Response.routingMethod
+        ElapsedMs = $voicing.Response.elapsedMs
+        WallClockMs = $voicing.WallClockMs
+        VexTabCount = ([regex]::Matches($answer, '```vextab')).Count
+        TraceStepCount = $traceSteps.Count
+        TraceSteps = $traceStepNames
+    }
+} | ConvertTo-Json -Depth 6
+
+Write-Host "Chatbot live QA passed." -ForegroundColor Green

--- a/Scripts/test-chatbot-quality.ps1
+++ b/Scripts/test-chatbot-quality.ps1
@@ -1,0 +1,144 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Run the maintained Guitar Alchemist chatbot quality gate.
+.DESCRIPTION
+    Runs the current chatbot-related backend, API, frontend unit, build, lint,
+    and Playwright suites. This intentionally excludes legacy/out-of-solution
+    harnesses that target removed APIs or old local ports.
+.PARAMETER SkipBuild
+    Skip the solution build step.
+.PARAMETER BackendOnly
+    Run only the .NET test projects.
+.PARAMETER FrontendOnly
+    Run only frontend build/lint/unit/e2e checks.
+.PARAMETER SkipE2E
+    Skip Playwright browser tests.
+.PARAMETER LiveA2A
+    Run live A2A smoke tests against a running chatbot API.
+.PARAMETER A2AApiUrl
+    Base URL for live A2A smoke tests.
+.PARAMETER A2ATimeoutSeconds
+    Per-request timeout for live A2A smoke tests.
+.PARAMETER OutRoot
+    Directory used for isolated .NET build/test outputs.
+#>
+
+param(
+    [switch]$SkipBuild,
+    [switch]$BackendOnly,
+    [switch]$FrontendOnly,
+    [switch]$SkipE2E,
+    [switch]$LiveA2A,
+    [string]$A2AApiUrl = "http://localhost:5252",
+    [int]$A2ATimeoutSeconds = 120,
+    [string]$OutRoot = (Join-Path $env:TEMP "ga-chatbot-quality")
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$frontendDir = Join-Path $repoRoot "Apps/ga-client"
+
+function Invoke-QualityStep {
+    param(
+        [string]$Name,
+        [scriptblock]$Script
+    )
+
+    Write-Host ""
+    Write-Host "== $Name ==" -ForegroundColor Cyan
+    $started = Get-Date
+    & $Script
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Name failed with exit code $LASTEXITCODE"
+    }
+    $elapsed = (Get-Date) - $started
+    Write-Host "OK: $Name ($($elapsed.TotalSeconds.ToString('F1'))s)" -ForegroundColor Green
+}
+
+function Invoke-DotNetTestProject {
+    param(
+        [string]$Name,
+        [string]$ProjectPath
+    )
+
+    $outDir = Join-Path $OutRoot $Name
+    if (Test-Path $outDir) {
+        Remove-Item -LiteralPath $outDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Invoke-QualityStep "dotnet test $Name" {
+        dotnet test $ProjectPath -c Debug -m:1 -p:OutDir="$outDir\"
+    }
+}
+
+Set-Location $repoRoot
+New-Item -ItemType Directory -Force -Path $OutRoot | Out-Null
+
+Write-Host "Guitar Alchemist chatbot quality gate" -ForegroundColor Cyan
+Write-Host "Repository: $repoRoot"
+Write-Host "Output:     $OutRoot"
+
+if (-not $SkipBuild -and -not $FrontendOnly) {
+    $buildOut = Join-Path $OutRoot "solution-build"
+    if (Test-Path $buildOut) {
+        Remove-Item -LiteralPath $buildOut -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Invoke-QualityStep "dotnet build AllProjects.slnx" {
+        dotnet build AllProjects.slnx -c Debug -m:1 -p:OutDir="$buildOut\"
+    }
+}
+
+if (-not $FrontendOnly) {
+    $testProjects = @(
+        @{ Name = "GaChatbot.Api.Tests"; Path = "Tests\Apps\GaChatbot.Api.Tests\GaChatbot.Api.Tests.csproj" },
+        @{ Name = "GaApi.Tests"; Path = "Tests\Apps\GaApi.Tests\GaApi.Tests.csproj" },
+        @{ Name = "GA.Business.ML.Tests"; Path = "Tests\Common\GA.Business.ML.Tests\GA.Business.ML.Tests.csproj" },
+        @{ Name = "GA.Business.Core.Tests"; Path = "Tests\Common\GA.Business.Core.Tests\GA.Business.Core.Tests.csproj" },
+        @{ Name = "GA.Business.DSL.Tests"; Path = "Tests\Common\GA.Business.DSL.Tests\GA.Business.DSL.Tests.csproj" },
+        @{ Name = "GA.Core.Tests"; Path = "Tests\Common\GA.Core.Tests\GA.Core.Tests.csproj" },
+        @{ Name = "GA.MusicTheory.Service.Tests"; Path = "Tests\Apps\GA.MusicTheory.Service.Tests\GA.MusicTheory.Service.Tests.csproj" },
+        @{ Name = "GA.InteractiveExtension.Tests"; Path = "Tests\Common\GA.InteractiveExtension\GA.InteractiveExtension.Tests.csproj" }
+    )
+
+    foreach ($project in $testProjects) {
+        Invoke-DotNetTestProject -Name $project.Name -ProjectPath $project.Path
+    }
+}
+
+if (-not $BackendOnly) {
+    Push-Location $frontendDir
+    try {
+        Invoke-QualityStep "ga-client npm run build" {
+            npm run build
+        }
+
+        Invoke-QualityStep "ga-client npm run lint" {
+            npm run lint
+        }
+
+        Invoke-QualityStep "ga-client targeted vitest" {
+            npm test -- --run src/services/agUiChatService.test.ts src/test/performance.test.ts
+        }
+
+        if (-not $SkipE2E) {
+            Invoke-QualityStep "ga-client Playwright chromium" {
+                npx playwright test --project=chromium
+            }
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+if ($LiveA2A) {
+    Invoke-QualityStep "live chatbot A2A smoke" {
+        pwsh (Join-Path $scriptDir "test-chatbot-a2a.ps1") -ApiUrl $A2AApiUrl -TimeoutSeconds $A2ATimeoutSeconds
+    }
+}
+
+Write-Host ""
+Write-Host "Chatbot quality gate passed." -ForegroundColor Green

--- a/Scripts/write-qa-diff-verdict.ps1
+++ b/Scripts/write-qa-diff-verdict.ps1
@@ -1,0 +1,59 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Write a Phase 0 QA diff verdict for the current repo or explicit paths.
+
+.EXAMPLE
+    pwsh Scripts/write-qa-diff-verdict.ps1
+
+.EXAMPLE
+    pwsh Scripts/write-qa-diff-verdict.ps1 -Path docs/contracts/foo.md,AllProjects.slnx -FailOnBlock
+#>
+
+param(
+    [string]$RepoRoot,
+    [string]$Repo = "guitar-alchemist/ga",
+    [string]$TargetKind = "working_tree",
+    [string]$TargetRef,
+    [string]$StorageKey,
+    [string]$BaseRef,
+    [string]$HeadRef,
+    [string]$Sha,
+    [string]$BaseSha,
+    [string]$OutputRoot,
+    [string[]]$Path = @(),
+    [switch]$ExcludeUntracked,
+    [switch]$FailOnBlock
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$defaultRepoRoot = Split-Path -Parent $scriptDir
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = $defaultRepoRoot
+}
+
+$cliArgs = @()
+$cliArgs += @("--repo-root", $RepoRoot)
+$cliArgs += @("--repo", $Repo)
+$cliArgs += @("--target-kind", $TargetKind)
+
+if (-not [string]::IsNullOrWhiteSpace($TargetRef)) { $cliArgs += @("--target-ref", $TargetRef) }
+if (-not [string]::IsNullOrWhiteSpace($StorageKey)) { $cliArgs += @("--storage-key", $StorageKey) }
+if (-not [string]::IsNullOrWhiteSpace($BaseRef)) { $cliArgs += @("--base-ref", $BaseRef) }
+if (-not [string]::IsNullOrWhiteSpace($HeadRef)) { $cliArgs += @("--head-ref", $HeadRef) }
+if (-not [string]::IsNullOrWhiteSpace($Sha)) { $cliArgs += @("--sha", $Sha) }
+if (-not [string]::IsNullOrWhiteSpace($BaseSha)) { $cliArgs += @("--base-sha", $BaseSha) }
+if (-not [string]::IsNullOrWhiteSpace($OutputRoot)) { $cliArgs += @("--output-root", $OutputRoot) }
+foreach ($item in $Path) {
+    foreach ($expandedPath in ($item -split ",")) {
+        if (-not [string]::IsNullOrWhiteSpace($expandedPath)) {
+            $cliArgs += @("--path", $expandedPath.Trim())
+        }
+    }
+}
+if ($ExcludeUntracked) { $cliArgs += "--exclude-untracked" }
+if ($FailOnBlock) { $cliArgs += "--fail-on-block" }
+
+dotnet run --project (Join-Path $RepoRoot "Apps/GaQaCli/GaQaCli.csproj") -- @cliArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
Close out the long-standing untracked set of chatbot quality / dev / smoke scripts that live and are executed under `Scripts/`, plus the GaApi hand-pose controller. Continuation of the hygiene pass landed in #101 — any \"fully tested\" claim is now reproducible from a clean clone.

## Files now tracked (9, +1069 lines, no code changes)
- `Apps/ga-server/GaApi/Controllers/GuitarPlayingController.cs` — slim hand-pose endpoint for `/demos/hand-pose`. Distinct from the richer `GA.Fretboard.Service/Controllers/GuitarPlayingController.cs` (different routes, different services — both intentional).
- `Scripts/chatbot-status.ps1` — local API/frontend reachability check
- `Scripts/measure-qa-architect-baseline.ps1` — Phase 0 baseline runner (323 lines)
- `Scripts/start-chatbot-api.ps1` — thin chatbot host launcher
- `Scripts/start-chatbot-dev.ps1` — chatbot API + ga-client co-launcher
- `Scripts/test-chatbot-a2a.ps1` — A2A endpoint smoke
- `Scripts/test-chatbot-live-qa.ps1` — live QA smoke
- `Scripts/test-chatbot-quality.ps1` — maintained quality gate
- `Scripts/write-qa-diff-verdict.ps1` — QA diff verdict writer

## Test plan
- [x] `dotnet build AllProjects.slnx -c Debug` clean (controller compiles)
- [x] PowerShell scripts have valid synopsis/parameter docstrings; Get-Help on each surfaces correctly
- [x] No script names collide with existing `Scripts/*.ps1`

## One-way / two-way door
**Two-way door.** Pure tracking; reversible by `git rm` if any file turns out to be ad-hoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)