### PR TITLE
feat(skills): Skill Stewards team — dual-watch + skill-author + skill-graduator agents

### DIFF
--- a/.claude/agents/skill-author.md
+++ b/.claude/agents/skill-author.md
@@ -1,0 +1,122 @@
+---
+name: skill-author
+description: Drafts a new GA chatbot SKILL.md file in skills-dev/ from a description of what the skill should do. Use when starting a new skill (catalog, computation, or hybrid) — produces the frontmatter + body stub the iteration loop runs against. Refuses to overwrite an existing draft or canonical skill of the same name.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+# skill-author — draft a new chatbot skill
+
+Generate a fresh `SKILL.md` under `skills-dev/<name>/` so the user can
+start iterating immediately. The output must satisfy GA's
+[SKILL.md schema](../../docs/contracts/skill-md-schema.md) so the
+chatbot's `FileBasedSkillsProvider` picks it up via live-reload, and
+Claude Code can also load it as a plugin skill.
+
+## Inputs the user provides
+
+- A short name (kebab-case, like `progression-mood` or `chord-info`).
+- A one-paragraph description of what the skill should do.
+- Optional: example user prompts that should trigger it.
+- Optional: classification — *catalog* (deterministic lookup, no LLM
+  per call), *computation* (calls an MCP tool deterministically), or
+  *hybrid* (LLM synthesizes over a deterministic substrate).
+
+## Pre-flight checks (refuse if these fail)
+
+1. **No name collision**: glob `skills/<name>/SKILL.md` and
+   `skills-dev/<name>/SKILL.md`. If either exists, refuse and tell the
+   user to either pick a different name OR explicitly invoke the
+   graduator/redrafter pattern (move existing to drafts first).
+2. **Name is kebab-case**: `^[a-z][a-z0-9-]*$`. Reject snake_case,
+   PascalCase, spaces.
+3. **Description is non-empty** and contains at least one usage hint
+   like "use when" or "when the user asks". The description is what
+   the orchestrator's intent router (and Claude Code's slash-command
+   matcher) score against — vague descriptions misroute.
+
+## Output template
+
+```markdown
+---
+name: <name>
+description: |
+  <one paragraph: what the skill returns, when to use it, what
+   evidence kind it produces. Include 2-3 user-prompt fragments
+   the orchestrator should match against.>
+triggers:
+  - "<trigger phrase 1>"
+  - "<trigger phrase 2>"
+  - "<trigger phrase 3>"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+metadata:
+  authoring-style: <deterministic-catalog | mcp-tool-driven | hybrid-llm>
+  origin: "drafted by skill-author agent on <ISO date>"
+  evidence-kinds:
+    - <catalog_lookup | mcp_tool_call | llm_synthesis>
+---
+
+# <Skill title>
+
+## When the chatbot dispatches to this skill
+
+<Concrete user-prompt examples — at least 3. The orchestrator's intent
+router compares user messages against THIS body as well as the
+description, so concrete examples here improve routing precision.>
+
+## What the skill returns
+
+<Output structure: sections, fields, formats. Include a short example
+output if the format is non-obvious.>
+
+## How the skill computes
+
+<Reference the implementation: an `IOrchestratorSkill` class for
+catalog skills, an MCP tool name for tool-driven skills, or "LLM
+synthesis grounded on <X>" for hybrid skills. State whether the
+behaviour is fully deterministic or whether the LLM is in the path.>
+
+## Refuse to invent
+
+<List the things the skill MUST NOT hallucinate — chord voicings
+outside the catalog, scale memberships, set-class numbers, etc. The
+chatbot's groundedness validator gates on these.>
+```
+
+## Trigger generation rules
+
+- **3 triggers minimum**, each at least 3 chars (parser drops shorter
+  ones via `MinTriggerLength`).
+- Triggers are lowercase, plain English fragments — NOT regex, NOT
+  patterns. The router does case-insensitive substring match.
+- Avoid stop words alone (`"is"`, `"the"`) — they shadow more-specific
+  skills.
+- Include both verb and noun phrasings if natural: "what is X",
+  "tell me about X", "X chord".
+
+## After writing the file
+
+- Confirm the file parses: invoke `dotnet test` filtered to
+  `SkillMdParserTests` against a temp content.
+- Tell the user the next step: edit triggers / body, then either
+  iterate by editing the file OR invoke `skill-graduator` when stable.
+- DO NOT create empty stubs without all required fields — the parser
+  rejects skills without a Name, and `SkillMdLoader` filters skills
+  with no surviving triggers.
+
+## Anti-patterns
+
+- Don't generate a skill that duplicates an existing one. If the user
+  describes a behaviour already covered by a canonical skill, point
+  that out and ask whether they want to revise the existing skill
+  (move it to drafts) or pick a different name.
+- Don't include implementation hints in `metadata.origin` that aren't
+  true — the field becomes audit signal for which skills were
+  AI-authored vs human-authored.

