### PR TITLE
feat(qa-tools): qa_score_quality_drift Phase 2 — SAE artifact drift

### DIFF
--- a/Apps/GaQaMcp/Tools/QaTools.cs
+++ b/Apps/GaQaMcp/Tools/QaTools.cs
@@ -78,7 +78,7 @@ public static class QaTools
     }
 
     [McpServerTool(Name = "qa_score_quality_drift")]
-    [Description("Score quality-snapshot drift over a window. Phase 0 returns null delta. Phase 1 stub: surfaces SAE artifact presence for 'optick-sae' metric; time-series drift wiring is Phase 2.")]
+    [Description("Score quality-snapshot drift over a window. For 'optick-sae' metric, computes reconstruction_mse / dead_features / partition_purity deltas across consecutive artifacts within the window.")]
     public static string ScoreQualityDrift(
         [Description("Metric name as it appears in state/quality/*.json.")] string metric,
         [Description("Window length in days.")] int windowDays)
@@ -92,24 +92,11 @@ public static class QaTools
     /// </summary>
     public static string ScoreQualityDriftAt(string metric, int windowDays, string stateQualityRoot)
     {
-        // Phase 1 stub: detect SAE artifacts and surface them.
-        // Real time-series drift computation is Phase 2 (qa-architect-cycle.ixql wiring).
         if (metric.Equals("optick-sae", StringComparison.OrdinalIgnoreCase))
         {
-            var saeRoot = Path.Combine(stateQualityRoot, "optick-sae");
-            var artifactFiles = Directory.Exists(saeRoot)
-                ? Directory.GetFiles(saeRoot, "optick-sae-artifact.json", SearchOption.AllDirectories)
-                : [];
-            var driftSummary = artifactFiles.Length > 0
-                ? $"SAE artifact found ({artifactFiles.Length} run(s) under {saeRoot}). Drift evidence wiring is Phase 2."
-                : $"No SAE artifacts found under {saeRoot}. Drift evidence wiring is Phase 2.";
-            var saeEvidence = new QaEvidence
-            {
-                Kind = "quality_snapshot",
-                Name = metric,
-                DriftSummary = driftSummary
-            };
-            return JsonSerializer.Serialize(saeEvidence, QaVerdictJson.Options);
+            return JsonSerializer.Serialize(
+                ComputeOptickSaeDrift(Path.Combine(stateQualityRoot, "optick-sae"), windowDays),
+                QaVerdictJson.Options);
         }
 
         var evidence = new QaEvidence
@@ -120,6 +107,164 @@ public static class QaTools
         };
         return JsonSerializer.Serialize(evidence, QaVerdictJson.Options);
     }
