### PR TITLE
fix(tabs): TabLineRegex requires a pipe in matched run — closes bare-digit known limitation

### DIFF
--- a/Common/GA.Business.ML/Tabs/TabTokenizer.cs
+++ b/Common/GA.Business.ML/Tabs/TabTokenizer.cs
@@ -8,12 +8,32 @@ using Models;
 /// </summary>
 public class TabTokenizer
 {
-    // Regex to identify a tab line (starts with optional string name, followed by - or |)
-    // Examples: "e|---", "E|---", "---", "|---"
-    // Regex to identify a tab line (unanchored to allow text prefixes)
-    // Matches "String|Content" or "|Content"
+    // Regex to identify a tab line (unanchored to allow text prefixes).
+    // Examples that match: "e|---3---|", "E|---3---|", "---3-----|", "|---0-2-0|"
+    // Examples that DON'T match (used to be false-positives, now rejected):
+    //   "0146"                        — bare pitch-class-set notation
+    //   "12-bar blues form"           — '12-b' has no pipe
+    //   "Released --12-04-- last week" — hyphenated date, no pipe
+    //   "Are 0146 and 0137 z-related?" — algebra query, no pipe
+    //
+    // Why the trailing `(?=[-0-9|hbp/\\svx~]*\|)` lookahead matters:
+    // tab notation always carries at least one bar-line `|` somewhere on
+    // the line — that's the inherent measure separator. Without that
+    // anchor the regex matches any digit/dash/letter run from prose
+    // (algebra set descriptors, "12-bar blues", dates) and the
+    // tokenizer dispatched theory questions to tab analysis. The
+    // lookahead requires a `|` to appear within the next run of
+    // tab-content characters, so:
+    //   - "e|---3---|" still matches (pipe in matched run)
+    //   - "---3-----0-----|" still matches (pipe at end)
+    //   - "0146" no longer matches (no pipe anywhere)
+    // Anonymous-row tab without pipes (extremely rare in the wild) IS
+    // rejected — pinned by Tokenize_BareDigitProseInputs_NoLongerProduceNoteSlices
+    // and the existing anonymous-row positive control which uses pipes.
     private static readonly Regex
-        TabLineRegex = new(@"([A-Ga-g]?[#b]?\|?|\|)[-0-9|hbp/\\svx~]+", RegexOptions.Compiled);
+        TabLineRegex = new(
+            @"([A-Ga-g]?[#b]?\|?|\|)(?=[-0-9|hbp/\\svx~]*\|)[-0-9|hbp/\\svx~]+",
+            RegexOptions.Compiled);
 
     // Regex to split inline tabs (e.g. "e|---| B|---|")
     // Loosely: patterns that look like [Space][PossibleStringName][|]

--- a/Tests/Common/GA.Business.ML.Tests/Tabs/TabTokenizerTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Tabs/TabTokenizerTests.cs
@@ -136,48 +136,38 @@ E|--10---|
     }
 
     [TestCase("Are 0146 and 0137 z-related?",
-        Description = "Pitch-class-set notation in algebra queries — matches via bare-digit path")]
+        Description = "Pitch-class-set notation in algebra queries")]
     [TestCase("Explain 12-bar blues form",
-        Description = "Common theory question — '12-b' matches digit+dash+b at length 4")]
+        Description = "Common theory question — '12-b' is digit+dash+b without a pipe")]
     [TestCase("Released --12-04-- last week.",
-        Description = "Dates / version strings with hyphens trip the same regex")]
-    public void Tokenize_BareDigitProseInputs_KnownLimitation(string input)
+        Description = "Hyphenated dates / version strings without pipes")]
+    public void Tokenize_BareDigitProseInputs_NoLongerProduceNoteSlices(string input)
     {
-        // KNOWN LIMITATION (documented, not a bug to silently regress):
-        // The TabLineRegex `([A-Ga-g]?[#b]?\|?|\|)[-0-9|hbp/\\svx~]+` allows
-        // every part of group 1 to be optional, so a bare digit run matches.
-        // Pitch-class-set notation like "0146", "12-bar form", and hyphenated
-        // dates therefore all tokenize as if they were single-string tab.
-        // Real fix is to require either a string-name letter OR a literal
-        // pipe in group 1; doing so without breaking real tabs that lack
-        // string-name prefixes (the
-        // Tokenize_AnonymousRowTabWithoutStringNamePrefix_ProducesNoteSlices
-        // positive control) requires care, so this is parked.
+        // FIXED: previously a "known limitation" — the original
+        // TabLineRegex `([A-Ga-g]?[#b]?\|?|\|)[-0-9|hbp/\\svx~]+` allowed
+        // every part of group 1 to be optional, so bare digit runs matched
+        // and pitch-class-set notation, "12-bar form" prose, and hyphenated
+        // dates all tokenized as if they were single-string tab. The
+        // upstream production misroute on /chatbot/ surfaced this regularly
+        // for theory questions.
         //
-        // Upstream guard: any orchestrator that gates on
-        // `Tokenize(message).Any(b => b.Slices.Any(s => s.Notes.Any()))`
-        // will treat these prompts as tab. Those orchestrators must either
-        // consult a complementary signal (algebra-intent classifier, or a
-        // refined tokenizer that requires multi-string blocks) OR reject
-        // single-block, single-slice tokenizations as ambiguous prose.
+        // Fix: a `(?=[-0-9|hbp/\\svx~]*\|)` lookahead now requires the
+        // matched run to contain at least one literal pipe — the inherent
+        // bar-line marker of tab notation. Real tabs (with or without
+        // string-name prefix) carry pipes; these prose inputs do not.
         //
-        // Test design rationale (per PR #110 review): we *document* current
-        // behaviour with TestContext.WriteLine + Assert.Pass rather than
-        // pinning Is.True. A future regex tightening can remove these cases
-        // when they start returning Is.False; but unrelated ProcessBlock
-        // refactors that incidentally drop single-slice blocks won't
-        // produce a misleading "regression" failure here.
+        // The existing anonymous-row positive control
+        // (Tokenize_AnonymousRowTabWithoutStringNamePrefix_ProducesNoteSlices)
+        // still passes because that case ends each line with `|`. If
+        // someone authors anonymous-row tab WITHOUT pipes, the tokenizer
+        // will now correctly reject it — that's a degenerate format that
+        // was producing false positives anyway.
         var blocks = _tokenizer.Tokenize(input);
         var hasNotes = blocks.Any(b => b.Slices.Any(s => s.Notes.Count > 0));
 
-        TestContext.WriteLine(
-            $"Input: {input}\n" +
-            $"  blocks={blocks.Count}, hasNotes={hasNotes} (current behaviour)");
-        Assert.Pass(
-            $"Documented limitation; current behaviour: hasNotes={hasNotes}. " +
-            "When the tokenizer is tightened to reject bare-digit prose, " +
-            "convert this to Assert.That(hasNotes, Is.False) and remove the " +
-            "inputs that no longer trigger the bug.");
+        Assert.That(hasNotes, Is.False,
+            $"Bare-digit prose must NOT tokenize as tab. Input: {input} → " +
+            $"blocks={blocks.Count}, hasNotes={hasNotes}");
     }
 
     [TestCase("Use a G chord then an A chord, then back to G.",


### PR DESCRIPTION
## Why
Closes the known limitation that PRs #110 and #114 documented and worked around. The original \`TabLineRegex\` allowed every part of group 1 to be optional, so any digit/dash/letter run from prose matched as if it were tab. Three classes of false positive went through and needed orchestrator-level mitigation:

- \`Are 0146 and 0137 z-related?\` — algebra pitch-class sets
- \`Explain 12-bar blues form\` — \`12-b\` = digit+dash+b
- \`Released --12-04-- last week\` — hyphenated dates

## Fix
Add a \`(?=[-0-9|hbp/\\svx~]*\|)\` lookahead requiring the matched run to contain at least one literal \`|\`. Tab notation always carries a bar-line — that's the inherent measure separator. None of the false-positive prose inputs have pipes; all real tab inputs do.

## Why the reviewer's concern doesn't bite
PR #110 review flagged that \"require letter OR pipe in group 1\" would break anonymous-row tabs:
\`\`\`
---3-----0-----|
-----2-----0---|
------0-----0--|
\`\`\`
This fix doesn't require letter-or-pipe at the START — it requires a pipe SOMEWHERE in the matched run. All those examples end with \`|\`, so they still match via regex backtracking. The existing \`Tokenize_AnonymousRowTabWithoutStringNamePrefix_ProducesNoteSlices\` positive control still passes.

## Test plan
- [x] \`Tokenize_BareDigitProseInputs_NoLongerProduceNoteSlices\` flips from \`Assert.Pass\` documentation to \`Assert.That(hasNotes, Is.False)\` for all 3 cases.
- [x] 21/21 TabTokenizerTests pass.
- [x] 25/25 with downstream TabAnalysisServiceTests + EndToEndTabAnalysisTests — no regression in real-tab parsing.
- [x] 60/60 in ChatbotApiSurfaceTests + ChatbotPathBaseTests + readiness probe — HasTabContent integration still works.

## Effect on PR #114's HasTabContent guard
Stays in place — defense in depth. With this regex tightening, the guard is now redundant for the documented bare-digit cases (tokenizer rejects them directly), but remains load-bearing for any FUTURE LLM mis-classification where the message has actual tab content yet shouldn't dispatch to AnalyzeTabAsync.

## Degenerate format note
Anonymous tab fragments WITHOUT any \`|\` (e.g. isolated chord positions like \`0-3-2-0-1-0\`) are now rejected. Extremely rare in published tab and producing false positives anyway. Flagging in case any consumer relies on the prior behaviour.

## One-way / two-way door
**Two-way door.** Single regex change; reverting is one revert away. Conservative — it only TIGHTENS what's accepted. False rejections (real tab the regex now misses) are limited to pipe-less degenerate fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)