### PR TITLE
fix(skills): canonical-skills audit — fix 5 shipped P0/P1 bugs caught by multi-LLM review

### DIFF
--- a/skills/key-identification/SKILL.md
+++ b/skills/key-identification/SKILL.md
@@ -79,7 +79,7 @@ These are hard constraints. Do NOT compute these from this catalog alone.
 
 - **Modal analysis** — modes (Dorian, Phrygian, etc.) are out of scope. The tool only ranks major/minor keys. If the user asks about modal context, defer.
 - **Chord-quality details beyond major/minor/7ths** — the tool's diatonic match doesn't distinguish a `Cmaj7` from a `C` for the purposes of key fitting.
-- **Recommend chords to ADD to the progression** — the tool detects a key from existing chords; it does not suggest continuations. For "what comes next?" defer to the progression-completion skill (when implemented).
+- **Recommend chords to ADD to the progression** — the tool detects a key from existing chords; it does not suggest continuations. For "what comes next?" defer to the `progression-completion` skill.
 
 ## Cross-reference
 

--- a/skills/progression-completion/SKILL.md
+++ b/skills/progression-completion/SKILL.md
@@ -60,7 +60,7 @@ Every suggestion you make must be one of these four cadence types:
 | **Deceptive** | V → vi (instead of V → I) | Surprises the ear by avoiding tonic; useful when you want to extend. |
 | **Plagal** | IV → I | Soft, "amen" cadence; less assertive than authentic. |
 
-In a minor key, substitute as needed (V is often borrowed from the parallel major to get a leading tone — `V7` is fine even when only `v` appears in the natural-minor diatonic set).
+In a minor key, substitute as needed (`V` is conventionally drawn from harmonic minor — the raised 7th degree gives a leading tone — so `V7` is the standard cadential dominant even when only `v` appears in the natural-minor diatonic set).
 
 ## How to phrase suggestions
 

--- a/skills/progression-mood/SKILL.md
+++ b/skills/progression-mood/SKILL.md
@@ -35,10 +35,13 @@ Reproduce the technique list verbatim — the choice of techniques and their ord
 Open with: *"Here are five reliable ways to darken a progression. Pick one or stack them — each shifts the harmonic mood without abandoning the underlying key."*
 
 1. **Swap to parallel minor** — replace the tonic's major chord with its parallel minor (C → Cm). Pulls everything that follows toward minor-mode resolution.
