### PR TITLE
fix(ci): gemini gate + GaApi merged-step (replaces #129, closes ga#128 hyp #1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,15 +138,19 @@ jobs:
         cd Tests/GuitarAlchemistChatbot.Tests.Playwright
         pwsh bin/Release/net10.0/playwright.ps1 install --with-deps
 
-    # Start GaApi in the background so Playwright tests have something to
-    # connect to on http://localhost:5232 (the http profile in
-    # Apps/ga-server/GaApi/Properties/launchSettings.json). Without this,
-    # tests fail with `ECONNREFUSED ::1:5232`. The 180s deadline matches
-    # observed startup: the API loads voicing/embedding binary caches,
-    # Yarp config, and the governance watcher before accepting requests
-    # (PR #122 first run reached cache-loading at ~30s, hadn't reached
-    # /api/chatbot/status by 60s).
-    - name: Start GaApi (background)
+    # Start GaApi + run Playwright tests in ONE step. Splitting them
+    # caused ga#128: GaApi spawned via Start-Process gets killed when
+    # the launching pwsh exits at step end (Windows attaches child
+    # processes to the parent's job object, even with -WindowStyle
+    # Hidden — confirmed by PR #129's "GaApi (PID N) exited between
+    # steps" diagnostic). By running both inside one step, the pwsh
+    # process stays alive throughout `dotnet test`, so the Start-Process
+    # child stays alive too. The trap at the end ensures GaApi is killed
+    # even if dotnet test throws, so we don't leak a runaway process.
+    # The 180s deadline matches observed startup: GaApi loads voicing/
+    # embedding binary caches, Yarp config, and the governance watcher
+    # before accepting requests.
+    - name: Start GaApi + Run Playwright tests (single step — see ga#128)
       shell: pwsh
       run: |
         $apiDll = "Apps/ga-server/GaApi/bin/Release/net10.0/GaApi.dll"
@@ -156,50 +160,66 @@ jobs:
         $env:ASPNETCORE_URLS = "http://localhost:5232"
         $env:ASPNETCORE_ENVIRONMENT = "CI"
         $start = Get-Date
-        Start-Process -NoNewWindow -FilePath "dotnet" -ArgumentList $apiDll `
+        $gaapiProc = Start-Process -NoNewWindow -PassThru -FilePath "dotnet" -ArgumentList $apiDll `
           -RedirectStandardOutput "gaapi-stdout.log" `
           -RedirectStandardError "gaapi-stderr.log"
+        Write-Host "GaApi spawned with PID $($gaapiProc.Id)"
+
+        # Liveness probe: any HTTP response = server up; only network
+        # errors (refused / timeout / DNS) keep polling. Background:
+        # ga#128 captured logs proving the previous 200-only probe
+        # missed a healthy GaApi returning 401 in CI's no-auth context.
+        # PowerShell Invoke-WebRequest throws on 4xx/5xx but
+        # $_.Exception.Response is non-null for HTTP errors and null
+        # for connection failures — that's how we separate "alive but
+        # rejecting" from "nothing listening yet."
         $deadline = $start.AddSeconds(180)
-        # Treat ANY HTTP response (200, 401, 404, etc.) as "server up" —
-        # the goal is liveness, not auth correctness. PR #122's first
-        # round captured logs proving GaApi was fully up but returning
-        # 401 on /api/chatbot/status (no auth header in CI), so the old
-        # 200-only check timed out the full 180s on a healthy server.
-        # PowerShell Invoke-WebRequest throws on any 4xx/5xx, but
-        # $_.Exception.Response is non-null for HTTP errors and null for
-        # network errors — that's how we cleanly separate "alive but
-        # rejecting this request" from "nothing listening yet."
-        while ((Get-Date) -lt $deadline) {
+        $apiUp = $false
+        while ((Get-Date) -lt $deadline -and -not $apiUp) {
           try {
             $r = Invoke-WebRequest -Uri "http://localhost:5232/api/chatbot/status" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
             $elapsed = [math]::Round(((Get-Date) - $start).TotalSeconds, 1)
             Write-Host "GaApi up after ${elapsed}s (HTTP $($r.StatusCode))"
-            exit 0
+            $apiUp = $true
           } catch {
             $resp = $_.Exception.Response
             if ($resp -ne $null) {
               $code = [int]$resp.StatusCode
               $elapsed = [math]::Round(((Get-Date) - $start).TotalSeconds, 1)
               Write-Host "GaApi up after ${elapsed}s (HTTP $code, treating non-2xx as live)"
-              exit 0
+              $apiUp = $true
+            } else {
+              Start-Sleep -Seconds 3
             }
-            Start-Sleep -Seconds 3
           }
         }
-        Write-Host "::error::GaApi failed to start within 180s"
-        Write-Host "--- gaapi-stdout.log (tail 80) ---"
-        if (Test-Path gaapi-stdout.log) { Get-Content gaapi-stdout.log -Tail 80 }
-        Write-Host "--- gaapi-stderr.log (tail 80) ---"
-        if (Test-Path gaapi-stderr.log) { Get-Content gaapi-stderr.log -Tail 80 }
-        exit 1
+        if (-not $apiUp) {
+          Write-Host "::error::GaApi failed to start within 180s"
+          Write-Host "--- gaapi-stdout.log (tail 80) ---"
+          if (Test-Path gaapi-stdout.log) { Get-Content gaapi-stdout.log -Tail 80 }
+          Write-Host "--- gaapi-stderr.log (tail 80) ---"
+          if (Test-Path gaapi-stderr.log) { Get-Content gaapi-stderr.log -Tail 80 }
+          if (-not $gaapiProc.HasExited) { Stop-Process -Id $gaapiProc.Id -Force -ErrorAction SilentlyContinue }
+          exit 1
+        }
 
-    - name: Run Playwright tests
-      run: |
-        dotnet test Tests/GuitarAlchemistChatbot.Tests.Playwright/GuitarAlchemistChatbot.Tests.Playwright.csproj `
-          --configuration Release `
-          --no-build `
-          --logger "trx;LogFileName=playwright-results.trx" `
-          --logger "console;verbosity=normal"
+        # GaApi is alive in this same pwsh process. Run Playwright tests
+        # synchronously here. The try/finally ensures the API process is
+        # always cleaned up, even on test failure or runner-side timeout.
+        try {
+          dotnet test Tests/GuitarAlchemistChatbot.Tests.Playwright/GuitarAlchemistChatbot.Tests.Playwright.csproj `
+            --configuration Release `
+            --no-build `
+            --logger "trx;LogFileName=playwright-results.trx" `
+            --logger "console;verbosity=normal"
+          $testExitCode = $LASTEXITCODE
+        } finally {
+          if (-not $gaapiProc.HasExited) {
+            Write-Host "Stopping GaApi PID $($gaapiProc.Id)"
+            Stop-Process -Id $gaapiProc.Id -Force -ErrorAction SilentlyContinue
+          }
+        }
+        exit $testExitCode
 
     - name: Upload GaApi logs (always)
       uses: actions/upload-artifact@v4

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -125,8 +125,15 @@ jobs:
 
   review:
     needs: 'dispatch'
+    # Gate on `vars.GEMINI_REVIEW_ENABLED == 'true'`. Without an API key
+    # (no GEMINI_API_KEY secret OR no APP_ID for Vertex), the gemini-review
+    # workflow 27s-fails on every PR with `Gemini CLI not found in PATH`
+    # / `Please set an Auth method`, blocking unrelated PRs. Repo admin
+    # opts in by setting the `GEMINI_REVIEW_ENABLED` variable to `true`
+    # AFTER configuring `GEMINI_API_KEY` (or `APP_ID` + `APP_PRIVATE_KEY`
+    # for the Vertex path used by the dispatch job's identity token).
     if: |-
-      ${{ needs.dispatch.outputs.command == 'review' }}
+      ${{ needs.dispatch.outputs.command == 'review' && vars.GEMINI_REVIEW_ENABLED == 'true' }}
     uses: './.github/workflows/gemini-review.yml'
     permissions:
       contents: 'read'

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -113,6 +113,7 @@ These are real problems guitarists hit. They're the North Star for every feature
 - **Chatbot chord diagram rendering** — when TheoryAgent mentions a chord, auto-generate a VexTab diagram inline in the chat response
 - **BSP room chord assignment** — assign a diatonic chord function (I, ii, V…) to each BSP room and visualise harmonic flow through rooms
 - **OPTIC-K similarity search UI** — let guitarists search by playing a rhythm pattern, find songs with similar harmonic structure
+- **Remote frontier-LLM provider for hard composition tasks** (parked 2026-05-05) — add a `frontier-remote` purpose to `IChatClientFactory` for tasks where local 3B genuinely fails (long-form composition, deep style imitation). Reference: Cloudflare Workers AI / Infire ([blog](https://blog.cloudflare.com/high-performance-llms/)) supports Kimi K2.5 / Llama 4 Scout via PD-disaggregation + EAGLE-3 spec decoding. **Preconditions before revisiting**: (a) Ollama is stable, (b) we have a concrete user-facing task that 3B fails at, (c) `IChatClientFactory` from migration Phase 1 is fully wired. Don't adopt to dodge an Ollama installer bug. NOT useful for OPTIC-K embeddings (custom 240-dim schema).
 
 ---
 

--- a/docs/solutions/integration-issues/ga-ci-test-job-preconditions-artifacts-services-liveness-2026-05-05.md
+++ b/docs/solutions/integration-issues/ga-ci-test-job-preconditions-artifacts-services-liveness-2026-05-05.md
@@ -148,6 +148,40 @@ exit 1
 
 **Compoundable principle:** A liveness probe answers "is it listening?", not "is this endpoint healthy and authorized?" — those are downstream concerns for the tests themselves. In any HTTP-client language with exceptions on non-2xx (PowerShell `Invoke-WebRequest`, .NET `HttpClient.EnsureSuccessStatusCode`, Python `requests.raise_for_status`, Node `axios`), use the presence of a response object on the exception to reclassify HTTP errors as "alive." Reserve retry-and-wait for true network failures only. This pattern generalizes to any background-service-then-poll CI step (databases, message brokers, tunnels, sidecars).
 
+### 4. Background process gets killed at step boundary (the deepest layer)
+
+**Symptom:** The 401-blind probe correctly reports `GaApi up after 11.9s (HTTP 401, treating non-2xx as live)`, then ~11s later in the *next* step Playwright tests fail uniformly with `Microsoft.Playwright.PlaywrightException : connect ECONNREFUSED ::1:5232` — against an API that was demonstrably alive moments before. The diagnostic verify step in the failed PR #129 captured the smoking gun: `##[error]GaApi (PID N) exited between steps`.
+
+**Root cause:** Windows attaches `Start-Process`-spawned children to the parent's job object. When the launching pwsh's `exit 0` fires at the end of the Start-GaApi step, the OS tears down the job and takes the child with it. `-WindowStyle Hidden` and `-PassThru` are *not* enough — the job-object association persists regardless. By the time the next step's pwsh starts and tries to connect, the listener is gone.
+
+**Fix — collapse Start-Service + Run-Tests into ONE step.** The pwsh executing the merged step stays alive throughout `dotnet test`, so the `Start-Process` child stays alive too. Use `try/finally` to guarantee cleanup on test failure or runner timeout:
+
+```yaml
+- name: Start GaApi + Run Playwright tests (single step)
+  shell: pwsh
+  run: |
+    $env:ASPNETCORE_URLS = "http://localhost:5232"
+    $env:ASPNETCORE_ENVIRONMENT = "CI"
+    $gaapiProc = Start-Process -NoNewWindow -PassThru -FilePath "dotnet" `
+      -ArgumentList "Apps/ga-server/GaApi/bin/Release/net10.0/GaApi.dll" `
+      -RedirectStandardOutput "gaapi-stdout.log" `
+      -RedirectStandardError "gaapi-stderr.log"
+
+    # ... liveness probe (see #3) — sets $apiUp on success ...
+
+    try {
+      dotnet test Tests/.../Playwright.csproj --no-build --logger trx
+      $testExitCode = $LASTEXITCODE
+    } finally {
+      if (-not $gaapiProc.HasExited) {
+        Stop-Process -Id $gaapiProc.Id -Force -ErrorAction SilentlyContinue
+      }
+    }
+    exit $testExitCode
+```
+
+**Compoundable principle:** Workflow steps are process-lifecycle boundaries on Windows runners. If your test needs a background service alive, run them in the same step (so one pwsh holds both lifetimes) — splitting "start" and "use" into separate steps requires a stronger-than-default detach (Scheduled Task, Windows Service, `cmd /c start /b` with explicit job-object detach) that's not worth the complexity for a CI test fixture. Same caveat applies to Linux runners with `bash` and `&`-backgrounded processes — the bash exits at step end and SIGHUPs its children unless explicitly disowned. The merged-step pattern dodges the entire problem class.
+
 ## Prevention
 
 ### 1. CI jobs that consume build outputs must declare an explicit artifact dependency, and `--no-build` runs must fail loudly when the expected DLL is absent
@@ -167,6 +201,12 @@ For each `localhost:<port>` reference in a test config, the workflow must contai
 **Tied to:** Bug #3 (probe required HTTP 200, missed a healthy API returning 401/404 in CI auth context)
 
 A liveness check is asking "is the socket answering?", not "am I authorized?" — so the probe should retry only on `ECONNREFUSED` / timeout / DNS failure, and treat 2xx/3xx/4xx/5xx all as proof the server is up. Reserve status-code assertions for separate functional checks downstream of liveness.
+
+### 4. Run start-service + use-service in the same step; never split them across step boundaries on Windows runners
+
+**Tied to:** Bug #4 (`-WindowStyle Hidden -PassThru` wasn't enough — Windows job-object association killed GaApi when the launching pwsh's `exit 0` fired between steps; PR #129's diagnostic step captured `GaApi (PID 8688) exited between steps`)
+
+Workflow steps are process-lifecycle boundaries on Windows. If a test needs a background service alive, the service-start command and the test command must run inside one step (one pwsh process holds both lifetimes) with a `try/finally` for cleanup. Splitting them requires a stronger-than-default detach (Scheduled Task, Windows Service, `cmd /c start /b` with explicit job-object detach) that's not worth the complexity for a CI test fixture. Same risk on Linux runners with `&`-backgrounded processes — bash SIGHUPs its children at step end unless explicitly disowned.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Two CI infra fixes bundled (both touch `.github/workflows/`):

1. **Gemini review gate** (`gemini-dispatch.yml`) — the `review / review` check has been 27s-failing on every PR with `Gemini CLI not found in PATH` because `GEMINI_API_KEY` isn't configured. Gates the dispatch's `review` job on a new opt-in repo variable `GEMINI_REVIEW_ENABLED == 'true'`. Default state = job skipped, no failed check. Admin opts in via `gh variable set GEMINI_REVIEW_ENABLED --body 'true'` after configuring the auth.

2. **GaApi merged-step pattern** (`ci.yml`, replaces the failed approach in #129) — ga#128 hypothesis #1 was confirmed by PR #129's diagnostic step: `##[error]GaApi (PID 8688) exited between steps`. Even with `-WindowStyle Hidden -PassThru`, Windows attaches the child process to the parent pwsh's job object, and the child dies when the parent's `exit 0` fires.

   Fix: merge Start-GaApi + Run-Playwright into ONE step. The pwsh executing the merged step stays alive throughout `dotnet test`, so the `Start-Process` child stays alive too. `try/finally` ensures GaApi gets stopped on test failure / runner timeout. Liveness probe (401-blind) and 180s window preserved.

## Why one PR for two fixes

Both are pure-CI-workflow patches. Gating `review/review` first means the merged-step PR's CI run will have 4 fewer failures masking the actual signal we care about (Playwright passing or not). Cleaner blast radius.

## Test plan

- [ ] CI on this PR shows `review / review` SKIP (no fail) with default vars
- [ ] CI shows `Playwright Tests` PASS — the keystone signal that the merged-step pattern keeps GaApi alive across the previous step boundary
- [ ] Backend Tests still fail with the 14 env-deps (pre-existing, separate issue)

## Closes

- ga#128 hypothesis #1 (assuming Playwright passes)
- Supersedes #129 (which validated the diagnosis but had the wrong remediation — `-WindowStyle Hidden` alone isn't enough on Windows; merged-step is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)