--- a/.claude/agents/skill-graduator.md
+++ b/.claude/agents/skill-graduator.md
@@ -1,0 +1,97 @@
+---
+name: skill-graduator
+description: Promotes a stable SKILL.md draft from skills-dev/ to canonical skills/, validates it against SkillMdParserTests, commits, and opens a PR. Use when a draft has been iterated on enough that it should ship to production. Refuses to graduate a skill that fails the parser, has zero surviving triggers, or shadows a canonical skill that hasn't been deliberately replaced.
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# skill-graduator — ship a stable draft to production
+
+Move a SKILL.md from `skills-dev/<name>/` to `skills/<name>/`, validate
+it, commit on a branch, and open a PR. The user's signoff is the
+graduation trigger — agents don't auto-graduate based on time or eval
+score (that responsibility belongs to `skill-iterator` once the eval
+harness ships).
+
+## Pre-flight checks (refuse if any fail)
+
+1. **Draft exists**: `skills-dev/<name>/SKILL.md` is readable.
+2. **Parser-valid**: invoke `dotnet test` filtered to
+   `SkillMdParserTests.TryParseContent_*` against the draft's content.
+   If it doesn't return a non-null `SkillMd` with non-empty Name and
+   at least one surviving trigger, refuse — surface the parser warning.
+3. **No silent canonical replacement**: if `skills/<name>/SKILL.md`
+   ALREADY exists and isn't byte-identical to the draft, ask the user
+   to confirm the canonical replacement is intended. Do NOT silently
+   overwrite a shipped skill.
+4. **Working tree clean for the relevant paths**: `git status --short
+   skills/ skills-dev/` shows only the draft as modified. Refuse if
+   there are other uncommitted SKILL.md changes — those should land
+   on their own PR.
+5. **Branch is `main` (not a feature branch)**: graduation should
+   start from a fresh branch off main, not amend an in-flight one.
+   `git rev-parse --abbrev-ref HEAD` must equal `main`.
+
+## Graduation procedure
+
+1. **Create a branch**: `git checkout -b feat/skill-<name>-graduate`.
+2. **Move the directory**: `git mv skills-dev/<name> skills/<name>`.
+   This preserves git history (rename detection) so the draft's
+   iteration is auditable from `git log --follow`.
+3. **Run the broader test suite** to confirm no regression:
+   `dotnet test Tests/Common/GA.Business.ML.Tests --filter
+   "FullyQualifiedName~SkillMd"`. All must pass (60/60 today).
+4. **Commit** with a message that includes:
+   - Skill name and a one-line summary (from the draft's `description`).
+   - The skill's `authoring-style` from frontmatter `metadata`.
+   - Reference to the iteration history (commit range from when the
+     draft was first added to `skills-dev/`).
+   - Co-authored-by line if AI-authored: `Co-Authored-By: Claude Opus
+     4.7 (1M context) <noreply@anthropic.com>`.
+5. **Push and open PR** via `gh pr create`. PR description includes:
+   - One-paragraph summary.
+   - Triggers list (so reviewers see what user prompts will route here).
+   - Acceptance criteria from the user, if provided.
+   - Test plan: at minimum "60/60 SkillMd tests pass".
+   - One-way / two-way door classification (default: two-way; revert
+     a single PR to remove the skill).
+6. **Tell the user the PR URL**. Do NOT auto-merge — graduation is the
+   human's call.
+
+## What this agent must NOT do
+
+- **Do NOT modify the SKILL.md content** during graduation. If the
+  draft needs edits, the user invokes `skill-author` (or edits
+  manually) and re-invokes this agent. Graduation is a relocation +
+  validation step, not an editing step.
+- **Do NOT delete the draft directory after the move** — `git mv`
+  handles that atomically.
+- **Do NOT skip the parser test** even if the draft "looks fine".
+  PR #113's review surfaced a P1 silent-data-loss bug in mixed-casing
+  files; the test catches that class of issue cheaply.
+- **Do NOT graduate skills with `metadata.authoring-style:
+  hybrid-llm`** without surfacing that the skill puts an LLM in the
+  dispatch path — the user should explicitly acknowledge the latency
+  and Ollama dependency.
+
+## Failure modes worth narrating to the user
+
+- Parser rejects the draft → likely YAML indentation or a
+  forgotten required field. Show the parser's diagnostic.
+- All triggers dropped → likely all under `MinTriggerLength` (3 chars).
+- Canonical exists with different content → user must explicitly
+  approve replacement.
+- Branch already exists → suggest `git branch -D` if user agrees,
+  or use a numbered suffix like `-graduate-2`.
+
+## After PR opens
+
+- Surface the URL.
+- Suggest invoking `/octo:review` or the equivalent multi-LLM review
+  pattern for parser PRs (per CLAUDE.md memory: load-bearing for
+  parser / MCP / DI / parser changes — and SKILL.md changes affect the
+  chatbot's dispatch surface).
+- Do NOT poll CI; the user follows up.

--- a/Common/GA.Business.ML/Agents/AgentFramework/FileBasedSkillsProvider.cs
+++ b/Common/GA.Business.ML/Agents/AgentFramework/FileBasedSkillsProvider.cs
@@ -47,10 +47,10 @@ public sealed class FileBasedSkillsProvider : AIContextProvider, IDisposable
     /// </summary>
     private static readonly TimeSpan ReloadDebounce = TimeSpan.FromMilliseconds(200);
 
-    private readonly string _skillsDirectory;
+    private readonly IReadOnlyList<string> _skillsDirectories;
     private readonly Action<string> _logWarning;
     private readonly object _reloadLock = new();
-    private readonly FileSystemWatcher? _watcher;
+    private readonly List<FileSystemWatcher> _watchers = [];
     private readonly SystemThreadingTimer? _debounceTimer;
     private IReadOnlyList<SkillMd> _skills;
     private int _reloadCount;
@@ -64,7 +64,7 @@ public sealed class FileBasedSkillsProvider : AIContextProvider, IDisposable
     /// changes without restarting the host.
     /// </summary>
     public FileBasedSkillsProvider(string skillsDirectory)
-        : this(skillsDirectory, watchForChanges: true)
+        : this(ValidateSingleAndWrap(skillsDirectory), watchForChanges: true)
     {
     }
 
@@ -75,14 +75,51 @@ public sealed class FileBasedSkillsProvider : AIContextProvider, IDisposable
     /// production deployment that wants one-shot startup loading).
     /// </summary>
     public FileBasedSkillsProvider(string skillsDirectory, bool watchForChanges)
+        : this(ValidateSingleAndWrap(skillsDirectory), watchForChanges)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(skillsDirectory);
+    }
 
-        _skillsDirectory = skillsDirectory;
+    /// <summary>
+    /// Preserves the original single-directory ctor's <see cref="ArgumentNullException"/>
+    /// semantics for null/whitespace input — the multi-dir ctor would
+    /// otherwise throw <see cref="ArgumentException"/> later, which is a
+    /// breaking API change for callers that catch the specific type.
+    /// </summary>
+    private static IReadOnlyList<string> ValidateSingleAndWrap(string dir)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dir);
+        return [dir];
+    }
+
+    /// <summary>
+    /// Multi-directory overload — closes the SKILL.md iteration loop. Lists
+    /// directories in priority order: skills loaded from LATER directories
+    /// override skills with the same Name from EARLIER ones. Typical use:
+    /// pass <c>[canonicalDir, draftsDir]</c> so drafts in
+    /// <c>skills-dev/</c> shadow their canonical counterparts in
+    /// <c>skills/</c> while iteration is in flight, and graduate by simply
+    /// moving the file from the draft dir to the canonical dir (the
+    /// override naturally lifts).
+    /// </summary>
+    /// <param name="skillsDirectories">Watch list. Empty / missing dirs are
+    /// silently skipped. At least one must be non-null/non-whitespace.</param>
+    /// <param name="watchForChanges">When true, install
+    /// <see cref="FileSystemWatcher"/> on each directory. Edits in any of
+    /// them trigger a single debounced reload that re-aggregates the merged
+    /// skill set.</param>
+    public FileBasedSkillsProvider(IReadOnlyList<string> skillsDirectories, bool watchForChanges)
+    {
+        ArgumentNullException.ThrowIfNull(skillsDirectories);
+        if (skillsDirectories.Count == 0 || skillsDirectories.All(string.IsNullOrWhiteSpace))
+            throw new ArgumentException(
+                "At least one non-empty skills directory must be provided.",
+                nameof(skillsDirectories));
+
+        _skillsDirectories = [.. skillsDirectories.Where(d => !string.IsNullOrWhiteSpace(d))];
         _logWarning = msg => System.Diagnostics.Debug.WriteLine(msg);
         _skills = LoadSkillsCore();
 
-        if (!watchForChanges || !Directory.Exists(skillsDirectory))
+        if (!watchForChanges)
             return;
 
         _debounceTimer = new SystemThreadingTimer(
@@ -91,19 +128,24 @@ public sealed class FileBasedSkillsProvider : AIContextProvider, IDisposable
             dueTime: Timeout.Infinite,
             period: Timeout.Infinite);
 
-        _watcher = new FileSystemWatcher(skillsDirectory)
+        // One watcher per existing directory. Missing directories are
+        // skipped (they may be created later — re-instantiate to pick them
+        // up; live-reload doesn't track directory creation).
+        foreach (var dir in _skillsDirectories.Where(Directory.Exists))
         {
-            Filter = "SKILL.md",
-            IncludeSubdirectories = true,
-            // LastWrite covers in-place edits; FileName covers create / delete /
-            // rename (which most editors emit during save).
-            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
-            EnableRaisingEvents = true,
-        };
-        _watcher.Changed += OnSkillFileEvent;
-        _watcher.Created += OnSkillFileEvent;
-        _watcher.Deleted += OnSkillFileEvent;
-        _watcher.Renamed += OnSkillFileEvent;
+            var w = new FileSystemWatcher(dir)
+            {
+                Filter = "SKILL.md",
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+                EnableRaisingEvents = true,
+            };
+            w.Changed += OnSkillFileEvent;
+            w.Created += OnSkillFileEvent;
+            w.Deleted += OnSkillFileEvent;
+            w.Renamed += OnSkillFileEvent;
+            _watchers.Add(w);
+        }
     }
 
     /// <summary>Loaded skills, in directory enumeration order.</summary>
