### PR TITLE
fix(skills): Trace.WriteLine, not Debug.WriteLine — Release-mode silent drop

### DIFF
--- a/Common/GA.Business.ML/Agents/AgentFramework/FileBasedSkillsProvider.cs
+++ b/Common/GA.Business.ML/Agents/AgentFramework/FileBasedSkillsProvider.cs
@@ -116,7 +116,9 @@ public sealed class FileBasedSkillsProvider : AIContextProvider, IDisposable
                 nameof(skillsDirectories));
 
         _skillsDirectories = [.. skillsDirectories.Where(d => !string.IsNullOrWhiteSpace(d))];
-        _logWarning = msg => System.Diagnostics.Debug.WriteLine(msg);
+        // Trace, not Debug — Debug.WriteLine is [Conditional("DEBUG")] and
+        // strips out of Release builds, silently dropping warnings in prod.
+        _logWarning = msg => System.Diagnostics.Trace.WriteLine(msg);
         _skills = LoadSkillsCore();
 
         if (!watchForChanges)

--- a/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
+++ b/Common/GA.Business.ML/Agents/Plugins/SkillMdPlugin.cs
@@ -39,9 +39,12 @@ public sealed class SkillMdPlugin : IChatPlugin
     {
         if (!Directory.Exists(path))
         {
-            // Warning is emitted at runtime via ILogger — here we use Trace as fallback
-            // (ILogger not available during DI registration, so use Debug.WriteLine)
-            System.Diagnostics.Debug.WriteLine(
+            // Warning is emitted via Trace (NOT Debug — Debug.WriteLine is
+            // [Conditional("DEBUG")] and compiles out of Release builds, which
+            // would silently drop this migration-critical warning in production).
+            // ILogger is not available during DI registration, so Trace is the
+            // fallback. Test fixture asserts via a Trace.Listeners hook.
+            System.Diagnostics.Trace.WriteLine(
                 $"[SkillMdPlugin] Skills directory not found: {path} — no SKILL.md skills registered.");
             return;
         }
@@ -60,7 +63,7 @@ public sealed class SkillMdPlugin : IChatPlugin
 
             if (legacySkillCount > 0)
             {
-                System.Diagnostics.Debug.WriteLine(
+                System.Diagnostics.Trace.WriteLine(
                     $"[SkillMdPlugin] Canonical '{path}' is empty but legacy '{legacy}' " +
                     $"still has {legacySkillCount} SKILL.md file(s). Production will register ZERO " +
                     $"skills. Either port them into the canonical directory or remove the empty " +
@@ -68,7 +71,7 @@ public sealed class SkillMdPlugin : IChatPlugin
             }
             else
             {
-                System.Diagnostics.Debug.WriteLine(
+                System.Diagnostics.Trace.WriteLine(
                     $"[SkillMdPlugin] No SKILL.md files with triggers found in {path}.");
             }
             return;
@@ -123,7 +126,7 @@ public sealed class SkillMdPlugin : IChatPlugin
                 IsPathInsideDirectory(resolved, rootForOverride))
                 return resolved;
 
-            System.Diagnostics.Debug.WriteLine(
+            System.Diagnostics.Trace.WriteLine(
                 $"[SkillMdPlugin] SKILLMD_SKILLS_PATH '{env}' resolves to '{resolved}' " +
                 $"which is outside the repo root '{rootForOverride}' — ignoring.");
         }


### PR DESCRIPTION
## Summary

CI's Backend Tests showed one real Release-only failure in `GA.Business.ML.Tests`:

```
Register_CanonicalEmptyButLegacyPopulated_WarnsAboutSilentSkillLoss
  Expected: String containing "Canonical" and containing "empty"
  But was:  <string.Empty>
```

The migration-footgun warning fires from `SkillMdPlugin.Register()` via `System.Diagnostics.Debug.WriteLine` — but `Debug.WriteLine` is decorated `[Conditional("DEBUG")]` and the JIT compiles those calls **out of Release builds entirely**. CI runs `dotnet test -c Release`, so the warning is silently dropped in production.

The exact bug class the test was added to catch — silent skill loss during migration — is the same bug class that hides the warning in production. Meta-bug.

## Fix

`System.Diagnostics.Trace.WriteLine` instead. Trace is not `[Conditional]` and always emits, routing through the same listener chain so both production warnings and the test fixture see the same output.

Also fixes the same pattern in `FileBasedSkillsProvider.cs` where `_logWarning` is initialized to `Debug.WriteLine` — same Release-mode silent-drop trap, no test currently catches it but the fix is one character and the comment now flags the trap for future readers.

## Verification

| Suite | Before | After |
|---|---|---|
| `GA.Business.ML.Tests` (Release) | 1003 pass / 1 fail | 1004 pass / 0 fail |
| `SkillMdPluginResolverTests` only | 7 pass / 1 fail | 8 pass / 0 fail |

## Out of scope

Backend Tests CI showed 13 other failures (GPU spectrogram tests, perf benchmarks, GaApi readiness probe timeout). Those are CI-runner environment issues, not Release-vs-Debug bugs. Separate PRs.

## Test plan

- [x] Failing test passes locally with `-c Release`
- [x] Full GA.Business.ML.Tests suite passes (1004 / 0)
- [ ] CI confirms: same test goes green on Backend Tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)