### PR TITLE
test(ga-api): EnsureStarted helper surfaces fixture-init exceptions

### DIFF
--- a/Tests/Apps/GaApi.Tests/TestInfrastructure/TestWebApplicationFactory.cs
+++ b/Tests/Apps/GaApi.Tests/TestInfrastructure/TestWebApplicationFactory.cs
@@ -1,6 +1,7 @@
 namespace GaApi.Tests;
 
 using System.Reflection;
+using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 
@@ -13,5 +14,60 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseContentRoot(TestPaths.RepositoryPath("Apps", "ga-server", "GaApi"));
         base.ConfigureWebHost(builder);
+    }
+
+    /// <summary>
+    /// Forces eager host construction so a startup failure surfaces with its
+    /// full inner-exception chain inlined into the rethrown exception's message.
+    /// Call from <c>[OneTimeSetUp]</c> in any test class that uses this factory.
+    ///
+    /// WHY: <see cref="WebApplicationFactory{TEntryPoint}"/> builds the host
+    /// lazily on first <see cref="WebApplicationFactory{TEntryPoint}.Server"/>
+    /// or <see cref="WebApplicationFactory{TEntryPoint}.CreateClient()"/>
+    /// access. When startup fails (DI resolution error, missing config,
+    /// unreachable content root), the exception fires from inside whichever
+    /// test method first touches the factory — and on CI the published TRX
+    /// often shows empty Error Message / Stack Trace fields for every test
+    /// in the class, making the failure look like a phantom mass-fail with
+    /// no diagnostic.
+    ///
+    /// Calling this in <c>[OneTimeSetUp]</c> moves the failure to a single
+    /// fixture-level error with a clean exception chain that even a lossy
+    /// TRX serializer reports verbatim, so the next CI failure for these
+    /// tests is immediately actionable.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public class MyGraphQLTests
+    /// {
+    ///     private readonly TestWebApplicationFactory _factory = new();
+    ///
+    ///     [OneTimeSetUp]
+    ///     public void OneTimeSetUp() => _factory.EnsureStarted();
+    ///
+    ///     [OneTimeTearDown]
+    ///     public void OneTimeTearDown() => _factory.Dispose();
+    /// }
+    /// </code>
+    /// </example>
+    public void EnsureStarted()
+    {
+        try
+        {
+            // Server is a public property on WebApplicationFactory<T>; touching it
+            // forces the underlying TestServer to build, which in turn builds and
+            // starts the host. No-op on subsequent calls.
+            _ = Server;
+        }
+        catch (Exception ex)
+        {
+            var chain = new StringBuilder("TestWebApplicationFactory.EnsureStarted failed during host startup. Inner exception chain:\n");
+            for (var e = (Exception?)ex; e is not null; e = e.InnerException)
+            {
+                chain.Append("  -> ").Append(e.GetType().FullName).Append(": ").AppendLine(e.Message);
+            }
+            chain.Append("Full stack trace:\n").Append(ex);
+            throw new InvalidOperationException(chain.ToString(), ex);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in \`EnsureStarted()\` method on \`TestWebApplicationFactory\` that consumers can call from \`[OneTimeSetUp]\` to force eager host construction with a clean exception chain when startup fails.

## Why

\`WebApplicationFactory<Program>\` builds the host lazily on first \`Server\` / \`CreateClient\` access. When startup fails (DI resolution, missing config, unreachable content root), the exception fires from inside whichever test method first touches the factory — and the published TRX often shows empty Error Message / Stack Trace fields for every test in the class, making CI failures look like phantom mass-fails with no diagnostic.

Visible in CI run 25411905491 where 14 tests failed with empty error text. This PR adds the diagnostic infrastructure; it doesn't update consumers.

## Pre-existing bug discovered while testing this change

**GaApi.Tests has a multi-WebApplicationFactory interference bug.** Running \`ChordNamingGraphQLTests\` with all 6 of its tests crashes the test host with \"Fatal error\" / Test Run Aborted at \`HostingAbstractionsHostExtensions.RunAsync\`. Single tests pass; multi-test runs crash.

Suspected cause: the class creates a class-level \`_factory\` at field init AND a second local \`TestWebApplicationFactory\` inside \`Validation_Error_On_Empty_Intervals\` (line 95). Likely shared static state in \`Program.cs\` interferes between the two factories.

This is the same bug class as the CI \"13 environmental failures\" — reproduces locally too. **Separate PR to fix the test isolation**; this PR is just the diagnostic infrastructure.

## What this PR adds

\`EnsureStarted()\` — touches \`Server\` to force eager init, wraps in try/catch, rebuilds the exception with the full inner-exception chain inlined into the message:

\`\`\`csharp
[OneTimeSetUp]
public void OneTimeSetUp() => _factory.EnsureStarted();
\`\`\`

Even a lossy TRX serializer surfaces the root cause verbatim because the chained text is in the outer exception's message string.

## Test plan

- [x] Additive only — no test classes updated, existing behavior unchanged
- [x] Single-test runs continue to pass with the new method present
- [ ] CI confirms (the multi-factory crash is independent and out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)