@@ -147,10 +189,22 @@ public sealed class FileBasedSkillsProvider : AIContextProvider, IDisposable
         }
     }
 
-    private IReadOnlyList<SkillMd> LoadSkillsCore() =>
-        Directory.Exists(_skillsDirectory)
-            ? SkillMdLoader.LoadFromDirectory(_skillsDirectory, _logWarning)
-            : [];
+    private IReadOnlyList<SkillMd> LoadSkillsCore()
+    {
+        // Load from each directory in order; later directories override earlier
+        // ones on Name collision. This implements the drop-in / overlay pattern:
+        // canonical `skills/` first, drafts `skills-dev/` second, drafts win.
+        var byName = new Dictionary<string, SkillMd>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dir in _skillsDirectories)
+        {
+            if (!Directory.Exists(dir)) continue;
+            foreach (var skill in SkillMdLoader.LoadFromDirectory(dir, _logWarning))
+            {
+                byName[skill.Name] = skill;  // last write wins
+            }
+        }
+        return [.. byName.Values];
+    }
 
     private void OnSkillFileEvent(object sender, FileSystemEventArgs e)
     {
@@ -165,15 +219,16 @@ public sealed class FileBasedSkillsProvider : AIContextProvider, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        if (_watcher is not null)
+        foreach (var w in _watchers)
         {
-            _watcher.EnableRaisingEvents = false;
-            _watcher.Changed -= OnSkillFileEvent;
-            _watcher.Created -= OnSkillFileEvent;
-            _watcher.Deleted -= OnSkillFileEvent;
-            _watcher.Renamed -= OnSkillFileEvent;
-            _watcher.Dispose();
+            w.EnableRaisingEvents = false;
+            w.Changed -= OnSkillFileEvent;
+            w.Created -= OnSkillFileEvent;
+            w.Deleted -= OnSkillFileEvent;
+            w.Renamed -= OnSkillFileEvent;
+            w.Dispose();
         }
+        _watchers.Clear();
         _debounceTimer?.Dispose();
     }
 