+
+    // ── Phase 2: optick-sae drift computation ────────────────────────────────
+
+    // Per-artifact-pair tolerances. Above any of these the evidence outcome
+    // flips from "pass" to "concern". Calibrated against the 2026-05-03 →
+    // 2026-05-04 supersede (synthetic → real-corpus): the synthetic baseline
+    // had MSE 1e-5 with 0% dead, the real run had MSE 4e-7 with 23.7% dead —
+    // a legitimate change that should surface as "concern" so a human reads it.
+    private const double DriftMseRelativeTolerance = 0.50;        // +50% relative
+    private const double DriftDeadFeaturesPctTolerance = 5.0;     // +5 pct points
+    private const double DriftPurityMeanAbsoluteTolerance = 0.05; // -0.05 absolute
+
+    private sealed record SaeArtifactSummary(
+        string Path,
+        string ArtifactId,
+        DateTimeOffset TrainedAt,
+        double ReconstructionMse,
+        double DeadFeaturesPct,
+        double PurityMean);
+
+    private static QaEvidence ComputeOptickSaeDrift(string saeRoot, int windowDays)
+    {
+        if (!Directory.Exists(saeRoot))
+        {
+            return new QaEvidence
+            {
+                Kind = "quality_snapshot",
+                Name = "optick-sae",
+                Outcome = "n/a",
+                DriftSummary = $"No SAE artifacts found under {saeRoot}."
+            };
+        }
+
+        var summaries = LoadSaeSummariesInWindow(saeRoot, windowDays);
+
+        if (summaries.Count == 0)
+        {
+            return new QaEvidence
+            {
+                Kind = "quality_snapshot",
+                Name = "optick-sae",
+                Outcome = "n/a",
+                DriftSummary = $"No SAE artifacts within {windowDays}d window under {saeRoot}."
+            };
+        }
+
+        if (summaries.Count == 1)
+        {
+            var only = summaries[0];
+            return new QaEvidence
+            {
+                Kind = "quality_snapshot",
+                Name = "optick-sae",
+                Outcome = "n/a",
+                Score = only.ReconstructionMse,
+                DriftSummary =
+                    $"Only one SAE artifact in window ({only.ArtifactId}, " +
+                    $"mse={only.ReconstructionMse:F6}, dead={only.DeadFeaturesPct:F2}%). " +
+                    "Drift requires ≥2 artifacts."
+            };
+        }
+
+        // Compare newest vs oldest in window — surfaces cumulative drift over the window.
+        var oldest = summaries[0];
+        var newest = summaries[^1];
+
+        var mseDelta = newest.ReconstructionMse - oldest.ReconstructionMse;
+        var mseRelative = oldest.ReconstructionMse > 0
+            ? mseDelta / oldest.ReconstructionMse
+            : 0.0;
+        var deadDelta = newest.DeadFeaturesPct - oldest.DeadFeaturesPct;
+        var purityDelta = newest.PurityMean - oldest.PurityMean;
+
+        var concerns = new List<string>();
+        if (mseRelative > DriftMseRelativeTolerance)
+            concerns.Add($"reconstruction_mse +{mseRelative * 100:F0}% (>+{DriftMseRelativeTolerance * 100:F0}%)");
+        if (deadDelta > DriftDeadFeaturesPctTolerance)
+            concerns.Add($"dead_features_pct +{deadDelta:F1}pp (>+{DriftDeadFeaturesPctTolerance:F1}pp)");
+        if (-purityDelta > DriftPurityMeanAbsoluteTolerance)
+            concerns.Add($"feature_partition_purity_mean {purityDelta:+0.000;-0.000} (drop >{DriftPurityMeanAbsoluteTolerance:F2})");
+
+        var outcome = concerns.Count == 0 ? "pass" : "concern";
+        var summary = concerns.Count == 0
+            ? $"{summaries.Count} artifact(s) in window. " +
+              $"mse {oldest.ReconstructionMse:F6} → {newest.ReconstructionMse:F6} ({mseRelative:+0.0%;-0.0%}), " +
+              $"dead {oldest.DeadFeaturesPct:F2}% → {newest.DeadFeaturesPct:F2}% ({deadDelta:+0.00;-0.00}pp), " +
+              $"purity {oldest.PurityMean:F3} → {newest.PurityMean:F3} ({purityDelta:+0.000;-0.000}). All within tolerance."
+            : $"{summaries.Count} artifact(s) in window. Drift concerns: {string.Join("; ", concerns)}.";
+
+        return new QaEvidence
+        {
+            Kind = "quality_snapshot",
+            Name = "optick-sae",
+            Outcome = outcome,
+            Score = newest.ReconstructionMse,
+            Baseline = oldest.ReconstructionMse,
+            DeltaFromBaseline = mseDelta,
+            GuardrailMax = 0.05,
+            DriftSummary = summary
+        };
+    }
+
+    private static List<SaeArtifactSummary> LoadSaeSummariesInWindow(string saeRoot, int windowDays)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-Math.Max(0, windowDays));
+        var summaries = new List<SaeArtifactSummary>();
+
+        foreach (var path in Directory.EnumerateFiles(saeRoot, "optick-sae-artifact.json", SearchOption.AllDirectories))
+        {
+            // Skip per-developer-machine experiment dirs (state/quality/optick-sae/<date>-local/).
+            // Those are validation runs, not the shared timeline.
+            var parentDir = Path.GetFileName(Path.GetDirectoryName(path));
+            if (parentDir is not null && parentDir.EndsWith("-local", StringComparison.Ordinal))
+                continue;
+
+            var summary = TryParseSummary(path);
+            if (summary is null) continue;
+            if (summary.TrainedAt < cutoff) continue;
+            summaries.Add(summary);
+        }
+
+        summaries.Sort((a, b) => a.TrainedAt.CompareTo(b.TrainedAt));
+        return summaries;
+    }
+
+    private static SaeArtifactSummary? TryParseSummary(string path)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+
+            if (!root.TryGetProperty("artifact_id", out var idEl) ||
+                !root.TryGetProperty("trained_at", out var tsEl) ||
+                !root.TryGetProperty("metrics", out var metricsEl))
+            {
+                return null;
+            }
+
+            if (!DateTimeOffset.TryParse(tsEl.GetString(), out var trainedAt)) return null;
+
+            return new SaeArtifactSummary(
+                path,
+                idEl.GetString() ?? "<unknown>",
+                trainedAt,
+                ReadDouble(metricsEl, "reconstruction_mse"),
+                ReadDouble(metricsEl, "dead_features_pct"),
+                ReadDouble(metricsEl, "feature_partition_purity_mean"));
+        }
+        catch (JsonException) { return null; }
+        catch (IOException) { return null; }
+    }
+
+    private static double ReadDouble(JsonElement parent, string name) =>
+        parent.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.Number
+            ? el.GetDouble()
+            : 0.0;
 
     [McpServerTool(Name = "qa_lookup_defect_memory")]
     [Description("Query the defect knowledge graph for past followups matching a pattern. Phase 0 returns an empty list.")]

