### PR TITLE
fix(skills): wire 4 graduated catalog skills (PR #124) into orchestrator routing

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -39,6 +39,13 @@ public sealed class GaPlugin : IChatPlugin
         services.AddOrchestratorSkillIntent<BeginnerChordsSkill>();
         services.AddOrchestratorSkillIntent<ProgressionMoodSkill>();
 
+        // Catalog skills graduated 2026-05-05 — body lives in SKILL.md,
+        // C# class supplies routing metadata + emits the body verbatim.
+        services.AddOrchestratorSkillIntent<CircleOfFifthsSkill>();
+        services.AddOrchestratorSkillIntent<PracticeRoutineSkill>();
+        services.AddOrchestratorSkillIntent<GenreEssentialsSkill>();
+        services.AddOrchestratorSkillIntent<WhatCanYouDoSkill>();
+
         // Skills using IChatClient are Scoped (IChatClient lifetime is Scoped).
         services.AddOrchestratorSkillIntent<KeyIdentificationSkill>(ServiceLifetime.Scoped);
         services.AddOrchestratorSkillIntent<ProgressionCompletionSkill>(ServiceLifetime.Scoped);

--- a/Common/GA.Business.ML/Agents/Skills/CatalogSkillMdLoader.cs
+++ b/Common/GA.Business.ML/Agents/Skills/CatalogSkillMdLoader.cs
@@ -1,0 +1,37 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using GA.Business.ML.Agents.Plugins;
+using GA.Business.ML.Skills;
+
+/// <summary>
+/// Reads a catalog SKILL.md body by folder name so C# wrapper classes can keep
+/// the SKILL.md as the single source of truth for catalog content while still
+/// supplying the routing metadata (Name, Description, ExamplePrompts) that
+/// <c>SemanticIntentRouter</c> requires.
+/// </summary>
+/// <remarks>
+/// The architectural rule for catalog skills is: SKILL.md = body + routing
+/// triggers; C# class = routing metadata + answer emission. Without a C#
+/// class the skill is invisible to the orchestrator's intent registry — see
+/// the smoke-test failure log "embedded 11 new intent(s)" that surfaced this
+/// gap when the four catalog skills (circle-of-fifths, practice-routine,
+/// genre-essentials, what-can-you-do) were graduated SKILL.md-only on
+/// 2026-05-05.
+/// </remarks>
+internal static class CatalogSkillMdLoader
+{
+    public static string LoadBodyOrFallback(string skillFolderName, string fallback)
+    {
+        try
+        {
+            var skillsDir = SkillMdPlugin.ResolveSkillsPath();
+            var path = Path.Combine(skillsDir, skillFolderName, "SKILL.md");
+            var skillMd = SkillMdParser.TryParse(path);
+            return skillMd?.Body ?? fallback;
+        }
+        catch (Exception)
+        {
+            return fallback;
+        }
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/CircleOfFifthsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/CircleOfFifthsSkill.cs
@@ -1,0 +1,51 @@
+namespace GA.Business.ML.Agents.Skills;
+
+/// <summary>
+/// Walks through the circle of fifths — key signatures, perfect-fifth
+/// relationships, the order of sharps and flats, and the practical use for
+/// navigation between keys. Pure catalog skill, zero LLM calls. Body is
+/// loaded from <c>skills/circle-of-fifths/SKILL.md</c> so the markdown
+/// stays the single source of truth.
+/// </summary>
+public sealed class CircleOfFifthsSkill(ILogger<CircleOfFifthsSkill> logger) : IOrchestratorSkill
+{
+    private const string SkillFolderName = "circle-of-fifths";
+
+    private static readonly Lazy<string> _bodyCache = new(
+        () => CatalogSkillMdLoader.LoadBodyOrFallback(
+            SkillFolderName,
+            "The circle of fifths arranges the twelve major keys so each clockwise step is a perfect fifth up. Each step adds one sharp (clockwise) or one flat (counter-clockwise). C major sits at the top with no sharps or flats."),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public string Name        => "CircleOfFifths";
+    public string Description =>
+        "Explains the circle of fifths: key signatures, the order of sharps " +
+        "(F C G D A E B) and flats (B E A D G C F), enharmonic equivalents at " +
+        "the bottom, and practical use for modulation. Pure catalog lookup, no LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "Explain the circle of fifths",
+        "How do key signatures work?",
+        "What's the order of sharps in key signatures?",
+        "Why do some keys have flats and others sharps?",
+        "How many sharps does D major have?",
+        "Walk me through the circle of fourths",
+    ];
+
+    public bool CanHandle(string message) => false; // semantic-routing only
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var body = _bodyCache.Value;
+        logger.LogDebug("CircleOfFifthsSkill: returned {Length} chars", body.Length);
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = body,
+            Confidence = 1.0f,
+            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
+        });
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/GenreEssentialsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/GenreEssentialsSkill.cs
@@ -1,0 +1,51 @@
+namespace GA.Business.ML.Agents.Skills;
+
+/// <summary>
+/// Explains the harmonic, melodic, rhythmic, and timbral signatures of common
+/// genres (blues, jazz, pop, folk, modal, country, rock). Pure catalog skill,
+/// zero LLM calls. Body is loaded from
+/// <c>skills/genre-essentials/SKILL.md</c> so the markdown stays the single
+/// source of truth.
+/// </summary>
+public sealed class GenreEssentialsSkill(ILogger<GenreEssentialsSkill> logger) : IOrchestratorSkill
+{
+    private const string SkillFolderName = "genre-essentials";
+
+    private static readonly Lazy<string> _bodyCache = new(
+        () => CatalogSkillMdLoader.LoadBodyOrFallback(
+            SkillFolderName,
+            "Genres are defined by harmony, melody, rhythm, and timbre. Blues uses 12-bar I7-IV7-V7 forms; jazz uses extended chords and ii-V-I cadences; pop favours diatonic 4-chord loops like I-V-vi-IV; modal music vamps on one chord with characteristic intervals."),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public string Name        => "GenreEssentials";
+    public string Description =>
+        "Returns harmonic / melodic / rhythmic / timbral signatures for blues, " +
+        "jazz, pop, folk, modal, country, and rock. Catalog answer; the user " +
+        "learns what makes a genre sound like itself. No LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What makes blues sound like blues?",
+        "What defines jazz harmony?",
+        "How do I write a country progression?",
+        "What's a typical pop chord progression?",
+        "Tell me about modal sound",
+        "What chords are common in folk music?",
+    ];
+
+    public bool CanHandle(string message) => false; // semantic-routing only
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var body = _bodyCache.Value;
+        logger.LogDebug("GenreEssentialsSkill: returned {Length} chars", body.Length);
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = body,
+            Confidence = 1.0f,
+            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
+        });
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/PracticeRoutineSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/PracticeRoutineSkill.cs
@@ -1,0 +1,51 @@
+namespace GA.Business.ML.Agents.Skills;
+
+/// <summary>
+/// Suggests a structured practice routine for a stated goal — jazz comping,
+/// soloing, ear training, fingerstyle technique, etc. Pure catalog skill,
+/// zero LLM calls. Body is loaded from
+/// <c>skills/practice-routine/SKILL.md</c> so the markdown stays the single
+/// source of truth.
+/// </summary>
+public sealed class PracticeRoutineSkill(ILogger<PracticeRoutineSkill> logger) : IOrchestratorSkill
+{
+    private const string SkillFolderName = "practice-routine";
+
+    private static readonly Lazy<string> _bodyCache = new(
+        () => CatalogSkillMdLoader.LoadBodyOrFallback(
+            SkillFolderName,
+            "Practice routines should match your goal: jazz comping, improvisation, ear training, fingerstyle, repertoire, or technique. Pick a 15-30 minute daily slot you can sustain rather than the time you'd ideally like."),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public string Name        => "PracticeRoutine";
+    public string Description =>
+        "Returns a structured practice plan for guitar/piano goals — jazz " +
+        "comping, soloing, ear training, fingerstyle, repertoire, barre " +
+        "technique. Templates with daily timings and drills. No LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "Give me a practice routine for jazz comping",
+        "What's a good practice plan for improvisation?",
+        "How do I practice ear training?",
+        "What should I practice for fingerstyle?",
+        "Drill for barre chords",
+        "Exercises for soloing over changes",
+    ];
+
+    public bool CanHandle(string message) => false; // semantic-routing only
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var body = _bodyCache.Value;
+        logger.LogDebug("PracticeRoutineSkill: returned {Length} chars", body.Length);
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = body,
+            Confidence = 1.0f,
+            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
+        });
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/WhatCanYouDoSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/WhatCanYouDoSkill.cs
@@ -1,0 +1,52 @@
+namespace GA.Business.ML.Agents.Skills;
+
+/// <summary>
+/// The chatbot's self-disclosure / capabilities meta-skill. Lists what the
+/// chatbot can do (chord/scale lookup, progression analysis, voicing search,
+/// etc.) with one-line examples. Pure catalog skill, zero LLM calls. Body
+/// is loaded from <c>skills/what-can-you-do/SKILL.md</c> so the markdown
+/// stays the single source of truth.
+/// </summary>
+public sealed class WhatCanYouDoSkill(ILogger<WhatCanYouDoSkill> logger) : IOrchestratorSkill
+{
+    private const string SkillFolderName = "what-can-you-do";
+
+    private static readonly Lazy<string> _bodyCache = new(
+        () => CatalogSkillMdLoader.LoadBodyOrFallback(
+            SkillFolderName,
+            "Guitar Alchemist's chatbot answers grounded music-theory questions — chord and scale lookup, progression analysis, voice leading, transposition, voicing search, and more. Every answer is computed from the GA symbolic engine, not recalled from training data."),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public string Name        => "WhatCanYouDo";
+    public string Description =>
+        "Lists the chatbot's currently-shipped capabilities — chord and scale " +
+        "lookup, key identification, progression completion, voicing search, " +
+        "interval computation, fret-span analysis. Discoverability skill for " +
+        "first-time visitors. No LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What can you do?",
+        "What can the chatbot do?",
+        "How do I use the chatbot?",
+        "What are your capabilities?",
+        "What features do you have?",
+        "List the chatbot's features",
+    ];
+
+    public bool CanHandle(string message) => false; // semantic-routing only
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var body = _bodyCache.Value;
+        logger.LogDebug("WhatCanYouDoSkill: returned {Length} chars", body.Length);
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = body,
+            Confidence = 1.0f,
+            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
+        });
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillParityMatrixTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillParityMatrixTests.cs
@@ -72,6 +72,21 @@ public class SkillParityMatrixTests
             typeof(GA.Business.ML.Agents.Skills.ModesSkill),
             [], "catalog"),
 
