### PR TITLE
feat(integration): Antigravity ↔ Claude Code bridge + plan + handoff protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,12 @@ state/quality/**/embedding-clusters-*.json
 state/claims/
 state/chatbot/
 
+# AI-surface handoff notes — working memory between Antigravity native, Claude
+# Code, and remote agents. Notes ARE ignored; the README explaining the
+# protocol is tracked.
+state/handoffs/*
+!state/handoffs/README.md
+
 # Thin chatbot host deployment files stay local/private
 Apps/GaChatbot.Api/appsettings.Production.json
 Apps/GaChatbot.Api/.env*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,20 @@ Apps live in `Apps/`: `ga-server/GaApi` (ASP.NET + SignalR + GraphQL), `GaChatbo
 
 For detailed C#/F#/Frontend standards, consult `.agent/skills/` (auto-discovered by Claude Code). For governance, use `demerzel-*` skills.
 
+## AI surfaces in this workspace
+
+This repo is typically opened in **Antigravity** (a VS Code fork). That gives two AI surfaces in the same window:
+
+- **Antigravity native AI** (bottom-right panel, Claude Opus 4.6 Thinking) — fast, ad-hoc, MCP-capped at 100 tools per instance.
+- **Claude Code extension** (top-right panel, `anthropic.claude-code-2.1.126`) — multi-step, large-context, no tool cap. Reads project-level `.mcp.json`.
+
+Split the work:
+
+- **Antigravity native** → quick lookups, single-file edits, sketch-level brainstorming.
+- **Claude Code** → multi-step plans, multi-file refactors, cross-repo work, anything that needs `/feature`, agent fanout, or the 1M context window.
+
+Hand off between surfaces via [`Scripts/antigravity-bridge.ps1`](Scripts/antigravity-bridge.ps1) — drops a note in `state/handoffs/` (gitignored) that the other surface reads on next ask. Plan: [docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md](docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md).
+
 ## Cross-repo contracts
 
 GA collaborates with sibling repos via JSON-on-disk contracts (the canonical handoff pattern across the GuitarAlchemist ecosystem). Sibling clones are typically peers under the same parent directory:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,20 @@ Apps live in `Apps/`: `ga-server/GaApi` (ASP.NET + SignalR + GraphQL), `GaChatbo
 
 For detailed C#/F#/Frontend standards, consult `.agent/skills/` (auto-discovered by Claude Code). For governance, use `demerzel-*` skills.
 
+## AI surfaces in this workspace
+
+This repo is typically opened in **Antigravity** (a VS Code fork). That gives two AI surfaces in the same window:
+
+- **Antigravity native AI** (bottom-right panel, Claude Opus 4.6 Thinking) — fast, ad-hoc, MCP-capped at 100 tools per instance.
+- **Claude Code extension** (top-right panel, `anthropic.claude-code-2.1.126`) — multi-step, large-context, no tool cap. Reads project-level `.mcp.json`.
+
+Split the work:
+
+- **Antigravity native** → quick lookups, single-file edits, sketch-level brainstorming.
+- **Claude Code** → multi-step plans, multi-file refactors, cross-repo work, anything that needs `/feature`, agent fanout, or the 1M context window.
+
+Hand off between surfaces via [`Scripts/antigravity-bridge.ps1`](Scripts/antigravity-bridge.ps1) — drops a note in `state/handoffs/` (gitignored) that the other surface reads on next ask. Plan: [docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md](docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md).
+
 ## Cross-repo contracts
 
 GA collaborates with sibling repos via JSON-on-disk contracts (the canonical handoff pattern across the GuitarAlchemist ecosystem). Sibling clones are typically peers under the same parent directory:

--- a/Scripts/antigravity-bridge.ps1
+++ b/Scripts/antigravity-bridge.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Bridge from a Claude Code session (terminal or extension) into the running Antigravity IDE.
+
+.DESCRIPTION
+    Wraps the Antigravity CLI (a VS Code-fork CLI at bin/antigravity) so a
+    finished Claude Code task can hand off visual artifacts to the IDE:
+
+      - jump the active editor to a file:line that the agent just edited
+      - open a diff in Antigravity for human review
+      - add a sibling repo to the active workspace
+      - drop a structured handoff note under state/handoffs/ that Antigravity
+        native AI can pick up by reading the workspace
+
+    No state is shared between the two AIs other than the file system. That
+    is the integration: cheap, reliable, no API surface to fight.
+
+.PARAMETER Goto
+    Path to a file (with optional :line:char). Example:
+      -Goto Apps/GaQaMcp/Tools/QaTools.cs:97:13
+
+.PARAMETER Diff
+    Two paths separated by a comma. Example:
+      -Diff "old.cs,new.cs"
+
+.PARAMETER AddFolder
+    Add a folder to the currently active Antigravity window.
+
+.PARAMETER Handoff
+    A short string describing what just landed. Writes a timestamped note
+    under state/handoffs/ that the other AI surface can read.
+
+.EXAMPLE
+    pwsh Scripts/antigravity-bridge.ps1 -Goto "Apps/GaQaMcp/Tools/QaTools.cs:97"
+
+.EXAMPLE
+    pwsh Scripts/antigravity-bridge.ps1 -Handoff "Phase 2 drift wiring landed in PR #112. Tests at QaToolsScoreQualityDriftTests."
+
+.NOTES
+    Plan: docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md
+#>
+[CmdletBinding(DefaultParameterSetName = 'Goto')]
+param(
+    [Parameter(ParameterSetName = 'Goto', Position = 0)]
+    [string]$Goto,
+
+    [Parameter(ParameterSetName = 'Diff')]
+    [string]$Diff,
+
+    [Parameter(ParameterSetName = 'AddFolder')]
+    [string]$AddFolder,
+
+    [Parameter(ParameterSetName = 'Handoff')]
+    [string]$Handoff,
+
+    [Parameter(ParameterSetName = 'Handoff')]
+    [ValidateSet('claude-code', 'antigravity-native', 'agent', 'human')]
+    [string]$From = 'claude-code'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$AntigravityCli = 'C:/Users/spare/AppData/Local/Programs/Antigravity/bin/antigravity'
+if (-not (Test-Path $AntigravityCli)) {
+    throw "Antigravity CLI not found at $AntigravityCli. Is Antigravity installed at the standard path?"
+}
+
+# Repo root — script lives in <repo>/Scripts/, so parent is the root.
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+switch ($PSCmdlet.ParameterSetName) {
+    'Goto' {
+        if (-not $Goto) {
+            Write-Host "Usage: -Goto <path[:line[:char]]>"
+            return
+        }
+        # Antigravity --goto wants the file path resolvable from CWD or absolute.
+        # If it's relative, join from repo root so calling from any cwd works.
+        $parts = $Goto -split ':', 2
+        $filePath = $parts[0]
+        $tail = if ($parts.Count -gt 1) { ":$($parts[1])" } else { '' }
+        if (-not [System.IO.Path]::IsPathRooted($filePath)) {
+            $filePath = Join-Path $RepoRoot $filePath
+        }
+        & $AntigravityCli --reuse-window --goto "${filePath}${tail}"
+        Write-Host "→ Antigravity: jumped to ${filePath}${tail}"
+    }
+    'Diff' {
+        $pair = $Diff -split ','
+        if ($pair.Count -ne 2) {
+            throw "Diff expects two paths separated by a comma."
+        }
+        $a, $b = $pair | ForEach-Object {
+            if ([System.IO.Path]::IsPathRooted($_.Trim())) { $_.Trim() }
+            else { Join-Path $RepoRoot $_.Trim() }
+        }
+        & $AntigravityCli --reuse-window --diff $a $b
+        Write-Host "→ Antigravity: diff $a vs $b"
+    }
+    'AddFolder' {
+        $folder = $AddFolder
+        if (-not [System.IO.Path]::IsPathRooted($folder)) {
+            $folder = Join-Path $RepoRoot $folder
+        }
+        if (-not (Test-Path $folder)) {
+            throw "Folder not found: $folder"
+        }
+        & $AntigravityCli --reuse-window --add $folder
+        Write-Host "→ Antigravity: added $folder to active window"
+    }
+    'Handoff' {
+        $handoffDir = Join-Path $RepoRoot 'state/handoffs'
+        if (-not (Test-Path $handoffDir)) {
+            New-Item -ItemType Directory -Path $handoffDir -Force | Out-Null
+        }
+        $stamp = (Get-Date -Format 'yyyy-MM-ddTHH-mm-ssZ').Replace(':', '-')
+        $file = Join-Path $handoffDir "$stamp-$From.md"
+
+        # Capture lightweight context: branch, last commit, working-tree summary.
+        $branch = (git -C $RepoRoot rev-parse --abbrev-ref HEAD 2>$null) ?? '<no-git>'
+        $head   = (git -C $RepoRoot log -1 --format='%h %s' 2>$null) ?? '<no-commits>'
+        $dirty  = (git -C $RepoRoot status --short 2>$null | Measure-Object -Line).Lines
+@"
+---
+from: $From
+at: $(Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ')
+branch: $branch
+head: $head
+working_tree_dirty_lines: $dirty
+---
+
+$Handoff
+"@ | Set-Content -Path $file -Encoding UTF8
+        Write-Host "→ Handoff written: $file"
+        Write-Host "  Pick up from the other AI surface by reading $($file.Replace($RepoRoot, '<repo>'))"
+    }
+}

--- a/docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md
+++ b/docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md
@@ -1,0 +1,108 @@
+---
+title: Antigravity ↔ Claude Code integration
+date: 2026-05-05
+type: tools
+reversibility: two-way door (config + docs only)
+revisit_trigger: when a third AI surface joins (Cursor, etc.) OR when the 181-tool overflow blocks real work
+status: draft
+---
+
+# Antigravity ↔ Claude Code integration
+
+## Why this exists
+
+Working in this repo currently means *two* AI surfaces sharing one editor:
+
+1. **Antigravity native AI** — bottom-right panel, Claude Opus 4.6 Thinking, has its own MCP loader. Currently throwing an MCP Error: *"adding this instance with 181 enabled tools would exceed max limit of 100."*
+2. **Claude Code extension** (`anthropic.claude-code-2.1.126`) — top-right panel, Spark icon, regular VS Code extension running inside Antigravity (which is a VS Code fork). Reads project-level `.mcp.json`.
+
+Neither surface is aware of what the other is doing. The shared workspace is the only coordination point — both can read files, both can run terminals, but the two chats don't see each other's history.
+
+This document maps what's where, the immediate blocker, and the integration angles worth investing in.
+
+## What feeds which surface
+
+| Layer | Surface | Source of truth | What it loads |
+|---|---|---|---|
+| Antigravity native AI | Antigravity panel | `C:/Users/spare/AppData/Roaming/Antigravity/User/mcp.json` | Just `GitKraken` at user level today; the rest of the 181-tool count comes from Antigravity built-ins + extension contributions (not auditable from outside the running process) |
+| Claude Code extension | top-right Spark panel | `<repo>/.mcp.json` (project-level) | This repo: `ix`, `meshy-ai`, `demerzel`, `paper-search`, `chrome-devtools` |
+| Claude Code CLI (terminal) | terminal | Same `<repo>/.mcp.json` + user `~/.claude/settings.json` | Same as the extension when run from the same workspace |
+
+The Claude Code extension is a straight VS Code extension targeting `vscode ^1.94.0`. It contributes 21 commands under `claude-vscode.*`, 7 keybindings, a webview, and a walkthrough. Antigravity is a VS Code fork and runs it as-is.
+
+## Immediate blocker — MCP tool budget
+
+Antigravity is hard-capped at 100 enabled MCP tools per AI instance. With 181 currently enabled, *some are being silently dropped*. Until this is resolved, every Antigravity AI session is running with a degraded, non-deterministic toolset.
+
+**Action needed (your call, not mine to execute)**:
+
+1. From Antigravity's MCP UI, list every connected server and its tool count.
+2. Decide which 81+ tools you can drop. Heuristic order:
+   - Servers that duplicate functionality (e.g. multiple GitHub-shaped MCPs)
+   - Servers whose tools you've never invoked in the last 30 days
+   - Servers that are research-mode only (paper-search, etc.) — keep enabled only when needed
+3. Where a server is genuinely useful only sometimes, prefer **disable + re-enable on demand** over leaving it loaded.
+4. Where the same server is useful in both surfaces, prefer leaving it on Claude Code (project-level `.mcp.json`) and *off* on Antigravity native — Claude Code has no 100-tool cap.
+
+This is reversible config — try cuts, observe what breaks. The blast radius is "the AI temporarily can't call X."
+
+## Integration angles, smallest first
+
+### 1. Surface routing (already implicit)
+
+You already do this informally: ad-hoc questions go to Antigravity native AI; deep multi-step work goes to Claude Code. Make it explicit:
+
+- **Antigravity native** — quick lookups, single-file edits, "what does this file do," sketch-level brainstorming.
+- **Claude Code** — multi-step plans, multi-file refactors, cross-repo work, anything that needs `/feature`, agent fanout, or the 1M context window.
+
+Cost: zero. Just discipline. Worth writing into `CLAUDE.md` so future-Claude knows.
+
+### 2. Project-level MCP separation (config-only, recoverable)
+
+Move servers that *only* Claude Code uses out of any user-level Antigravity config. Keep them in `<repo>/.mcp.json` so Claude Code still loads them when you open the workspace, but they don't count against Antigravity's 100-tool cap.
+
+Status: `.mcp.json` already does this for `ix`, `meshy-ai`, `demerzel`, `paper-search`, `chrome-devtools`. Verify the same servers aren't *also* in Antigravity's list — if they are, drop them from there.
+
+### 3. Claude Code as Antigravity's "deep work" handoff
+
+When Antigravity native hits a multi-step task, have it write a brief into a known location (e.g. `state/handoffs/<timestamp>.md`) and prompt the user to spawn a Claude Code session. Inverse: Claude Code session results land in the same dir and Antigravity reads them on next ask.
+
+Cost: a folder + a convention. Low. Useful only if you actually do the handoff often enough to justify it.
+
+### 4. Antigravity-MCP server (speculative — needs Antigravity-side investigation)
+
+If Antigravity exposes an MCP server for *its own* IDE state — open tabs, current selection, diagnostics, terminal output, agent task list — Claude Code could connect to it and gain situational awareness it can't get from file-reads alone.
+
+I don't know whether this exists. To find out:
+
+- Check Antigravity's settings/docs for "MCP server" or "expose IDE state."
+- Check the `extensions.json` and look for any extension that exposes a local socket / port.
+- If it doesn't exist: file-system handoff (option 3) is the cheap substitute.
+
+### 5. Slash-command bridge (speculative — see #4)
+
+If Antigravity has commands you invoke often (Spark workflows, etc.), wrap them as Claude Code slash commands that shell out via `code --command <name>` (or whatever the Antigravity equivalent is). One muscle memory instead of two.
+
+Cost: per-command, ~30 min each. Worth it only for commands you use multiple times a day.
+
+## What I won't recommend
+
+- **Forcing both AIs to share chat history.** Two AIs with overlapping memory but distinct personas usually produces worse outputs than two clean instances. Keep their contexts separate.
+- **Replacing one with the other.** Antigravity native is faster for casual asks; Claude Code is deeper for multi-step work. Keep both.
+- **Auto-tool-trimming via heuristics.** Which 81 tools to drop is a judgment call about your workflow, not something an agent can optimize blindly.
+
+## Ordered next steps
+
+1. **Audit the 181** — open Antigravity's MCP UI, screenshot or copy the server list, sort by tool count. (~10 min, blocking.)
+2. **Cut to ≤ 100** — disable the deltas. Re-test the AI surfaces with a real prompt to confirm nothing critical broke. (~30 min.)
+3. **Write the surface-routing rule** into [CLAUDE.md](../../CLAUDE.md) and [AGENTS.md](../../AGENTS.md). (~5 min.)
+4. **Check for an Antigravity MCP server** — search docs / settings / known port-binders. (~30 min, speculative.)
+5. **Pick one slash-command bridge** if (4) shows promise. (~30 min trial.)
+
+Steps 1–3 are clear wins. Steps 4–5 are exploration; do them only if (1–3) leave you wanting deeper integration.
+
+## What this plan deliberately does NOT do
+
+- Touch any user-level Antigravity config (those can hold tokens; agent shouldn't read or write them without explicit per-file authorization).
+- Trim or namespace MCP servers automatically — destructive to the running tool topology, judgment call.
+- Promise integrations whose API surface I haven't verified (the speculative items are clearly marked).

--- a/state/handoffs/README.md
+++ b/state/handoffs/README.md
@@ -1,0 +1,47 @@
+# state/handoffs/
+
+Drop-zone for asynchronous notes between AI surfaces working in this repo
+(Antigravity native AI ↔ Claude Code extension/CLI ↔ remote agents).
+
+## Why this exists
+
+Two AIs working in the same workspace can't read each other's chat history.
+The file system is the cheapest coordination point — write a small markdown
+note here, the other surface reads it on next ask.
+
+This is intentionally low-tech: no daemon, no event bus, no schema beyond
+the YAML frontmatter the bridge emits. If you need stronger guarantees
+(ordering, ack), use a real PR or a tracked artifact under `state/quality/`.
+
+## How to write a handoff
+
+```powershell
+pwsh Scripts/antigravity-bridge.ps1 -Handoff "Phase 2 drift wiring landed in PR #112. Tests at QaToolsScoreQualityDriftTests." -From claude-code
+```
+
+The `-From` field is one of:
+
+- `claude-code` — Claude Code extension or CLI session
+- `antigravity-native` — Antigravity's native AI panel
+- `agent` — a remote scheduled CCR / cloud agent
+- `human` — you, dropping a note for the AIs
+
+The bridge auto-captures the current branch, the last commit, and a
+working-tree-dirty line count so the receiving surface gets context, not
+just prose.
+
+## How to read handoffs
+
+Sort by filename — names are timestamp-prefixed (`yyyy-MM-ddTHH-mm-ssZ-from.md`)
+so newest is last. Each note is small (≤ 1 KB typical); a single `cat` or
+`Read` is enough.
+
+When the work referenced is fully landed (PR merged, snapshot promoted),
+delete the note. This directory is a queue, not a log.
+
+## Retention policy
+
+- Notes are gitignored — they're working memory, not project artifacts.
+- This README is tracked.
+- If a handoff becomes load-bearing (someone needs it weeks later), promote
+  it to `docs/learnings/` or `docs/plans/` with a real filename.


### PR DESCRIPTION
## Summary

Implements the actually-executable pieces of the dual-AI-surface integration. Two commits:

1. **Plan doc** — maps the dual-surface situation, names the immediate blocker (181 enabled tools vs Antigravity's 100 cap), and orders five integration angles smallest-first.
2. **Bridge + protocol** — adds the pieces I could ship without touching protected user-level config.

## What lands

| File | Role |
|---|---|
| `docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md` | The plan document |
| `Scripts/antigravity-bridge.ps1` | Wraps Antigravity CLI: `-Goto file:line`, `-Diff a,b`, `-AddFolder`, `-Handoff "note"` |
| `state/handoffs/README.md` | Documents the cross-AI handoff protocol (notes are gitignored, README is tracked) |
| `.gitignore` | Adds `state/handoffs/*` exclusion (preserves the README) |
| `CLAUDE.md` + `AGENTS.md` | Adds an **AI surfaces in this workspace** section telling a fresh session how to split work between Antigravity native and Claude Code |

## What was verified

- Antigravity CLI exists at `C:/Users/spare/AppData/Local/Programs/Antigravity/bin/antigravity` (version 1.107.0) and exposes the `--goto`, `--diff`, `--add` flags the bridge wraps.
- Claude Code extension is `anthropic.claude-code-2.1.126`, a regular VS Code extension (`vscode ^1.94.0`), 21 commands under `claude-vscode.*`.
- Bridge `-Handoff` smoke-tested end-to-end: writes the timestamped note, captures branch + HEAD + dirty-line count from git, file is readable from any session in the workspace.

## What stayed speculative

- **Slash-command bridge** (plan §5) — Antigravity CLI follows the standard VS Code CLI surface, which doesn't expose arbitrary extension-command invocation. Only file/folder operations are reachable from outside the running process. Bridge already wraps those.
- **Antigravity-MCP server** (plan §4) — sandbox blocked reading the user-level Antigravity settings.json (could hold tokens). To verify whether Antigravity exposes its own MCP server, you'd need to inspect the running process or its own docs.

## What this PR deliberately does NOT do

- Trim the 181 → 100 MCP tools (judgment call, must happen inside Antigravity's MCP UI)
- Touch user-level Antigravity config (could hold credentials)
- Promise integrations whose API surface I haven't verified

## Test plan

- [x] Bridge `-Handoff` smoke-tested
- [x] Antigravity CLI surface verified
- [x] Doc updates render correctly in markdown preview (cross-repo contracts section preserved from #116)
- [ ] First real-world handoff between surfaces happens whenever you next switch AIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)