### PR TITLE
test(tabs): pin prose-vs-tab boundary on TabTokenizer

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Tabs/TabTokenizerTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Tabs/TabTokenizerTests.cs
@@ -135,30 +135,49 @@ E|--10---|
             $"Prose prompt should not produce note-bearing slices: {prompt}");
     }
 
-    [Test]
-    public void Tokenize_AlgebraQueryWithNumericPitchClassSets_KnownLimitation()
+    [TestCase("Are 0146 and 0137 z-related?",
+        Description = "Pitch-class-set notation in algebra queries — matches via bare-digit path")]
+    [TestCase("Explain 12-bar blues form",
+        Description = "Common theory question — '12-b' matches digit+dash+b at length 4")]
+    [TestCase("Released --12-04-- last week.",
+        Description = "Dates / version strings with hyphens trip the same regex")]
+    public void Tokenize_BareDigitProseInputs_KnownLimitation(string input)
     {
         // KNOWN LIMITATION (documented, not a bug to silently regress):
         // The TabLineRegex `([A-Ga-g]?[#b]?\|?|\|)[-0-9|hbp/\\svx~]+` allows
         // every part of group 1 to be optional, so a bare digit run matches.
-        // Pitch-class-set notation like "0146" or "0137" therefore tokenizes
-        // as if it were single-string tab. Real fix is to require either a
-        // string-name letter OR a literal pipe in group 1; doing so without
-        // breaking real tabs that lack string-name prefixes (the Tokenize_
-        // SingleLineThatLooksLikeTab_StillNeedsMultipleStrings case)
-        // requires care, so this is parked.
+        // Pitch-class-set notation like "0146", "12-bar form", and hyphenated
+        // dates therefore all tokenize as if they were single-string tab.
+        // Real fix is to require either a string-name letter OR a literal
+        // pipe in group 1; doing so without breaking real tabs that lack
+        // string-name prefixes (the
+        // Tokenize_AnonymousRowTabWithoutStringNamePrefix_ProducesNoteSlices
+        // positive control) requires care, so this is parked.
         //
         // Upstream guard: any orchestrator that gates on
         // `Tokenize(message).Any(b => b.Slices.Any(s => s.Notes.Any()))`
-        // will treat algebra prompts as tab. Those orchestrators must
-        // either consult a complementary signal (algebra-intent classifier)
-        // OR reject single-block, single-slice tokenizations as
-        // ambiguous prose.
-        var blocks = _tokenizer.Tokenize("Are 0146 and 0137 z-related?");
+        // will treat these prompts as tab. Those orchestrators must either
+        // consult a complementary signal (algebra-intent classifier, or a
+        // refined tokenizer that requires multi-string blocks) OR reject
+        // single-block, single-slice tokenizations as ambiguous prose.
+        //
+        // Test design rationale (per PR #110 review): we *document* current
+        // behaviour with TestContext.WriteLine + Assert.Pass rather than
+        // pinning Is.True. A future regex tightening can remove these cases
+        // when they start returning Is.False; but unrelated ProcessBlock
+        // refactors that incidentally drop single-slice blocks won't
+        // produce a misleading "regression" failure here.
+        var blocks = _tokenizer.Tokenize(input);
         var hasNotes = blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0));
 
-        Assert.That(hasNotes, Is.True,
-            "Documenting current behaviour. Flip this assertion when the tokenizer is tightened to require a pipe or string-name letter.");
+        TestContext.WriteLine(
+            $"Input: {input}\n" +
+            $"  blocks={blocks.Count}, hasNotes={hasNotes} (current behaviour)");
+        Assert.Pass(
+            $"Documented limitation; current behaviour: hasNotes={hasNotes}. " +
+            "When the tokenizer is tightened to reject bare-digit prose, " +
+            "convert this to Assert.That(hasNotes, Is.False) and remove the " +
+            "inputs that no longer trigger the bug.");
     }
 
     [TestCase("Use a G chord then an A chord, then back to G.",
@@ -167,10 +186,19 @@ E|--10---|
         Description = "Mentions fret numbers in prose — no pipes, no tab grid")]
     [TestCase("The chord progression I-V-vi-IV is common in pop music.",
         Description = "Roman numerals + general theory talk")]
