### PR TITLE
feat(chatbot): public access via demos.guitaralchemist.com/chatbot/ + hero CTA on /test

### DIFF
--- a/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
+++ b/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
@@ -180,13 +180,31 @@ public sealed class ChatbotController(
 
 public sealed class ChatRequest
 {
+    /// <summary>
+    /// The user's current message. Capped at 2 KB so a single request
+    /// can't ship a megabyte of prompt-injection or DoS payload to the
+    /// local LLM.
+    /// </summary>
     [Required]
     [MaxLength(2000)]
     public string Message { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Prior conversation turns. Capped at 50 turns total per request
+    /// AND at 2 KB per turn content so the public chatbot endpoint
+    /// (demos.guitaralchemist.com/chatbot) can't be used as a free
+    /// LLM-resource-exhaustion proxy. Without these caps an unauthenticated
+    /// attacker could ship 28 MB (Kestrel default body limit) of context
+    /// to local Ollama, parking it behind LlmConcurrencyGate and starving
+    /// real users — exactly the abuse vector flagged in PR #111 review.
+    /// </summary>
+    [MaxLength(MaxConversationHistoryTurns)]
     public List<ChatMessage>? ConversationHistory { get; set; }
 
     public bool UseSemanticSearch { get; set; } = true;
+
+    public const int MaxConversationHistoryTurns = 50;
+    public const int MaxConversationTurnContentChars = 2000;
 }
 
 public sealed record ChatJsonResponse(
@@ -201,8 +219,10 @@ public sealed record ChatJsonResponse(
 
 public sealed class ChatMessage
 {
+    [MaxLength(32)]
     public string Role { get; set; } = string.Empty;
 
+    [MaxLength(ChatRequest.MaxConversationTurnContentChars)]
     public string Content { get; set; } = string.Empty;
 }
 

--- a/Apps/GaChatbot.Api/GaChatbot.Api.csproj
+++ b/Apps/GaChatbot.Api/GaChatbot.Api.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Program.cs overrides ContentRootPath = AppContext.BaseDirectory so the
+         host can run from any deploy location. The Web SDK's implicit wwwroot
+         items default to CopyToOutputDirectory=Never; that breaks
+         StaticFiles middleware lookups under <BaseDirectory>/wwwroot at
+         runtime. Use Update (not Include — would duplicate the implicit
+         items) to flip the implicit ones to PreserveNewest. -->
+    <Content Update="wwwroot\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Common\GA.Domain.Core\GA.Domain.Core.csproj" />
     <ProjectReference Include="..\..\Common\GA.Domain.Services\GA.Domain.Services.csproj" />
     <ProjectReference Include="..\..\Common\GA.Business.ML\GA.Business.ML.csproj" />

--- a/Apps/GaChatbot.Api/Program.cs
+++ b/Apps/GaChatbot.Api/Program.cs
@@ -36,6 +36,17 @@ if (allowedOrigins.Length > 0)
 
 var app = builder.Build();
 
+// Optional path-base for hosting under a public host's sub-path
+// (e.g. demos.guitaralchemist.com/chatbot via Cloudflare Tunnel ingress
+// `path: ^/chatbot(/.*)?$ -> localhost:5252`). Empty by default so direct
+// localhost:5252/ access continues to work; UsePathBase only strips the
+// prefix when present, so BOTH access modes coexist.
+var pathBase = builder.Configuration["Chatbot:PathBase"];
+if (!string.IsNullOrWhiteSpace(pathBase))
+{
+    app.UsePathBase(pathBase);
+}
+
 app.UseExceptionHandler();
 app.UseStaticFiles();
 
@@ -245,13 +256,13 @@ app.MapGet("/", () => Results.Content(
           <h2>Examples</h2>
           <div id="examples" class="examples"></div>
           <div class="links">
-            <a href="/api/chatbot/status">Status JSON</a>
-            <a href="/api/chatbot/examples">Examples JSON</a>
-            <a href="/api">API metadata</a>
+            <a href="api/chatbot/status">Status JSON</a>
+            <a href="api/chatbot/examples">Examples JSON</a>
+            <a href="api">API metadata</a>
           </div>
         </aside>
       </main>
-      <script src="/vendor/vexflow/vexflow.js"></script>
+      <script src="vendor/vexflow/vexflow.js"></script>
       <script>
         const form = document.getElementById('chatForm');
         const input = document.getElementById('messageInput');
@@ -427,7 +438,7 @@ app.MapGet("/", () => Results.Content(
 
         async function refreshStatus() {
           try {
-            const response = await fetch('/api/chatbot/status');
+            const response = await fetch('api/chatbot/status');
             const status = await response.json();
             statusDot.className = `dot ${status.isAvailable ? 'ready' : 'down'}`;
             statusText.textContent = status.message || (status.isAvailable ? 'Available' : 'Unavailable');
@@ -439,7 +450,7 @@ app.MapGet("/", () => Results.Content(
 
         async function loadExamples() {
           try {
-            const response = await fetch('/api/chatbot/examples');
+            const response = await fetch('api/chatbot/examples');
             const items = await response.json();
             examples.replaceChildren(...items.map(text => {
               const button = document.createElement('button');
@@ -490,7 +501,7 @@ app.MapGet("/", () => Results.Content(
           }, CHAT_CLIENT_TIMEOUT_MS);
 
           try {
-            const response = await fetch('/api/chatbot/chat', {
+            const response = await fetch('api/chatbot/chat', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ message, conversationHistory: history }),

--- a/Apps/GaChatbot.Api/Program.cs
+++ b/Apps/GaChatbot.Api/Program.cs
@@ -44,7 +44,37 @@ var app = builder.Build();
 var pathBase = builder.Configuration["Chatbot:PathBase"];
 if (!string.IsNullOrWhiteSpace(pathBase))
 {
-    app.UsePathBase(pathBase);
+    // Normalise: must start with '/'. A misconfigured value like "chatbot"
+    // (no leading slash) would silently bypass UsePathBase. Force the
+    // slash so config typos still produce correct routing. Strip any
+    // trailing slash on the configured value too — the redirect logic
+    // below adds it back deliberately.
+    if (!pathBase.StartsWith('/')) pathBase = "/" + pathBase;
+    pathBase = pathBase.TrimEnd('/');
+
+    var pathBaseNoSlash   = pathBase;
+    var pathBaseWithSlash = pathBase + "/";
+
+    // Trailing-slash redirect: must run BEFORE UsePathBase so it sees
+    // the unstripped request path. A user landing at `/chatbot` (no
+    // slash) resolves the inline HTML's relative URLs against the
+    // parent dir, so `fetch('api/chatbot/chat')` becomes
+    // `/api/chatbot/chat` at the host root — bypasses the Cloudflare
+    // path-based ingress and 404s. PR #111 review flagged this as the
+    // same regression class as shipped bug #2 (VexFlow not loaded).
+    // 308 (permanent + preserveMethod) so POSTs redirect cleanly too.
+    app.Use(async (ctx, next) =>
+    {
+        if (string.Equals(ctx.Request.Path.Value, pathBaseNoSlash, StringComparison.Ordinal))
+        {
+            var qs = ctx.Request.QueryString.HasValue ? ctx.Request.QueryString.Value : string.Empty;
+            ctx.Response.Redirect(pathBaseWithSlash + qs, permanent: true, preserveMethod: true);
+            return;
+        }
+        await next();
+    });
+
+    app.UsePathBase(pathBaseNoSlash);
 }
 
 app.UseExceptionHandler();

--- a/ReactComponents/ga-react-components/src/pages/TestIndex.tsx
+++ b/ReactComponents/ga-react-components/src/pages/TestIndex.tsx
@@ -10,8 +10,11 @@ import {
   TableHead,
   TableRow,
   Paper,
-  Chip
+  Chip,
+  Button,
+  Stack
 } from '@mui/material';
+import ChatIcon from '@mui/icons-material/Chat';
 import { useNavigate } from 'react-router-dom';
 
 interface TestPageInfo {
@@ -332,12 +335,78 @@ export const TestIndex: React.FC = () => {
 
   return (
     <Container maxWidth="xl" sx={{ py: 4 }}>
-      <Box sx={{ mb: 3 }}>
-        <Typography variant="h4" gutterBottom>
+      {/* HERO: GA Chatbot is the headline product on this site. The component
+          test suite below is supporting / dev material. */}
+      <Paper
+        elevation={4}
+        sx={{
+          mb: 4,
+          p: { xs: 3, md: 4 },
+          background: 'linear-gradient(135deg, #1d4ed8 0%, #1f6feb 50%, #06b6d4 100%)',
+          color: 'white',
+          borderRadius: 3,
+        }}
+      >
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={3}
+          alignItems={{ xs: 'flex-start', md: 'center' }}
+          justifyContent="space-between"
+        >
+          <Box sx={{ flex: 1 }}>
+            <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1 }}>
+              <ChatIcon sx={{ fontSize: 36 }} />
+              <Typography variant="h3" sx={{ fontWeight: 700, m: 0 }}>
+                GA Chatbot
+              </Typography>
+            </Stack>
+            <Typography variant="h6" sx={{ fontWeight: 400, opacity: 0.95, maxWidth: 720 }}>
+              Ask grounded music theory questions — chord voicings, voice leading, scale modes,
+              set-class algebra. Powered by Guitar Alchemist's symbolic engine and a local LLM.
+            </Typography>
+          </Box>
+          <Stack direction={{ xs: 'row', md: 'column' }} spacing={1.5} sx={{ minWidth: { md: 220 } }}>
+            <Button
+              variant="contained"
+              size="large"
+              href="/chatbot/"
+              sx={{
+                bgcolor: 'white',
+                color: 'primary.main',
+                fontWeight: 700,
+                fontSize: '1.05rem',
+                px: 3,
+                py: 1.5,
+                '&:hover': { bgcolor: '#f1f5f9' },
+              }}
+              startIcon={<ChatIcon />}
+            >
+              Launch Chatbot
+            </Button>
+            <Button
+              variant="outlined"
+              size="large"
+              href="/chatbot/"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{
+                borderColor: 'white',
+                color: 'white',
+                '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.1)' },
+              }}
+            >
+              Open in new tab
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="h5" gutterBottom>
           🎸 Component Test Suite
         </Typography>
         <Typography variant="body2" color="text.secondary">
-          Click any row to open the test page
+          Supporting demos and component sandboxes. Click any row to open.
         </Typography>
       </Box>
 

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotApiSurfaceTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotApiSurfaceTests.cs
@@ -508,6 +508,102 @@ public class ChatbotApiSurfaceTests
         });
     }
 
+    // ── ConversationHistory caps (PR #111 review — abuse prevention) ──────────
+    //
+    // Without these caps an unauthenticated caller could ship up to ~28 MB
+    // (Kestrel default body limit) of conversation context to local Ollama
+    // via the public /chatbot/api/chatbot/chat endpoint, parking that
+    // request behind LlmConcurrencyGate and starving real users. Caps:
+    // 50 turns max, 2 KB content per turn (matches Message cap).
+
+    [Test]
+    public async Task Chat_ConversationHistoryOverMaxTurns_ReturnsBadRequest()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var tooManyTurns = Enumerable.Range(0, 51)
+            .Select(i => new { role = "user", content = $"turn {i}" })
+            .ToArray();
+
+        var response = await client.PostAsJsonAsync("/api/chatbot/chat", new
+        {
+            message = "test",
+            conversationHistory = tooManyTurns
+        });
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest),
+            "Conversation history over 50 turns must reject — DoS protection " +
+            "for the public chatbot endpoint");
+    }
+
+    [Test]
+    public async Task Chat_ConversationHistoryTurnContentOverMaxLength_ReturnsBadRequest()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var oneFatTurn = new[]
+        {
+            new { role = "user", content = new string('x', 2001) },
+        };
+
+        var response = await client.PostAsJsonAsync("/api/chatbot/chat", new
+        {
+            message = "test",
+            conversationHistory = oneFatTurn
+        });
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest),
+            "Per-turn content over 2 KB must reject — without this cap, " +
+            "50 turns × 28 MB total body could ship a full payload of " +
+            "prompt-injection / DoS material to local Ollama");
+    }
+
+    [Test]
+    public async Task Chat_ConversationHistoryAtMaxTurnsAndMaxContent_IsAccepted()
+    {
+        // Off-by-one defence: exactly 50 turns at exactly 2000 chars must
+        // still validate. The cap is an upper bound, not a strict-less-than.
+        using var factory = CreateFactory(chatService: new FakeChatApplicationServiceForValidation());
+        using var client = factory.CreateClient();
+
+        var maxTurns = Enumerable.Range(0, 50)
+            .Select(i => new { role = "user", content = new string('x', 2000) })
+            .ToArray();
+
+        var response = await client.PostAsJsonAsync("/api/chatbot/chat", new
+        {
+            message = "test",
+            conversationHistory = maxTurns
+        });
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK),
+            "At-cap inputs must be accepted; only over-cap inputs reject");
+    }
+
+    private sealed class FakeChatApplicationServiceForValidation : IChatApplicationService
+    {
+        public Task<ChatExecutionResult> ChatAsync(ChatExecutionRequest request, CancellationToken ct = default) =>
+            Task.FromResult(new ChatExecutionResult(
+                "ok",
+                new AgentRoutingMetadata("fake", 1f, "fake"),
+                null,
+                null));
+
+        public async IAsyncEnumerable<ChatStreamUpdate> ChatStreamAsync(
+            ChatExecutionRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new ChatStreamUpdate("ok");
+            await Task.Yield();
+            yield return new ChatStreamUpdate(IsCompleted: true);
+        }
+
+        public Task<ChatbotStatus> GetStatusAsync(CancellationToken ct = default) =>
+            Task.FromResult(new ChatbotStatus { IsAvailable = true, Message = "ok", Timestamp = DateTime.UtcNow });
+    }
+
     [Test]
     public async Task Chat_WhenConcurrencyGateIsFull_ReturnsServiceUnavailable()
     {

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotApiSurfaceTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotApiSurfaceTests.cs
@@ -36,13 +36,17 @@ public class ChatbotApiSurfaceTests
             Assert.That(html, Does.Contain("id=\"messageInput\""));
             Assert.That(html, Does.Contain("id=\"sendButton\""));
             Assert.That(html, Does.Contain("Agentic trace"));
-            Assert.That(html, Does.Contain("/vendor/vexflow/vexflow.js"));
+            // URLs in the inline HTML are RELATIVE (no leading slash) so the
+            // page works when mounted under a path-base (e.g.
+            // demos.guitaralchemist.com/chatbot/) via Cloudflare Tunnel
+            // ingress. Match the path component without anchoring on /.
+            Assert.That(html, Does.Contain("vendor/vexflow/vexflow.js"));
             Assert.That(html, Does.Contain("renderTabNotation"));
             Assert.That(html, Does.Contain("parseTabPositions"));
             Assert.That(html, Does.Contain("```(?:vextab|vexflow|tab)"));
-            Assert.That(html, Does.Contain("/api/chatbot/status"));
-            Assert.That(html, Does.Contain("/api/chatbot/examples"));
-            Assert.That(html, Does.Contain("/api/chatbot/chat"));
+            Assert.That(html, Does.Contain("api/chatbot/status"));
+            Assert.That(html, Does.Contain("api/chatbot/examples"));
+            Assert.That(html, Does.Contain("api/chatbot/chat"));
         });
     }
 

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotPathBaseTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotPathBaseTests.cs
@@ -128,6 +128,70 @@ public class ChatbotPathBaseTests
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
     }
 
+    // ── Trailing-slash redirect (PR #111 review) ──────────────────────────────
+    //
+    // When a user lands at `/chatbot` (no slash), the inline HTML's relative
+    // URLs (e.g. `fetch('api/chatbot/chat')`) resolve against the PARENT dir
+    // — `/api/chatbot/chat` at the host root — bypassing the Cloudflare
+    // ingress regex `^/chatbot(/.*)?$` and breaking the chatbot. A 308
+    // permanent redirect to `/chatbot/` makes the URL canonical so relative
+    // URLs anchor correctly.
+
+    [Test]
+    public async Task Root_NoTrailingSlash_RedirectsToTrailingSlash()
+    {
+        using var factory = CreatePathBaseFactory();
+        // Disable auto-redirect handling so we can inspect the response.
+        using var client = factory.CreateClient(new()
+        {
+            AllowAutoRedirect = false,
+        });
+
+        var response = await client.GetAsync(PathBase);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.PermanentRedirect),
+            "GET /chatbot (no slash) must 308-redirect to /chatbot/ " +
+            "so relative URLs in the served HTML resolve correctly");
+        Assert.That(response.Headers.Location?.OriginalString, Is.EqualTo(PathBase + "/"));
+    }
+
+    [Test]
+    public async Task Root_NoTrailingSlash_PreservesQueryStringInRedirect()
+    {
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient(new()
+        {
+            AllowAutoRedirect = false,
+        });
+
+        var response = await client.GetAsync(PathBase + "?source=test");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.PermanentRedirect));
+        Assert.That(response.Headers.Location?.OriginalString,
+            Is.EqualTo(PathBase + "/?source=test"),
+            "Query string must survive the trailing-slash redirect");
+    }
+
+    [Test]
+    public async Task PathBase_WithoutLeadingSlash_IsNormalised()
+    {
+        // Misconfigured value `chatbot` (no leading slash) used to silently
+        // bypass UsePathBase. After normalisation it behaves the same as
+        // `/chatbot`. This pins that the typo no longer causes a routing
+        // bug.
+        using var factory = new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting("Chatbot:PathBase", "chatbot");  // no leading /
+            });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/chatbot/api/chatbot/status");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK),
+            "PathBase value normalised to /chatbot — controller still routable under prefix");
+    }
+
     private static WebApplicationFactory<Program> CreatePathBaseFactory() =>
         new TestWebApplicationFactory()
             .WithWebHostBuilder(builder =>

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotPathBaseTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotPathBaseTests.cs
@@ -1,0 +1,137 @@
+namespace GaChatbot.Api.Tests.Controllers;
+
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+/// <summary>
+/// Pins the contract for hosting GaChatbot.Api under a path-base mount
+/// (e.g. <c>https://demos.guitaralchemist.com/chatbot</c>). Cloudflare
+/// Tunnel ingress forwards <c>/chatbot/*</c> verbatim to
+/// <c>localhost:5252</c>; <c>app.UsePathBase("/chatbot")</c> in
+/// <c>Program.cs</c> strips the prefix on the way in so controllers and
+/// the static-file middleware see clean paths.
+/// </summary>
+/// <remarks>
+/// Regression guards for two related production bugs:
+/// (1) the inline chatbot HTML originally used absolute URLs
+///     (<c>/api/chatbot/status</c>, <c>/vendor/vexflow/vexflow.js</c>),
+///     so even with the tunnel + path-base mount in place, browser-side
+///     requests bypassed the prefix and 404'd; and
+/// (2) <c>wwwroot/vendor/vexflow/vexflow.js</c> wasn't shipping to
+///     <c>bin/</c> because <c>Program.cs</c> overrides
+///     <c>ContentRootPath = AppContext.BaseDirectory</c> and the Web
+///     SDK's implicit wwwroot items default to
+///     <c>CopyToOutputDirectory=Never</c>. Fixed by an explicit
+///     <c>&lt;Content Update="wwwroot\**\*"&gt;</c> in the csproj.
+/// Both modes (direct localhost root and prefixed mount) must coexist
+/// so dev workflow doesn't change.
+/// </remarks>
+[TestFixture]
+public class ChatbotPathBaseTests
+{
+    private const string PathBase = "/chatbot";
+
+    [Test]
+    public async Task Root_UnderPathBase_ReturnsChatbotHtml()
+    {
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(PathBase + "/");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Content.Headers.ContentType?.MediaType, Is.EqualTo("text/html"));
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.That(html, Does.Contain("id=\"chatForm\""));
+    }
+
+    [Test]
+    public async Task Root_DirectRoot_StillReturnsChatbotHtml_WhenPathBaseIsConfigured()
+    {
+        // UsePathBase only ACTIVATES when the request path starts with the
+        // base. A direct request to "/" still flows through the pipeline
+        // unchanged so localhost dev usage isn't broken by configuring the
+        // production path-base.
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Content.Headers.ContentType?.MediaType, Is.EqualTo("text/html"));
+    }
+
+    [Test]
+    public async Task ApiStatus_UnderPathBase_RoutesToController()
+    {
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(PathBase + "/api/chatbot/status");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Content.Headers.ContentType?.MediaType, Is.EqualTo("application/json"));
+    }
+
+    [Test]
+    public async Task ApiStatus_DirectRoot_StillRoutesToController_WhenPathBaseIsConfigured()
+    {
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/chatbot/status");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+    }
+
+    [Test]
+    public async Task VexFlowAsset_UnderPathBase_ServesFromStaticFiles()
+    {
+        // The bug we shipped: wwwroot/vendor/vexflow/vexflow.js wasn't
+        // being copied to bin/, so static-files middleware 404'd at
+        // /chatbot/vendor/vexflow/vexflow.js and the chatbot UI rendered
+        // "VexFlow is not loaded" under every chord. Pins both the
+        // copy-to-output csproj rule AND the path-base resolution.
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(PathBase + "/vendor/vexflow/vexflow.js");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(response.Content.Headers.ContentType?.MediaType, Is.EqualTo("text/javascript"));
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.That(body, Does.Contain("TabStave"),
+            "must be the real VexFlow bundle, not an HTML fallback page");
+    }
+
+    [Test]
+    public async Task VexFlowAsset_DirectRoot_StillServesFromStaticFiles()
+    {
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/vendor/vexflow/vexflow.js");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+    }
+
+    [Test]
+    public async Task UnknownPathInsideBase_ReturnsNotFound_NotChatbotHtml()
+    {
+        using var factory = CreatePathBaseFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(PathBase + "/this-route-does-not-exist");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    private static WebApplicationFactory<Program> CreatePathBaseFactory() =>
+        new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting("Chatbot:PathBase", PathBase);
+            });
+}


