### PR TITLE
audit(skills): pro-guitarist trigger tightening + vocab additions (loop iter 1)

### DIFF
--- a/skills/chord-info/SKILL.md
+++ b/skills/chord-info/SKILL.md
@@ -2,16 +2,29 @@
 name: "chord-info"
 description: "Returns the notes and intervals of a named chord (e.g. Cmaj7 = C E G B). Calls the deterministic `ga_chord_info` MCP tool — never recall an answer from training data, since LLMs commonly flip enharmonics (Db vs C#) based on which source they saw."
 triggers:
-  - "what is a"
-  - "what is the"
+  # Tightened 2026-05-05 (pro-guitarist audit) — removed bare
+  # "what is a" / "what is the" / "make up a" (matched any
+  # what-is question; routes belonged elsewhere). Each trigger
+  # now anchors on a chord-shaped or chord-vocabulary token so
+  # SKILL.md-driven dispatch (FileBasedSkillsProvider, Claude
+  # Code path) doesn't pull non-chord queries here.
+  - "what is a chord"
+  - "what is the chord"
+  - "what chord is"
   - "what notes are in"
   - "notes in a"
   - "notes of a"
-  - "spell a"
-  - "spell the"
+  - "spell a chord"
+  - "spell the chord"
   - "chord notes"
   - "chord intervals"
-  - "make up a"
+  - "spell a c"
+  - "spell a d"
+  - "spell a e"
+  - "spell a f"
+  - "spell a g"
+  - "spell an a"
+  - "spell a b"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"

--- a/skills/chord-substitution/SKILL.md
+++ b/skills/chord-substitution/SKILL.md
@@ -2,11 +2,13 @@
 name: "chord-substitution"
 description: "Finds harmonic substitutions for a chord, or classifies the relationship between two chords (tritone sub, secondary dominant, backdoor dominant, set-class equivalent, ICV neighbor). Calls deterministic Grothendieck-ICV math via MCP tools — never recall theory rules from training data."
 triggers:
+  # Tightened 2026-05-05 (pro-guitarist audit) — removed bare
+  # "instead of" (matched "go left instead of right" etc.).
+  # Added pro-relevant vocabulary anchors.
   - "substitute"
   - "substitution"
   - "reharmonize"
   - "reharmoni"
-  - "instead of"
   - "alternative chord"
   - "swap chord"
   - "replace chord"
@@ -15,6 +17,8 @@ triggers:
   - "secondary dominant"
   - "backdoor"
   - "related chord"
+  - "upper structure"
+  - "modal interchange"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"

--- a/skills/fret-span/SKILL.md
+++ b/skills/fret-span/SKILL.md
@@ -2,6 +2,9 @@
 name: "fret-span"
 description: "Computes the fret span and playability of a 6-string guitar chord diagram. Calls the deterministic `ga_fret_span` MCP tool — never recall the answer from training data, since the math depends on knowing exactly which strings are open vs muted vs fretted."
 triggers:
+  # Tightened 2026-05-05 (pro-guitarist audit) — removed bare
+  # "reach for" (matched "reach for the stars" etc.). The other
+  # 7 triggers all anchor on a guitar-specific token.
   - "fret span"
   - "fret stretch"
   - "stretch of"
@@ -9,7 +12,8 @@ triggers:
   - "is this difficult"
   - "playability"
   - "how playable"
-  - "reach for"
+  - "fingering reach"
+  - "left hand reach"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"

--- a/skills/modes/SKILL.md
+++ b/skills/modes/SKILL.md
@@ -2,12 +2,18 @@
 name: "modes"
 description: "Lists the seven modes of the major scale (Ionian, Dorian, Phrygian, Lydian, Mixolydian, Aeolian, Locrian) with their scale-degree formulas and characteristic sound. Pure catalog — same fixed pedagogy whether the user asks for the whole list or a single mode."
 triggers:
+  # Pro-relevant vocab added 2026-05-05 (audit) — modal harmony
+  # / cadence / characteristic-interval are pro idioms.
   - "modes of"
   - "diatonic modes"
   - "major scale modes"
   - "seven modes"
   - "what are the modes"
   - "list the modes"
+  - "modal harmony"
+  - "modal cadence"
+  - "characteristic note"
+  - "characteristic interval"
   - "ionian"
   - "dorian"
   - "phrygian"

--- a/skills/practice-routine/SKILL.md
+++ b/skills/practice-routine/SKILL.md
@@ -2,14 +2,23 @@
 name: "practice-routine"
 description: "Suggests a structured practice routine for a stated goal — jazz comping, soloing, ear training, fingerstyle technique, etc. Pure catalog skill drawing on guitar-pedagogy templates. Use when a learner asks 'give me a practice plan for X' / 'how do I practice Y'."
 triggers:
+  # Tightened 2026-05-05 (pro-guitarist audit) — bare "drill"
+  # matched non-music senses ("drill a hole", "fire drill").
+  # Music-anchored "drilling" / "drill for" / "warm-up drill"
+  # keep the music-pedagogy intent.
   - "practice routine"
   - "practice plan"
   - "practice schedule"
   - "how do i practice"
   - "what should i practice"
-  - "drill"
+  - "drilling"
+  - "drill for"
+  - "warm-up drill"
   - "exercises for"
   - "improve at"
+  - "transcription drill"
+  - "sight-reading"
+  - "ear training drill"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"