--- a/Scripts/export_session_to_md.py
+++ b/Scripts/export_session_to_md.py
@@ -1,0 +1,154 @@
+"""
+Export a Claude Code session JSONL log to readable markdown.
+
+Filters out tool calls, tool results, thinking blocks, system reminders, hooks
+and attachment noise. Keeps the user/assistant text exchange — what a colleague
+would want to read.
+
+Usage:
+    python Scripts/export_session_to_md.py <input.jsonl> <output.md>
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SYSTEM_REMINDER_RE = re.compile(
+    r"<system-reminder>.*?</system-reminder>", re.DOTALL
+)
+COMMAND_TAG_RE = re.compile(
+    r"<(command-name|command-message|command-args|local-command-stdout|"
+    r"user-prompt-submit-hook|stdin|ide_selection|ide_opened_file)>.*?"
+    r"</\1>",
+    re.DOTALL,
+)
+SLASH_HEADER_RE = re.compile(r"^<.*?>\s*$", re.MULTILINE)
+
+
+def clean_user_text(text: str) -> str:
+    text = SYSTEM_REMINDER_RE.sub("", text)
+    text = COMMAND_TAG_RE.sub("", text)
+    text = SLASH_HEADER_RE.sub("", text)
+    return text.strip()
+
+
+def fmt_ts(iso: str) -> str:
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone(timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return iso
+
+
+def extract_text(message: dict) -> list[str]:
+    """Pull text blocks out of a message. Skip thinking/tool_use/tool_result."""
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return [content] if content.strip() else []
+    if not isinstance(content, list):
+        return []
+    out: list[str] = []
+    for c in content:
+        if not isinstance(c, dict):
+            continue
+        if c.get("type") == "text":
+            t = c.get("text", "")
+            if t.strip():
+                out.append(t)
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <input.jsonl> <output.md>", file=sys.stderr)
+        return 2
+    src = Path(sys.argv[1])
+    dst = Path(sys.argv[2])
+    if not src.exists():
+        print(f"FAIL: {src} not found", file=sys.stderr)
+        return 2
+
+    turns: list[tuple[str, str, str]] = []  # (role, ts, text)
+    n_user = n_assistant = n_skipped = 0
+
+    with src.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            t = d.get("type")
+            if t not in ("user", "assistant"):
+                continue
+            if d.get("isSidechain"):
+                # Subagent transcript — skip; keeps the export focused on the
+                # main user<->assistant thread.
+                continue
+
+            ts = d.get("timestamp", "")
+            msg = d.get("message", {})
+            texts = extract_text(msg)
+            if not texts:
+                n_skipped += 1
+                continue
+
+            for raw in texts:
+                cleaned = clean_user_text(raw)  # Same cleaner is safe for both roles.
+                if not cleaned:
+                    n_skipped += 1
+                    continue
+                if t == "user":
+                    turns.append(("user", ts, cleaned))
+                    n_user += 1
+                else:
+                    turns.append(("assistant", ts, cleaned))
+                    n_assistant += 1
+
+    if not turns:
+        print("FAIL: no user/assistant text found", file=sys.stderr)
+        return 1
+
+    first_ts = fmt_ts(turns[0][1])
+    last_ts = fmt_ts(turns[-1][1])
+
+    with dst.open("w", encoding="utf-8") as f:
+        f.write(f"# Claude Code session — {src.name}\n\n")
+        f.write(
+            f"Span: **{first_ts}** → **{last_ts}**  \n"
+            f"Turns: {n_user} user / {n_assistant} assistant "
+            f"(skipped {n_skipped} empty/tool-only frames)  \n"
+            f"Source: `{src}`\n\n"
+        )
+        f.write(
+            "Tool calls, tool results, thinking blocks, system reminders, "
+            "hooks, IDE selection markers, and subagent sidechains are filtered "
+            "out. What remains is the user/assistant text exchange.\n\n"
+        )
+        f.write("---\n\n")
+
+        for role, ts, text in turns:
+            label = "User" if role == "user" else "Claude"
+            f.write(f"### {label} — {fmt_ts(ts)}\n\n")
+            # Quote user prose; leave assistant prose unquoted so its own
+            # markdown (lists, code fences, headings) renders properly.
+            if role == "user":
+                quoted = "\n".join("> " + l if l else ">" for l in text.splitlines())
+                f.write(quoted + "\n\n")
+            else:
+                f.write(text + "\n\n")
+            f.write("---\n\n")
+
+    print(f"wrote {dst}  ({n_user + n_assistant} turns, {dst.stat().st_size:,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tests/Common/GA.Business.ML.Tests/Unit/QaToolsScoreQualityDriftTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/QaToolsScoreQualityDriftTests.cs
@@ -4,9 +4,10 @@ using System.Text.Json;
 using GA.QaMcp.Tools;
 
 /// <summary>
-/// Unit tests for the Phase 1 stub branch in <see cref="QaTools.ScoreQualityDriftAt"/>.
-/// PR #82 added the "optick-sae" metric special-case logic but shipped without coverage;
-/// this class is the regression guard.
+/// Unit tests for <see cref="QaTools.ScoreQualityDriftAt"/> covering the Phase 1
+/// SAE-detection branch and the Phase 2 drift-computation branch
+/// (reconstruction_mse / dead_features_pct / partition_purity deltas across
+/// consecutive artifacts in a window).
 /// </summary>
 [TestFixture]
 public class QaToolsScoreQualityDriftTests
@@ -27,94 +28,215 @@ public class QaToolsScoreQualityDriftTests
             Directory.Delete(_tempRoot, recursive: true);
     }
 
+    // ── Phase 1 SAE-branch detection (preserved) ─────────────────────────────
+
     [Test]
-    public void OptickSae_NoArtifacts_ReturnsExpectedDriftSummary()
+    public void OptickSae_NoArtifacts_ReturnsNotApplicable()
     {
-        // No optick-sae directory exists at all.
         var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
 
-        var doc = JsonDocument.Parse(result);
-        var root = doc.RootElement;
+        var root = JsonDocument.Parse(result).RootElement;
         Assert.That(root.GetProperty("kind").GetString(), Is.EqualTo("quality_snapshot"));
         Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("optick-sae"));
-        Assert.That(root.GetProperty("drift_summary").GetString(), Does.Contain("No SAE artifacts found"));
-    }
-
-    [Test]
-    public void OptickSae_OneArtifact_ReportsCount()
-    {
-        var saeDir = Path.Combine(_tempRoot, "optick-sae", "2026-05-04");
-        Directory.CreateDirectory(saeDir);
-        File.WriteAllText(Path.Combine(saeDir, "optick-sae-artifact.json"), "{}");
-
-        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
-
-        var doc = JsonDocument.Parse(result);
-        var summary = doc.RootElement.GetProperty("drift_summary").GetString();
-        Assert.That(summary, Does.Contain("SAE artifact found"));
-        Assert.That(summary, Does.Contain("(1 run(s)"));
-    }
-
-    [Test]
-    public void OptickSae_MultipleArtifacts_ReportsCorrectCount()
-    {
-        // Three artifacts across three different date directories — supersedes chain.
-        foreach (var date in (string[])["2026-05-03", "2026-05-04", "2026-05-05"])
-        {
-            var dir = Path.Combine(_tempRoot, "optick-sae", date);
-            Directory.CreateDirectory(dir);
-            File.WriteAllText(Path.Combine(dir, "optick-sae-artifact.json"), "{}");
-        }
-
-        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
-
-        var doc = JsonDocument.Parse(result);
-        var summary = doc.RootElement.GetProperty("drift_summary").GetString();
-        Assert.That(summary, Does.Contain("(3 run(s)"));
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("n/a"));
+        Assert.That(root.GetProperty("drift_summary").GetString(), Does.Contain("No SAE artifacts"));
     }
 
     [Test]
     public void OptickSae_CaseInsensitiveMetric_TriggersSaeBranch()
     {
-        // The metric switch is case-insensitive — verify "OPTICK-SAE" hits the same path.
         var result = QaTools.ScoreQualityDriftAt("OPTICK-SAE", 7, _tempRoot);
 
-        var doc = JsonDocument.Parse(result);
-        var summary = doc.RootElement.GetProperty("drift_summary").GetString();
-        Assert.That(summary, Does.Contain("No SAE artifacts found"),
-            "Case-insensitive match means OPTICK-SAE should hit the SAE branch (not the default phase 0 stub).");
+        var root = JsonDocument.Parse(result).RootElement;
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("n/a"),
+            "Case-insensitive match means OPTICK-SAE hits the SAE branch.");
+        Assert.That(root.GetProperty("drift_summary").GetString(), Does.Contain("No SAE artifacts"));
     }
 
     [Test]
     public void OtherMetric_FallsThroughToPhase0Stub()
     {
-        // Metrics other than "optick-sae" should hit the phase 0 fall-through path.
         var result = QaTools.ScoreQualityDriftAt("voicing-analysis", 14, _tempRoot);
 
-        var doc = JsonDocument.Parse(result);
-        var root = doc.RootElement;
+        var root = JsonDocument.Parse(result).RootElement;
         Assert.That(root.GetProperty("kind").GetString(), Is.EqualTo("quality_snapshot"));
         Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("voicing-analysis"));
-        // Phase 0 stub shape: drift_summary mentions skeleton state, no artifact-found language.
         var summary = root.GetProperty("drift_summary").GetString();
         Assert.That(summary, Does.Not.Contain("SAE artifact"));
         Assert.That(summary, Does.Contain("skeleton").Or.Contain("Phase 0"));
     }
 
+    // ── Phase 2 drift computation ───────────────────────────────────────────
+
     [Test]
-    public void OptickSae_DriftSummaryIsContractEvidenceShape()
+    public void Drift_OneArtifact_ReportsInsufficientHistory()
     {
-        // The returned JSON should be parseable as a QaEvidence record per the
-        // qa-verdict.contract.md §3.5: kind, name, drift_summary at minimum.
+        WriteArtifact("2026-05-04", DaysAgo(1), mse: 0.001, dead: 10.0, purity: 0.50);
+
         var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
-        var doc = JsonDocument.Parse(result);
-        var root = doc.RootElement;
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("n/a"));
+        Assert.That(root.GetProperty("drift_summary").GetString(),
+            Does.Contain("Only one SAE artifact").And.Contain("≥2"));
+    }
+
+    [Test]
+    public void Drift_TwoArtifacts_StableMetrics_OutcomePass()
+    {
+        WriteArtifact("2026-04-29", DaysAgo(5), mse: 0.001, dead: 10.0, purity: 0.50);
+        WriteArtifact("2026-05-04", DaysAgo(0), mse: 0.0011, dead: 10.5, purity: 0.49);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("pass"));
+        Assert.That(root.GetProperty("score").GetDouble(), Is.EqualTo(0.0011).Within(1e-9));
+        Assert.That(root.GetProperty("baseline").GetDouble(), Is.EqualTo(0.001).Within(1e-9));
+        Assert.That(root.GetProperty("drift_summary").GetString(), Does.Contain("within tolerance"));
+    }
+
+    [Test]
+    public void Drift_MseJumpAboveTolerance_OutcomeConcern()
+    {
+        // +100% MSE vs baseline — well above the 50% relative tolerance.
+        WriteArtifact("2026-04-29", DaysAgo(5), mse: 0.001, dead: 10.0, purity: 0.50);
+        WriteArtifact("2026-05-04", DaysAgo(0), mse: 0.002, dead: 10.0, purity: 0.50);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("concern"));
+        Assert.That(root.GetProperty("drift_summary").GetString(),
+            Does.Contain("reconstruction_mse").And.Contain("100%"));
+        Assert.That(root.GetProperty("delta_from_baseline").GetDouble(), Is.EqualTo(0.001).Within(1e-9));
+    }
+
+    [Test]
+    public void Drift_DeadFeaturesAboveTolerance_OutcomeConcern()
+    {
+        // +10 pct points dead features — above the 5pp tolerance.
+        WriteArtifact("2026-04-29", DaysAgo(5), mse: 0.001, dead: 10.0, purity: 0.50);
+        WriteArtifact("2026-05-04", DaysAgo(0), mse: 0.001, dead: 20.0, purity: 0.50);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("concern"));
+        Assert.That(root.GetProperty("drift_summary").GetString(),
+            Does.Contain("dead_features_pct"));
+    }
+
+    [Test]
+    public void Drift_PurityDropAboveTolerance_OutcomeConcern()
+    {
+        // -0.10 absolute purity drop — above the 0.05 tolerance.
+        WriteArtifact("2026-04-29", DaysAgo(5), mse: 0.001, dead: 10.0, purity: 0.50);
+        WriteArtifact("2026-05-04", DaysAgo(0), mse: 0.001, dead: 10.0, purity: 0.40);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("concern"));
+        Assert.That(root.GetProperty("drift_summary").GetString(),
+            Does.Contain("feature_partition_purity_mean"));
+    }
+
+    [Test]
+    public void Drift_LocalSuffixDirs_AreExcluded()
+    {
+        // Two -local artifacts should be ignored (per-developer experiments,
+        // not the shared timeline). With both excluded, drift falls back to "n/a".
+        WriteArtifact("2026-04-29-local", DaysAgo(5), mse: 0.001, dead: 10.0, purity: 0.50);
+        WriteArtifact("2026-05-04-local", DaysAgo(0), mse: 0.50, dead: 90.0, purity: 0.01);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("n/a"),
+            "All -local artifacts should be filtered out, leaving zero in window.");
+    }
+
+    [Test]
+    public void Drift_ArtifactsOutsideWindow_AreExcluded()
+    {
+        // Old artifact (30d ago) outside a 7d window; only newest counts → insufficient history.
+        WriteArtifact("2026-04-04", DaysAgo(30), mse: 0.001, dead: 10.0, purity: 0.50);
+        WriteArtifact("2026-05-04", DaysAgo(0), mse: 0.001, dead: 10.0, purity: 0.50);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("n/a"));
+        Assert.That(root.GetProperty("drift_summary").GetString(), Does.Contain("Only one SAE artifact"));
+    }
+
+    [Test]
+    public void Drift_MalformedArtifact_IsSkipped()
+    {
+        // A corrupt artifact JSON should be silently skipped, not crash the tool.
+        WriteArtifact("2026-04-29", DaysAgo(5), mse: 0.001, dead: 10.0, purity: 0.50);
+        var corruptDir = Path.Combine(_tempRoot, "optick-sae", "2026-05-01");
+        Directory.CreateDirectory(corruptDir);
+        File.WriteAllText(Path.Combine(corruptDir, "optick-sae-artifact.json"), "{ not valid json");
+        WriteArtifact("2026-05-04", DaysAgo(0), mse: 0.0011, dead: 10.5, purity: 0.49);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
+
+        Assert.That(root.GetProperty("outcome").GetString(), Is.EqualTo("pass"),
+            "Two well-formed artifacts should drive the outcome; the malformed one is skipped.");
+    }
+
+    [Test]
+    public void Drift_EvidenceShape_MatchesContract()
+    {
+        WriteArtifact("2026-04-29", DaysAgo(5), mse: 0.001, dead: 10.0, purity: 0.50);
+        WriteArtifact("2026-05-04", DaysAgo(0), mse: 0.0011, dead: 10.5, purity: 0.49);
+
+        var result = QaTools.ScoreQualityDriftAt("optick-sae", 7, _tempRoot);
+        var root = JsonDocument.Parse(result).RootElement;
 
         Assert.Multiple(() =>
         {
-            Assert.That(root.TryGetProperty("kind", out _), Is.True, "missing 'kind'");
-            Assert.That(root.TryGetProperty("name", out _), Is.True, "missing 'name'");
-            Assert.That(root.TryGetProperty("drift_summary", out _), Is.True, "missing 'drift_summary'");
+            Assert.That(root.TryGetProperty("kind", out _), Is.True);
+            Assert.That(root.TryGetProperty("name", out _), Is.True);
+            Assert.That(root.TryGetProperty("outcome", out _), Is.True);
+            Assert.That(root.TryGetProperty("score", out _), Is.True);
+            Assert.That(root.TryGetProperty("baseline", out _), Is.True);
+            Assert.That(root.TryGetProperty("delta_from_baseline", out _), Is.True);
+            Assert.That(root.TryGetProperty("guardrail_max", out _), Is.True);
+            Assert.That(root.TryGetProperty("drift_summary", out _), Is.True);
         });
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>UTC timestamp <paramref name="days"/> ago, ISO-8601.</summary>
+    private static string DaysAgo(int days) =>
+        DateTimeOffset.UtcNow.AddDays(-days).ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+    /// <summary>
+    /// Writes a minimally-shaped SAE artifact to
+    /// <c>{_tempRoot}/optick-sae/{dateDir}/optick-sae-artifact.json</c> with
+    /// the metrics fields the drift logic reads.
+    /// </summary>
+    private void WriteArtifact(string dateDir, string trainedAtIso, double mse, double dead, double purity)
+    {
+        var dir = Path.Combine(_tempRoot, "optick-sae", dateDir);
+        Directory.CreateDirectory(dir);
+        var artifactId = $"optick-sae-{trainedAtIso.Replace(':', '-')}-test{Guid.NewGuid():N}-topk-sae".Replace(":", "-");
+        var json = $$"""
+        {
+          "artifact_id": "{{artifactId}}",
+          "trained_at": "{{trainedAtIso}}",
+          "metrics": {
+            "reconstruction_mse": {{mse.ToString("G17", System.Globalization.CultureInfo.InvariantCulture)}},
+            "dead_features_pct": {{dead.ToString("G17", System.Globalization.CultureInfo.InvariantCulture)}},
+            "feature_partition_purity_mean": {{purity.ToString("G17", System.Globalization.CultureInfo.InvariantCulture)}}
+          }
+        }
+        """;
+        File.WriteAllText(Path.Combine(dir, "optick-sae-artifact.json"), json);
     }
 }


### PR DESCRIPTION
## Summary

Replaces the Phase 1 stub that only counted artifact presence with a real
time-series drift computation. The MCP tool `qa_score_quality_drift` now
reads consecutive optick-sae artifacts in the requested window, computes
deltas on three metrics, and reports a structured `QaEvidence` record
with `outcome ∈ { pass, concern, n/a }`.

## What changed

**Drift metrics + per-pair tolerances** — calibrated against the
2026-05-03 → 2026-05-04 supersede so legitimate baseline shifts surface
as `concern` for human review:

| Metric | Tolerance |
|---|---|
| `reconstruction_mse` | relative +50% |
| `dead_features_pct` | absolute +5 pp |
| `feature_partition_purity_mean` | absolute drop −0.05 |

**Filtering rules**:
- `<date>-local/` directories excluded (per-developer experiments, not the shared timeline)
- Artifacts older than `windowDays` excluded
- Malformed JSON silently skipped (not allowed to crash the tool)
- Newest vs oldest in window — surfaces cumulative drift

**Evidence fields populated**:
- `score` = newest `reconstruction_mse`
- `baseline` = oldest `reconstruction_mse` in window
- `delta_from_baseline` = absolute MSE delta
- `guardrail_max` = 0.05 (the contract guardrail)
- `drift_summary` = side-by-side text or specific concerns

**Reusable tooling**: also brings `Scripts/export_session_to_md.py` —
parses a Claude Code session JSONL log into readable markdown (filters
tool calls, results, thinking blocks, system reminders, hooks, IDE
markers, subagent sidechains). Used to surface the conversation that
led to the SAE proposal.

## Tests

12 unit tests in `QaToolsScoreQualityDriftTests`:

- 4 Phase 1 paths preserved (no artifacts, case-insensitive metric, fall-through, evidence shape)
- 8 new Phase 2 cases:
  - one-artifact insufficient-history → `n/a`
  - two-artifact stable metrics → `pass`
  - MSE jump above tolerance → `concern`
  - dead_features jump above tolerance → `concern`
  - purity drop above tolerance → `concern`
  - `-local` dirs excluded
  - artifacts outside window excluded
  - malformed artifact silently skipped

## Cross-repo context

Companion to ix PR #29 (`feat/optick-sae-phase1`) which produces the
artifacts this tool consumes. The handoff is the JSON-on-disk contract
defined in `docs/contracts/2026-05-02-optick-sae-artifact.contract.md`
(v0.1.1) and the schema in `docs/contracts/optick-sae-artifact.schema.json`.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~QaToolsScoreQualityDriftTests"` — 12/12 pass
- [x] `dotnet build Apps/GaQaMcp/GaQaMcp.csproj -c Debug` — 0 errors
- [ ] Watch CI for any regressions in adjacent tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)