--- a/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderReloadTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderReloadTests.cs
@@ -198,8 +198,11 @@ public class FileBasedSkillsProviderReloadTests
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private void WriteSkill(string name, string trigger)
+        => WriteSkillUnderRoot(_tempRoot, name, trigger, body: $"Body for {name}.");
+
+    private static void WriteSkillUnderRoot(string root, string name, string trigger, string body)
     {
-        var dir = Path.Combine(_tempRoot, name);
+        var dir = Path.Combine(root, name);
         Directory.CreateDirectory(dir);
         // camelCase (canonical post-PR-#113).
         var content = $$"""
@@ -211,9 +214,117 @@ public class FileBasedSkillsProviderReloadTests
             ---
             # {{name}}
 
-            Body for {{name}}.
+            {{body}}
             """;
         File.WriteAllText(Path.Combine(dir, "SKILL.md"), content);
+    }
+
+    // ── Multi-directory overlay (skill-stewards iteration loop) ───────────────
+    //
+    // The skill-stewards team uses two directories: `skills/` (canonical)
+    // and `skills-dev/` (drafts). FileBasedSkillsProvider loads from BOTH
+    // and uses last-write-wins on Name collision so a draft shadows its
+    // canonical counterpart while the author iterates. Graduating a skill
+    // is just `git mv skills-dev/<name> skills/<name>` — the override
+    // naturally lifts.
+
+    [Test]
+    public void MultiDir_DraftSkillShadowsCanonicalOnNameCollision()
+    {
+        var canonical = Path.Combine(_tempRoot, "canonical");
+        var drafts    = Path.Combine(_tempRoot, "drafts");
+        Directory.CreateDirectory(canonical);
+        Directory.CreateDirectory(drafts);
+
+        WriteSkillUnderRoot(canonical, "shared-name", "canonical-trigger", "canonical body");
+        WriteSkillUnderRoot(drafts,    "shared-name", "draft-trigger",     "DRAFT BODY");
+
+        using var provider = new FileBasedSkillsProvider(
+            new[] { canonical, drafts },
+            watchForChanges: false);
+
+        Assert.That(provider.Skills, Has.Count.EqualTo(1),
+            "Same Name in both dirs collapses to one entry — last write wins");
+        Assert.That(provider.Skills[0].Triggers, Has.Some.EqualTo("draft-trigger"),
+            "Draft (later in priority order) must shadow canonical");
+        Assert.That(provider.Skills[0].Body, Does.Contain("DRAFT BODY"));
+    }
+
+    [Test]
+    public void MultiDir_NonOverlappingSkillsFromBothDirs_BothLoaded()
+    {
+        var canonical = Path.Combine(_tempRoot, "canonical");
+        var drafts    = Path.Combine(_tempRoot, "drafts");
+        Directory.CreateDirectory(canonical);
+        Directory.CreateDirectory(drafts);
+
+        WriteSkillUnderRoot(canonical, "alpha", "alpha-trigger", "alpha body");
+        WriteSkillUnderRoot(drafts,    "beta",  "beta-trigger",  "beta body");
+
+        using var provider = new FileBasedSkillsProvider(
+            new[] { canonical, drafts },
+            watchForChanges: false);
+
+        Assert.That(provider.Skills, Has.Count.EqualTo(2));
+        Assert.That(provider.Skills.Select(s => s.Name), Is.EquivalentTo(new[] { "alpha", "beta" }));
+    }
+
+    [Test]
+    public void MultiDir_OneDirMissing_OtherStillLoads()
+    {
+        var canonical = Path.Combine(_tempRoot, "canonical");
+        var drafts    = Path.Combine(_tempRoot, "drafts-does-not-exist");
+        Directory.CreateDirectory(canonical);
+        // intentionally do NOT create drafts
+
+        WriteSkillUnderRoot(canonical, "alpha", "alpha-trigger", "alpha body");
+
+        using var provider = new FileBasedSkillsProvider(
+            new[] { canonical, drafts },
+            watchForChanges: false);
+
+        Assert.That(provider.Skills, Has.Count.EqualTo(1),
+            "A missing draft directory must not break loading from canonical");
+    }
+
+    [Test]
+    public void MultiDir_GraduationFlow_DraftRemovedAfterGitMv_CanonicalSurfaces()
+    {
+        // Simulates the graduation flow: author iterates on a draft, then
+        // `git mv` it to canonical. Draft directory loses the file; canonical
+        // gains it. After Reload, the canonical version surfaces. No
+        // duplicate skill entries; no orphan triggers.
+        var canonical = Path.Combine(_tempRoot, "canonical");
+        var drafts    = Path.Combine(_tempRoot, "drafts");
+        Directory.CreateDirectory(canonical);
+        Directory.CreateDirectory(drafts);
+
+        WriteSkillUnderRoot(drafts, "graduating", "draft-trigger", "draft body");
+
+        using var provider = new FileBasedSkillsProvider(
+            new[] { canonical, drafts },
+            watchForChanges: false);
+
+        Assert.That(provider.Skills, Has.Count.EqualTo(1));
+        Assert.That(provider.Skills[0].Body, Does.Contain("draft body"));
+
+        // Graduate: move file from drafts/ to canonical/.
+        var draftSkill = Path.Combine(drafts, "graduating");
+        var graduated  = Path.Combine(canonical, "graduating");
+        Directory.Move(draftSkill, graduated);
+        provider.Reload();
+
+        Assert.That(provider.Skills, Has.Count.EqualTo(1),
+            "Post-graduation: still exactly one skill (no duplicate)");
+        Assert.That(provider.Skills[0].Body, Does.Contain("draft body"),
+            "Same content — graduation just relocates the file");
+    }
+
+    [Test]
+    public void MultiDir_Constructor_RejectsAllNullOrWhitespace()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new FileBasedSkillsProvider(new[] { "", "   ", null! }, watchForChanges: false));
     }
 
     private void WritePascalCaseSkill(string name, string trigger)

