### PR TITLE
chore(tests): TestTraceListener doc reflects Trace, not Debug

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdPluginResolverTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdPluginResolverTests.cs
@@ -161,25 +161,32 @@ public class SkillMdPluginResolverTests
             Path.Combine(legacyDir, "SKILL.md"),
             "---\nName: \"alpha\"\nDescription: \"Test\"\nTriggers:\n  - \"alpha\"\n---\n\nBody.");
 
-        var debugListener = new TestTraceListener();
-        Trace.Listeners.Add(debugListener);
+        var traceListener = new TestTraceListener();
+        Trace.Listeners.Add(traceListener);
         try
         {
             new SkillMdPlugin().Register(new ServiceCollection(), canonical);
         }
         finally
         {
-            Trace.Listeners.Remove(debugListener);
+            Trace.Listeners.Remove(traceListener);
         }
 
-        var output = debugListener.Output;
+        var output = traceListener.Output;
         Assert.That(output, Does.Contain("Canonical").And.Contain("empty"),
             "Register() must warn when canonical is empty and legacy still has skills, otherwise the migration silently bricks production.");
         Assert.That(output, Does.Contain("1 SKILL.md"),
             "warning must include the legacy skill count so the operator knows what's being shadowed");
     }
 
-    /// <summary>Captures Debug.WriteLine output for inspection.</summary>
+    /// <summary>
+    /// Captures <see cref="System.Diagnostics.Trace.WriteLine(string?)"/> output for inspection.
+    /// Debug.Listeners and Trace.Listeners share the same underlying collection, so in practice
+    /// this listener captures both — but production code in
+    /// <c>SkillMdPlugin</c> / <c>FileBasedSkillsProvider</c> deliberately uses
+    /// <c>Trace.WriteLine</c> rather than <c>Debug.WriteLine</c>, because the latter is
+    /// <c>[Conditional("DEBUG")]</c> and silently strips out of Release builds.
+    /// </summary>
     private sealed class TestTraceListener : TraceListener
     {
         private readonly System.Text.StringBuilder _buf = new();


### PR DESCRIPTION
## Summary

After #125 swapped `SkillMdPlugin` and `FileBasedSkillsProvider` over to `Trace.WriteLine` (because `Debug.WriteLine` is `[Conditional(\"DEBUG\")]` and strips out of Release), the test listener's docstring was stale: it still claimed to capture `Debug.WriteLine` output, which would mislead a future reader into thinking the production code uses Debug.

Functionally nothing changes — `Debug.Listeners` and `Trace.Listeners` share the same collection — but the comment now matches the production code path it's verifying.

## Codebase sweep

\`git grep \"Debug.WriteLine\"\` across the C# tree: clean. The two #125 fixes were the only sites in production code. The only remaining match was this stale doc comment.

## Test plan

- [x] Doc-only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)