### PR TITLE
fix(ci): Backend Tests + Playwright Tests — pre-existing infra repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,19 +55,30 @@ jobs:
     name: Backend Tests
     runs-on: windows-latest
     needs: build
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-        
+
+    # The build job uploads `**/bin/Release/**` so test jobs can run with
+    # --no-build instead of recompiling. Without this download, dotnet test
+    # fails immediately with "test source file ... was not found" for every
+    # *.Tests.dll. The artifact restores into the workspace at the same
+    # relative paths it was uploaded from, so dotnet test finds the DLLs
+    # at their expected `Tests/.../bin/Release/net10.0/` locations.
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-artifacts
+
     - name: Restore dependencies
       run: dotnet restore AllProjects.slnx
-      
+
     - name: Run backend tests
       run: |
         dotnet test AllProjects.slnx `
@@ -101,27 +112,70 @@ jobs:
     name: Playwright Tests
     runs-on: windows-latest
     needs: build
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-        
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-artifacts
+
     - name: Restore dependencies
       run: dotnet restore AllProjects.slnx
-      
+
     - name: Build Playwright tests
       run: dotnet build Tests/GuitarAlchemistChatbot.Tests.Playwright/GuitarAlchemistChatbot.Tests.Playwright.csproj --configuration Release
-      
+
     - name: Install Playwright browsers
       run: |
         cd Tests/GuitarAlchemistChatbot.Tests.Playwright
         pwsh bin/Release/net10.0/playwright.ps1 install --with-deps
-      
+
+    # Start GaApi in the background so Playwright tests have something to
+    # connect to on http://localhost:5232 (the http profile in
+    # Apps/ga-server/GaApi/Properties/launchSettings.json). Without this,
+    # tests fail with `ECONNREFUSED ::1:5232` because the runner has no
+    # service listening. The poll loop waits up to 60s for the API to
+    # respond before declaring it ready.
+    - name: Start GaApi (background)
+      shell: pwsh
+      run: |
+        $apiDll = "Apps/ga-server/GaApi/bin/Release/net10.0/GaApi.dll"
+        if (-not (Test-Path $apiDll)) {
+          throw "GaApi.dll not found at $apiDll — build artifacts may not have downloaded correctly"
+        }
+        $env:ASPNETCORE_URLS = "http://localhost:5232"
+        $env:ASPNETCORE_ENVIRONMENT = "CI"
+        Start-Process -NoNewWindow -FilePath "dotnet" -ArgumentList $apiDll `
+          -RedirectStandardOutput "gaapi-stdout.log" `
+          -RedirectStandardError "gaapi-stderr.log"
+        # Poll up to 60s for the API to come up. /api/chatbot/status returns
+        # 200 once GaApi finishes startup; any other response or timeout
+        # fails the job loudly with the captured logs.
+        $deadline = (Get-Date).AddSeconds(60)
+        while ((Get-Date) -lt $deadline) {
+          try {
+            $r = Invoke-WebRequest -Uri "http://localhost:5232/api/chatbot/status" -UseBasicParsing -TimeoutSec 2
+            if ($r.StatusCode -eq 200) {
+              Write-Host "GaApi up after $([math]::Round(((Get-Date) - $deadline).TotalSeconds + 60, 1))s"
+              exit 0
+            }
+          } catch { Start-Sleep -Seconds 2 }
+        }
+        Write-Host "::error::GaApi failed to start within 60s"
+        Write-Host "--- gaapi-stdout.log ---"
+        if (Test-Path gaapi-stdout.log) { Get-Content gaapi-stdout.log -Tail 60 }
+        Write-Host "--- gaapi-stderr.log ---"
+        if (Test-Path gaapi-stderr.log) { Get-Content gaapi-stderr.log -Tail 60 }
+        exit 1
+
     - name: Run Playwright tests
       run: |
         dotnet test Tests/GuitarAlchemistChatbot.Tests.Playwright/GuitarAlchemistChatbot.Tests.Playwright.csproj `
@@ -129,6 +183,17 @@ jobs:
           --no-build `
           --logger "trx;LogFileName=playwright-results.trx" `
           --logger "console;verbosity=normal"
+
+    - name: Upload GaApi logs (always)
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: gaapi-logs
+        path: |
+          gaapi-stdout.log
+          gaapi-stderr.log
+        if-no-files-found: ignore
+        retention-days: 7
       
     - name: Upload Playwright test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,11 @@ jobs:
     # Start GaApi in the background so Playwright tests have something to
     # connect to on http://localhost:5232 (the http profile in
     # Apps/ga-server/GaApi/Properties/launchSettings.json). Without this,