--- a/skills/progression-completion/SKILL.md
+++ b/skills/progression-completion/SKILL.md
@@ -2,6 +2,10 @@
 name: "progression-completion"
 description: "Suggests 2-3 diatonic cadence completions for an in-progress chord progression. Reuses the `ga_key_identify` MCP tool for deterministic key detection, then names cadence types (authentic / half / deceptive / plagal) drawn from the detected key's diatonic set."
 triggers:
+  # Pro-relevant vocab added 2026-05-05 (audit). The bare
+  # "end this" / "end it" / "continue this" / "extend this"
+  # remain because the substring requires a chord-progression
+  # in the same prompt to match the dispatch criteria.
   - "what comes next"
   - "next chord"
   - "what should follow"
@@ -15,6 +19,10 @@ triggers:
   - "how do i end"
   - "continue this"
   - "extend this"
+  - "cadence"
+  - "how to resolve"
+  - "how do i resolve"
+  - "resolve to"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"

--- a/skills/progression-mood/SKILL.md
+++ b/skills/progression-mood/SKILL.md
@@ -2,6 +2,10 @@
 name: "progression-mood"
 description: "Reliable techniques for darkening or brightening a chord progression — parallel-mode swaps, modal interchange (Phrygian / Aeolian / Dorian / Lydian / Mixolydian), and borrowed-chord substitutions. Use when a learner asks how to make a progression sound darker / sadder / moodier / brighter / more uplifting."
 triggers:
+  # Pro-relevant vocab added 2026-05-05 (audit) — borrowed-chord
+  # / modal-interchange queries land here. Note: "modal interchange"
+  # also appears in chord-substitution; the body of each skill
+  # already documents the deferral relationship.
   - "darker"
   - "darken"
   - "moodier"
@@ -13,6 +17,9 @@ triggers:
   - "brighten"
   - "uplifting"
   - "happier"
+  - "borrowed chord"
+  - "borrow from"
+  - "modal mixture"
 license: internal
 compatibility:
   agent-framework: ">=1.0.0-preview"


### PR DESCRIPTION
## Summary

First iteration of `/octo:loop \"improve the chatbot until really usable by a professional guitarist\"` (skill-content audit scope, 20 max iterations, audit + PR per finding). Cross-cutting trigger audit of all 12 substantive chatbot skills, batched into one PR for CI efficiency.

## Over-broad triggers removed

| Skill | Trigger | What it incorrectly matched |
|---|---|---|
| `chord-info` | `\"what is a\"`, `\"what is the\"`, `\"make up a\"` | \"what is a guitar / metronome / time signature\"; \"make up a song / band name\" |
| `chord-substitution` | `\"instead of\"` | \"go left instead of right\" |
| `fret-span` | `\"reach for\"` | \"reach for the stars\" |
| `practice-routine` | bare `\"drill\"` | \"drill a hole\", \"fire drill\" |

## Pro-relevant vocabulary added

| Skill | New triggers |
|---|---|
| `chord-info` | `\"what is a chord\"`, `\"what is the chord\"`, `\"what chord is\"`, `\"spell a c\"`/`\"spell a d\"`/.../`\"spell a b\"` |
| `chord-substitution` | `\"upper structure\"`, `\"modal interchange\"` |
| `progression-completion` | `\"cadence\"`, `\"how to resolve\"`, `\"how do i resolve\"`, `\"resolve to\"` |
| `modes` | `\"modal harmony\"`, `\"modal cadence\"`, `\"characteristic note\"`, `\"characteristic interval\"` |
| `progression-mood` | `\"borrowed chord\"`, `\"borrow from\"`, `\"modal mixture\"` |
| `fret-span` | `\"fingering reach\"`, `\"left hand reach\"` |
| `practice-routine` | `\"drilling\"`, `\"drill for\"`, `\"warm-up drill\"`, `\"transcription drill\"`, `\"sight-reading\"`, `\"ear training drill\"` |

## Production routing impact

Minimal. Production routing for C#-backed skills uses each class's `ExamplePrompts` (semantic-router input), not SKILL.md triggers. The triggers feed:

1. SKILL.md-driven dispatch (`FileBasedSkillsProvider`, Claude Code agent framework) — affected ✓
2. Documentation truthfulness — affected ✓
3. The 4 SKILL.md-only catalog skills (PR #126's wrappers register via `ExamplePrompts`; their SKILL.md triggers surface in docs / Claude path) — affected ✓

No production C# regex changes — those remain narrow and correct (per existing tests).

## Out of scope (BACKLOG candidates)

The audit also surfaced pro-relevant gaps that need **new MCP-tool work**, not trigger tightening. Logged for future PRs:

- `chord-info`: support for sus2/sus4, add9, 9/11/13 extensions, altered dominants (`7b5`, `7#9`, `7alt`), `m7b5` (half-diminished), slash chords (`C/E`)
- **New skill**: alternate-tuning chord shapes (DADGAD, drop-D, open G/D)
- **New skill**: capo / transpose chord progressions
- **New skill**: voice leading between two chords

These are dealbreakers for pro guitarist usability but each requires substantial new tool work (separate workstreams).

## Test plan

- [x] `dotnet test --filter Skill|Catalog` → 202/202 pass (all skill suites)
- [x] Build clean
- [ ] CI gates (Build Solution + Build Frontend + Code Quality + claude-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)