### PR TITLE
feat(optick-sae): contract v0.1.1 — optional compact_training_dim field

### DIFF
--- a/Scripts/optick_sae_postprocess.py
+++ b/Scripts/optick_sae_postprocess.py
@@ -43,11 +43,13 @@ def main() -> int:
     # ── 1. Load original artifact + adjust ────────────────────────────────
     art = json.loads(src_artifact.read_text(encoding="utf-8"))
 
-    # WHY override: the trainer records the actual training dim (124 for v1.8
-    # compact) but the contract field optick_dim wants TotalDimension (240).
-    # Schema's input object has additionalProperties=false so we can't add a
-    # parallel compact_training_dim slot; narrative records it explicitly.
+    # The trainer records the actual training dim (124 for v1.8 compact) in
+    # optick_dim. Per contract v0.1.1, optick_dim is the OPTIC-K embedding's
+    # TOTAL dimension (240); the actual training dim moves to the dedicated
+    # compact_training_dim slot.
+    actual_training_dim = int(art["input"]["optick_dim"])
     art["input"]["optick_dim"] = 240
+    art["input"]["compact_training_dim"] = actual_training_dim
 
     # Update narrative for clarity
     metrics = art["metrics"]

--- a/docs/contracts/2026-05-02-optick-sae-artifact.contract.md
+++ b/docs/contracts/2026-05-02-optick-sae-artifact.contract.md
@@ -1,6 +1,6 @@
 # OPTIC-K SAE Artifact — Cross-Repo Contract
 
-**Version:** 0.1.0 (draft, pending sign-off)
+**Version:** 0.1.1 (draft, pending sign-off — additive change from v0.1.0: optional `input.compact_training_dim` field)
 **Schema version:** 1
 **Status:** Draft (Phase 0 of `optick-sae` plan, 2026-05-02)
 **Producer:** `ix/crates/ix-optick-sae` (Rust orchestrator + Python PyTorch trainer via subprocess)
@@ -39,6 +39,7 @@ The contract is a **two-way door** until Phase 4 freeze (target 2026-Q3). Field 
     "optick_index_path": "state/voicings/optick.index",
     "optick_index_sha": "sha256:89354bcb3513efbe1523651b734743c6921186a9e807f53bfbe4a74a254bd267",
     "optick_dim": 240,
+    "compact_training_dim": 124,
     "schema_version": "OPTIC-K-v1.8",
     "corpus_size": 313487,
     "partitions_used": ["IDENTITY", "STRUCTURE", "MORPHOLOGY", "CONTEXT", "SYMBOLIC", "MODAL", "ROOT"]
@@ -108,7 +109,8 @@ The contract is a **two-way door** until Phase 4 freeze (target 2026-Q3). Field 
 |---|---|---|
 | `optick_index_path` | string | Repo-relative path. Usually `state/voicings/optick.index`. |
 | `optick_index_sha` | string | `sha256:...`. Lets consumers detect when the index changed since training. |