-    [TestCase("Compare voicing 0-2-2-1-0-0 to 0-2-2-2-0-0",
-        Description = "Hyphen-separated frets in prose — but no string-name pipe markers")]
     public void Tokenize_ProseWithChordOrFretReferences_HasNoNoteSlices(string prose)
     {
+        // Per PR #110 review: removed the "Compare voicing 0-2-2-1-0-0..." case
+        // from this fixture because it passed for the WRONG reason. The
+        // tokenizer regex matches at offset 8 ('v' of "voicing", which is in
+        // the tab-content character class) with length 1 — failing the
+        // `match.Length > 3` gate, so no block accumulates. The hyphen-fret
+        // run later in the string never gets evaluated. The case was meant
+        // to show "hyphen-separated frets aren't tab" but actually
+        // demonstrates "leading prose with sub-3-char regex match short-
+        // circuits". The bare-digit/hyphen failure mode is now covered
+        // explicitly and at the right layer in
+        // Tokenize_BareDigitProseInputs_KnownLimitation.
         var blocks = _tokenizer.Tokenize(prose);
 
         Assert.That(blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0)), Is.False,
@@ -223,6 +251,36 @@ E|--10---|
         // current behaviour. If someone tightens the tokenizer to require
         // multi-string blocks, they should update this test deliberately.
         Assert.Pass($"Documented behaviour: blocks={blocks.Count}, hasNotes={hasNotes}");
+    }
+
+    [Test]
+    public void Tokenize_AnonymousRowTabWithoutStringNamePrefix_ProducesNoteSlices()
+    {
+        // Positive control added per PR #110 review. Many real-world tabs
+        // published on forums omit string-name prefixes entirely:
+        //
+        //     ---3-----0-----|
+        //     -----2-----0---|
+        //     ------0-----0--|
+        //
+        // These rely on Group 1's optionality: the regex matches starting
+        // at the leading dash via empty Group 1 + Group 2 spanning the
+        // dashes/digits. ANY future tightening of Group 1 to require a
+        // string-name letter OR a literal pipe must NOT break this case
+        // — that's why the fix proposed in the bare-digit known-limitation
+        // comment is non-trivial. This test fails LOUDLY if such a fix
+        // is naively applied without preserving anonymous-row support.
+        var input = @"
+---3-----0-----|
+-----2-----0---|
+------0-----0--|
+";
+
+        var blocks = _tokenizer.Tokenize(input);
+
+        Assert.That(blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0)), Is.True,
+            "Anonymous-row tab (no string-name prefix) must still tokenize. " +
+            "If you tightened TabLineRegex Group 1, this is the case you broke.");
     }
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Tabs/TabTokenizerTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Tabs/TabTokenizerTests.cs
@@ -87,4 +87,166 @@ E|--10---|
             Assert.That(aString?.Fret, Is.EqualTo(12));
         });
     }