### PR DESCRIPTION
## User-visible bug

\`https://demos.guitaralchemist.com/chatbot/\` was returning **404**. Cloudflare Tunnel ingress was forwarding \`/chatbot/*\` verbatim to \`localhost:5252\`, but \`Program.cs\` had no \`UsePathBase\` to strip the prefix. The chatbot home page also rendered \"VexFlow is not loaded\" under every chord because the inline HTML used absolute \`/api/...\` and \`/vendor/...\` URLs, AND because \`wwwroot/vendor/vexflow/vexflow.js\` wasn't shipping to \`bin/\` at all.

The hero CTA on \`/test\` was missing — the chatbot is the headline product, so it needs to be obviously launchable from there.

## Three coordinated changes

### 1. \`Apps/GaChatbot.Api/Program.cs\`
Optional \`app.UsePathBase(Chatbot:PathBase)\`. Empty by default so direct \`localhost:5252/\` dev is unchanged; \`UsePathBase\` only activates when the request path starts with the configured base, so both access modes coexist. Inline HTML URLs switched from absolute to relative (\`api/...\`, \`vendor/...\`) so they resolve correctly under either mount.

### 2. \`Apps/GaChatbot.Api/GaChatbot.Api.csproj\`
\`<Content Update=\"wwwroot\**\*\" CopyToOutputDirectory=\"PreserveNewest\" />\`. \`Program.cs\` overrides \`ContentRootPath = AppContext.BaseDirectory\` so the host can run from any deploy location; the Web SDK's implicit wwwroot items default to \`CopyToOutputDirectory=Never\`, so static assets never reached \`bin/\`. \`Update\` (not \`Include\` — would duplicate implicit items) flips them to \`PreserveNewest\`.

### 3. \`ReactComponents/ga-react-components/src/pages/TestIndex.tsx\`
Gradient hero banner at the top of \`/test\`: h3 \"GA Chatbot\" title, subhead, primary \"Launch Chatbot\" white button + \"Open in new tab\" outlined button, both pointing at \`/chatbot/\`. Demotes the component test suite to a smaller h5 \"Supporting demos and component sandboxes\".

## Test coverage

- Updated \`ChatbotApiSurfaceTests\` assertions to expect relative URLs.
- **New \`ChatbotPathBaseTests\` (7 cases)** pinning dual-mode behaviour:
  - \`Root_UnderPathBase_ReturnsChatbotHtml\`
  - \`Root_DirectRoot_StillReturnsChatbotHtml_WhenPathBaseIsConfigured\`
  - \`ApiStatus_UnderPathBase_RoutesToController\`
  - \`ApiStatus_DirectRoot_StillRoutesToController_WhenPathBaseIsConfigured\`
  - \`VexFlowAsset_UnderPathBase_ServesFromStaticFiles\`
  - \`VexFlowAsset_DirectRoot_StillServesFromStaticFiles\`
  - \`UnknownPathInsideBase_ReturnsNotFound_NotChatbotHtml\`

38/38 combined \`ChatbotApiSurfaceTests + ChatbotPathBaseTests\` pass.

## Verified end-to-end
| URL | Status |
| --- | ---: |
| \`localhost:5252/\` | 200 |
| \`localhost:5252/chatbot/\` | 200 |
| \`demos.guitaralchemist.com/chatbot/\` | 200 (16,346 bytes) |
| \`demos.guitaralchemist.com/chatbot/vendor/vexflow/vexflow.js\` | 200 |
| \`demos.guitaralchemist.com/test\` | 200 (hero rendered) |

## Two-way / one-way door
**Two-way door.** Reversible: drop the \`UsePathBase\` block and the csproj \`Content Update\`, and revert TestIndex.tsx. Configuration-driven (empty path-base = no behaviour change), so a flag flip can roll back without code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)