### PR TITLE
feat(skills): graduate 4 catalog skills (circle-of-fifths, practice-routine, genre-essentials, what-can-you-do)

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillParityMatrixTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillParityMatrixTests.cs
@@ -225,19 +225,33 @@ public class SkillParityMatrixTests
 
         var matrixFolders = Contracts.Select(c => c.SkillMdFolder).ToHashSet();
 
-        // qa-architect predates the chatbot migration (PR #66 — a non-
-        // chatbot skill for QA Architect agent collaboration). Excluded
-        // from the parity matrix by design.
+        // Excluded from the parity matrix by design:
         //
-        // **Follow-up** (per PR #97 review): replace this hardcoded
-        // exclusion with a SKILL.md frontmatter convention, e.g.
+        // - qa-architect: predates the chatbot migration (PR #66 — a non-
+        //   chatbot skill for QA Architect agent collaboration).
+        // - circle-of-fifths, practice-routine, genre-essentials,
+        //   what-can-you-do: pure-SKILL.md catalog skills graduated
+        //   2026-05-05; no C# fast-path by design (the data lives in
+        //   the body, no IOrchestratorSkill needed).
+        //
+        // **Follow-up** (per PR #97 review): replace this hardcoded list
+        // with a SKILL.md frontmatter convention, e.g.
         //     metadata:
         //       chatbot-migration: false
         // and filter on absence-or-true here. Defers the next exclusion
-        // debate to where it belongs (the SKILL.md file itself). Not
-        // doing it now — single-row exclusion isn't a maintenance burden
-        // until there's a second one.
-        skillFolders.Remove("qa-architect");
+        // debate to where it belongs (the SKILL.md file itself).
+        // Maintenance cost is now 5 rows; revisit when it hits 8+.
+        foreach (var skillMdOnly in new[]
+        {
+            "qa-architect",
+            "circle-of-fifths",
+            "practice-routine",
+            "genre-essentials",
+            "what-can-you-do",
+        })
+        {
+            skillFolders.Remove(skillMdOnly);
+        }
 
         Assert.That(skillFolders, Is.EquivalentTo(matrixFolders),
             "Every chatbot SKILL.md folder MUST appear in the parity matrix " +

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillStewardsDraftLoadTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillStewardsDraftLoadTests.cs
@@ -48,17 +48,22 @@ public class SkillStewardsDraftLoadTests
                                   $"body={skill.Body.Length} chars");
         }
 
+        // skills-dev/ may legitimately be empty when all drafts have
+        // graduated to skills/ (the desired terminal state of the
+        // skill-stewards loop). The remaining assertions are
+        // conditional on having drafts to validate.
         Assert.Multiple(() =>
         {
-            Assert.That(skills, Is.Not.Empty,
-                "skills-dev/ should contain drafts after the skill-stewards batch landed");
-            Assert.That(skills.All(s => !string.IsNullOrWhiteSpace(s.Name)), Is.True,
-                "Every draft must have a non-empty Name");
-            Assert.That(skills.All(s => !string.IsNullOrWhiteSpace(s.Description)), Is.True,
-                "Every draft must have a non-empty Description (intent-router input)");
-            Assert.That(skills.All(s => s.Triggers.Count >= 3), Is.True,
-                "Every draft must have at least 3 surviving triggers — fewer would " +
-                "shadow nothing and thus never dispatch");
+            if (skills.Count > 0)
+            {
+                Assert.That(skills.All(s => !string.IsNullOrWhiteSpace(s.Name)), Is.True,
+                    "Every draft must have a non-empty Name");
+                Assert.That(skills.All(s => !string.IsNullOrWhiteSpace(s.Description)), Is.True,
+                    "Every draft must have a non-empty Description (intent-router input)");
+                Assert.That(skills.All(s => s.Triggers.Count >= 3), Is.True,
+                    "Every draft must have at least 3 surviving triggers — fewer would " +
+                    "shadow nothing and thus never dispatch");
+            }
             Assert.That(warnings, Is.Empty,
                 $"SkillMdLoader emitted warnings: {string.Join(" | ", warnings)}");
         });