+
+    // ── Prose-vs-tab boundary ──────────────────────────────────────────────
+    //
+    // Every "should I dispatch to tab analysis?" check upstream
+    // (orchestrators, intent routers, semantic dispatch) eventually grounds
+    // out in `tokenizer.Tokenize(message).Any(b => b.Slices.Any(s => s.Notes.Any()))`.
+    // If the tokenizer thinks prose is tab, the user gets the canned
+    // "I detected tab but couldn't parse any chords." fallback for theory
+    // questions — exactly the misroute we hit on /chatbot/ for
+    // "Explain voice leading in jazz".
+    //
+    // These tests pin the negative contract: plain English, including
+    // English with stray pipes, chord names, fret numbers, or markdown
+    // tables, MUST tokenize to zero note-bearing slices.
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("\n\n  \n\t\n")]
+    public void Tokenize_EmptyOrWhitespace_ReturnsNoBlocks(string input)
+    {
+        var blocks = _tokenizer.Tokenize(input);
+        Assert.That(blocks, Is.Empty);
+    }
+
+    [TestCase("Explain voice leading in jazz")]
+    [TestCase("Show me some easy beginner chords")]
+    [TestCase("What are the modes of the major scale?")]
+    [TestCase("Generate a mellow ii-V-I in C")]
+    [TestCase("How do I make this progression sound darker?")]
+    public void Tokenize_ChatbotExamplePrompts_HaveNoNoteSlices(string prompt)
+    {
+        // The 5 prompts surfaced by /api/chatbot/examples. These regress the
+        // production bug where the LLM filter extractor mis-tagged prose as
+        // Intent=AnalyzeTab and the orchestrator dispatched to tab analysis.
+        // The tokenizer is the ultimate source of truth — none of these
+        // contain tab.
+        //
+        // The default textarea seed "Are 0146 and 0137 z-related?" is
+        // covered separately in
+        // Tokenize_AlgebraQueryWithNumericPitchClassSets_KnownLimitation
+        // because pitch-class-set notation collides with the bare-digit
+        // path in TabLineRegex.
+        var blocks = _tokenizer.Tokenize(prompt);
+
+        Assert.That(blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0)), Is.False,
+            $"Prose prompt should not produce note-bearing slices: {prompt}");
+    }
+
+    [Test]
+    public void Tokenize_AlgebraQueryWithNumericPitchClassSets_KnownLimitation()
+    {
+        // KNOWN LIMITATION (documented, not a bug to silently regress):
+        // The TabLineRegex `([A-Ga-g]?[#b]?\|?|\|)[-0-9|hbp/\\svx~]+` allows
+        // every part of group 1 to be optional, so a bare digit run matches.
+        // Pitch-class-set notation like "0146" or "0137" therefore tokenizes
+        // as if it were single-string tab. Real fix is to require either a
+        // string-name letter OR a literal pipe in group 1; doing so without
+        // breaking real tabs that lack string-name prefixes (the Tokenize_
+        // SingleLineThatLooksLikeTab_StillNeedsMultipleStrings case)
+        // requires care, so this is parked.
+        //
+        // Upstream guard: any orchestrator that gates on
+        // `Tokenize(message).Any(b => b.Slices.Any(s => s.Notes.Any()))`
+        // will treat algebra prompts as tab. Those orchestrators must
+        // either consult a complementary signal (algebra-intent classifier)
+        // OR reject single-block, single-slice tokenizations as
+        // ambiguous prose.
+        var blocks = _tokenizer.Tokenize("Are 0146 and 0137 z-related?");
+        var hasNotes = blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0));
+
+        Assert.That(hasNotes, Is.True,
+            "Documenting current behaviour. Flip this assertion when the tokenizer is tightened to require a pipe or string-name letter.");
+    }
+
+    [TestCase("Use a G chord then an A chord, then back to G.",
+        Description = "Mentions chord names — could fool a regex but has no fret/string syntax")]
+    [TestCase("Play the 5th fret on the A string, then the 7th fret.",
+        Description = "Mentions fret numbers in prose — no pipes, no tab grid")]
+    [TestCase("The chord progression I-V-vi-IV is common in pop music.",
+        Description = "Roman numerals + general theory talk")]
+    [TestCase("Compare voicing 0-2-2-1-0-0 to 0-2-2-2-0-0",
+        Description = "Hyphen-separated frets in prose — but no string-name pipe markers")]
+    public void Tokenize_ProseWithChordOrFretReferences_HasNoNoteSlices(string prose)
+    {
+        var blocks = _tokenizer.Tokenize(prose);
+
+        Assert.That(blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0)), Is.False,
+            $"Prose with casual chord/fret references should not parse as tab: {prose}");
+    }
+
+    [Test]
+    public void Tokenize_MarkdownTableLikeText_HasNoNoteSlices()
+    {
+        // Markdown tables use pipes too. The tokenizer must not hallucinate
+        // notes from header separators or cell content that looks numeric.
+        var markdown = @"
+| Chord | Fret | Difficulty |
+|-------|------|------------|
+| C     | 1    | Easy       |
+| G     | 3    | Easy       |
+| F     | 1    | Hard       |
+";
+        var blocks = _tokenizer.Tokenize(markdown);
+
+        Assert.That(blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0)), Is.False,
+            "Markdown tables must not be misread as tablature");
+    }
+
+    [Test]
+    public void Tokenize_AsciiSeparatorLine_HasNoNoteSlices()
+    {
+        // A row of dashes is a common section separator; tab-line regex must
+        // not catch it because there's no string identifier and no digits.
+        var blocks = _tokenizer.Tokenize("Section break:\n----------------\nMore prose.");
+
+        Assert.That(blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0)), Is.False);
+    }
+
+    [Test]
+    public void Tokenize_SingleLineThatLooksLikeTab_StillNeedsMultipleStrings()
+    {
+        // One line that matches the tab-line regex shouldn't on its own
+        // produce a parseable chord; tab notation is inherently
+        // multi-string. This pins that minimum-viable-tab boundary.
+        var blocks = _tokenizer.Tokenize("e|---3---|");
+
+        // We accept that a block may exist (the line matches the regex), but
+        // a parseable note slice requires the multi-string vertical alignment
+        // a real tab provides.
+        var hasNotes = blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0));
+        TestContext.WriteLine($"Single tab-like line produced {blocks.Count} block(s); has notes: {hasNotes}");
+
+        // No assertion either direction — this test exists to document
+        // current behaviour. If someone tightens the tokenizer to require
+        // multi-string blocks, they should update this test deliberately.
+        Assert.Pass($"Documented behaviour: blocks={blocks.Count}, hasNotes={hasNotes}");
+    }
+
+    [Test]
+    public void Tokenize_RealTabEmbeddedInProse_ProducesNoteSlices()
+    {
+        // Positive control for the prose pruning above: when REAL tab is
+        // present, the tokenizer must still find it even with prose around
+        // it. Prevents the prose-pruning tests from passing trivially via
+        // a broken tokenizer.
+        var input = @"
+Here's a G chord I want you to analyze:
+
+e|---3---|
+B|---0---|
+G|---0---|
+D|---0---|
+A|---2---|
+E|---3---|
+
+What inversion is this?";
+
+        var blocks = _tokenizer.Tokenize(input);
+
+        Assert.That(blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0)), Is.True,
+            "Embedded tab must still be detected even when surrounded by prose");
+    }
 }