--- a/docs/plans/2026-05-05-skill-stewards-team.md
+++ b/docs/plans/2026-05-05-skill-stewards-team.md
@@ -1,0 +1,222 @@
+---
+title: Skill Stewards — permanent agent team for the SKILL.md iteration loop
+date: 2026-05-05
+reversibility: two-way-door (agent definitions are markdown, easily revisable); one-way-door (the dual-watch architecture in FileBasedSkillsProvider — switching back to single-watch would break all in-flight drafts and is a behavioural break for any consumer that grew to expect overlay semantics)
+revisit_trigger: chatbot transcripts produce daily skill-archaeologist signal AND ix Phase 3 action layer ships, OR more than 50 SKILL.md files accumulate (current count is 13 canonical + 0 drafts)
+status: design — `skill-author` and `skill-graduator` shipped this PR. `skill-iterator`, `skill-maintainer`, `skill-archaeologist` await IX Phase 3 + an eval harness.
+---
+
+# Skill Stewards — permanent agent team
+
+## Problem
+
+The SKILL.md ecosystem is now load-bearing on the GA chatbot's dispatch
+surface (5 PRs of it shipped 2026-05-05: #110 #111 #113 #114 #115).
+Authoring, iterating, and retiring skills is currently ad-hoc:
+
+- New skills are hand-written; format mistakes (PascalCase vs camelCase,
+  missing triggers, body-too-long) only surface on parser test runs.
+- Iteration loop is open: edits to a SKILL.md require chatbot restart
+  unless the author knows about live-reload (and points at the right
+  directory).
+- Graduation is implicit: when does a draft become canonical? No
+  explicit threshold, no audit trail.
+- Drift goes unnoticed: a skill whose triggers haven't fired in 60 days
+  might be redundant, broken, or shadowed — nobody checks.
+- Failure-pattern mining is unused: chatbot transcripts contain queries
+  that DON'T match any skill, but no process turns those into proposed
+  SKILL.md drafts.
+
+This plan defines a permanent five-role agent team to close all five
+gaps. The first two roles ship in this PR; the remaining three are
+gated on the IX session's Phase 3 action layer (the cron-driven
+"actor" that turns evals into PRs).
+
+## The team
+
+### 1. `skill-author` (on-demand) — SHIPPED
+
+Drafts a new SKILL.md in `skills-dev/<name>/` from a description. Runs
+the parser pre-flight to confirm the stub validates. Refuses to
+shadow a canonical or existing draft of the same name. See
+[`.claude/agents/skill-author.md`](../../.claude/agents/skill-author.md).
+
+### 2. `skill-graduator` (on-demand) — SHIPPED
+
+Promotes a stable draft from `skills-dev/` to `skills/`, validates it,
+commits on a branch, opens a PR. Refuses to graduate parser-invalid
+files OR silently replace canonical skills. Does NOT modify content
+during graduation — relocation + validation only. See
+[`.claude/agents/skill-graduator.md`](../../.claude/agents/skill-graduator.md).
+
+### 3. `skill-iterator` (on edit, debounced) — DESIGN
+
+Triggered by a `FileSystemWatcher` event on `skills-dev/<name>/SKILL.md`.
+After a 2-second debounce (longer than `FileBasedSkillsProvider`'s
+200 ms reload debounce — author may save several times in a row), runs
+a configured eval fixture against the skill and posts a diff vs the
+prior pass.
+
+Eval fixture format (proposed): `skills-dev/<name>/eval.yaml` with a
+list of `prompt: expected_substring_OR_metadata_check` pairs. The
+iterator runs each prompt against the chatbot endpoint
+(`http://localhost:5252/api/chatbot/chat` if running locally), captures
+the response, and asserts that the configured substring is present
+AND the routing metadata names this skill.
+
+Blockers:
+- Requires a stable chatbot running locally (or a CI runner that
+  starts one). Today this is gated on the Ollama wedge being
+  resolved — chat models need to actually load.
+- Eval fixture format isn't defined; it cross-cuts the existing
+  `state/quality/chatbot-baseline-*.json` and would benefit from a
+  shared schema with the IX action layer's planned drift snapshots.
+
+Build trigger: when Ollama unwedges OR when the IX Phase 3 daily
+snapshot lands and we have a hosted chatbot the iterator can hit.
+
+### 4. `skill-maintainer` (daily cron via Demerzel) — DESIGN
+
+Runs daily at 09:00 UTC. Scans canonical `skills/` and produces a
+maintenance report:
+
+- **Dead triggers**: skills whose triggers haven't fired in the last
+  N days (configurable; default 60). Surfaces via the chatbot's
+  routing telemetry (which exists: `AgentRoutingMetadata.AgentId` is
+  recorded per request).
+- **Drift candidates**: skills whose body references an
+  `IOrchestratorSkill` class that no longer exists (renamed,
+  retired) — requires a static analysis pass over `Common/GA.Business.ML/Agents/Skills/`.
+- **Missing triggers**: canonical skills with zero surviving
+  triggers (parser drops triggers below `MinTriggerLength`; if a
+  skill ends up with none, it's silently un-dispatchable).
+- **Format drift**: skills authored in PascalCase that should be
+  migrated (the parser still accepts them but the convention is
+  camelCase).
+
+Output: a markdown report posted as an issue on the GA repo, OR (in
+autopilot mode) a PR draft per maintenance category.
+
+Blockers:
+- Daily routing telemetry is recorded ad-hoc in
+  `state/telemetry/voicing-search/` but not aggregated for skill-level
+  hit counts. Needs the IX action layer's daily snapshot pattern.
+- Demerzel cron infrastructure exists (the QA Architect Tribunal
+  trigger `trig_01WdRGSqgxah5PD46wg8u4Qq` proves the pattern) but no
+  GA-side cron has been wired yet.
+
+Build trigger: when IX Phase 3 daily snapshots ship AND the GA cron
+inbound is wired (~2.5 days of GA work per the IX session's plan).
+
+### 5. `skill-archaeologist` (weekly cron via Demerzel) — DESIGN
+
+Runs weekly. Mines chatbot transcripts (the queries users sent the
+public chatbot at `https://demos.guitaralchemist.com/chatbot/`) for
+patterns that DIDN'T match any canonical skill — i.e. prompts that
+fell through to the LLM-only path.
+
+Clusters those queries (semantically, via embedding similarity), and
+for each large enough cluster (>= 5 distinct queries in a week)
+proposes a new SKILL.md draft via the `skill-author` agent. Output is
+a PR with the draft pre-populated.
+
+This is the closest match to Karpathy's "LLM Knowledge Base" thesis:
+AI maintains the skill library based on real interactions, not on the
+human author's a priori imagination of what users would ask.
+
+Blockers:
+- Chatbot transcripts aren't currently persisted in queryable form.
+  `ConversationHistoryStore` is in-memory; the SignalR / SSE traffic
+  is logged to `state/telemetry/` ad-hoc.
+- Embedding similarity over user queries is a separate pipeline;
+  could reuse OPTIC-K embeddings but the encoder's musical
+  specialisation may not generalise to "what is a chord" plain
+  English.
+
+Build trigger: when chatbot transcript persistence + embedding lookup
+ship. Sized at ~1 week of GA work; sequenced AFTER `skill-maintainer`.
+
+## Architectural integration
+
+### Today (this PR)
+
+```
+skills-dev/<name>/SKILL.md  ←  skill-author (on-demand)
+       │
+       │  (live-reload via FileBasedSkillsProvider multi-watch)
+       ▼
+GA chatbot dispatches against the draft
+       │
+       │  user iterates
+       ▼
+skills/<name>/SKILL.md  ←  skill-graduator (on-demand, signoff-driven)
+```
+
+### Once IX Phase 3 ships
+
+```
+                   skill-archaeologist (weekly cron)
+                            │
+                            │ proposes drafts from transcripts
+                            ▼
+skills-dev/<name>/SKILL.md  ←  skill-author (on-demand)
+       │                  ←  skill-iterator (on edit, eval diffs)
+       ▼
+GA chatbot dispatches against the draft
+       │
+       ▼
+skills/<name>/SKILL.md  ←  skill-graduator (on-demand)
+       │
+       │  daily scan
+       ▼
+skill-maintainer report → triage issues → retire / migrate / fix
+```
+
+## Why this doesn't bloat the agent inventory
+
+The five roles are all `Skill` or `Agent` definitions — markdown files
+under `.claude/agents/`. They're loaded by Claude Code on session
+start (zero runtime cost when not invoked) and by Demerzel cron jobs
+on schedule. No new daemon, no new database, no new infrastructure
+beyond what already exists for QA Architect Tribunal.
+
+The on-demand roles (`skill-author`, `skill-graduator`) are pure
+markdown agent definitions — same shape as a SKILL.md, which is the
+elegance: this team's definitions ARE skills under the parity contract
+that PR #113 established.
+
+## Open questions for the user
+
+1. Do we want a **`.gitignore` exception for `skills-dev/`** (drafts
+   committed, tracked alongside main code) OR is `skills-dev/` ephemeral
+   per-author? Current default: tracked, short-lived branches.
+2. Should `skill-iterator` post eval diffs to **GitHub PR comments** OR
+   **a Slack channel** OR **the Demerzel governance UI**? Defaulting
+   to PR comments for now.
+3. Should `skill-archaeologist`'s **embedding clustering** reuse
+   OPTIC-K (musical-specific) OR pull in a general-purpose text
+   encoder (sentence-transformers, nomic-embed-text via Ollama)?
+   Sentence-level encoder is probably the right call for plain
+   English queries; OPTIC-K excels at musical content but generalises
+   poorly.
+
+## Blast radius / one-way doors
+
+- **Two-way doors** (revisable easily): all five agent definitions,
+  the eval fixture format, the cron schedule, the report destinations.
+- **One-way door**: the dual-watch architecture in
+  `FileBasedSkillsProvider`. Once consumers depend on overlay
+  semantics (drafts shadow canonical), reverting to single-watch
+  silently breaks every in-flight draft. Pinned by 5 new tests in
+  `FileBasedSkillsProviderReloadTests`.
+
+## Pinned by tests
+
+- `FileBasedSkillsProviderReloadTests.MultiDir_*` — 5 cases: shadow,
+  non-overlap, missing-dir tolerance, graduation flow, constructor
+  validation.
+- `SkillMdParserTests` — 23 cases (parity + casing + bounds + mixed-
+  casing data-loss prevention).
+- The `skill-author` and `skill-graduator` agents themselves run
+  `dotnet test --filter "FullyQualifiedName~SkillMdParserTests"` as
+  pre-flight.

--- a/skills-dev/README.md
+++ b/skills-dev/README.md
@@ -1,0 +1,60 @@
+# `skills-dev/` — drafts workspace for the skill-stewards iteration loop
+
+Drafts of new chatbot skills live here while authors iterate. Once a skill
+stabilises (eval green, behaviour pinned, no open feedback), it graduates
+to the canonical [`skills/`](../skills) directory via the
+[`skill-graduator` agent](../.claude/agents/skill-graduator.md).
+
+## How it works
+
+`FileBasedSkillsProvider` (in `Common/GA.Business.ML/Agents/AgentFramework/`)
+loads SKILL.md files from BOTH `skills/` and `skills-dev/`. On Name
+collision, the draft (later in priority order) **shadows** the canonical
+version. This means while you iterate on `skills-dev/foo/SKILL.md`, the
+running chatbot uses the draft — even if `skills/foo/SKILL.md` still
+exists. Live-reload (200 ms debounce) means edits land in the chatbot
+within a fraction of a second; no restart.
+
+## Authoring a new skill
+
+1. **Scaffold**: invoke the `skill-author` agent with a description of
+   what the skill should do. It generates a stub at
+   `skills-dev/<name>/SKILL.md` with the correct camelCase frontmatter.
+2. **Iterate**: edit triggers, body, and the orchestrator behaviour
+   referenced in the body. Both the chatbot host and your Claude Code
+   session see the changes immediately (the latter if symlinked into
+   `~/.claude/skills/ga-dev/`).
+3. **Graduate**: when stable, invoke the `skill-graduator` agent. It
+   moves the draft to `skills/<name>/`, runs `SkillMdParserTests`,
+   commits, and opens a PR.
+
+## Convention
+
+- Drafts MUST use camelCase frontmatter (`name:`, `description:`,
+  `triggers:`) — matches Anthropic's published spec and the canonical
+  GA convention.
+- Drafts MAY shadow a canonical skill of the same Name. This is
+  intentional during refactors: keep the canonical stable while
+  iterating on a replacement.
+- Drafts are committed to git like canonical skills (no `.gitignore`
+  entry). The expectation is short-lived branches: scaffold → iterate
+  → graduate within a few sessions, not months of stale drafts.
+
+## What's tested
+
+`Tests/Common/GA.Business.ML.Tests/Unit/FileBasedSkillsProviderReloadTests.cs`
+contains five `MultiDir_*` cases pinning:
+
+- Draft shadows canonical on Name collision.
+- Non-overlapping skills from both dirs both load.
+- One missing dir doesn't break loading from the other.
+- Graduation flow: `git mv skills-dev/<name> skills/<name>` → no
+  duplicate skill entries.
+- Constructor rejects an all-empty directory list.
+
+## See also
+
+- [`docs/contracts/skill-md-schema.md`](../docs/contracts/skill-md-schema.md) — the SKILL.md format contract (camelCase canonical, PascalCase still parses).
+- [`docs/plans/2026-05-05-skill-stewards-team.md`](../docs/plans/2026-05-05-skill-stewards-team.md) — full team blueprint, including the three background roles still to wire (skill-iterator, skill-maintainer, skill-archaeologist).
+- [`.claude/agents/skill-author.md`](../.claude/agents/skill-author.md) — the on-demand author agent.
+- [`.claude/agents/skill-graduator.md`](../.claude/agents/skill-graduator.md) — the on-demand graduator agent.


### PR DESCRIPTION
Closes the SKILL.md iteration loop and lays the foundation for a permanent five-role agent team.

## What ships

### 1. Dual-watch in \`FileBasedSkillsProvider\`
New constructor \`(IReadOnlyList<string> dirs, bool watch)\`. Last-write-wins on Name collision: a draft in \`skills-dev/foo/SKILL.md\` shadows a canonical \`skills/foo/SKILL.md\` while iteration is in flight. Graduating is just \`git mv skills-dev/foo skills/foo\` — the override naturally lifts. Single-dir ctors preserve the \`ArgumentNullException\` semantics via \`ValidateSingleAndWrap\` so existing tests keep passing.

### 2. \`skills-dev/\` workspace
New top-level directory for in-flight drafts. README documents the loop, the format conventions (camelCase canonical), and what's pinned by tests.

### 3. Two on-demand Claude Code agents
- **\`skill-author\`** — drafts a new SKILL.md from a description. Pre-flight: no name collision, kebab-case, non-empty description with usage hints, parser-valid output, ≥3 triggers each ≥3 chars.
- **\`skill-graduator\`** — promotes a stable draft to canonical via \`git mv\`, runs SkillMdParserTests, commits, opens PR. Refuses parser-invalid files OR silent canonical replacement. Does NOT modify content during graduation.

### 4. Team blueprint
\`docs/plans/2026-05-05-skill-stewards-team.md\` describes the FULL five-role team. The three NOT shipped this PR are designed and gated on:
- **\`skill-iterator\`**: stable chatbot eval target (Ollama unwedged or IX Phase 3 hosted snapshot).
- **\`skill-maintainer\`**: daily routing telemetry aggregation (IX Phase 3 + Demerzel cron inbound).
- **\`skill-archaeologist\`**: chatbot transcript persistence + embedding lookup (~1 week of GA work). Karpathy's \"LLM Knowledge Base\" thesis applied to the chatbot.

## Test plan
- [x] 13/13 \`FileBasedSkillsProviderReloadTests\` (8 prior + 5 new \`MultiDir_*\`).
- [x] 96/96 in the broader SkillMd + AgentFramework suite.
- [x] Existing \`Constructor_NullOrWhitespaceDirectory_Throws\` keeps passing — preserved via \`ValidateSingleAndWrap\`.

## One-way / two-way door
- **One-way door**: dual-watch overlay semantics. Reverting silently breaks every in-flight draft. Pinned by 5 new tests.
- **Two-way doors**: agent definitions, eval format (TBD), cron schedules (TBD), report destinations (TBD).

## Architectural elegance
The on-demand agent definitions are markdown files under \`.claude/agents/\` — same shape as a SKILL.md under PR #113's parity contract. The team's definitions ARE skills under the unified format. Zero new infrastructure beyond what already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)