+        // Catalog skills graduated 2026-05-05 — body lives in SKILL.md,
+        // C# class supplies routing metadata + emits the body verbatim.
+        new("circle-of-fifths",      "circle-of-fifths",
+            typeof(GA.Business.ML.Agents.Skills.CircleOfFifthsSkill),
+            [], "catalog"),
+        new("practice-routine",      "practice-routine",
+            typeof(GA.Business.ML.Agents.Skills.PracticeRoutineSkill),
+            [], "catalog"),
+        new("genre-essentials",      "genre-essentials",
+            typeof(GA.Business.ML.Agents.Skills.GenreEssentialsSkill),
+            [], "catalog"),
+        new("what-can-you-do",       "what-can-you-do",
+            typeof(GA.Business.ML.Agents.Skills.WhatCanYouDoSkill),
+            [], "catalog"),
+
         // MCP-tool-driven skills (SKILL.md → ga_* tool → IOrchestratorSkill)
         new("interval",              "interval",
             typeof(GA.Business.ML.Agents.Skills.IntervalSkill),
@@ -225,33 +240,16 @@ public class SkillParityMatrixTests
 
         var matrixFolders = Contracts.Select(c => c.SkillMdFolder).ToHashSet();
 
-        // Excluded from the parity matrix by design:
+        // qa-architect predates the chatbot migration (PR #66 — a non-
+        // chatbot skill for QA Architect agent collaboration). Excluded
+        // from the parity matrix by design.
         //
-        // - qa-architect: predates the chatbot migration (PR #66 — a non-
-        //   chatbot skill for QA Architect agent collaboration).
-        // - circle-of-fifths, practice-routine, genre-essentials,
-        //   what-can-you-do: pure-SKILL.md catalog skills graduated
-        //   2026-05-05; no C# fast-path by design (the data lives in
-        //   the body, no IOrchestratorSkill needed).
-        //
-        // **Follow-up** (per PR #97 review): replace this hardcoded list
-        // with a SKILL.md frontmatter convention, e.g.
+        // **Follow-up** (per PR #97 review): replace this hardcoded
+        // exclusion with a SKILL.md frontmatter convention, e.g.
         //     metadata:
         //       chatbot-migration: false
-        // and filter on absence-or-true here. Defers the next exclusion
-        // debate to where it belongs (the SKILL.md file itself).
-        // Maintenance cost is now 5 rows; revisit when it hits 8+.
-        foreach (var skillMdOnly in new[]
-        {
-            "qa-architect",
-            "circle-of-fifths",
-            "practice-routine",
-            "genre-essentials",
-            "what-can-you-do",
-        })
-        {
-            skillFolders.Remove(skillMdOnly);
-        }
+        // and filter on absence-or-true here.
+        skillFolders.Remove("qa-architect");
 
         Assert.That(skillFolders, Is.EquivalentTo(matrixFolders),
             "Every chatbot SKILL.md folder MUST appear in the parity matrix " +


### PR DESCRIPTION
## Summary

Smoke test of the deployed chatbot exposed a real shipped bug: the 4 catalog skills graduated in PR #124 (`circle-of-fifths`, `practice-routine`, `genre-essentials`, `what-can-you-do`) shipped as **SKILL.md-only** files. The chatbot's `SemanticIntentRouter` only sees skills registered as `IOrchestratorSkill` in DI; `SKILL.md` alone isn't enough.

Concrete evidence from chatbot startup log:

```
SemanticIntentRouter: embedded 11 new intent(s); cache now holds 11 intent vectors
query=explain the circle of fifths
  top=skill.interval=0.587 | skill.keyidentification=0.555 | algebra=0.543
```

— Only 11 routable intents; none of the 4 graduated skills appear. Queries fell through to direct-Ollama fallback which then hung.

## Fix

Add 4 minimal C# wrapper classes (`CircleOfFifthsSkill`, `PracticeRoutineSkill`, `GenreEssentialsSkill`, `WhatCanYouDoSkill`) that:
- implement `IOrchestratorSkill` (so `SemanticIntentRouter` sees them)
- declare `Description` + `ExamplePrompts` — the routing-discovery metadata
- delegate body content to the matching `SKILL.md` via `CatalogSkillMdLoader` so the `.md` remains the single source of truth
- keep `CanHandle()` returning `false` (semantic-routing only)

The wrappers register in `GaPlugin.cs` alongside the existing 10 C# skills. Each is sealed, ~50 lines, follows the same pattern as `BeginnerChordsSkill` / `ProgressionMoodSkill`.

## SkillParityMatrixTests update

Removed the 4 from the exclusion list (introduced incorrectly during PR #124 graduation) and added them as proper `Contracts` entries. The exclusion was a false workaround — it told the parity test "no C# class needed" when in fact the dispatch pipeline strictly requires one. Without this PR, the parity test was lying.

## Files

- `Common/GA.Business.ML/Agents/Skills/CatalogSkillMdLoader.cs` (new)
- `Common/GA.Business.ML/Agents/Skills/CircleOfFifthsSkill.cs` (new)
- `Common/GA.Business.ML/Agents/Skills/PracticeRoutineSkill.cs` (new)
- `Common/GA.Business.ML/Agents/Skills/GenreEssentialsSkill.cs` (new)
- `Common/GA.Business.ML/Agents/Skills/WhatCanYouDoSkill.cs` (new)
- `Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs` (4 new registrations)
- `Tests/Common/GA.Business.ML.Tests/Unit/SkillParityMatrixTests.cs` (4 new Contracts; exclusion list back to just `qa-architect`)

## Test plan

- [x] `dotnet test --filter SkillStewards|SkillMd|FileBasedSkillsProvider|SkillParityMatrix` — 117 passed, 0 failed
- [x] Build clean (zero errors)
- [ ] CI gates (Build Solution + Build Frontend + Code Quality + claude-review)
- [ ] Live retest against `localhost:5252/api/chatbot/chat` after merge — verify all 4 prompts route to their respective skill IDs

## Why this matters

PR #121's audit caught 5 P0/P1 bugs in shipped SKILL.md files. PR #124's pre-promotion audit caught 6 more. **This PR catches a 7th: the dispatch path was broken from day one of graduation.** The parity test would have caught it but my exclusion-list workaround in PR #124 muted the signal. Lesson: when the parity test fails, the answer is rarely "exclude the skill"; it's almost always "wire the missing C# class."

🤖 Generated with [Claude Code](https://claude.com/claude-code)