### PR DESCRIPTION
## Why
Every \"should I dispatch to tab analysis?\" check upstream — orchestrators, intent routers, semantic dispatch — eventually grounds out in:

\`\`\`csharp
tokenizer.Tokenize(message).Any(b => b.Slices.Any(s => s.Notes.Any()))
\`\`\`

If the tokenizer thinks prose is tab, the user gets the canned \"I detected tab but couldn't parse any chords.\" fallback for theory questions — exactly the misroute observed when the LLM filter extractor mis-tagged \"Explain voice leading in jazz\" as \`Intent=AnalyzeTab\` and \`ProductionOrchestrator\` dispatched to \`TabAnalysisService\`.

The orchestrator-level fix (`HasTabContent` guard) is independent and lives elsewhere; this PR pins the foundation.

## What
Adds 17 cases to \`TabTokenizerTests\` covering the negative contract — plain English MUST tokenize to zero note-bearing slices:

- **Empty/whitespace** — 3 cases
- **Chatbot example prompts** (the 5 from \`/api/chatbot/examples\`)
- **Prose with chord/fret/Roman-numeral references** — 4 cases (\"Use a G chord\", \"play the 5th fret\", \"I-V-vi-IV\", hyphen-separated frets without pipes)
- **Markdown tables** — pipes ≠ tab
- **ASCII separator lines** — dashes ≠ tab
- **Single-line tab-like fragment** — documents current behaviour
- **Real tab embedded in prose** — positive control so the prose-pruning suite can't pass trivially via a broken tokenizer

## Known limitation pinned by the suite
\`Tokenize_AlgebraQueryWithNumericPitchClassSets_KnownLimitation\` documents that the regex \`([A-Ga-g]?[#b]?\|?|\|)[-0-9|hbp/\\svx~]+\` allows every part of group 1 to be optional, so bare digit runs like \"0146\" match as if they were tab. The textarea seed \"Are 0146 and 0137 z-related?\" trips this. Test asserts \`Is.True\` so it passes, with a comment instructing reviewers to flip the assertion when the tokenizer is tightened.

## Test plan
- [x] \`dotnet test --filter \"FullyQualifiedName~TabTokenizerTests\"\` → 19/19 pass.
- [x] No production code touched, no behaviour change.

## One-way / two-way door
**Two-way door.** Pure test additions. Reversible by \`git revert\`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)