### PR TITLE
test(skills): verification harness for 4 catalog C# wrappers (PR #126)

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Unit/CatalogSkillMdLoaderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/CatalogSkillMdLoaderTests.cs
@@ -1,0 +1,52 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+
+/// <summary>
+/// Tests for <see cref="CatalogSkillMdLoader"/> — the helper that lets C#
+/// catalog-skill wrappers (CircleOfFifthsSkill, etc.) load their answer body
+/// from the matching SKILL.md file at runtime, keeping the markdown as the
+/// single source of truth.
+/// </summary>
+[TestFixture]
+public class CatalogSkillMdLoaderTests
+{
+    [Test]
+    public void LoadBodyOrFallback_ReturnsBody_WhenSkillMdExists()
+    {
+        // The 4 graduated catalog skills (PR #124) each have a SKILL.md
+        // present in the repo's skills/ directory. Loading any of them
+        // should return a body substantially longer than the fallback
+        // string, proving the loader actually reads the file.
+        const string folderName = "circle-of-fifths";
+        const string fallback = "FALLBACK_SHORT";
+
+        var body = CatalogSkillMdLoader.LoadBodyOrFallback(folderName, fallback);
+
+        Assert.That(body, Is.Not.EqualTo(fallback),
+            $"loader should have returned the SKILL.md body, not the fallback — " +
+            $"either the file is missing or the loader is broken");
+        Assert.That(body.Length, Is.GreaterThan(500),
+            $"circle-of-fifths SKILL.md body should be substantial (>500 chars); " +
+            $"got {body.Length}. Length sanity-check guards against returning " +
+            $"frontmatter-only or partial content.");
+    }
+
+    [Test]
+    public void LoadBodyOrFallback_ReturnsFallback_WhenSkillMdMissing()
+    {
+        // A folder that doesn't exist forces the fallback path. The loader
+        // must NOT throw — production code calls this from a static Lazy<T>
+        // initializer, so an exception would surface as a TypeInitializationException
+        // on first request, not at startup. The fallback ensures the
+        // chatbot still says something useful even if the SKILL.md is
+        // missing in deployment.
+        const string folderName = "this-folder-definitely-does-not-exist-2026-05-05";
+        const string fallback = "Sentinel fallback answer for a missing skill.";
+
+        var body = CatalogSkillMdLoader.LoadBodyOrFallback(folderName, fallback);
+
+        Assert.That(body, Is.EqualTo(fallback),
+            "missing SKILL.md must yield the fallback string verbatim");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/CatalogSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/CatalogSkillTests.cs
@@ -1,0 +1,180 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Skills;
+using GA.Business.ML.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// Verification harness for the four catalog SKILL.md skills graduated in
+/// PR #124 and wired in PR #126: <c>circle-of-fifths</c>,
+/// <c>practice-routine</c>, <c>genre-essentials</c>, <c>what-can-you-do</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These skills are intentionally <i>SKILL.md-only</i> at the body level —
+/// each C# class is a thin wrapper that supplies the routing metadata
+/// (Description, ExamplePrompts) the <c>SemanticIntentRouter</c> needs and
+/// emits the SKILL.md body verbatim on <c>ExecuteAsync</c>. Tests verify
+/// that contract end to end without requiring Ollama (the embedding-driven
+/// routing layer is exercised separately).
+/// </para>
+/// <para>
+/// Stub-resistance: the strongest test in this fixture is
+/// <see cref="ExecuteAsync_BodyMatchesSkillMdVerbatim"/>, which compares
+/// the wrapper's output to the actual file content byte-for-byte (after
+/// frontmatter strip) — a stubbed wrapper that returns a hardcoded string
+/// would fail.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class CatalogSkillTests
+{
+    /// <summary>
+    /// One row per catalog skill: the wrapper type + the SKILL.md folder
+    /// name. Anything else needed (Name, Description) is read off the
+    /// instance — tests check those properties are non-trivial without
+    /// hardcoding their exact values, so the test stays robust to copy
+    /// edits in the SKILL.md.
+    /// </summary>
+    public sealed record CatalogSkillCase(Type SkillType, string SkillMdFolder, string ExpectedFrontmatterName);
+
+    private static readonly CatalogSkillCase[] Cases =
+    [
+        new(typeof(CircleOfFifthsSkill),  "circle-of-fifths",  "circle-of-fifths"),
+        new(typeof(PracticeRoutineSkill), "practice-routine",  "practice-routine"),
+        new(typeof(GenreEssentialsSkill), "genre-essentials",  "genre-essentials"),
+        new(typeof(WhatCanYouDoSkill),    "what-can-you-do",   "what-can-you-do"),
+    ];
+
+    private static IEnumerable<TestCaseData> AllCases =>
+        Cases.Select(c => new TestCaseData(c).SetName($"Catalog_{c.SkillMdFolder}"));
+
+    private static IOrchestratorSkill MakeSkill(Type skillType)
+    {
+        // Each wrapper takes a single ILogger<TSkill> dependency. NullLogger
+        // is the standard test stand-in; we don't assert on log output here.
+        var loggerType  = typeof(NullLogger<>).MakeGenericType(skillType);
+        var loggerInst  = loggerType.GetField("Instance",
+                              System.Reflection.BindingFlags.Public |
+                              System.Reflection.BindingFlags.Static)!.GetValue(null);
+        return (IOrchestratorSkill)Activator.CreateInstance(skillType, loggerInst)!;
+    }
+
+    [TestCaseSource(nameof(AllCases))]
+    public void HasSubstantiveDescription(CatalogSkillCase c)
+    {
+        var skill = MakeSkill(c.SkillType);
+
+        Assert.That(skill.Description, Is.Not.Null.And.Not.Empty,
+            $"{c.SkillType.Name}.Description must be non-empty — it's the " +
+            $"primary input to SemanticIntentRouter's similarity match");
+        Assert.That(skill.Description.Length, Is.GreaterThan(50),
+            $"{c.SkillType.Name}.Description is too short ({skill.Description.Length} chars). " +
+            $"A one-word stub passes Is.Not.Empty but starves the router; require >50 chars.");
+    }
+
+    [TestCaseSource(nameof(AllCases))]
+    public void HasAtLeast3ExamplePrompts(CatalogSkillCase c)
+    {
+        var skill = MakeSkill(c.SkillType);
+
+        // 3 is the floor used elsewhere in the corpus (see
+        // SkillMdParser.MinTriggerLength → SkillStewardsDraftLoadTests).
+        // Fewer prompts means the router's discovery surface is too narrow
+        // to route on diverse phrasings.
+        Assert.That(skill.ExamplePrompts, Has.Count.GreaterThanOrEqualTo(3),
+            $"{c.SkillType.Name} must declare >=3 example prompts for routing diversity");
+    }
+
+    [TestCaseSource(nameof(AllCases))]
+    public void CanHandle_AlwaysFalse(CatalogSkillCase c)
+    {
+        // Catalog skills route exclusively via SemanticIntentRouter
+        // (ExamplePrompts → embeddings → similarity). The legacy
+        // CanHandle path stays disabled so a substring match doesn't
+        // shadow a more specific skill — e.g., "what" appearing in a
+        // chord-info question shouldn't pull in WhatCanYouDoSkill.
+        var skill = MakeSkill(c.SkillType);
+
+        Assert.That(skill.CanHandle("any random message"),       Is.False);
+        Assert.That(skill.CanHandle("what is the circle of fifths"), Is.False);
+        Assert.That(skill.CanHandle(string.Empty),                Is.False);
+    }
+
+    [TestCaseSource(nameof(AllCases))]
+    public async Task ExecuteAsync_ReturnsTheoryAgentResponse(CatalogSkillCase c)
+    {
+        var skill = MakeSkill(c.SkillType);
+
+        var response = await skill.ExecuteAsync("test query");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.AgentId, Is.EqualTo(AgentIds.Theory),
+                $"catalog skills emit Theory-bucket responses (per migration plan)");
+            Assert.That(response.Confidence, Is.EqualTo(1.0f),
+                $"deterministic catalog answer — confidence is always 1.0");
+            Assert.That(response.Result, Is.Not.Null.And.Not.Empty,
+                $"{c.SkillType.Name} returned an empty body");
+            Assert.That(response.Result.Length, Is.GreaterThan(200),
+                $"catalog body too short ({response.Result.Length} chars) — " +
+                $"either the SKILL.md is empty or the loader returned the fallback. " +
+                $"All four real SKILL.md bodies are >2KB.");
+            Assert.That(response.Evidence, Has.Some.Contains($"skills/{c.SkillMdFolder}"),
+                $"evidence should cite the source SKILL.md path");
+        });
+    }
+
+    [TestCaseSource(nameof(AllCases))]
+    public async Task ExecuteAsync_BodyMatchesSkillMdVerbatim(CatalogSkillCase c)
+    {
+        // The strongest test: the wrapper must return the SKILL.md body
+        // exactly. A stubbed implementation that returns a hardcoded
+        // string would fail this immediately. Drift between SKILL.md and
+        // the C# answer is also caught here (the bug pattern from the
+        // PR #121 audit, where SKILL.md fixes hadn't propagated to the
+        // duplicated C# fast-path content).
+        var skill = MakeSkill(c.SkillType);
+
+        var skillsDir = GA.Business.ML.Agents.Plugins.SkillMdPlugin.ResolveSkillsPath();
+        var path = Path.Combine(skillsDir, c.SkillMdFolder, "SKILL.md");
+        Assert.That(File.Exists(path), Is.True,
+            $"prerequisite: skills/{c.SkillMdFolder}/SKILL.md must exist on disk; " +
+            $"if this fails, the test environment is broken, not the code under test");
+
+        var skillMd = SkillMdParser.TryParse(path);
+        Assert.That(skillMd, Is.Not.Null,
+            $"prerequisite: SKILL.md at {path} must parse cleanly");
+
+        var response = await skill.ExecuteAsync("test query");
+
+        Assert.That(response.Result, Is.EqualTo(skillMd!.Body),
+            $"{c.SkillType.Name}.ExecuteAsync must emit the SKILL.md body verbatim — " +
+            $"any drift means the C# class is duplicating content that should live " +
+            $"only in the .md, OR the loader returned the fallback");
+    }
+
+    [TestCaseSource(nameof(AllCases))]
+    public void Name_MatchesSkillMdFrontmatterName(CatalogSkillCase c)
+    {
+        // The C# Name property doesn't have to match the SKILL.md
+        // frontmatter Name — they serve different audiences (C# uses
+        // PascalCase 'CircleOfFifths' for routing tags; the .md uses
+        // kebab-case 'circle-of-fifths' for filesystem layout). What
+        // MUST match is the SKILL.md folder ↔ frontmatter name (the
+        // chatbot's intent registry keys off the latter). Verify that
+        // the folder name we expect resolves to a SKILL.md whose
+        // frontmatter actually carries the same name — proves nothing
+        // got renamed-and-forgotten.
+        var skillsDir = GA.Business.ML.Agents.Plugins.SkillMdPlugin.ResolveSkillsPath();
+        var path      = Path.Combine(skillsDir, c.SkillMdFolder, "SKILL.md");
+        var skillMd   = SkillMdParser.TryParse(path);
+
+        Assert.That(skillMd, Is.Not.Null);
+        Assert.That(skillMd!.Name, Is.EqualTo(c.ExpectedFrontmatterName),
+            $"SKILL.md frontmatter name '{skillMd.Name}' must equal " +
+            $"the folder name '{c.ExpectedFrontmatterName}' for the parity " +
+            $"matrix and intent registry to agree");
+    }
+}


