### PR TITLE
fix(test-isolation): root cause of '13 environmental CI failures' — multi-factory crash

### DIFF
--- a/Tests/Apps/GaApi.Tests/ChordNamingGraphQLTests.cs
+++ b/Tests/Apps/GaApi.Tests/ChordNamingGraphQLTests.cs
@@ -91,9 +91,11 @@ public class ChordNamingGraphQLTests
   chordBestName(formulaName:$name, root:$root, intervals:$intervals)
 }";
 
-        // Use a raw client to assert that the server rejects the request (either via non-200 or GraphQL errors[])
-        using var factory = new TestWebApplicationFactory();
-        var client = factory.CreateClient();
+        // Reuse the class-level factory rather than building a second one — running multiple
+        // WebApplicationFactory<Program> instances inside a single test class crashes the
+        // test host with a Fatal error at HostingAbstractionsHostExtensions.RunAsync (likely
+        // shared static state in Program.cs / Aspire orchestration). Single-factory works fine.
+        var client = _factory.CreateClient();
         var payload = new { query = q, variables = new { name = "Demo", root = 0, intervals = Array.Empty<int>() } };
         using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
         var resp = await client.PostAsync("/graphql", content);


### PR DESCRIPTION
## Summary

**TL;DR**: a single line that created a redundant `WebApplicationFactory<Program>` was crashing the test host, masking 14 unrelated tests as 'environmental failures'. One-line fix.

## The bug

\`Validation_Error_On_Empty_Intervals\` in \`ChordNamingGraphQLTests\` was creating a **second** \`TestWebApplicationFactory\` locally despite the class already having a class-level \`_factory\`:

\`\`\`csharp
[Test]
public async Task Validation_Error_On_Empty_Intervals()
{
    // ...
    using var factory = new TestWebApplicationFactory();   // <-- the second factory
    var client = factory.CreateClient();
    // ...
}
\`\`\`

Running multiple \`WebApplicationFactory<Program>\` instances inside one test class crashes the test host with **\"Fatal error\" / Test Run Aborted at HostingAbstractionsHostExtensions.RunAsync\"** — likely shared static state in \`Program.cs\` / Aspire orchestration.

## Why this matters — the load-bearing finding

This single bug was the **load-bearing root cause of ~14 'environmental' CI failures** we attributed to GPU / perf / config issues over the course of yesterday and today:

- Phrygian_Half_Cadence
- BestName_Returns_NonEmpty_String
- AllNames_Contains_At_Least_One_And_Includes_Best
- Comprehensive_Returns_Primary_And_Alternates
- Validation_Error_On_Empty_Intervals
- Validation_Error_On_OutOfRange_Bass
- Validation_Error_On_OutOfRange_Root
- GetDomainSchema_Returns_Relationships
- GetKey_Returns_Data
- GetNote_Returns_Data
- AnalyzeSpectra_ComputesCentroidCloseToCpu
- AnalyzeSpectra_MatchesCpuMagnitudes
- Provider_CachesCpuAnalyzerInstances
- ... (and more)

When \`ChordNamingGraphQLTests\` crashed the test host, every subsequent test was reported with **empty Error Message + ~5ms duration** — looking like each was independently broken. They weren't. They were collateral.

This explains why earlier I saw all those tests pass locally when run in isolation (single test or single class) — the crash only triggered when the multi-factory class actually executed multiple test methods together.

## Local verification

| Command | Before | After |
|---|---|---|
| `--filter "ChordNamingGraphQL\|MusicTheoryGraphQL"` | Test Run Aborted | **8/8 pass** |
| `--filter "ChordNamingGraphQL"` | Test Run Aborted | **6/6 pass** |
| Full GaApi.Tests run | Host crash, all results lost | **111 pass / 13 fail / 9 skip** |

The 13 remaining failures are **Ollama-dependent** tests (`ChatStream_*`, `GetExamples_*`, `GetStatus_*`) that were pre-existing but masked by the host crash. Separate PR — they need `[Category(\"RequiresOllama\")]` gating.

## The fix

Single line. Replace the second-factory construction with the class-level \`_factory.CreateClient()\` that everyone else in the class already uses, plus an inline comment explaining why this matters.

## Test plan

- [x] Run filter that previously crashed: `dotnet test --filter "ChordNamingGraphQL"` → 6/6 pass
- [x] Run two-class filter: `dotnet test --filter "ChordNamingGraphQL|MusicTheoryGraphQL"` → 8/8 pass
- [x] Run full GaApi.Tests → 111 pass, 13 fail (all Ollama-dependent, pre-existing)
- [ ] CI confirms: the 14 collateral failures across Backend Tests should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)