-    # tests fail with `ECONNREFUSED ::1:5232` because the runner has no
-    # service listening. The poll loop waits up to 60s for the API to
-    # respond before declaring it ready.
+    # tests fail with `ECONNREFUSED ::1:5232`. The 180s deadline matches
+    # observed startup: the API loads voicing/embedding binary caches,
+    # Yarp config, and the governance watcher before accepting requests
+    # (PR #122 first run reached cache-loading at ~30s, hadn't reached
+    # /api/chatbot/status by 60s).
     - name: Start GaApi (background)
       shell: pwsh
       run: |
@@ -153,27 +155,26 @@ jobs:
         }
         $env:ASPNETCORE_URLS = "http://localhost:5232"
         $env:ASPNETCORE_ENVIRONMENT = "CI"
+        $start = Get-Date
         Start-Process -NoNewWindow -FilePath "dotnet" -ArgumentList $apiDll `
           -RedirectStandardOutput "gaapi-stdout.log" `
           -RedirectStandardError "gaapi-stderr.log"
-        # Poll up to 60s for the API to come up. /api/chatbot/status returns
-        # 200 once GaApi finishes startup; any other response or timeout
-        # fails the job loudly with the captured logs.
-        $deadline = (Get-Date).AddSeconds(60)
+        $deadline = $start.AddSeconds(180)
         while ((Get-Date) -lt $deadline) {
           try {
             $r = Invoke-WebRequest -Uri "http://localhost:5232/api/chatbot/status" -UseBasicParsing -TimeoutSec 2
             if ($r.StatusCode -eq 200) {
-              Write-Host "GaApi up after $([math]::Round(((Get-Date) - $deadline).TotalSeconds + 60, 1))s"
+              $elapsed = [math]::Round(((Get-Date) - $start).TotalSeconds, 1)
+              Write-Host "GaApi up after ${elapsed}s"
               exit 0
             }
-          } catch { Start-Sleep -Seconds 2 }
+          } catch { Start-Sleep -Seconds 3 }
         }
-        Write-Host "::error::GaApi failed to start within 60s"
-        Write-Host "--- gaapi-stdout.log ---"
-        if (Test-Path gaapi-stdout.log) { Get-Content gaapi-stdout.log -Tail 60 }
-        Write-Host "--- gaapi-stderr.log ---"
-        if (Test-Path gaapi-stderr.log) { Get-Content gaapi-stderr.log -Tail 60 }
+        Write-Host "::error::GaApi failed to start within 180s"
+        Write-Host "--- gaapi-stdout.log (tail 80) ---"
+        if (Test-Path gaapi-stdout.log) { Get-Content gaapi-stdout.log -Tail 80 }
+        Write-Host "--- gaapi-stderr.log (tail 80) ---"
+        if (Test-Path gaapi-stderr.log) { Get-Content gaapi-stderr.log -Tail 80 }
         exit 1
 
     - name: Run Playwright tests


### PR DESCRIPTION
## Summary

Both `test-backend` and `test-playwright` jobs in `.github/workflows/ci.yml` have been failing on every CI run on `main` (verified against `d53e947`, `04c159e`, and latest run `25358500486`). Two simple, distinct infra bugs blocking PRs #112 and #119 from merging despite passing review.

## Bug 1 — Backend Tests: missing build artifacts

The `build` job uploads `**/bin/Release/**` as `build-artifacts`, but `test-backend` runs `dotnet test --no-build` without ever downloading them. Result: every `*.Tests.dll` absent on the runner, "test source file ... was not found" × 7+ projects, exit 1.

**Fix**: add `actions/download-artifact@v4` step before `dotnet test`.

## Bug 2 — Playwright Tests: GaApi never started

Tests connect to `http://localhost:5232` (the `http` profile in `GaApi/Properties/launchSettings.json`) but no service runs in CI. Result: `ECONNREFUSED ::1:5232`.

**Fix**: download artifacts, start GaApi via `Start-Process -NoNewWindow dotnet GaApi.dll` with stdout/stderr captured, poll `/api/chatbot/status` for up to 60s, dump captured logs on timeout. Adds `gaapi-logs` artifact upload for post-mortem.

## Why this PR exists

PRs #112 + #119 are SAFE-TO-MERGE per multi-LLM review but blocked by these CI failures. Two options: admin-merge bypass (propagates broken CI) or infra fix (clears the way). This is the latter.

## Test plan

- [ ] CI run shows Backend Tests green (artifacts downloaded, test DLLs found)
- [ ] CI run shows Playwright Tests green (GaApi starts, status endpoint responds)
- [ ] On failure, gaapi-stdout/stderr logs uploaded for forensics

🤖 Generated with [Claude Code](https://claude.com/claude-code)