--- a/skills/circle-of-fifths/SKILL.md
+++ b/skills/circle-of-fifths/SKILL.md
@@ -67,18 +67,24 @@ Order of added flats: **B – E – A – D – G – C – F** (mnemonic: *Batt
 
 Each major key shares its key signature with its **relative minor** — three semitones down (or a minor third), same notes:
 
+**Sharp side:**
 - C major ↔ A minor
 - G major ↔ E minor
 - D major ↔ B minor
 - A major ↔ F# minor
 - E major ↔ C# minor
 - B major ↔ G# minor
+- F# major ↔ D# minor
+- C# major ↔ A# minor
+
+**Flat side:**
 - F major ↔ D minor
 - Bb major ↔ G minor
 - Eb major ↔ C minor
 - Ab major ↔ F minor
 - Db major ↔ Bb minor
 - Gb major ↔ Eb minor
+- Cb major ↔ Ab minor
 
 ## Enharmonic equivalence at the bottom of the circle
 

--- a/skills/genre-essentials/SKILL.md
+++ b/skills/genre-essentials/SKILL.md
@@ -4,7 +4,10 @@ description: "Explains what makes a genre sound like itself — the harmonic, me
 triggers:
   - "what makes blues"
   - "what makes jazz"
-  - "what defines"
+  - "what makes country"
+  - "what makes pop"
+  - "what makes rock"
+  - "what defines a genre"
   - "blues progression"
   - "jazz progression"
   - "country progression"
@@ -78,10 +81,10 @@ Catalog skill. When a user asks what defines a genre's sound, match to one of th
 
 ## When to call other skills
 
-- *"What chords are in [genre] in key X?"* → `diatonic-chords` first, then map genre constraints.
-- *"Generate a [genre] progression"* → `progression-generator` with `style=` set.
-- *"Voicing for jazz"* → `voicing-search` with `"jazz"` in the query.
-- *"Modal harmony"* deeper dive → `modes` skill.
+- *"What chords are in [key]?"* → `scale-info` returns the scale notes; the canonical diatonic-set table is in the `circle-of-fifths` and `key-identification` skills' `DiatonicSet` outputs.
+- *"What key is this progression in?"* → `key-identification`.
+- *"How do I darken / brighten this progression?"* → `progression-mood` (modal-interchange techniques).
+- *"Modal harmony"* deeper dive → `modes`.
 
 ## When to refuse / clarify
 

--- a/skills/practice-routine/SKILL.md
+++ b/skills/practice-routine/SKILL.md
@@ -39,8 +39,6 @@ Daily 30-min routine:
 3. **Comping rhythms (10 min)** — Charleston, *bossa*, four-on-the-floor; each over the same ii-V-I.
 4. **Free comping (5 min)** — over a backing track, no charts.
 
-Skills you can chain: `voicing-search` (find voicings), `voice-leading` (smooth between them).
-
 ### 🎸 Soloing / improvisation
 
 Daily 30-min routine:
@@ -48,8 +46,6 @@ Daily 30-min routine:
 2. **Arpeggio drilling (10 min)** — arpeggios of the chords in your target tune, ascending and descending.
 3. **Target-tone practice (10 min)** — over a backing track, land on chord tones at the bar line.
 4. **Free solo (5 min)** — record yourself; listen back.
-
-Skills you can chain: `arpeggio` (find arpeggios over chords), `progression-analysis` (understand your tune's harmony).
 
 ### 👂 Ear training
 
@@ -64,7 +60,7 @@ Tools: any ear-training app (functional-ear-trainer, EarBeater, Tenuto). The cha
 
 Daily 20-min routine:
 1. **Right-hand independence (5 min)** — alternate-bass over a held chord (e.g. C: bass C–G–C–E with melody on top).
-2. **Travis picking (5 min)** — thumb on bass, fingers on top three strings, classic 3+3+2 pattern.
+2. **Travis picking (5 min)** — alternating thumb (root then 5th of the chord) on bass strings, fingers playing syncopated melody on top three strings.
 3. **Tune work (10 min)** — one section of an arrangement (e.g. Tommy Emmanuel, Chet Atkins, Don Ross).
 
 ### 📈 Repertoire building
@@ -94,6 +90,6 @@ Pick the time you can SUSTAIN, not the time you'd ideally like.
 
 ## When to call other skills
 
-- *"What chords should I practice for jazz?"* → `diatonic-chords` for the key, `chord-info` for each.
-- *"Voicings for comping"* → `voicing-search`.
-- *"Arpeggios for my solo"* → `arpeggio`.
+- *"What chords should I practice for jazz?"* → `chord-info` for individual chords; for the diatonic set, `scale-info` returns the scale notes (full diatonic-chords lookup is roadmap).
+- *"What key is this progression in?"* → `key-identification`.
+- *"What chord comes next?"* → `progression-completion`.

--- a/skills/what-can-you-do/SKILL.md
+++ b/skills/what-can-you-do/SKILL.md
@@ -5,11 +5,13 @@ triggers:
   - "what can you do"
   - "what can the chatbot do"
   - "what does the chatbot do"
-  - "how do i use"
-  - "help"
-  - "capabilities"
-  - "show me what"
+  - "how do i use this"
+  - "how do i use the chatbot"
+  - "your capabilities"
+  - "chatbot capabilities"
   - "what are you good for"
+  - "what features"
+  - "list features"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"


### PR DESCRIPTION
## Summary

Graduates the 4 active SKILL.md-only catalog drafts from `skills-dev/` to canonical `skills/`. **Audit before promotion caught 6 issues** in the same class as PR #121's findings — all fixed in this PR.

## Audit fixes (before promotion)

| Severity | Skill | Issue | Fix |
|---|---|---|---|
| P1 | `practice-routine` | References 5 non-existent skills (`voicing-search`, `voice-leading`, `arpeggio`, `progression-analysis`, `diatonic-chords` — all pending-tools) as if live | Replaced with canonical references only |
| P1 | `genre-essentials` | References fictional `progression-generator` + pending-tools `voicing-search`, `diatonic-chords` | Pointed at canonical `scale-info`, `key-identification`, `progression-mood`, `modes` |
| P1 | `genre-essentials` | Trigger `"what defines"` too generic — would catch `"what defines a major chord"` | Tightened to `"what defines a genre"` + per-genre `"what makes <genre>"` |
| P1 | `what-can-you-do` | Trigger `"help"` shadows every help-me-do-X query; `"show me what"` matches non-capability queries | Replaced with specific phrasings (`"how do i use the chatbot"`, `"your capabilities"`, `"what features"`, `"list features"`) |
| P2 | `circle-of-fifths` | Relative-minor pairings table missing 3 entries (F#/D#m, C#/A#m, Cb/Abm) | Completed and grouped by sharp/flat side |
| P2 | `practice-routine` | Travis-picking description incorrect (`"3+3+2 pattern"` — that's pop strumming) | Corrected to alternating thumb on root/5th with syncopated melody on top three strings |

## Music-theory verification (catalog content audit)

- ✅ Order of sharps/flats (FCGDAEB / BEADGCF)
- ✅ All 15 major key signatures (C through C# / Cb)
- ✅ Bottom-of-circle enharmonics (F#≡Gb, C#≡Db, Cb≡B)
- ✅ Blues 12-bar form, blues scale (1, b3, 4, b5, 5, b7)
- ✅ Pop axis progression (I-V-vi-IV)
- ✅ Mixolydian-rock signature (I-bVII-IV)
- ✅ Country I-IV-V

## Test fixture updates

- `SkillParityMatrixTests`: extended exclusion list (was just `qa-architect`) to include the 4 SKILL.md-only catalog skills. They intentionally have no C# fast-path — data lives in the body, no `IOrchestratorSkill` needed.
- `SkillStewardsDraftLoadTests`: tolerate empty `skills-dev/` now that all drafts have graduated (the desired terminal state of the iteration loop).

## Test plan

- [x] `dotnet test` filtered to skill suite — 109 passed (SkillMd, FileBasedSkillsProvider, SkillStewards, SkillParityMatrix).
- [x] Graduation gate (`AllowedToolsAcrossSkills_ResolveToRegisteredMcpTools`) passes — none of the 4 promoted skills declare `allowed-tools`, so no MCP-tool resolution needed.
- [ ] CI (Build Solution + Build Frontend + Code Quality + claude-review).

## Post-merge state

- `skills/` grows from 11 to 15 canonical skills.
- `skills-dev/` empty of active drafts (specialist drafts remain at `skills-dev/_pending-tools/<name>/DRAFT.md` awaiting their backing MCP tools).
- `what-can-you-do` now correctly lists `circle-of-fifths` as live canonical (was a forward reference; now satisfied by the same PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)