### PR DESCRIPTION
## Summary

PR #126 wired the 4 graduated catalog skills (`CircleOfFifthsSkill`, `PracticeRoutineSkill`, `GenreEssentialsSkill`, `WhatCanYouDoSkill`) into orchestrator routing. The planned live retest was blocked by an Ollama runner segfault (see [`reference_ollama_runner_crash_2026_05_05.md`](../memory/reference_ollama_runner_crash_2026_05_05.md)), so this PR adds an **offline verification harness** — no embeddings, no LLM, no network — that proves the same wiring deterministically.

## Test inventory (26 cases)

**`CatalogSkillMdLoaderTests`** (2):

- `LoadBodyOrFallback_ReturnsBody_WhenSkillMdExists` — proves the loader actually reads from disk (real body >500 chars vs 14-char sentinel fallback)
- `LoadBodyOrFallback_ReturnsFallback_WhenSkillMdMissing` — graceful degradation; the loader is called from a static `Lazy<T>` initializer where an exception would surface as `TypeInitializationException` on first request

**`CatalogSkillTests`** (6 methods × 4 skills = 24):

| Test | What it proves | Stub-resistance |
|---|---|---|
| `HasSubstantiveDescription` | `Description` > 50 chars (router-embedding fuel) | Medium — guards against `=> \"x\"` |
| `HasAtLeast3ExamplePrompts` | Routing-discovery hook wired | High |
| `CanHandle_AlwaysFalse` | Semantic-routing only (no legacy-regex shadow) | High |
| `ExecuteAsync_ReturnsTheoryAgentResponse` | `AgentId`, `Confidence`, body length, evidence path | High |
| `ExecuteAsync_BodyMatchesSkillMdVerbatim` | Response body equals `SkillMdParser.TryParse(...).Body` byte-for-byte | **Highest** — see below |
| `Name_MatchesSkillMdFrontmatterName` | Folder/frontmatter consistency | High |

## Why `ExecuteAsync_BodyMatchesSkillMdVerbatim` matters

This is the load-bearing case. A hardcoded-string stub trivially fails (the SKILL.md bodies are 2-5KB of structured markdown each). It **also catches the bug class from PR #121's audit**: when SKILL.md is fixed but the C# fast-path class still emits the old (duplicated) content, the answer drifts silently. By making the wrapper *load* the body rather than *embed* it, we make this drift impossible — and this test enforces it.

## Why not test SemanticIntentRouter directly

Routing requires Ollama embeddings, which is broken on this host. The parity-matrix gate (`SkillParityMatrixTests.Skill_GaPluginRegistersTheCSharpClassAsIntent`) already verifies the `GaPlugin.Register()` call site via source grep. Combined with the body-emission tests in this PR, the static chain `SKILL.md → wrapper → DI registration → router candidate set` is fully covered.

## Test plan

- [x] `dotnet test --filter Catalog` → 26/26 pass
- [x] `dotnet test --filter Skill|Catalog` → 228/228 pass (full skill suite, no regressions)
- [x] Build clean (zero errors)
- [ ] CI gates (Build Solution + Build Frontend + Code Quality + claude-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)