### PR TITLE
chore: document cross-repo contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,13 @@ Apps live in `Apps/`: `ga-server/GaApi` (ASP.NET + SignalR + GraphQL), `GaChatbo
 - Pre-commit hook (`pwsh Scripts/install-git-hooks.ps1`) enforces `dotnet format` and build.
 
 For detailed C#/F#/Frontend standards, consult `.agent/skills/` (auto-discovered by Claude Code). For governance, use `demerzel-*` skills.
+
+## Cross-repo contracts
+
+GA collaborates with sibling repos via JSON-on-disk contracts (the canonical handoff pattern across the GuitarAlchemist ecosystem). Sibling clones are typically peers under the same parent directory:
+
+- **ix** (`../ix/`, Rust ML algorithms): produces `state/voicings/optick.index` consumed by GA's RAG layer; produces SAE artifacts at `state/quality/optick-sae/<date>/optick-sae-artifact.json` per `docs/contracts/2026-05-02-optick-sae-artifact.contract.md` (schema: `docs/contracts/optick-sae-artifact.schema.json`).
+- **Demerzel** (`../Demerzel/`, governance + IXQL): orchestrates the QA Architect tribunal per `docs/contracts/2026-05-02-qa-verdict.contract.md` (schema: `docs/contracts/qa-verdict.schema.json`); pipelines under `Demerzel/pipelines/*.ixql`.
+- **tars** (`../tars/`, F# grammar + metacognition): cross-model theory validator.
+
+Locked-field changes need cross-repo coordination. The `links.supersedes` pattern in `optick-sae-artifact` is how to introduce a non-breaking baseline shift without freezing the schema. Contracts marked v0.1.x in their headers are still drafts — only freeze at the explicitly named Phase 4 milestone of their respective plans.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,16 @@ Apps live in `Apps/`: `ga-server/GaApi` (ASP.NET + SignalR + GraphQL), `GaChatbo
 
 For detailed C#/F#/Frontend standards, consult `.agent/skills/` (auto-discovered by Claude Code). For governance, use `demerzel-*` skills.
 
+## Cross-repo contracts
+
+GA collaborates with sibling repos via JSON-on-disk contracts (the canonical handoff pattern across the GuitarAlchemist ecosystem). Sibling clones are typically peers under the same parent directory:
+
+- **ix** (`../ix/`, Rust ML algorithms): produces `state/voicings/optick.index` consumed by GA's RAG layer; produces SAE artifacts at `state/quality/optick-sae/<date>/optick-sae-artifact.json` per `docs/contracts/2026-05-02-optick-sae-artifact.contract.md` (schema: `docs/contracts/optick-sae-artifact.schema.json`).
+- **Demerzel** (`../Demerzel/`, governance + IXQL): orchestrates the QA Architect tribunal per `docs/contracts/2026-05-02-qa-verdict.contract.md` (schema: `docs/contracts/qa-verdict.schema.json`); pipelines under `Demerzel/pipelines/*.ixql`.
+- **tars** (`../tars/`, F# grammar + metacognition): cross-model theory validator.
+
+Locked-field changes need cross-repo coordination. The `links.supersedes` pattern in `optick-sae-artifact` is how to introduce a non-breaking baseline shift without freezing the schema. Contracts marked v0.1.x in their headers are still drafts — only freeze at the explicitly named Phase 4 milestone of their respective plans.
+
 ## Collaboration discipline
 
 Drawn from Karpathy's skill + sohaibt/product-mode (merged, not installed). Apply to non-trivial work — typos and one-liners skip this.


### PR DESCRIPTION
## Summary

Adds a **Cross-repo contracts** section to CLAUDE.md and AGENTS.md (which mirror each other) naming the JSON-on-disk handoffs GA participates in with sibling repos:

- **ix** produces `state/voicings/optick.index` + SAE artifacts (`docs/contracts/2026-05-02-optick-sae-artifact.contract.md`)
- **Demerzel** orchestrates QA verdicts (`docs/contracts/2026-05-02-qa-verdict.contract.md`) via `pipelines/*.ixql`
- **tars** cross-validates theory

Documents the `links.supersedes` pattern for non-breaking baseline shifts and flags that v0.1.x contracts remain drafts until their Phase 4 freeze milestones.

A fresh session opening this repo cold now knows immediately that schema and artifact-shape changes are coordinated changes across three repos, not local-only ones.

## Test plan

- [x] No code changes — doc only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)