### PR TITLE
test(qa-tools): coverage for qa_score_quality_drift + SAE artifact schema validator

### DIFF
--- a/Apps/GaQaMcp/Tools/QaTools.cs
+++ b/Apps/GaQaMcp/Tools/QaTools.cs
@@ -82,12 +82,21 @@ public static class QaTools
     public static string ScoreQualityDrift(
         [Description("Metric name as it appears in state/quality/*.json.")] string metric,
         [Description("Window length in days.")] int windowDays)
+        => ScoreQualityDriftAt(metric, windowDays, Path.Combine("state", "quality"));
+
+    /// <summary>
+    /// Testable form of <see cref="ScoreQualityDrift"/> with an injectable
+    /// state-quality root. WHY: the MCP tool resolves paths relative to CWD
+    /// (the MCP server's working dir at runtime); tests need to point at a
+    /// temp dir without mutating process-wide CWD.
+    /// </summary>
+    public static string ScoreQualityDriftAt(string metric, int windowDays, string stateQualityRoot)
     {
         // Phase 1 stub: detect SAE artifacts and surface them.
         // Real time-series drift computation is Phase 2 (qa-architect-cycle.ixql wiring).
         if (metric.Equals("optick-sae", StringComparison.OrdinalIgnoreCase))
         {
-            var saeRoot = Path.Combine("state", "quality", "optick-sae");
+            var saeRoot = Path.Combine(stateQualityRoot, "optick-sae");
             var artifactFiles = Directory.Exists(saeRoot)
                 ? Directory.GetFiles(saeRoot, "optick-sae-artifact.json", SearchOption.AllDirectories)
                 : [];

--- a/Scripts/validate_optick_sae_artifacts.py
+++ b/Scripts/validate_optick_sae_artifacts.py
@@ -1,0 +1,77 @@
+"""
+Validate every committed OPTIC-K SAE artifact against the JSON Schema.
+
+WHY: PR #82 shipped a synthetic-data smoke artifact with three metadata bugs that
+the existing test suite didn't catch (partitions_used missing ROOT, narrative
+inconsistency, etc.). This script is the regression guard so future drift is
+caught at CI time, not by spotting it in code review.
+
+USAGE:
+    python Scripts/validate_optick_sae_artifacts.py
+    # Exit 0: all artifacts validate
+    # Exit 1: at least one artifact failed schema validation
+    # Exit 2: schema or fixture missing
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parent.parent
+    schema_path = repo / "docs" / "contracts" / "optick-sae-artifact.schema.json"
+    artifacts_root = repo / "state" / "quality" / "optick-sae"
+
+    if not schema_path.exists():
+        print(f"FAIL: missing schema {schema_path}", file=sys.stderr)
+        return 2
+    if not artifacts_root.exists():
+        print(f"INFO: {artifacts_root} does not exist; nothing to validate.")
+        return 0
+
+    try:
+        import jsonschema
+    except ImportError:
+        print("FAIL: jsonschema not installed. Install with `pip install jsonschema`.",
+              file=sys.stderr)
+        return 2
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    artifact_paths = sorted(artifacts_root.rglob("optick-sae-artifact.json"))
+    if not artifact_paths:
+        print(f"INFO: no artifacts under {artifacts_root}; nothing to validate.")
+        return 0
+
+    print(f"Validating {len(artifact_paths)} artifact(s) against {schema_path.name}")
+
+    failures = []
+    for path in artifact_paths:
+        rel = path.relative_to(repo)
+        try:
+            artifact = json.loads(path.read_text(encoding="utf-8"))
+            jsonschema.validate(artifact, schema)
+            print(f"  PASS  {rel}")
+        except json.JSONDecodeError as e:
+            print(f"  FAIL  {rel} (invalid JSON: {e.msg})")
+            failures.append((rel, f"invalid JSON: {e.msg}", []))
+        except jsonschema.ValidationError as e:
+            loc = " > ".join(str(p) for p in e.absolute_path) or "<root>"
+            print(f"  FAIL  {rel}")
+            print(f"        at {loc}: {e.message}")
+            failures.append((rel, e.message, list(str(p) for p in e.absolute_path)))
+
+    if failures:
+        print(f"\n{len(failures)} artifact(s) failed validation:", file=sys.stderr)
+        for rel, msg, location in failures:
+            loc = " > ".join(location) or "<root>"
+            print(f"  {rel}: {msg} (at {loc})", file=sys.stderr)
+        return 1
+
+    print(f"\nAll {len(artifact_paths)} artifact(s) validated successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj
+++ b/Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\..\Common\GA.Domain.Core\GA.Domain.Core.csproj"/>
     <ProjectReference Include="..\..\..\Common\GA.Domain.Services\GA.Domain.Services.csproj"/>
     <ProjectReference Include="..\..\..\Common\GA.Core\GA.Core.csproj"/>
+    <ProjectReference Include="..\..\..\Apps\GaQaMcp\GaQaMcp.csproj"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Common/GA.Business.ML.Tests/Unit/QaToolsScoreQualityDriftTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/QaToolsScoreQualityDriftTests.cs
@@ -1,0 +1,120 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Text.Json;
+using GA.QaMcp.Tools;
+
+/// <summary>
+/// Unit tests for the Phase 1 stub branch in <see cref="QaTools.ScoreQualityDriftAt"/>.
+/// PR #82 added the "optick-sae" metric special-case logic but shipped without coverage;
+/// this class is the regression guard.
+/// </summary>
+[TestFixture]
+public class QaToolsScoreQualityDriftTests
+{
+    private string _tempRoot = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), $"qa-tools-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    [Test]
+    public void OptickSae_NoArtifacts_ReturnsExpectedDriftSummary()
+    {
+        // No optick-sae directory exists at all.
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+
+        var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        Assert.That(root.GetProperty("kind").GetString(), Is.EqualTo("quality_snapshot"));
+        Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("optick-sae"));
+        Assert.That(root.GetProperty("drift_summary").GetString(), Does.Contain("No SAE artifacts found"));
+    }
+
+    [Test]
+    public void OptickSae_OneArtifact_ReportsCount()
+    {
+        var saeDir = Path.Combine(_tempRoot, "optick-sae", "2026-05-04");
+        Directory.CreateDirectory(saeDir);
+        File.WriteAllText(Path.Combine(saeDir, "optick-sae-artifact.json"), "{}");
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+
+        var doc = JsonDocument.Parse(result);
+        var summary = doc.RootElement.GetProperty("drift_summary").GetString();
+        Assert.That(summary, Does.Contain("SAE artifact found"));
+        Assert.That(summary, Does.Contain("(1 run(s)"));
+    }
+
+    [Test]
+    public void OptickSae_MultipleArtifacts_ReportsCorrectCount()
+    {
+        // Three artifacts across three different date directories — supersedes chain.
+        foreach (var date in (string[])["2026-05-03", "2026-05-04", "2026-05-05"])
+        {
+            var dir = Path.Combine(_tempRoot, "optick-sae", date);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "optick-sae-artifact.json"), "{}");
+        }
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+
+        var doc = JsonDocument.Parse(result);
+        var summary = doc.RootElement.GetProperty("drift_summary").GetString();
+        Assert.That(summary, Does.Contain("(3 run(s)"));
+    }
+
+    [Test]
+    public void OptickSae_CaseInsensitiveMetric_TriggersSaeBranch()
+    {
+        // The metric switch is case-insensitive — verify "OPTICK-SAE" hits the same path.
+        var result = QaTools.ScoreQualityDriftAt("OPTICK-SAE", 7, _tempRoot);
+
+        var doc = JsonDocument.Parse(result);
+        var summary = doc.RootElement.GetProperty("drift_summary").GetString();
+        Assert.That(summary, Does.Contain("No SAE artifacts found"),
+            "Case-insensitive match means OPTICK-SAE should hit the SAE branch (not the default phase 0 stub).");
+    }
+
+    [Test]
+    public void OtherMetric_FallsThroughToPhase0Stub()
+    {
+        // Metrics other than "optick-sae" should hit the phase 0 fall-through path.
+        var result = QaTools.ScoreQualityDriftAt("voicing-analysis", 14, _tempRoot);
+
+        var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        Assert.That(root.GetProperty("kind").GetString(), Is.EqualTo("quality_snapshot"));
+        Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("voicing-analysis"));
+        // Phase 0 stub shape: drift_summary mentions skeleton state, no artifact-found language.
+        var summary = root.GetProperty("drift_summary").GetString();
+        Assert.That(summary, Does.Not.Contain("SAE artifact"));
+        Assert.That(summary, Does.Contain("skeleton").Or.Contain("Phase 0"));
+    }
+
+    [Test]
+    public void OptickSae_DriftSummaryIsContractEvidenceShape()
+    {
+        // The returned JSON should be parseable as a QaEvidence record per the
+        // qa-verdict.contract.md §3.5: kind, name, drift_summary at minimum.
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.TryGetProperty("kind", out _), Is.True, "missing 'kind'");
+            Assert.That(root.TryGetProperty("name", out _), Is.True, "missing 'name'");
+            Assert.That(root.TryGetProperty("drift_summary", out _), Is.True, "missing 'drift_summary'");
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Three things land:

1. **`QaTools.ScoreQualityDriftAt` overload** — testable form of the MCP tool (takes injectable state-quality root). Pure additive.
2. **6 unit tests** for the `qa_score_quality_drift` "optick-sae" branch (PR #82 added the logic with zero coverage)
3. **`Scripts/validate_optick_sae_artifacts.py`** — regression guard that schema-validates every committed SAE artifact

## Why

PR #82 shipped a synthetic-data smoke artifact with three metadata bugs (missing ROOT, narrative inconsistency, etc.) that nothing in the test suite caught. This PR adds:
- Tests for the new logic so regressions show up in `dotnet test`
- A script that validates every artifact against the schema so structural drift shows up in CI

## What lands

| File | What |
|---|---|
| `Apps/GaQaMcp/Tools/QaTools.cs` | `ScoreQualityDriftAt(metric, windowDays, stateQualityRoot)` overload — testable form |
| `Tests/Common/GA.Business.ML.Tests/Unit/QaToolsScoreQualityDriftTests.cs` | 6 unit tests covering: no artifacts, one artifact, multiple artifacts, case-insensitive match, fall-through to phase 0 stub, JSON contract shape |
| `Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj` | adds `ProjectReference` to `Apps/GaQaMcp/GaQaMcp.csproj` |
| `Scripts/validate_optick_sae_artifacts.py` | walks `state/quality/optick-sae/**/optick-sae-artifact.json` and validates each against the JSON Schema |

## Honest limitation

The validator catches **structural** drift (missing required fields, wrong types, enum violations). It does **NOT** catch **semantic** drift — PR #82's buggy artifact still passes because:
- Its `partitions_used` array is structurally valid (every element is an allowed enum value); the fact that ROOT is missing is a semantic bug
- Its narrative is a structurally-valid string; the "118-dim" / `optick_dim: 240` mismatch is semantic

For semantic checks we'd need either richer schema constraints (cross-field `if`/`then` assertions) or a separate semantic linter. Tracked as future work.

## Verification

- `dotnet test --filter "FullyQualifiedName~QaToolsScoreQualityDrift"` → **Passed: 6, Failed: 0** (72ms)
- `python Scripts/validate_optick_sae_artifacts.py` → 4 artifacts validated successfully (incl. yesterday's PR #82 bug artifact, which is structurally valid)

## What this PR does NOT do

- ❌ Does not add the validator to a GitHub Actions workflow (separate step if desired; running locally already catches structural drift)
- ❌ Does not add semantic-validity checks (separate linter / richer schema)
- ❌ Does not modify the buggy 2026-05-03 artifact (immutable per contract; 2026-05-04 already supersedes it via PR #106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)