### PR TITLE
chore: track 4 architecture docs + ignore subset slnx + claude-octopus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,11 @@ Apps/ga-client/playwright-report/
 # Local SAE training artifacts (per-developer-machine validation runs).
 # Real Phase 1 agent runs land at state/quality/optick-sae/<date>/ (no -local suffix).
 state/quality/optick-sae/*-local/
+
+# Claude Octopus per-machine session state.
+.claude-octopus/
+
+# Subset solution experiments at repo root — Codex / agent scratch when
+# restoring a partial graph. Block everything except the canonical one.
+/*.slnx
+!/AllProjects.slnx

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,131 @@
+---
+title: Guitar Alchemist — Architecture
+scope: Master index for the GA solution architecture. Links to subsystem detail docs and the latest audit.
+status: authoritative
+last_verified: 2026-04-25
+---
+
+# Guitar Alchemist — Architecture
+
+Authoritative entry point for understanding what runs, what stores data, what serves chat, and what is wired into what. Detail lives in the six subsystem docs linked below; this file is an index, a status snapshot, and a small set of conventions.
+
+If a section here disagrees with a subsystem doc, the subsystem doc wins (it was verified more recently against the code). If a subsystem doc disagrees with the running code, the code wins — open an issue and update the doc.
+
+## How to use these docs
+
+- **New to the codebase?** Read this file top-to-bottom, then `apps-and-processes.md`, then whichever subsystem you're touching.
+- **Making a change?** Find the relevant subsystem doc and update the `last_verified` date if you confirm or correct anything.
+- **Adding a new subsystem doc?** Use kebab-case (`my-subsystem.md`), include the standard frontmatter, and add a row in the index below. Do not create new SCREAMING_SNAKE files at this level — the legacy ones are pending sweep (see audit).
+
+## Layered architecture (recap)
+
+Five-layer strict bottom-up dependency model, per `CLAUDE.md`:
+
+1. **Core** — pure primitives (Note, Interval, Fretboard). `GA.Core`, `GA.Domain.Core`.
+2. **Domain** — logic, YAML, BSP. `GA.Business.Core`, `GA.Business.Config`, `GA.BSP.Core`.
+3. **Analysis** — chord/scale, voice leading, spectral. `GA.Business.Core.Harmony`, `GA.Business.Core.Fretboard`.
+4. **AI/ML** — embeddings, vector search, RAG, OPTIC-K schema. `GA.Business.ML`.
+5. **Orchestration** — `GA.Business.Core.Orchestration`, `GA.Business.Assets`, `GA.Business.Intelligence`.
+
+Apps live in `Apps/`; AI code in layer 4; orchestration in layer 5; never in lower layers. Detail of who-uses-what is in `apps-and-processes.md`.
+
+## Subsystem index
+
+| Doc | Scope | One-line state |
+|---|---|---|
+| [apps-and-processes.md](apps-and-processes.md) | Every runnable .NET app, frontend, microservice, external dep | 19 .NET apps, 4 frontends, 13 external services; many half-built or referenced-but-deleted |
+| [chat-surfaces.md](chat-surfaces.md) | All chat/agent entry points (REST, SignalR, GraphQL, agents, IChatService) | 11 HTTP entry points + 1 dead SignalR hub; one canonical path (`/api/nebula/chat`) plus parallel implementations |
+| [data-storage.md](data-storage.md) | OPTIC-K mmap, MongoDB collections, FalkorDB, Qdrant, config YAMLs | OPTK + 20 Mongo collections; 4 RAG collections registered but never populated; Qdrant orphaned |
+| [rag-pipeline.md](rag-pipeline.md) | Voicing-grounded chat, knowledge-grounded chat, partitioned RAG, agent grounding | One live RAG path (voicings via OPTK); knowledge-grounded path scaffolded but not wired |
+| [frontends.md](frontends.md) | React, Angular, Blazor (none, actually), CLIs, MCP servers | ga-client React is the only verified-live UI; "GaChatbot" is a console REPL, the Blazor app's source is gone |
+| [llm-providers.md](llm-providers.md) | IChatClient, IChatService, embeddings, TTS, selection rules | Three parallel chat abstractions in flight (MEAI IChatClient, legacy IChatService, raw HTTP in NebulaSidekick) |
+
+## High-level process topology
+
+```mermaid
+flowchart LR
+  subgraph Frontend
+    react[ga-client React :5176 LIVE]
+    ang[ga-dashboard Angular :4200 UNKNOWN]
+    repl[GaChatbot REPL HALF]
+    cli[GaChatbotCli UNKNOWN]
+  end
+
+  subgraph Backend
+    api[GaApi :5232 LIVE]
+    mcp[GaMcpServer LIVE]
+    aiservice[GA.AI.Service UNKNOWN]
+    lsp[GaMusicTheoryLsp UNKNOWN]
+  end
+
+  subgraph Data
+    optk[(OPTK mmap 175MB)]
+    mongo[(MongoDB :27017)]
+    falkor[(FalkorDB :6379)]
+    qdrant[(Qdrant :6333 ORPHAN)]
+  end
+
+  subgraph LLM
+    ollama[Ollama :11434 LIVE]
+    anthropic[Anthropic API]
+    openai[OpenAI API]
+    mistral[Mistral API]
+  end
+
+  react -->|HTTP via Vite proxy| api
+  ang -->|HTTP| api
+  repl -.->|in-process| api
+  api --> optk
+  api --> mongo
+  api --> ollama
+  api --> anthropic
+  mcp --> optk
+  api --> falkor
+```
+
+## Status snapshot (verified 2026-04-25)
+
+What's actually running and answering requests today:
+
+- **LIVE and serving traffic**: `GaApi /api/nebula/chat` (verified end-to-end with Ollama tool-loop), `ga-client` (React on :5176), MongoDB (:27017), Ollama (:11434), OPTIC-K mmap loaded by GaApi (667,125 voicings).
+- **HALF-BUILT but compiles**: `GaChatbot` console REPL (DI gaps with Mongo and RAG; not currently running), `KnowledgeSyncHostedService` work on Track A worktree (not merged).
+- **DEAD or stranded**: `GuitarAlchemistChatbot` (source deleted, still referenced from `AllProjects.AppHost/Program.cs:135` + `docker-compose.yml:104` + `Scripts/start-all.ps1`), `ChatbotHub` SignalR (zero frontend consumers), Qdrant container (no code references), 4 RAG MongoDB collections registered with no caller invoking SyncAsync.
+- **DRIFTING**: OPTIC-K schema (CLAUDE.md says 228-dim v1.7; actual is 112-dim compact / 240-dim full v1.8 per `data-storage.md`), database name (`guitar-alchemist` in Aspire vs `guitaralchemist` in Docker Compose env vars).
+
+A more granular Keep / Consolidate / Delete decision table lives in [audit-2026-04-25.md](audit-2026-04-25.md).
+
+## Conventions
+
+**Filenames in this directory:** kebab-case for canonical docs (`apps-and-processes.md`). The remaining SCREAMING_SNAKE files in this folder are legacy and pending the sweep recommended in the audit.
+
+**Frontmatter on every doc:**
+```yaml
+---
+title: <Human-readable title>
+scope: <One-sentence scope statement — what this doc covers and does not cover>
+status: authoritative | draft | superseded
+last_verified: YYYY-MM-DD
+parent: docs/architecture/README.md     # optional, for child docs
+---
+```
+
+**Status tokens** (use text, not emoji — project rule): `LIVE`, `HALF`, `DEAD`, `UNKNOWN`, `DRIFT`.
+
+**File paths in claims:** forward slashes, repo-relative (e.g. `Apps/ga-server/GaApi/Program.cs:42`).
+
+**Cross-doc references:** relative markdown links (`[chat-surfaces.md](chat-surfaces.md)`).
+
+**No recommendations in subsystem docs.** Recommendations and decisions live in audit docs (dated `audit-YYYY-MM-DD.md`).
+
+## Out of scope for this index
+
+- Implementation history ("how we got here") — see `docs/archive/` and git log.
+- One-off plans and refactor progress trackers — `docs/plans/` and `docs/archive/`.
+- Methodology and invariants — `docs/methodology/`.
+- Quality baselines — `docs/quality/` and `state/quality/`.
+
+## See also
+
+- `CLAUDE.md` — project conventions, build commands, the layered architecture rule.
+- `docs/architecture/audit-2026-04-25.md` — current Keep/Consolidate/Delete decisions.
+- `docs/methodology/` — invariants, methodologies that constrain architecture.

--- a/docs/architecture/apps-and-processes.md
+++ b/docs/architecture/apps-and-processes.md
@@ -1,0 +1,209 @@
+---
+title: Apps & Processes
+scope: Inventory of runnable processes (apps, frontends, external services) in the GA solution
+status: authoritative
+last_verified: 2026-04-25
+parent: docs/architecture/README.md
+---
+
+# Apps & Processes
+
+Authoritative inventory of every runnable process in the Guitar Alchemist solution: .NET apps, frontends, microservices, and external dependencies. Scope: things that *run as a process*. Sibling docs cover chat surfaces, data storage, RAG pipelines, and LLM provider selection.
+
+## Status legend
+
+| Symbol | Meaning |
+|---|---|
+| OK live | Has code, builds, and a running process has been observed (port listening, request answered, or container running). |
+| HALF half-built | Has code and may build, but DI is incomplete, dependencies are commented out in the Aspire host, or the process has never been verified end-to-end. |
+| DEAD deprecated | Source still in repo, but referenced only from `docker-compose.yml` or stale config; no active path runs it. |
+| ? unknown | Source compiles, but no evidence of when it was last invoked. |
+
+The same legend symbols are used in the tables below.
+
+## .NET apps under `Apps/`
+
+Ports listed are the development defaults from `Properties/launchSettings.json` unless noted. "Aspire override" means `AllProjects.AppHost/Program.cs` may bind a different port at runtime.
+
+| App | Path | Type | Default port(s) | Purpose | Status |
+|---|---|---|---|---|---|
+| **GaApi** | `Apps/ga-server/GaApi` | ASP.NET Core Web API + SignalR + GraphQL (HotChocolate) + YARP gateway | http 5232 / https 7184 | Main backend gateway: chat, voicing search, fretboard, OPTIC-K, GraphQL. Project type `Microsoft.NET.Sdk.Web`. | OK live (verified: `POST /api/nebula/chat` returns correct theory answers; ~97s on Ollama CPU) |
+| **GA.MusicTheory.Service** | `Apps/ga-server/GA.MusicTheory.Service` | ASP.NET Core microservice | http 6001 / https 7001 | Theory operations (chords, scales, keys, intervals). Wired into Aspire host as `music-theory-service` and referenced by GaApi. | OK live (Aspire-registered) |
+| **GA.AI.Service** | `Apps/ga-server/GA.AI.Service` | ASP.NET Core microservice | http 6003 / https 7003 | Independent AI/ML surface with its own `ChatController`, `AIAnalysisController`, `AdaptiveAIController`, etc. Has its own Dockerfile. Aspire registration is **commented out** (`AllProjects.AppHost/Program.cs:86-90`). | HALF half-built (code exists, not started by Aspire) |
+| **GA.DocumentProcessing.Service** | `Apps/ga-server/GA.DocumentProcessing.Service` | ASP.NET Core microservice | http 7007 / https 7107 | YouTube ingestion, autonomous curation, retroaction loop (`AutonomousCurationController`, `DocumentProcessingController`, `RetroactionLoopController`, `YouTubeController`). Not in Aspire host. | HALF half-built |
+| **GA.BSP.Service** | `Apps/ga-server/GA.BSP.Service` | ASP.NET Core microservice | http 6002 / https 7002 | BSP (binary space partition) dungeon/floor logic. Aspire registration commented out (`AllProjects.AppHost/Program.cs:79-83`). | HALF half-built |
+| **GA.Knowledge.Service** | `Apps/ga-server/GA.Knowledge.Service` | ASP.NET Core microservice | http 6004 / https 7004 | Knowledge graph queries. Aspire registration commented out (`AllProjects.AppHost/Program.cs:92-96`). | HALF half-built |
+| **GA.Fretboard.Service** | `Apps/ga-server/GA.Fretboard.Service` | ASP.NET Core microservice | http 6005 / https 7005 | Fretboard/voicing analysis. Referenced as a *project* by `GaApi.csproj` but Aspire registration commented out (`AllProjects.AppHost/Program.cs:99-103`). | HALF half-built (in-process via project ref; not running standalone) |
+| **GA.Analytics.Service** | `Apps/ga-server/GA.Analytics.Service` | ASP.NET Core microservice | http 6006 / https 7006 | Analytics surface. Aspire registration commented out (`AllProjects.AppHost/Program.cs:106-110`). | HALF half-built |
+| **AllProjects.AppHost** | `AllProjects.AppHost` | .NET Aspire orchestrator (`Aspire.Hosting.AppHost`) | Aspire dashboard (random) | Single entry point that boots Redis, MongoDB, FalkorDB, Graphiti, hand-pose, sound-bank, GaApi, MusicTheory service, chatbot, ScenesService, FloorManager, GaMcpServer, ga-client. | OK live |
+| **GaChatbot** | `Apps/GaChatbot` | .NET Generic Host (Console with `Microsoft.Extensions.Hosting`) — *not Blazor; csproj is plain `Microsoft.NET.Sdk`* | none (console) | Spectral RAG chatbot driver loop ("Phase 15 — Qdrant Backend"). Many services are `<Compile Remove>`'d from the csproj — their replacements live in `GA.Business.Core.Orchestration`. | HALF half-built (DI partially gutted; runs interactive loop but RAG path is uncertain) |
+| **GuitarAlchemistChatbot** | `Apps/GuitarAlchemistChatbot` | (was Blazor) | docker-compose: 7002 → 8080 | **Source folder is empty except for `obj/`.** `Apps/GuitarAlchemistChatbot/Dockerfile` and `docker-compose.yml:104-133` still reference it; `AllProjects.AppHost/Program.cs:135` still calls `builder.AddProject("chatbot", ...)`. The `.csproj` is missing — the Aspire/Docker references will fail. | DEAD deprecated (source removed; references stale) |
+| **GaChatbotCli** | `Apps/GaChatbotCli` | .NET console (`OutputType=Exe`, `Microsoft.Extensions.Hosting`) | none | One-shot/interactive CLI for `ProductionOrchestrator`. Reads ANTHROPIC_API_KEY for SKILL.md skills. Usage: `dotnet run --project Apps/GaChatbotCli -- "parse Am7"`. | ? unknown (compiles; no telemetry on actual invocations) |
+| **GaCli** | `Apps/GaCli` | F# console (`OutputType=Exe`) | none | Closure-runtime CLI: invokes `GaClosureRegistry.Global` — Domain, Pipeline, Agent, IO, Tab closures. Reads stdin when piped. | ? unknown |
+| **GaMusicTheoryLsp** | `Apps/GaMusicTheoryLsp` | F# console — Language Server (LSP over stdio) | stdio | Music-theory DSL language server: chord progressions, fretboard navigation, scale transformations. VSCode client lives at `Apps/GaMusicTheoryLsp/client-vscode`. | ? unknown |
+| **GaMcpServer** | `GaMcpServer` (repo root, *not* under `Apps/`) | .NET console — MCP server (stdio) | stdio | Exposes GA domain operations as MCP tools (`mcp__ga-dsl__*`). Holds `state/voicings/optick.index` mmap-locked at runtime — must be stopped before re-indexing. Aspire-registered as `ga-mcp-server`. | OK live (Aspire boots it; mmap-lock observable during OPTIC-K rebuild) |
+| **FloorManager** | `Apps/FloorManager` | Blazor Server (`AddRazorComponents().AddInteractiveServerComponents()`) | http 5233 / https 7233 | BSP dungeon floor viewer. Talks to GaApi via Aspire service-discovery (`http://gaapi`). Aspire-registered as `floor-manager`. | OK live (Aspire-registered) |
+| **ScenesService** | `Apps/ScenesService` | ASP.NET Core Web API (Swagger + MongoDB/GridFS) | http 5190 / https 7190 | GLB scene generator/server with cells/portals metadata. CORS allows `http://localhost:5173` and `:3000`. Aspire-registered as `scenes-service`. | OK live (Aspire-registered) |
+| **InteractiveTutorial** | `Apps/InteractiveTutorial` | .NET console (Spectre.Console TUI) | none | Spectre-rendered interactive learning experience (figlet banner + menu). Note: csproj `<Compile Remove="Program.cs"/>` actually excludes Program.cs from build — only `DummyMain.cs` ships. | DEAD deprecated (Program.cs explicitly excluded from compilation) |
+| **VoicingSearchDemo** | `Apps/VoicingSearchDemo` | .NET console (`OutputType=Exe`) | none | Standalone demo of the voicing semantic-search RAG path against the legacy `VoicingIndexingService`. | ? unknown (single-file demo; no Aspire registration) |
+| **DemerzelBridge** | `Apps/demerzel-bridge/DemerzelBridge` | .NET console — MCP server (stdio) | stdio | MCP-to-ACP bridge: translates Claude Code MCP tool calls into HTTP runs against the Python ACP agent at `localhost:8200`. Configured in `.mcp.json` under key `demerzel`. | OK live (referenced from `.mcp.json:13-21`) |
+
+### Python/F# apps under `Apps/`
+
+| App | Path | Type | Default port(s) | Purpose | Status |
+|---|---|---|---|---|---|
+| **demerzel-agent** | `Apps/demerzel-agent` | Python ACP agent (FastAPI/uvicorn, `acp-sdk`) | http 8200 | Governance / pipeline / epistemic / what's-next agents over ACP. All run endpoints require `Authorization: Bearer ${DEMERZEL_API_KEY}`. | OK live (running paired with DemerzelBridge MCP) |
+| **ga-graphiti-service** | `Apps/ga-graphiti-service` | Python FastAPI | http 8000 | Temporal knowledge graph (Graphiti) on top of FalkorDB + MongoDB. Aspire boots it as a Docker container with Dockerfile build. | OK live (port 8000 listening; Aspire-registered) |
+| **hand-pose-service** | `Apps/hand-pose-service` | Python FastAPI (MediaPipe Hands) | http 8081 → container 8080 | Guitar hand-pose detection from images/video frames. Aspire-registered as `hand-pose-service`. | ? unknown (registered in Aspire; runtime not verified this session) |
+| **sound-bank-service** | `Apps/sound-bank-service` | Python FastAPI (MusicGen) | http 8082 → container 8080 | AI-powered guitar sound-sample generation. Aspire-registered with Redis + MongoDB references. | ? unknown |
+
+## Frontends
+
+| Frontend | Path | Tech | Default port | Backend it talks to | Status |
+|---|---|---|---|---|---|
+| **ga-client** | `Apps/ga-client` | React 18 + Vite 5 + R3F (`@react-three/fiber`) + MUI v5 | 5176 (dev script `Scripts/start-dev.ps1`); Aspire binds 5173 via `AddNpmApp` | GaApi at `http://localhost:5232` — proxied via `vite.config.ts` for `/api` and `/hubs` (SignalR ws). Override via `GA_API_URL`. | OK live (port 5176 LISTENING) |
+| **ga-dashboard** | `Apps/ga-dashboard` | Angular 21 + three.js 0.182 | 4200 (Angular default; docker-compose maps 4200→80 via nginx) | Not pinned in code; intended as standalone admin/dashboard. | ? unknown (no observed running process; not in Aspire) |
+| **ga-react-components** | `ReactComponents/ga-react-components` | React 18 component library + Vite (build mode) — also has SignalR client and ag-grid | n/a (library, but ships a Vite dev mode + Playwright tests) | Component library consumed by `ga-client` via `file:../../ReactComponents/ga-react-components`. Not deployed standalone. | OK live (build target — consumed by ga-client) |
+| **GaMusicTheoryLsp/client-vscode** | `Apps/GaMusicTheoryLsp/client-vscode` | VSCode extension (TypeScript) | n/a | Speaks LSP (stdio) to `GaMusicTheoryLsp` F# server. | ? unknown |
+
+## External services
+
+External processes the solution depends on. Aspire-managed = `AllProjects.AppHost/Program.cs` boots it as a container. Compose-managed = listed in `docker-compose.yml` only.
+
+| Service | Port(s) | Source | Purpose | Status |
+|---|---|---|---|---|
+| **MongoDB** | 27017 | Aspire (`builder.AddMongoDB("mongodb")`) + `docker-compose.yml:7` (`mongo:7.0.5-alpine`) | Primary document store; database `guitar-alchemist`. | OK live (27017 LISTENING) |
+| **Mongo Express** | 8081 (compose) | Aspire (`.WithMongoExpress()`) + `docker-compose.yml:33` | Mongo admin UI. | OK live |
+| **Redis** | 6379 (default; falkordb shares via remap below) | Aspire (`builder.AddRedis("redis").WithRedisCommander().WithDataVolume(...)`) | Distributed cache (`Aspire.StackExchange.Redis.DistributedCaching`); shared LLM concurrency gate, hybrid cache. | OK live (port 6379 LISTENING) |
+| **FalkorDB** | 6380 (host) → 6379 (container) | Aspire (`builder.AddContainer("falkordb", "falkordb/falkordb", "edge")`) + `docker-compose.yml:194` (4.0.0) | Redis-compatible graph DB used by Graphiti. Aspire remaps to 6380 to avoid clash with stock Redis. | OK live (containers running; FalkorDB UI at compose port 3000 if compose-launched) |
+| **Qdrant** | 6333 (HTTP), 6334 (gRPC) | `docker-compose.yml:278` (`qdrant/qdrant:v1.10.1`); **not in Aspire host** | Vector DB for legacy/Phase-15 RAG (referenced from `GaChatbot/Program.cs:21` comment). | OK live (port 6333 LISTENING) |
+| **Ollama** | 11434 | `docker-compose.yml:301` (`ollama/ollama:0.1.32`); also runs natively on host | Local LLM runner; default model `qwen:0.5b` per compose; production uses larger Ollama models for chat. | OK live (port 11434 LISTENING; ~97s latency on CPU verified through GaApi) |
+| **Jaeger** | 16686 (UI), 4317/4318 (OTLP) | `docker-compose.yml:256` (`jaegertracing/all-in-one:1.51.0`); **not in Aspire host** (Aspire dashboard handles tracing locally) | Distributed tracing UI for OTLP exports. | ? unknown (compose-only; not running this session) |
+| **Graphiti service** | 8000 | Aspire container build from `Apps/ga-graphiti-service` + `docker-compose.yml:217` | Temporal knowledge graph API (Python FastAPI). Depends on FalkorDB + MongoDB. | OK live (port 8000 LISTENING) |
+| **MCP Gateway (Docker AI)** | 8811 | `docker-compose.yml:322` (`docker/mcp-gateway:latest`) | Docker MCP gateway (SSE) bridging mongodb/redis/memory MCP servers. | ? unknown (compose-only) |
+| **Meshy AI MCP** | n/a (idle container) | `docker-compose.yml:339` builds from `mcp-servers/meshy-ai`; also referenced from `.mcp.json:8` as a stdio Node process | Meshy AI 3D-model generation MCP server. Compose runs it idle (`tail -f /dev/null`); active usage is via stdio per `.mcp.json`. | OK live (stdio invocation when Claude Code uses it) |
+| **Mistral API** | (cloud HTTPS) | External — `MISTRAL_API_KEY` env var; Voxtral TTS (`voxtral-mini-tts-2603`) and `guitar-alchemist` agent on Mistral Medium | Cloud LLM/TTS provider (theory tribunal cross-validator + Demerzel "Oliver" voice). | OK live (per memory: `MISTRAL_API_KEY` set) |
+| **Anthropic API** | (cloud HTTPS) | External — `ANTHROPIC_API_KEY`; package `Anthropic 12.8.0` in `GaApi.csproj` | Claude API for SKILL.md-driven skills in `GaChatbotCli` and other surfaces. | OK live |
+| **Cloudflare Tunnel** | n/a (outbound tunnel) | External — `cloudflared` daemon, no in-repo config | Exposes `demos.guitaralchemist.com` to the public internet. Domain at Network Solutions; DNS on Cloudflare. | OK live (per memory `reference_cloudflare_deployment`) |
+| **OpenAI / Azure OpenAI** | (cloud HTTPS) | External — packages `Azure.AI.OpenAI 2.2.0-beta.1`, `Microsoft.Extensions.AI.OpenAI` | Optional OpenAI/Azure OpenAI provider for chat/embeddings. | ? unknown (referenced; runtime usage not confirmed) |
+
+## Process topology
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        gac[ga-client React/Vite :5176]
+        gad[ga-dashboard Angular :4200]
+        rcl[(ga-react-components<br/>library)]
+        fm[FloorManager Blazor :5233]
+        vsc[VSCode + LSP client]
+    end
+
+    subgraph MCP_Clients
+        cc[Claude Code]
+        cli[GaChatbotCli / GaCli]
+    end
+
+    subgraph Backend
+        api[GaApi :5232<br/>SignalR + GraphQL + YARP]
+        mts[GA.MusicTheory.Service :6001/7001]
+        ais[GA.AI.Service :6003/7003<br/>HALF half-built]
+        dps[GA.DocumentProcessing.Service :7007]
+        bsp[GA.BSP.Service :6002 HALF]
+        ks[GA.Knowledge.Service :6004 HALF]
+        fbs[GA.Fretboard.Service :6005 HALF]
+        ans[GA.Analytics.Service :6006 HALF]
+        scn[ScenesService :5190]
+        mcp[GaMcpServer stdio]
+        lsp[GaMusicTheoryLsp F# stdio]
+        bridge[DemerzelBridge stdio]
+        cb[GaChatbot loop HALF]
+    end
+
+    subgraph Python_Services
+        gph[ga-graphiti-service :8000]
+        hps[hand-pose-service :8081]
+        sbs[sound-bank-service :8082]
+        dem[demerzel-agent ACP :8200]
+    end
+
+    subgraph Data
+        mongo[(MongoDB :27017)]
+        redis[(Redis :6379)]
+        falkor[(FalkorDB :6380)]
+        qdrant[(Qdrant :6333)]
+        optick[/optick.index<br/>mmap state/voicings//]
+    end
+
+    subgraph External_LLMs
+        oll[Ollama :11434]
+        mistral[Mistral API]
+        anth[Anthropic API]
+        oai[OpenAI / Azure OpenAI]
+    end
+
+    subgraph Edge
+        cf[Cloudflare Tunnel<br/>demos.guitaralchemist.com]
+    end
+
+    gac -->|/api /hubs proxy| api
+    gac -.uses.-> rcl
+    gad -->|HTTP| api
+    fm -->|service discovery| api
+    vsc -->|LSP stdio| lsp
+
+    cc -->|MCP stdio| mcp
+    cc -->|MCP stdio| bridge
+    cli --> api
+    bridge -->|HTTP ACP| dem
+
+    api --> mts
+    api --> mongo
+    api --> redis
+    api --> oll
+    api --> anth
+    api --> mistral
+    api --> oai
+    api -->|in-proc| fbs
+
+    mcp --> optick
+    api -.OPTIC-K mmap.-> optick
+
+    cb --> qdrant
+    cb --> mongo
+    cb --> oll
+
+    gph --> falkor
+    gph --> mongo
+    gph --> oll
+
+    dem --> api
+
+    cf --> gac
+    cf --> api
+```
+
+## Open questions
+
+- **GaChatbotCli** — is this still invoked in any workflow, or vestigial from pre-orchestrator era? `Program.cs` mentions "SKILL.md-driven skills" suggesting recent maintenance, but no script under `Scripts/` calls it.
+- **GaCli** (F#) — same question. Closure registry has been actively extended (Domain/Pipeline/Agent/IO/Tab closures), but no production caller is visible.
+- **VoicingSearchDemo** — single-file demo against the *legacy* `VoicingIndexingService`. Has the OPTIC-K migration superseded it? No Aspire registration, no `Scripts/` reference.
+- **InteractiveTutorial** — csproj `<Compile Remove="Program.cs"/>` removes the entry point; only `DummyMain.cs` is compiled. Is this intentionally stubbed or pending revival?
+- **GuitarAlchemistChatbot** — folder contains only `obj/`; the `.csproj` is gone but `AllProjects.AppHost/Program.cs:135` and `docker-compose.yml:104` still reference it. Confirm: is this fully retired, or expected to be restored?
+- **ga-dashboard (Angular)** — is this an active second frontend or an experiment? It is in `docker-compose.yml` but not in the Aspire host. No backend wiring observed in the Angular source.
+- **Six microservices commented out in Aspire** (`GA.AI.Service`, `GA.BSP.Service`, `GA.Knowledge.Service`, `GA.Fretboard.Service`, `GA.Analytics.Service`, `GA.DocumentProcessing.Service`) — code exists with controllers, ports defined; orchestration disabled with TODO comments. Status of completion criteria unclear.
+- **GA.AI.Service vs GaApi chat** — both expose chat controllers. Which one is the canonical chat backend going forward, given GaApi already proxies and runs in-process?
+- **Jaeger** — listed in compose but not in the Aspire host (Aspire has its own dashboard). Is compose-Jaeger still used for any production tracing?
+- **MCP Gateway (Docker AI)** — runtime usage unknown; has it been superseded by direct stdio MCP entries in `.mcp.json`?
+- **Hand-pose / sound-bank services** — registered in Aspire but no observed runtime traffic this session. Are these used by ga-client, or experimental?
+- **HTTPS profile for GaApi (port 7184)** — referenced from `launchSettings.json` but `Apps/ga-client/vite.config.ts` defaults to `http://localhost:5232`. Is HTTPS dev workflow still supported?
+
+## File references
+
+- Aspire host: `AllProjects.AppHost/Program.cs:1-160`
+- GaApi entry: `Apps/ga-server/GaApi/Program.cs:1-60`, `Apps/ga-server/GaApi/Properties/launchSettings.json:17`
+- Vite proxy: `Apps/ga-client/vite.config.ts:14-43`
+- MCP registry: `.mcp.json:1-23`
+- Compose stack: `docker-compose.yml:1-368`
+- Stale Blazor reference: `AllProjects.AppHost/Program.cs:135`, `docker-compose.yml:104-133`, `Apps/GuitarAlchemistChatbot/` (only `obj/`)
+- Microservice TODOs: `AllProjects.AppHost/Program.cs:79-110`

--- a/docs/architecture/audit-2026-04-25.md
+++ b/docs/architecture/audit-2026-04-25.md
@@ -1,0 +1,187 @@
+---
+title: Architecture Audit — 2026-04-25
+scope: Keep / Consolidate / Delete decisions across the GA solution, derived from the six subsystem inventory docs. Drives streamlining work.
+status: draft
+last_verified: 2026-04-25
+parent: docs/architecture/README.md
+---
+
+# Architecture Audit — 2026-04-25
+
+## Method
+
+Six subsystem docs were written against the `main` branch state on 2026-04-25 (apps, chat, data, rag, frontends, llm). Each was authored by a separate agent reading the actual code, not the prior architecture documents. This audit cross-references those findings and proposes one of three dispositions per component:
+
+- **KEEP** — canonical, in active use, no action needed.
+- **CONSOLIDATE** — overlapping with another component; merge or pick a winner.
+- **DELETE** — dead code, ghost reference, or replaced by a canonical alternative.
+
+Status tokens: LIVE / HALF / DEAD / UNKNOWN / DRIFT (see `README.md` conventions).
+
+## Top-priority recommendations
+
+Listed by impact-over-effort, highest first. Numbered for reference in conversation.
+
+1. **Adopt `GaApi /api/nebula/chat` as the single canonical chat path.** It is the only end-to-end-verified working path. Everything else (AgUi, ChatbotController, ChatbotHub, GA.AI.Service ChatController, GaChatbot console REPL) is parallel-and-untested or known-dead. Until this is settled, every "improvement" risks landing on the wrong front door (this happened to the in-flight Track A worktree this session).
+
+2. **Retarget the Track A worktree from `GaChatbot` to `GaApi/NebulaSidekickService`.** Its scaffolding (YamlKnowledgeRagService, PartitionedRagService.Theory bridge, KnowledgeSyncHostedService) is ~80% reusable; only the agent-injection step needs to move. Without retargeting, merging the worktree changes nothing the React user sees.
+
+3. **Delete the `GuitarAlchemistChatbot` ghost.** Source is gone; references remain in `AllProjects.AppHost/Program.cs:135`, `Scripts/start-all.ps1`, `docker-compose.yml:104`. These references break local startup or silently no-op. One commit removes all three.
+
+4. **Resolve the OPTIC-K schema drift in `CLAUDE.md`.** CLAUDE.md says 228-dim v1.7; actual on disk is 112-dim compact / 240-dim full v1.8 per `data-storage.md`. Either update CLAUDE.md or roll back the index — agents reading CLAUDE.md will make wrong assumptions today.
+
+5. **Pick one chat-LLM abstraction.** Three are in flight: MEAI `IChatClient` (forward-looking), legacy `IChatService` (three impls), raw HTTP in `NebulaSidekickService` (bypasses both). Keeping all three indefinitely is what produced "5 chatbot apps" in the first place.
+
+6. **Run `YamlKnowledgeSyncService.SyncAsync()` once in any environment.** All four "knowledge-base RAG" Mongo collections are empty in every environment because no host invokes the sync. The infrastructure exists; nobody has ever pulled the trigger.
+
+7. **Sweep the legacy architecture docs** (12+ in `docs/architecture/`, 4+ in `docs/`) into `docs/archive/architecture-pre-2026-04/`. The new kebab-case docs supersede them; keeping both creates ambiguity about what's authoritative.
+
+## Per-subsystem decisions
+
+### Apps & processes
+
+| Component | Path | State | Disposition | Rationale |
+|---|---|---|---|---|
+| GaApi | `Apps/ga-server/GaApi` | LIVE | **KEEP** | Verified working, hosts the canonical chat endpoint. |
+| ga-client (React) | `Apps/ga-client` | LIVE | **KEEP** | Verified live, only fully-functional UI. |
+| GaMcpServer | `GaMcpServer` | LIVE | **KEEP** | Provides MCP tool surface, holds OPTK mmap. |
+| MongoDB / Ollama / FalkorDB | docker / Aspire | LIVE | **KEEP** | All in active use. |
+| GaChatbot (console REPL) | `Apps/GaChatbot` | HALF | **CONSOLIDATE** | If a non-HTTP chat surface is needed, formalize against GaApi services; otherwise delete. |
+| GaChatbotCli | `Apps/GaChatbotCli` | UNKNOWN | **CONSOLIDATE** | Determine if it's actively used; if yes, fold into GaChatbot or document role. If no, delete. |
+| GuitarAlchemistChatbot | `Apps/GuitarAlchemistChatbot` | DEAD | **DELETE** | Source already gone; remove three orphan references (AppHost, start-all.ps1, docker-compose). |
+| GA.AI.Service | `Apps/ga-server/GA.AI.Service` | UNKNOWN | **CONSOLIDATE** | Has its own ChatController + ProductionOrchestrator. Either fold into GaApi or document why it must stay separate (microservice boundary?). |
+| GA.MusicTheory.Service, GA.DocumentProcessing.Service | `Apps/ga-server/...` | UNKNOWN | **CONSOLIDATE** | Same question. Six services are commented-out in AppHost (`// TODO: Uncomment when service implementation is complete`). Decide: complete them or delete them. |
+| GaMusicTheoryLsp (F#) | `Apps/GaMusicTheoryLsp` | UNKNOWN | **KEEP** unless proven dead | F# language server; if any IDE config references it, keep. |
+| ga-dashboard (Angular) | `Apps/ga-dashboard` | UNKNOWN | **CONSOLIDATE** | Not in AppHost orchestration. Decide if it's a separate product or should fold into ga-client. |
+| InteractiveTutorial | `Apps/InteractiveTutorial` | DEAD | **DELETE** | csproj explicitly excludes its own Program.cs. |
+
+### Chat surfaces
+
+| Component | State | Disposition | Rationale |
+|---|---|---|---|
+| `POST /api/nebula/chat` (NebulaChatController + NebulaSidekickService) | LIVE | **KEEP** | Canonical. All RAG/grounding work targets this. |
+| `AgUiChatController` (`/api/chatbot/agui/*`) | UNKNOWN | **DELETE** | No identified frontend consumer. AG-UI protocol parallel to NebulaChat. |
+| `ChatbotController` (generic) | UNKNOWN | **CONSOLIDATE** or **DELETE** | If any route here is used, fold into NebulaChat. Else delete. |
+| `GA.AI.Service/ChatController` (ProductionOrchestrator) | UNKNOWN | **CONSOLIDATE** | Decide microservice boundary. If GA.AI.Service stays, document. If not, merge into GaApi. |
+| `ChatbotHub` (SignalR) | DEAD | **DELETE** | Zero frontend consumers found in `Apps/`. |
+| GraphQL chat | n/a | n/a | None exists; CLAUDE.md mention is aspirational. Update CLAUDE.md to match. |
+| `SemanticRouter` | LIVE in GaChatbot REPL only | **CONSOLIDATE** | Rich routing logic but only one caller. Either expose via NebulaSidekick (richer agent fan-out) or accept it's dormant. |
+| `ChatbotSessionOrchestrator` | HALF | **CONSOLIDATE** | Partly used; clarify role vs NebulaSidekickService. |
+| `TabAwareOrchestrator`, `SpectralRagOrchestrator` | LIVE | **KEEP** | Used by NebulaSidekick path or invokable. |
+| Specialized agents (Tab/Theory/Technique/Composer/Critic) | LIVE in GaChatbot REPL | **CONSOLIDATE** | Only `VoicingAgent` is reachable from the canonical chat path. Decide whether the others should be exposed via NebulaSidekick tools or retired. |
+
+### Data storage
+
+| Component | State | Disposition | Rationale |
+|---|---|---|---|
+| OPTIC-K mmap (`state/voicings/optick.index`) | LIVE | **KEEP** | Backbone of voicing search. |
+| MongoDB `voicings`, `chord_templates`, scales, instruments, etc. (typed-domain) | LIVE | **KEEP** | All have active SyncServices that run. |
+| MongoDB `music_theory_knowledge_base_rag`, `guitar_technique_library_rag`, `style_learning_library_rag` | DEAD (empty everywhere) | **DELETE** | Three RAG collections registered but no SyncAsync caller. Either commit to populating them with a real seeder or remove the collections + DI registrations to stop the false signal. |
+| MongoDB `yaml_knowledge` | DEAD (empty everywhere) | **CONSOLIDATE** | YamlKnowledgeSyncService exists but no host invokes it. Track A worktree wires this in; finish that work and run the sync once. |
+| FalkorDB + Graphiti service | UNKNOWN | **CONSOLIDATE** | Investigate what writes to it. If nothing in production paths, mark for delete. |
+| Qdrant container (`:6333`) | DEAD | **DELETE** | docker-compose runs it, no code references it. Drop from compose. |
+| OPTK backups (`optick.index.backup-2026-04-19-pre-jazz-fix`, `.v4-backup-2026-04-18`) | n/a | **CONSOLIDATE** | Define retention policy. Move stale ones out of `state/voicings/` to a long-term-archive subfolder. |
+| Database name drift (`guitar-alchemist` Aspire vs `guitaralchemist` docker-compose env) | DRIFT | **FIX** | Pick one, update both. |
+
+### RAG pipelines
+
+| Component | State | Disposition | Rationale |
+|---|---|---|---|
+| Voicing-grounded chat (NebulaSidekick → search_voicings tool → OPTK) | LIVE | **KEEP** | The only end-to-end-verified RAG path. |
+| Knowledge-grounded chat scaffolding (YAML → Mongo → PartitionedRagService) | HALF | **KEEP and complete** | Track A worktree is most of the way there but targets the wrong process. |
+| `PartitionedRagService.Theory` → `MusicTheoryRagService` (empty collection) | DEAD | **CONSOLIDATE** | Track A worktree fixes this by routing to `yaml_knowledge`. Adopt that fix. |
+| `RagEvaluationService` | DEAD (zero callers) | **CONSOLIDATE** | Either integrate into CI / a smoke job, or delete. |
+| `StructuredMusicalQuery` parser in `PartitionedRagService` | DEAD (never called) | **DELETE** | Regex-based query parser with no consumers. Remove or wire it up. |
+| Track A worktree (`agent-ae01d4370c1d35baa`) | HALF, NOT MERGED | **RETARGET** | Move agent-injection from GaChatbot/TheoryAgent to GaApi/NebulaSidekickService.Tools (add a `search_theory_knowledge` tool). Keep all the scaffolding (YamlKnowledgeRagService, bridge, hosted sync, DI). |
+
+### Frontends
+
+| Component | State | Disposition | Rationale |
+|---|---|---|---|
+| ga-client (React) | LIVE | **KEEP** | Canonical UI. |
+| ga-react-components | UNKNOWN | **CONSOLIDATE** | Library project; some routes referenced from ga-client. Clarify whether it's a stranded library or genuinely shared. If only ga-client consumes it, consider folding in. |
+| ga-dashboard (Angular 21) | UNKNOWN | **CONSOLIDATE** | Six routes hitting `/api/*`. Decide product status: separate dashboard, or absorb into ga-client. |
+| GaChatbot REPL | HALF | **CONSOLIDATE** with GaChatbotCli | Two CLI-shaped chat tools without a clear distinction. |
+| GaChatbotCli | UNKNOWN | **CONSOLIDATE** | Same. |
+| GuitarAlchemistChatbot | DEAD | **DELETE** | See Apps section. |
+| GaMcpServer | LIVE | **KEEP** | MCP tool server. |
+| `mcp-servers/meshy-ai` | UNTRACKED | **DECIDE** | Untracked Node TS project. Either commit or delete. |
+| `https://localhost:7001` default in `GaMcpServer/Program.cs:39` | DRIFT | **FIX** | Doesn't match GaApi's https profile (`:7184`). |
+
+### LLM providers
+
+| Component | State | Disposition | Rationale |
+|---|---|---|---|
+| MEAI `IChatClient` | LIVE in GaChatbot REPL, shim-only in GaApi | **KEEP** as the target abstraction | Forward-looking, multi-provider via env var. |
+| Legacy `IChatService` (Ollama / Claude / DockerModelRunner) | LIVE-ish | **CONSOLIDATE** | Three impls, selected by `AI:ChatProvider`. Migrate to IChatClient or accept they're frozen-legacy. |
+| `NebulaSidekickService` raw HTTP path | LIVE (canonical) | **DECIDE** | Bypasses both abstractions for tool-loop control. Either accept this as deliberate (and document why) or rebuild on IChatClient. |
+| `ClaudeChatService` | UNKNOWN | **DELETE** likely | If unused, drop. NebulaSidekick has its own Anthropic path. |
+| `OllamaChatService` (legacy) | UNKNOWN | **DELETE** likely | Same — NebulaSidekick has its own Ollama path. |
+| `DockerModelRunnerChatService` | UNKNOWN | **DELETE** likely | Niche; verify any consumer. |
+| Embedding providers | LIVE | **KEEP** | Ollama default; SimpleEmbeddingService for tests; ONNX/HF for offline. |
+| GitHub Models embedding (`NotImplementedException`) | DEAD | **DELETE** the registration | Throws when called. Either implement or remove. |
+| TTS — Voxtral (Mistral cloud) | UNKNOWN | **KEEP** | Per MEMORY.md, in active use. |
+| TTS — Kokoro-82M | UNKNOWN | **CONSOLIDATE** | Two TTS backends behind one controller. Pick canonical. |
+| "Theory Tribunal" multi-model orchestration | DEAD in C# | **CONSOLIDATE** | Per MEMORY.md it exists; per llm-providers.md it's only in the React frontend. Either build the C# orchestrator or stop referencing it as if it exists. |
+
+### Documentation sweep
+
+The following docs are pending move to `docs/archive/architecture-pre-2026-04/` (verify each first; some may have content not yet in the new docs).
+
+In `docs/architecture/`:
+- `ACTOR_MODEL.md`, `ACTOR_SYSTEM_FIX.md`, `ACTOR_SYSTEM_IMPLEMENTATION.md`, `ACTOR_SYSTEM_STATUS.md` — actor-system series, likely all superseded
+- `COMMON_FOLDER_REORGANIZATION_ANALYSIS.md`, `_EXECUTION.md`, `_PLAN.md` — completed refactor
+- `MODULAR_RESTRUCTURING_PLAN.md`, `MODULAR_RESTRUCTURING_PROGRESS.md` — completed refactor
+- `MONADIC_MICROSERVICES_GUIDE.md`, `_SUMMARY.md`, `MONADIC_SERVICES_REFACTORING_COMPLETE.md` — completed refactor
+- `MICROSERVICES_ANALYSIS.md`, `MICROSERVICES_IMPROVEMENTS_SUMMARY.md`, `FUNCTIONAL_MICROSERVICES.md` — superseded by `apps-and-processes.md`
+- `FRONTEND_CONSOLIDATION_STRATEGY.md` — read first; may have content to fold into `frontends.md`
+- `CODE_SHARING_ARCHITECTURE.md` — read first
+- `PIPELINE_STRATEGY.md` — read first
+- `DOMAIN_SCHEMA.md` — read first; may belong as a sibling
+- `service-inventory.md` — overlaps with `apps-and-processes.md`; reconcile then archive
+
+In `docs/`:
+- `ARCHITECTURE.md`, `CURRENT_ARCHITECTURE_2026.md`, `ARCHITECTURE_INVESTIGATION_2026-01.md`, `ARCHITECTURE_VALIDATION_2026.md` — superseded by `docs/architecture/README.md`
+- `MICROSERVICES_ARCHITECTURE.md` — superseded by `apps-and-processes.md`
+- `DOMAIN_ARCHITECTURE_REVIEW.md`, `DOMAIN_CONFIG_ARCHITECTURE.md`, `DOMAIN_CONTEXT_PROPOSAL.md` — read first; some may be current
+
+Each archived doc gets a one-line "Superseded by `docs/architecture/<doc>.md` (2026-04-25)" header at the top of its archived copy, so future readers landing via search know where the canonical content went.
+
+## Sequencing plan
+
+Suggested order, with each step independently shippable:
+
+1. **Land master + audit** (this PR). Decide on the audit's recommendations.
+2. **Documentation sweep** — `git mv` the legacy arch docs to archive. Add redirect headers. Low risk, high signal.
+3. **Delete `GuitarAlchemistChatbot` ghost** — remove three references. Verify `start-all.ps1` still works after.
+4. **Fix CLAUDE.md OPTIC-K drift** — one-line edit, removes a footgun for every future session.
+5. **Retarget Track A worktree** — move RAG injection from TheoryAgent to a NebulaSidekick tool (`search_theory_knowledge`). Run YAML sync once. Verify `/api/nebula/chat` answers a "what is a deceptive cadence" query with citations.
+6. **Resolve UNKNOWN apps** — for each row in the apps table marked CONSOLIDATE/UNKNOWN, decide keep-or-delete. Likely deletions: GaChatbot REPL or GaChatbotCli (pick one), AgUiChatController, ChatbotHub, three legacy IChatService impls, Qdrant container.
+7. **Pick LLM abstraction direction** — commit to one of: (a) migrate everything to MEAI IChatClient including NebulaSidekick, (b) accept NebulaSidekick's bypass as deliberate and document why, (c) freeze legacy IChatService and route everything new through (a) or (b).
+8. **Resolve database name drift** — `guitar-alchemist` vs `guitaralchemist` — pick one.
+
+Steps 1-4 are quick wins (~1 hour each). Step 5 is the unblocker for the original RAG-into-agents goal. Steps 6-8 are larger consolidation work and probably want their own session.
+
+## Open questions for human input
+
+- Is `Apps/ga-dashboard` (Angular) a separate product or pending consolidation into ga-client?
+- Are the six commented-out Aspire services (`// TODO: Uncomment when service implementation is complete`) on a roadmap or abandoned?
+- Should `GA.AI.Service` remain a separate microservice or fold into GaApi? (Affects Decision 6 and the ChatController question.)
+- Should `mcp-servers/meshy-ai` be committed and added to docker-compose, or deleted?
+- Does the React "Theory Tribunal" feature have a roadmap entry, or is it cosmetic?
+- Retention policy for OPTK index backups in `state/voicings/`?
+
+## Worktree disposition (Track A)
+
+Recommended action: **do not merge as-is, but do not abandon.** Reusable pieces (target-agnostic):
+
+- `GA.Data.MongoDB/Services/DocumentServices/Rag/YamlKnowledgeRagService.cs` — keep verbatim
+- `GA.Data.MongoDB/Extensions/ServiceCollectionExtensions.cs` registration — keep verbatim
+- `Common/GA.Business.ML/Rag/PartitionedRagService.cs` Theory→yaml_knowledge bridge — keep verbatim
+- `KnowledgeSyncHostedService` pattern — keep, move to GaApi instead of GaChatbot
+- `Apps/GaChatbot/Extensions/ServiceCollectionExtensions.cs` MongoDB+RAG wiring — port to GaApi DI
+
+Drop:
+- `TheoryAgent` constructor change — TheoryAgent is not on the canonical path. Replace with a NebulaSidekick tool that calls `IPartitionedRagService.QueryAsync(query, [Theory], 3)` and surfaces results to the LLM via the existing tool-loop pattern.
+
+Estimated retarget effort: 1-2 hours given the scaffolding is already written.

--- a/docs/architecture/chat-surfaces.md
+++ b/docs/architecture/chat-surfaces.md
@@ -1,0 +1,289 @@
+---
+title: Chat & Agent Surfaces
+scope: All HTTP/SignalR/GraphQL chat endpoints and the orchestrator/agent stack behind them
+status: authoritative
+last_verified: 2026-04-25
+parent: docs/architecture/README.md
+---
+
+# Chat & Agent Surfaces
+
+Authoritative map of every chat / agent entry point in the Guitar Alchemist solution. Sibling docs cover non-chat concerns (`apps-and-processes.md` for the full app inventory, `data-storage.md` for stores, `rag-pipeline.md` for the RAG corpus, `llm-providers.md` for provider configuration).
+
+Conventions used throughout:
+- Status tags: ✅ canonical, 🟡 parallel-to-canonical, 🪦 deprecated-candidate, ❓ unknown / unverified.
+- Verified canonical path (used by the production Harmonic Nebula UI): `NebulaChatController` → `NebulaSidekickService` → Anthropic Claude Haiku 4.5 (or Ollama).
+
+---
+
+## 1. HTTP chat endpoints (REST + GraphQL)
+
+| Route | Verb | Controller | App | Request shape | Response shape | Status | Notes |
+|---|---|---|---|---|---|---|---|
+| `/api/nebula/chat` | POST | `NebulaChatController.Chat` (`Apps/ga-server/GaApi/Controllers/NebulaChatController.cs:19`) | GaApi | `NebulaChatRequest { Message: string; History?: NebulaChatTurn[]; Context?: NebulaChatContext; Mode?: "fast" \| "scholar" }` | `NebulaChatReply { Reply: string; ToolCalls: NebulaToolCall[]; Error: string? }` | ✅ live, verified working | Single dependency: `NebulaSidekickService`. Returns `400` if `Message` is blank. Provider switches via `Nebula:Provider` (`anthropic` / `ollama`); `Mode = "scholar"` forces local frankenmerge model with no tool-use. |
+| `/api/chatbot/agui/json` | POST | `AgUiChatController.AgUiJson` (`Apps/ga-server/GaApi/Controllers/AgUiChatController.cs:45`) | GaApi | `RunAgentInput { ThreadId: string; RunId: string; Messages: AgUiMessage[]; State?: object }` (mirrors `@ag-ui/core`) | `{ answer; routing; candidates; filters; progression }` | 🟡 parallel-to-canonical | Non-streaming sibling of `/agui/stream`. Behind `ILlmConcurrencyGate`. Picks the **last** message with role `user`. |
+| `/api/chatbot/agui/stream` | POST | `AgUiChatController.AgUiStream` (`Apps/ga-server/GaApi/Controllers/AgUiChatController.cs:92`) | GaApi | `RunAgentInput` | `text/event-stream` — AG-UI SSE: `RUN_STARTED` → `STATE_SNAPSHOT` → text → `STEP_STARTED` → `CUSTOM` (`ga:diatonic`, `ga:scale`, `ga:candidates`, `ga:progression`) → `STATE_DELTA` → `RUN_FINISHED` (or `RUN_ERROR`). | 🟡 parallel-to-canonical | Hits `IHarmonicChatOrchestrator.AnswerStreamingAsync` (production binding = `ProductionOrchestrator`). Used by `<GAChatPanel>` mounted in `ga-react-components/src/main.tsx:358`. |
+| `/api/chatbot/skills` | GET | `AgUiChatController.ListSkills` (`Apps/ga-server/GaApi/Controllers/AgUiChatController.cs:33`) | GaApi | _(none)_ | `[ { Name, Description } ]` per registered `IOrchestratorSkill` | 🟡 metadata helper | Used by MCP / agent discovery. Not chat traffic per se. |
+| `/api/chatbot/chat/stream` | POST | `ChatbotController.ChatStream` (`Apps/ga-server/GaApi/Controllers/ChatbotController.cs:36`) | GaApi | `ChatRequest { Message: string [Required, MaxLen 2000]; ConversationHistory?: ChatMessage[]; UseSemanticSearch: bool = true }` (`Apps/ga-server/GaApi/Controllers/ChatRequest.cs:6`) | `text/event-stream`: first frame is `{"type":"routing", agentId, confidence, routingMethod}`, subsequent frames are sentence chunks (`Helpers.SseChunker.SplitIntoChunks`), final frame `data: [DONE]`. Errors delivered as `{ "error": "…" }` SSE frame. | 🟡 parallel-to-canonical | Pre-AG-UI streaming protocol. Backed by `ProductionOrchestrator.AnswerAsync` (NOT the streaming overload — text is split client-side after the full answer is generated). Behind `ILlmConcurrencyGate`. |
+| `/api/chatbot/chat` | POST | `ChatbotController.Chat` (`Apps/ga-server/GaApi/Controllers/ChatbotController.cs:119`) | GaApi | `ChatRequest` (same as above) | `ChatJsonResponse { NaturalLanguageAnswer; AgentId; Confidence; RoutingMethod; ElapsedMs; TraceId? }` (`ChatRequest.cs:15`) | 🟡 parallel-to-canonical | Non-streaming JSON for MCP tool callers. |
+| `/api/chatbot/status` | GET | `ChatbotController.GetStatus` (`Apps/ga-server/GaApi/Controllers/ChatbotController.cs:159`) | GaApi | _(none)_ | `ChatbotStatus { IsAvailable; Message; Timestamp }` (`Apps/ga-server/GaApi/Controllers/ChatbotStatus.cs:3`) | 🟡 health helper | Probes `IChatService.IsAvailableAsync` (Ollama by default). |
+| `/api/chatbot/examples` | GET | `ChatbotController.GetExamples` (`Apps/ga-server/GaApi/Controllers/ChatbotController.cs:177`) | GaApi | _(none)_ | `string[]` of canned prompts | 🟡 helper | Hard-coded list, no orchestrator hop. |
+| `/api/chatbot/ask` | POST | _(no controller)_ | GaApi (?) | unknown — frontend sends `{question?, query?}` (`ReactComponents/.../PrimeRadiant/TriageDropZone.tsx:82`) | _N/A_ | 🪦 deprecated-candidate / dangling | No matching server-side action found via grep across `Apps/ga-server/`. Frontend caller likely fails with 404 today. |
+| `/api/Chat` | POST | `GA.AI.Service.Controllers.ChatController.Chat` (`Apps/ga-server/GA.AI.Service/Controllers/ChatController.cs:14`) | **GA.AI.Service** (separate microservice) | `GA.Business.Core.Orchestration.Models.ChatRequest { Message; SessionId?; KeyContext?; History? }` (`Common/GA.Business.Core.Orchestration/Models/ChatModels.cs:11`) | `ChatResponse { NaturalLanguageAnswer; Candidates; Progression?; Routing?; QueryFilters?; DebugParams? }` (`ChatModels.cs:86`) | 🪦 deprecated-candidate | Service is **not started** by Aspire AppHost — `AddProject("ai-service", …)` is commented out at `AllProjects.AppHost/Program.cs:87`. Reachable only if launched manually. |
+| GraphQL `/graphql` chat mutations | _N/A_ | _N/A_ | GaApi | _(none)_ | _(none)_ | ❌ none exist | The HotChocolate schema is built from `Query` + four `TypeExtension`s only (`Apps/ga-server/GaApi/Program.cs:113-121`). Grep for `[Mutation]`, `MutationType`, `Subscription` in `Apps/ga-server/GaApi/GraphQL/**` returns no matches. |
+
+### Detail — `NebulaChatRequest` shape
+
+```csharp
+// Apps/ga-server/GaApi/Services/NebulaSidekickService.cs:595
+public sealed record NebulaChatRequest(
+    string Message,
+    List<NebulaChatTurn>? History,
+    NebulaChatContext? Context,
+    string? Mode = null);                      // "fast" | "scholar"
+
+public sealed record NebulaChatTurn(string Role, string Content);
+
+public sealed record NebulaChatContext(
+    NebulaSelectedVoicing? SelectedVoicing,
+    Dictionary<string, int>? InstrumentCounts);
+
+public sealed record NebulaSelectedVoicing(
+    string GlobalId, string ClusterId, string ClusterLabel,
+    string Instrument, string ChordName, string Family,
+    int[] Midi, string[] Frets, int[] PitchClasses);
+
+public sealed record NebulaChatReply(
+    string Reply,
+    List<NebulaToolCall> ToolCalls,
+    string? Error);
+
+public sealed record NebulaToolCall(string Name, string InputJson, string ResultJson);
+```
+
+Tool catalogue exposed to the model: `search_voicings`, `describe_selected_voicing`, `get_corpus_stats` — defined inline at `NebulaSidekickService.cs:414` (Anthropic shape) and `NebulaSidekickService.cs:450` (Ollama / OpenAI shape). Tool-loop budget = 6 iterations (`MaxToolIterations`).
+
+---
+
+## 2. SignalR hubs
+
+| Hub | Path | App | Methods | Status |
+|---|---|---|---|---|
+| `ChatbotHub` (`Apps/ga-server/GaApi/Hubs/ChatbotHub.cs:15`) | `/hubs/chatbot` (mapped at `Apps/ga-server/GaApi/Program.cs:404`) | GaApi | `SendMessage(string, bool useSemanticSearch = true)`, `ClearHistory()`, `GetHistory() : List<ChatMessage>`, `SearchKnowledge(string, int = 10) : List<SemanticSearchResult>`, `OnConnectedAsync`, `OnDisconnectedAsync`. Server pushes: `Connected`, `Error`, `MessageRoutingMetadata { agentId, confidence, routingMethod }`, `ReceiveMessageChunk(string)`, `MessageComplete(string)`. | 🟡 parallel-to-canonical (no frontend grep hit) |
+
+Per-connection conversation history kept in a static `ConcurrentDictionary<string, List<ChatMessage>>` capped at 50 messages; pipeline budget is `25s` (`ChatbotHub.cs:24`). Uses `[Authorize]` and `ILlmConcurrencyGate`. Backed by `ProductionOrchestrator` + `ChatbotSessionOrchestrator` for history normalisation.
+
+Other hubs (`PipelineHub`, `GovernanceHub`) handle non-chat traffic and are out of scope here.
+
+---
+
+## 3. Agent orchestrators
+
+| Orchestrator | Where used | Inputs | Outputs | Status |
+|---|---|---|---|---|
+| `NebulaSidekickService` (`Apps/ga-server/GaApi/Services/NebulaSidekickService.cs:21`) | `NebulaChatController` only | `NebulaChatRequest` + `CancellationToken` | `NebulaChatReply` | ✅ canonical for the Harmonic Nebula UI. Holds its own long-timeout `HttpClient` (5 min) to bypass the default Polly 30s timeout. Three providers: `anthropic` (Claude Haiku 4.5), `ollama` (default, OpenAI-shape tool_calls), and `scholar` mode (Ollama, no tools, big system prompt). |
+| `ProductionOrchestrator` (`Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs:18`) | `ChatbotController` (REST), `ChatbotHub` (SignalR), `AgUiChatController` (AG-UI) — registered by `AddChatbotOrchestration()` (`Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs:23`) and resolved as `IHarmonicChatOrchestrator`. Also wired into `GaChatbotCli` (`Apps/GaChatbotCli/Program.cs:55`). | `ChatRequest` (orchestration model), optional streaming callback | `ChatResponse` (with `Routing`, `QueryFilters`, `Candidates`, `Progression`) | ✅ canonical for the agentic stack (theory/tab/etc.). Pipeline: hooks → fast-path skills (`IOrchestratorSkill`) → parallel `QueryUnderstandingService` + `SemanticRouter` → tab/path-optimization branch _or_ `TabAwareOrchestrator`. Persists turns via `ConversationHistoryStore`. |
+| `TabAwareOrchestrator` (`Common/GA.Business.Core.Orchestration/Services/TabAwareOrchestrator.cs:12`) | Called by `ProductionOrchestrator` for non-skill, non-tab paths | `ChatRequest` | `ChatResponse` | ✅ canonical sub-orchestrator. Detects ASCII tablature via `TabTokenizer` and either routes to `tabAnalyzer` + `presenter` or delegates to `SpectralRagOrchestrator`. |
+| `SpectralRagOrchestrator` (`Common/GA.Business.Core.Orchestration/Services/SpectralRagOrchestrator.cs:18`) | Called by `TabAwareOrchestrator` for knowledge queries; also implements `IHarmonicChatOrchestrator` directly | `ChatRequest` | `ChatResponse` (with grounded `Candidates`) | ✅ canonical voicing-grounded path. Steps: staleness check → comparison shortcut → identity lookup → chord parser → embedding gen → `SpectralRetrievalService.Search` → `IGroundedNarrator.NarrateAsync` (production binding = `OllamaGroundedNarrator`) → progression extraction. |
+| `ChatbotSessionOrchestrator` (`Apps/ga-server/GaApi/Services/ChatbotSessionOrchestrator.cs:14`) | Used by `ChatbotHub.SendMessage` for `NormalizeHistory` only; broader `GetResponseAsync`/`StreamResponseAsync` paths register but no controller invokes them | `ChatSessionRequest { Message; ConversationHistory?; UseSemanticSearch }` | `string` (full) or `IAsyncEnumerable<string>` (stream) | 🟡 partially used. Owns its own `IChatService`-based prompt-construction pipeline that bypasses `ProductionOrchestrator` entirely (semantic search → system prompt → `IChatService.ChatStreamAsync`). Currently a vestigial parallel path. |
+| `SemanticRouter` (`Common/GA.Business.ML/Agents/SemanticRouter.cs:17`) | Injected into `ProductionOrchestrator` and `AgentCoordinator` | `query: string` (or `AgentRequest`) | `RoutingResult { SelectedAgent, Confidence, AllScores, RoutingMethod }`; also `ProcessAsync`, `AggregateAsync` (parallel fan-out), `DebateAsync` (top-2 with `CriticAgent` adjudication) | ✅ canonical router. Three-tier strategy: cached agent-description embeddings (cosine, threshold 0.85) → LLM router (threshold 0.6) → keyword fallback. Optional `IRoutingFeedback` learned-bias overlay. Memory cache for query embeddings (256 entries, 5 min sliding TTL). |
+
+`ChatbotSessionOrchestrator.NormalizeHistory` is the only method called from production today (`ChatbotHub.cs:74`); the rest of the class is dead-code-adjacent.
+
+---
+
+## 4. Specialized agents
+
+All concrete subclasses of `GuitarAlchemistAgentBase` (`Common/GA.Business.ML/Agents/GuitarAlchemistAgentBase.cs:26`). Base class signature: `(IChatClient chatClient, ILogger logger)`; `IChatClient` is `Microsoft.Extensions.AI.IChatClient`. The production `IChatClient` binding in GaApi is `OllamaChatClientAdapter` (`Apps/ga-server/GaApi/Extensions/AIServiceExtensions.cs:102`).
+
+| Agent | Class | Purpose | Constructor deps | Currently invoked from | Status |
+|---|---|---|---|---|---|
+| Theory | `TheoryAgent` (`Common/GA.Business.ML/Agents/TheoryAgent.cs:20`) | Pitch-class set analysis, harmonic function, key/mode detection, voice leading. Uses `ChatWithCritiqueAsync` (3-pass draft → critique → refine). | `IChatClient`, `ILogger<TheoryAgent>` | `SemanticRouter` (selected when `AgentIds.Theory` wins) | ✅ live |
+| Tab | `TabAgent` (`Common/GA.Business.ML/Agents/TabAgent.cs:20`) | ASCII tab parsing, fret/string extraction, tab-to-pitch conversion. Heuristic `ContainsTabNotation` switches prompt. | `IChatClient`, `ILogger<TabAgent>` | `SemanticRouter`; also `ProductionOrchestrator` short-circuits to `HandleTabAnalysisAsync` (uses `TabAnalysisService`, not the LLM agent) when the agent ID matches **and** `filters.Intent in {AnalyzeTab, OptimizePath}` | 🟡 partly bypassed by deterministic tab pipeline |
+| Technique | `TechniqueAgent` (`Common/GA.Business.ML/Agents/SpecializedAgents.cs:8`) | Fingering validation, ergonomics, barre optimisation, playability scoring. | `IChatClient`, `ILogger<TechniqueAgent>` | `SemanticRouter` | ✅ live |
+| Composer | `ComposerAgent` (`Common/GA.Business.ML/Agents/SpecializedAgents.cs:70`) | Reharmonization, substitutions, progression generation. Delegates key-context queries to `TheoryAgent` via `IAgentCoordinator`. | `IChatClient`, `ILogger<ComposerAgent>` | `SemanticRouter` | ✅ live |
+| Critic | `CriticAgent` (`Common/GA.Business.ML/Agents/SpecializedAgents.cs:153`) | Contradiction detection, accuracy/consistency scoring, improvement suggestions. | `IChatClient`, `ILogger<CriticAgent>` | `SemanticRouter` (direct routing) and `SemanticRouter.DebateAsync` adjudication path | ✅ live |
+| Voicing | `VoicingAgent` (`Common/GA.Business.ML/Agents/VoicingAgent.cs:19`) | OPTIC-K voicing retrieval by chord/mode/tag. Encodes intent via `MusicalQueryEncoder` → 112-dim compact vector → `EnhancedVoicingSearchService`. Returns ranked diagrams; **does not necessarily call the LLM** for fully-structured queries. | `IChatClient`, `ILogger<VoicingAgent>`, `EnhancedVoicingSearchService`, `IMusicalQueryExtractor`, `MusicalQueryEncoder` | `SemanticRouter` (when `AgentIds.Voicing` wins) | ✅ live |
+
+Agent IDs: `AgentIds.{Tab, Theory, Technique, Composer, Critic, Voicing}` (`Common/GA.Business.ML/Agents/AgentConstants.cs`).
+
+Streaming: only `GuitarAlchemistAgentBase.ProcessStreamingAsync` (line 178) yields tokens. `ProductionOrchestrator.AnswerStreamingAsync` (`ProductionOrchestrator.cs:134-153`) takes the streaming path **only** when the selected agent is a `GuitarAlchemistAgentBase` AND the request is not a tab/path-optimization intent — otherwise it word-splits the final answer to simulate streaming.
+
+---
+
+## 5. `IChatService` implementations
+
+`IChatService` (`Apps/ga-server/GaApi/Services/IChatService.cs:3`) is the **GaApi-local** abstraction used by `ChatbotSessionOrchestrator` and surfaced via `ChatbotController.GetStatus`. Selection happens at startup in `Apps/ga-server/GaApi/Extensions/AIServiceExtensions.cs:92-99` based on the `AI:ChatProvider` config key.
+
+| Implementation | Backend | When selected | Path |
+|---|---|---|---|
+| `OllamaChatService` | Local Ollama HTTP `/api/chat` (named HttpClient `Ollama`, model from `Ollama:ChatModel` or `ChatbotOptions.Model`, default `llama3.2:3b`). Streaming JSON-lines. | `AI:ChatProvider` ∉ {claude, docker} (default) | `Apps/ga-server/GaApi/Services/OllamaChatService.cs:13` |
+| `ClaudeChatService` | Anthropic SDK `MessagesService.CreateStreaming` (default model `claude-haiku-4-5-20251001`). Reads `Anthropic:ApiKey` or `ANTHROPIC_API_KEY`. | `AI:ChatProvider == "claude"` | `Apps/ga-server/GaApi/Services/ClaudeChatService.cs:12` |
+| `DockerModelRunnerChatService` | Docker Desktop's OpenAI-compatible `/v1/chat/completions` on port 12434 (default model `docker.io/ai/llama3.2:latest`). | `AI:ChatProvider == "docker"` | `Apps/ga-server/GaApi/Services/DockerModelRunnerChatService.cs:16` |
+
+Important: `IChatService` is **not** the same channel as the `IChatClient` (Microsoft.Extensions.AI) used by the specialized agents. GaApi registers `IChatClient` as `OllamaChatClientAdapter` regardless of `AI:ChatProvider` (`AIServiceExtensions.cs:102`). The Nebula pipeline bypasses both interfaces and talks to providers directly via its own `HttpClient`.
+
+---
+
+## 6. Frontend consumers
+
+| Caller (file) | Endpoint | Notes |
+|---|---|---|
+| `<NebulaChat>` (`ReactComponents/ga-react-components/src/components/NebulaChat.tsx:64`) | `POST /api/nebula/chat` | Mounted by `HarmonicNebulaDemo` (`ReactComponents/ga-react-components/src/pages/HarmonicNebulaDemo.tsx:1707`). Sends `{ message, mode, history, context: { selectedVoicing, instrumentCounts } }`. Renders `reply` and surfaces `toolCalls` for inspection. Verified working 2026-04-21. |
+| `<GAChatPanel agentUrl={…/api/chatbot/agui/stream}>` (`ReactComponents/ga-react-components/src/main.tsx:358`) | `POST /api/chatbot/agui/stream` | Wraps the AG-UI SSE protocol. Parses `TEXT_MESSAGE_CONTENT`, `CUSTOM` (`ga:diatonic`), `RUN_ERROR` events (`Apps/ga-client/src/services/agUiChatService.ts:88`). |
+| `Apps/ga-client/src/store/chatAtoms.ts:110` (Jotai send-message atom) | `POST /api/chatbot/agui/stream` | Drives the ga-client React UI's chat composer. |
+| `Apps/ga-client/src/services/chatApi.ts` (`ChatApiService.streamChat`, `sendMessage`, `checkStatus`, `getExamples`) | `POST /api/chatbot/chat/stream`, `POST /api/chatbot/chat`, `GET /api/chatbot/status`, `GET /api/chatbot/examples` | Pre-AG-UI SSE protocol still imported by some ga-client surfaces. Singleton exported as `chatApi`. |
+| `Apps/ga-client/src/services/chatService.ts:94` (`sendChatMessageStream`) | `POST /api/chatbot/chat/stream` | Same protocol, alternate functional API. |
+| `<ChatWidget>` (`ReactComponents/ga-react-components/src/components/PrimeRadiant/ChatWidget.tsx:917`) | `POST /api/chatbot/chat` | Non-streaming. Used inside the Prime Radiant operator console. |
+| `<TriageDropZone>` (`ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx:82`) | `POST /api/chatbot/ask` | **No matching server endpoint exists.** Likely 404 today — see Open Questions. |
+| `<ForceRadiant>` (`…/PrimeRadiant/ForceRadiant.tsx:3502`), `HealthBindingEngine.ts:198` | `GET/HEAD /api/chatbot/status` | Health probe only. |
+| Apps/GaChatbot Console (`Apps/GaChatbot/Program.cs:25`) | _(no HTTP)_ | In-process: instantiates `ProductionOrchestrator` directly via DI and calls `AnswerAsync`. Console REPL. |
+| Apps/GaChatbotCli (`Apps/GaChatbotCli/Program.cs:55,91`) | _(no HTTP)_ | In-process: resolves `IHarmonicChatOrchestrator` (= `ProductionOrchestrator`) via DI. Single-shot or `--interactive` REPL. JSON output mode for tooling. |
+| Apps/ga-dashboard (`Apps/ga-dashboard/src/app/chat/chat.component.ts`) | `(grep hit; not deeply audited here)` | Angular shell. Not on the critical path for 2026-04 work. |
+| `Apps/GA.AI.Service/Controllers/ChatController` | _(no caller found)_ | The microservice itself isn't started by the Aspire AppHost (commented at `AllProjects.AppHost/Program.cs:87`), so no live consumer is reachable through the standard dev flow. |
+
+`Apps/GaChatbot` Blazor pages: **none found** under `Apps/GaChatbot/**/*.razor`. The `GaChatbot` project is a console host, not a Blazor app — earlier MEMORY notes about "Blazor in-process chat" are stale.
+
+---
+
+## 7. Canonical-vs-redundant analysis
+
+| Functional cluster | Canonical path | Parallels / redundancies |
+|---|---|---|
+| **HTTP endpoint serving the Harmonic Nebula React UI** | ✅ `POST /api/nebula/chat` → `NebulaChatController` → `NebulaSidekickService` → Anthropic Claude Haiku 4.5 (`ANTHROPIC_API_KEY`) or local Ollama tool-loop. | None — only `NebulaChat.tsx` consumes this route. |
+| **HTTP endpoint serving the legacy ga-client / Prime Radiant chat UIs** | ✅ AG-UI: `POST /api/chatbot/agui/stream` → `AgUiChatController.AgUiStream` → `IHarmonicChatOrchestrator.AnswerStreamingAsync` (= `ProductionOrchestrator`). | 🟡 `POST /api/chatbot/chat/stream` (`ChatbotController`) — same orchestrator backend, different SSE shape; still consumed by `chatApi.ts` + `chatService.ts`. 🟡 `POST /api/chatbot/agui/json` — non-streaming sibling, same orchestrator, used by MCP / agent callers. 🟡 `POST /api/chatbot/chat` — non-streaming sibling, same orchestrator, used by `<ChatWidget>`. |
+| **In-process chat for console / CLI** | ✅ `IHarmonicChatOrchestrator` (= `ProductionOrchestrator`) resolved via DI in `GaChatbotCli` and `GaChatbot`. | None notable — both apps share the same `AddChatbotOrchestration` registrations. |
+| **AG-UI protocol bridge** | ✅ `AgUiChatController` (`/agui/stream` for SSE, `/agui/json` for non-streaming). | None (single implementation). |
+| **SignalR streaming chat** | 🟡 `ChatbotHub` at `/hubs/chatbot` — same `ProductionOrchestrator` backend, but no JS/TS frontend hits the hub today (`signalR`/`hubConnection` greps return zero matches under `Apps/`). | 🪦 deprecated-candidate unless a consumer is reintroduced. |
+| **GraphQL chat mutation** | ❌ none defined; `GaApi/Program.cs:113-121` registers Query types only. | _N/A_ |
+| **`IChatService` (GaApi-local)** | ✅ used by `ChatbotSessionOrchestrator.NormalizeHistory` and `ChatbotController.GetStatus` only. Provider chosen via `AI:ChatProvider`. | 🟡 `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` exist but are not called from any controller or hub today. |
+| **Specialized agent invocation** | ✅ via `SemanticRouter.RouteAsync` (called by `ProductionOrchestrator`). | 🟡 `SemanticRouter.AggregateAsync` and `DebateAsync` exist but are not currently exposed through any HTTP/SignalR surface. |
+| **Voicing-grounded retrieval inside chat** | ✅ `SpectralRagOrchestrator` reached via `TabAwareOrchestrator`. | 🟡 `VoicingAgent` performs an independent OPTIC-K retrieval path through `EnhancedVoicingSearchService` whenever the router selects it — produces a structured-list response rather than a narrated one. Two independent retrieval surfaces over the same corpus. |
+| **GA.AI.Service / `POST /api/Chat`** | _N/A_ | 🪦 deprecated-candidate — service not in the AppHost composition; `ChatController` still resolves `ProductionOrchestrator` so it would work standalone, but no client is wired to it. |
+| **`POST /api/chatbot/ask`** | _N/A_ | 🪦 dangling frontend call (TriageDropZone) with no server implementation. |
+
+---
+
+## 8. Topology diagram
+
+```mermaid
+flowchart LR
+    %% ── Frontends ──────────────────────────────────────────────
+    subgraph Frontends
+        NB["NebulaChat.tsx<br/>(HarmonicNebulaDemo)"]
+        GAP["GAChatPanel<br/>(ga-react-components/main.tsx)"]
+        GACL["ga-client chat<br/>(chatAtoms / agUiChatService)"]
+        CHATAPI["chatApi.ts /<br/>chatService.ts"]
+        CW["PrimeRadiant ChatWidget"]
+        TDZ["PrimeRadiant TriageDropZone"]
+        CLI["GaChatbotCli /<br/>GaChatbot console"]
+    end
+
+    %% ── HTTP / SignalR endpoints ───────────────────────────────
+    subgraph "GaApi endpoints"
+        NEB["POST /api/nebula/chat ✅"]
+        AGS["POST /api/chatbot/agui/stream ✅"]
+        AGJ["POST /api/chatbot/agui/json 🟡"]
+        CCS["POST /api/chatbot/chat/stream 🟡"]
+        CC["POST /api/chatbot/chat 🟡"]
+        ASK["POST /api/chatbot/ask 🪦"]
+        STAT["GET /api/chatbot/status 🟡"]
+        HUB["SignalR /hubs/chatbot 🟡"]
+    end
+
+    subgraph "GA.AI.Service (not in AppHost)"
+        AICHAT["POST /api/Chat 🪦"]
+    end
+
+    %% ── Orchestrators ──────────────────────────────────────────
+    subgraph Orchestrators
+        NSS["NebulaSidekickService ✅"]
+        PROD["ProductionOrchestrator ✅"]
+        TAB["TabAwareOrchestrator ✅"]
+        RAG["SpectralRagOrchestrator ✅"]
+        SESS["ChatbotSessionOrchestrator 🟡"]
+        ROUTE["SemanticRouter ✅"]
+    end
+
+    %% ── Agents ─────────────────────────────────────────────────
+    subgraph Agents
+        TH["TheoryAgent ✅"]
+        TA["TabAgent 🟡"]
+        TQ["TechniqueAgent ✅"]
+        CO["ComposerAgent ✅"]
+        CR["CriticAgent ✅"]
+        VO["VoicingAgent ✅"]
+    end
+
+    %% ── IChatService / IChatClient ─────────────────────────────
+    subgraph "Chat backends"
+        ICS["IChatService<br/>(Ollama / Claude / Docker)"]
+        ICC["IChatClient<br/>(OllamaChatClientAdapter)"]
+        ANTHTTP["Anthropic API<br/>(direct HttpClient)"]
+        OLLAMA["Ollama HTTP /api/chat"]
+    end
+
+    %% ── Wiring ─────────────────────────────────────────────────
+    NB --> NEB --> NSS
+    NSS -->|provider=anthropic / scholar| ANTHTTP
+    NSS -->|provider=ollama / scholar| OLLAMA
+
+    GAP --> AGS
+    GACL --> AGS
+    AGS --> PROD
+    AGJ --> PROD
+
+    CHATAPI --> CCS
+    CHATAPI --> CC
+    CHATAPI --> STAT
+    CW --> CC
+    TDZ -.dangling.-> ASK
+
+    CCS --> PROD
+    CC --> PROD
+    HUB --> PROD
+    HUB --> SESS
+
+    CLI --> PROD
+    AICHAT --> PROD
+
+    PROD --> ROUTE
+    ROUTE --> TH
+    ROUTE --> TA
+    ROUTE --> TQ
+    ROUTE --> CO
+    ROUTE --> CR
+    ROUTE --> VO
+
+    PROD --> TAB
+    TAB --> RAG
+
+    SESS --> ICS
+    STAT --> ICS
+
+    TH --> ICC
+    TA --> ICC
+    TQ --> ICC
+    CO --> ICC
+    CR --> ICC
+    VO --> ICC
+
+    ICC --> OLLAMA
+    ICS --> OLLAMA
+    ICS -.AI:ChatProvider=claude.-> ANTHTTP
+```
+
+---
+
+## 9. Open questions (unverified claims)
+
+- Is `Apps/GaChatbot` (console REPL) still reachable in the Aspire `start-all` flow? `AllProjects.AppHost/Program.cs:135` adds a different project (`GuitarAlchemistChatbot.csproj`); the `Apps/GaChatbot` project appears to be a separate console host that is never started by Aspire.
+- Does `AgUiChatController` have any active frontend consumer beyond `<GAChatPanel>` and the ga-client `chatAtoms`? Confirm whether the legacy SSE endpoints (`/chat/stream`, `/chat`) can be retired.
+- Does any client connect to `ChatbotHub` (`/hubs/chatbot`)? Grep for `signalR`/`hubConnection` under `Apps/` returns zero matches; the hub may be dead today.
+- `POST /api/chatbot/ask` is called by `TriageDropZone` but no controller action implements it — does this fail silently or is it served by a route fallback elsewhere?
+- Is `GA.AI.Service` (whose `ChatController` shadows `ProductionOrchestrator` directly) ever launched in CI/dev? AppHost registration is commented out (`AllProjects.AppHost/Program.cs:87`); confirm no other entry point spins it up.
+- `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` are registered but not invoked from any controller. Should they be removed, or are they intended for an upcoming SignalR/REST surface?
+- `SemanticRouter.AggregateAsync` and `DebateAsync` (multi-agent fan-out / Critic adjudication) are implemented but no HTTP endpoint exposes them. Plan to surface, or dead code?
+- The Nebula tool `get_corpus_stats` falls back to a hard-coded `{guitar=667125, bass=12614, ukulele=8612}` distribution when `InstrumentCounts` is missing from context (`NebulaSidekickService.cs:545`). Does the React frontend ever populate `instrumentCounts`, or is the fallback the only value the LLM ever sees?
+- `ProductionOrchestrator.AnswerStreamingAsync` only true-streams when the selected agent is a `GuitarAlchemistAgentBase`; tab/path branches and skill fast-paths emit word-level simulated tokens. Is this intentional given the AG-UI contract that frontends interpret as token streaming?
+- `NebulaSidekickService` constructs its own `HttpClient` with a 5-min timeout to bypass Polly. Is this still required, or can a named `HttpClient` with a configured policy replace it?


### PR DESCRIPTION
## Summary

Two unrelated chores bundled — both pure cleanup, neither touches code.

### 1. Track 4 architecture docs that fell through the cracks

Authored 2026-05-02, referenced from `CLAUDE.md`, but never `git add`-ed:

- `docs/architecture/README.md` (131 lines) — master index
- `docs/architecture/apps-and-processes.md` (209 lines) — runnable-process inventory
- `docs/architecture/audit-2026-04-25.md` (187 lines) — Keep/Consolidate/Delete decisions
- `docs/architecture/chat-surfaces.md` (289 lines) — chat endpoint + orchestrator stack

These are the canonical replacement for the 28 stale architecture docs PR #58 archived yesterday.

### 2. Stop tracking subset slnx experiments + .claude-octopus

- `/*.slnx` with `!/AllProjects.slnx` allows the canonical solution but ignores all subset experiments (`application`, `businessconfig`, `businesscore`, `core-only`, `domaincore*`, `mongo-only`, `subset-root`, `subset-test`, etc.) — Codex agents create these when restoring partial graphs.
- `.claude-octopus/` — per-machine session state.

## What this PR does NOT do

- Does not touch other untracked WIP (`Apps/GaQaCli/`, `Common/GA.Business.ML/Quality/*`, ChatbotGoldenPromptTests, etc.)
- Does not auto-commit `.env.example` or test files in `Apps/ga-client/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)