-2. **Borrow from Aeolian (natural minor)** — substitute IV → iv, vi → bVI, V → v. So `C F G` → `C Fm G` or `C bA G`. Standard pop-ballad move.
-3. **Borrow from Phrygian** — drop in bII (Db in C major) or use bII–I as a final resolution. The half-step approach gives a Spanish/cinematic colour.
-4. **Borrow from Dorian** — keep the i minor but swap iv → IV (Dorian's natural 6) for the bittersweet, modal-folk feel of *Scarborough Fair*.
-5. **Replace V with bVII** — `C bB F` instead of `C G F`. Common in rock; the lack of a leading tone weakens the pull home and reads as moodier.
+2. **Borrow from Aeolian (natural minor)** — substitute `IV → iv`, `V → v`, and add chords from the parallel minor (`bIII`, `bVI`, `bVII`). Worked examples in C major:
+   - `C F G` → `C Fm G` (the `IV → iv` move; standard pop-ballad).
+   - `C F G` → `C F Gm` (the `V → v` move; weakens the pull home).
+   - `C Am F G` → `C Am Ab G` — substitute `bVI` (`Ab`) for the original `IV` (`F`); the `vi → bVI` swap also works in this slot when the progression contains a vi chord.
+3. **Borrow from Phrygian** — drop in `bII` (`Db` in C major) or use `bII → I` as a final resolution. The half-step approach gives a Spanish/cinematic colour.
+4. **Borrow from Dorian** — keep the `i` minor but swap `iv → IV` (Dorian's natural 6) for the bittersweet, modal-folk feel of *Scarborough Fair*.
+5. **Replace V with bVII** — `C Bb F` instead of `C G F`. Common in rock; the lack of a leading tone weakens the pull home and reads as moodier.
 
 Close with: *"Combine 1 + 2 for a strong sad-pop transformation; 3 alone for film-score gravity; 4 alone for folk melancholy."*
 
@@ -47,7 +50,7 @@ Close with: *"Combine 1 + 2 for a strong sad-pop transformation; 3 alone for fil
 Open with: *"Here are four reliable ways to brighten a progression that feels too dark or static."*
 
 1. **Swap to parallel major** — flip a minor tonic to its parallel major (Am → A). Strongest mood-flip available.
-2. **Borrow from Lydian** — raise IV → #IV (#iv° actually), or hold a IV with a #11 colour. Floating, dreamy lift.
+2. **Borrow from Lydian** — use a `IVmaj7#11` colour, or substitute the `II` major chord (`D` in C Lydian) for the diatonic `ii` (`Dm`). The Lydian raised 4th gives a floating, dreamy lift.
 3. **Borrow from Mixolydian** — add bVII as a passing chord that doesn't resolve down (`I bVII IV I`); rock-anthem brightness.
 4. **Reinforce V → I** — make sure the dominant resolves cleanly back to tonic. Add a V7 or V/V to strengthen pull.
 

--- a/skills/scale-info/SKILL.md
+++ b/skills/scale-info/SKILL.md
@@ -2,17 +2,23 @@
 name: "scale-info"
 description: "Returns the seven notes of a major or minor key plus its key signature and relative key. Calls the deterministic `ga_scale_get_notes` MCP tool — never recall an answer from training data."
 triggers:
-  - "notes in"
-  - "notes are in"
-  - "notes of"
-  - "scale of"
+  # Tightened 2026-05-05 (skill-audit) to remove overlap with key-identification
+  # ("what key" / "key of") and chord-info ("notes in" / "notes of"). Each trigger
+  # below requires either a "scale" / "key signature" anchor OR a major/minor
+  # quality token, so user prompts that should route to chord-info or
+  # key-identification don't get pulled here.
   - "scale notes"
+  - "scale of"
+  - "notes in the key"
+  - "notes in c major"
+  - "notes in c minor"
+  - "notes in a major"
+  - "notes in a minor"
+  - "notes of the key"
   - "what is c major"
   - "what is c minor"
-  - "show me the"
-  - "list the notes"
-  - "key of"
-  - "what key"
+  - "key signature of"
+  - "list the notes of"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"
@@ -62,9 +68,9 @@ If `Error` is non-null, surface the message verbatim and ask the user to clarify
 
 ## When to ask for clarification
 
-- User names a chord rather than a key: *"what notes are in a C major chord"* → that's a chord-intervals question; defer to the chord-info skill (when implemented). Do NOT call `ga_scale_get_notes`.
-- User asks about modes (Dorian, Phrygian, etc.) other than major / minor — the tool only supports major and minor. Decline cleanly: *"This tool returns only major and minor scales; for modes I'd need different tooling."*
-- User asks for a scale other than the diatonic 7-note one (whole-tone, blues, pentatonic, harmonic minor): same — decline rather than fabricating notes.
+- User names a chord rather than a key: *"what notes are in a C major chord"* → that's a chord-intervals question; defer to the `chord-info` skill. Do NOT call `ga_scale_get_notes`.
+- User asks about modes (Dorian, Phrygian, etc.) other than major / minor — defer to the `modes` skill, which lists the seven major-scale modes with their degree formulas. `ga_scale_get_notes` itself only returns major or minor.
+- User asks for a scale other than the diatonic 7-note one (whole-tone, blues, pentatonic, harmonic minor): decline rather than fabricating notes.
 
 ## Out of scope
 


### PR DESCRIPTION
Three parallel adversarial reviewers audited the **11 canonical SKILL.md files** (Octopus-style multi-LLM review per CLAUDE.md memory). They caught **5 bugs SHIPPING TO USERS today** on \`demos.guitaralchemist.com/chatbot/\`. This PR fixes them.

## Bugs fixed (all in canonical, all shipping)

### P0 — \`skills/progression-mood/SKILL.md\`
Three issues in one file:

1. **\"bA\" and \"bB\" emitted as chord symbols** — standard is \"Ab\" / \"Bb\". A learner copy-pasting \"bA\" gets nothing from any chord-search tool. Fixed lines 38, 41.
2. **The \"vi → bVI\" rule was illustrated by \"C F G\"** which contains no vi. Two distinct Aeolian-borrowing techniques conflated. Reworked to show three discrete examples each tagged to its specific rule.
3. **\"Borrow from Lydian — raise IV → #IV (#iv° actually)\"** — same LLM-thinking-out-loud artefact PR #118 caught in skills-dev/polychord. The parenthetical self-correction shipped into the published catalog. Lydian's signature is II major or IVmaj7#11, not a diminished chord. Rewrote.

### P1 — \`skills/scale-info/SKILL.md\` trigger overlap
\`scale-info\` had \`\"what key\"\` and \`\"key of\"\` triggers — exact-string overlap with \`key-identification\`'s entire trigger set. PR #118 review caught this pattern in skills-dev/ drafts; the canonical has been shipping it longer. Tightened triggers to require a \`scale\` / \`notes in\` / \`key signature\` / explicit major-or-minor anchor.

### P1 — Stale \`(when implemented)\` parentheticals
\`scale-info\` and \`key-identification\` referenced skills as \`(when implemented)\` that are now canonical (\`chord-info\`, \`progression-completion\`, \`modes\`). Created false refusals — the chatbot was telling users \"feature not available\" when the feature existed. Cleaned up three deferrals.

### P2 — \`skills/progression-completion/SKILL.md\` harmonic-minor terminology
Line 63 described V7 in a minor key as \"borrowed from the parallel major\". Standard pedagogy frames this as drawn from harmonic minor (raised 7th degree) — same notes, but the conventional term aligns with every textbook a learner cross-references.

## Scoped out (follow-up cleanup)

The reviewers surfaced a longer list of P2/P3 issues (compatibility version drift, section-name drift, chord-substitution missing sections, fret-span argument-shape claims drift, chord-info/chord-substitution capability asymmetry, modes formula notation). All filed for the future \`skill-maintainer\` agent (per \`docs/plans/2026-05-05-skill-stewards-team.md\`).

## Test plan
- [x] 99/99 SkillMd + FileBasedSkillsProvider + SkillStewards tests pass.
- [x] Graduation gate (every \`allowed-tools\` entry resolves to a real \`[McpServerTool]\`) still passes.
- [x] All 11 canonical SKILL.md files still parse via \`SkillMdLoader\`.

## What multi-LLM review caught (empirical confirmation)

Three reviewer agents in parallel, each with a different lens:
- **Music-theory accuracy** — verified every chord-tone / interval / mode formula / cadence claim mechanically. Caught the \"bA\"/\"bB\" notation, the muddled vi → bVI example, and the Lydian artefact.
- **Format + trigger overlap** — built a collision matrix across all 15 files. Caught the \`scale-info\` ↔ \`key-identification\` trigger collision.
- **Pedagogy + scope boundaries** — checked refuse/clarify completeness. Caught the stale \`(when implemented)\` parentheticals creating false refusals.

Each lens caught bugs the others missed. The pattern continues to validate the \"multi-LLM review is load-bearing\" framing in CLAUDE.md memory.

## One-way / two-way door
**Two-way door.** Pure SKILL.md content edits; reverting any file is one revert away. No code, no tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)