-| `optick_dim` | int | Currently 240 (v1.8 — bumped from 228 on 2026-04-19 with the 12-dim ROOT partition added). Pinned per CLAUDE.md OPTIC-K rule. Read from `EmbeddingSchema.TotalDimension`, do not hardcode. |
+| `optick_dim` | int | The OPTIC-K embedding's *total* dimension. Currently 240 (v1.8 — bumped from 228 on 2026-04-19 with the 12-dim ROOT partition added). Read from `EmbeddingSchema.TotalDimension`, do not hardcode. |
+| `compact_training_dim` | int (optional, v0.1.1+) | The dimension the SAE *actually trained on*. For the canonical OPTK v4 file this is `EmbeddingSchema.CompactDimension` (124 for v1.8 — sum of similarity-weighted partition dims, IDENTITY excluded since it's not in the compact format). MUST equal `optick_dim` if the trainer used the full embedding. WHY this exists: the 2026-05-03 local validation surfaced that "what was trained" and "what the embedding nominally is" diverge for the production OPTK pipeline; conflating them in `optick_dim` made narratives inconsistent (PR #82 wrote "118-dim" while `optick_dim: 240`). Optional in v0.1.x for compat with v0.1.0 artifacts; required candidate for v1.0 freeze. |
 | `schema_version` | string | OPTIC-K schema version, exact match of `EmbeddingSchema.Version` (e.g. `"OPTIC-K-v1.8"`). |
 | `corpus_size` | int | Number of voicings in the index. |
 | `partitions_used` | array<string> | Which OPTIC-K partitions the SAE trained over. Phase 1 default trains over similarity-weighted partitions plus IDENTITY: `[IDENTITY, STRUCTURE, MORPHOLOGY, CONTEXT, SYMBOLIC, MODAL, ROOT]`. Skip info-only partitions (EXTENSIONS, SPECTRAL, HIERARCHY, ATONAL_MODAL) initially since they don't carry similarity weight. |

--- a/docs/contracts/optick-sae-artifact.schema.json
+++ b/docs/contracts/optick-sae-artifact.schema.json
@@ -73,7 +73,12 @@
         "optick_dim": {
           "type": "integer",
           "minimum": 1,
-          "description": "Currently 240 for v1.8. Read from EmbeddingSchema.TotalDimension."
+          "description": "OPTIC-K embedding TOTAL dimension. Currently 240 for v1.8. Read from EmbeddingSchema.TotalDimension."
+        },
+        "compact_training_dim": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Dimension the SAE actually trained on (compact OPTK format = 124 for v1.8). Optional in v0.1.x; equal to optick_dim if the trainer used the full embedding. Surfaces the conflation that produced PR #82's bugs."
         },
         "schema_version": {
           "type": "string",

--- a/state/quality/optick-sae/2026-05-04/optick-sae-artifact.json
+++ b/state/quality/optick-sae/2026-05-04/optick-sae-artifact.json
@@ -17,7 +17,8 @@
       "SYMBOLIC",
       "MODAL",
       "ROOT"
-    ]
+    ],
+    "compact_training_dim": 124
   },
   "model": {
     "kind": "topk_sae",


### PR DESCRIPTION
## Summary

Resolves the contract ambiguity surfaced as a follow-up during PR #106:

- `optick_dim` → the OPTIC-K embedding's **total** dim (240 for v1.8)
- `compact_training_dim` (NEW, optional) → what the SAE actually trained on (124 for v1.8 compact)

PR #82's buggy artifact wrote `"118-dim"` in the narrative while `optick_dim` was 240 because the agent couldn't disambiguate. v0.1.1 splits them.

## What lands

| File | Change |
|---|---|
| `docs/contracts/2026-05-02-optick-sae-artifact.contract.md` | Version 0.1.0 → 0.1.1 (additive draft change). New §3.1 row for `compact_training_dim`. JSON example updated. |
| `docs/contracts/optick-sae-artifact.schema.json` | New `compact_training_dim` property in input (integer, min=1). Optional in v0.1.x. Existing v0.1.0 artifacts continue to validate. |
| `Scripts/optick_sae_postprocess.py` | Preserves the field instead of stripping it (was stripped in v0.1.0 because schema had no slot). |
| `state/quality/optick-sae/2026-05-04/optick-sae-artifact.json` | Regenerated to populate the new field. Same `artifact_id` — metadata enrichment from a contract version bump, not re-training. |

## Backwards compatibility

- Optional field → existing v0.1.0 artifacts on main (`2026-05-03/optick-sae-artifact.json`) keep validating without modification.
- Producer SHOULD populate it when generating new artifacts.
- Required-candidate at v1.0 freeze (target 2026-Q3).

## Verification

```
python Scripts/validate_optick_sae_artifacts.py
→ 4 artifacts pass (incl. the older v0.1.0 form without the new field)
```

The 2026-05-04 artifact now reads:
```
optick_dim: 240
compact_training_dim: 124
```

## What this PR does NOT do

- ❌ Does not modify the v0.1.0 buggy 2026-05-03 artifact (immutable; supersede chain via 2026-05-04 already documents the fix)
- ❌ Does not update the May 19 agent's brief (agent reads the contract + schema fresh on fire; the new field will land in its artifact naturally if its trainer/postprocess emits it)
- ❌ Does not freeze the schema (still v0.1.x draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)