### PR TITLE
fix(ci+tests): Playwright BaseUrl + GaApi ContentRoot + restore merged-step (ga#134 step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,18 +139,23 @@ jobs:
         pwsh bin/Release/net10.0/playwright.ps1 install --with-deps
 
     # Start GaApi + run Playwright tests in ONE step. Splitting them
-    # caused ga#128: GaApi spawned via Start-Process gets killed when
-    # the launching pwsh exits at step end (Windows attaches child
-    # processes to the parent's job object, even with -WindowStyle
-    # Hidden — confirmed by PR #129's "GaApi (PID N) exited between
-    # steps" diagnostic). By running both inside one step, the pwsh
-    # process stays alive throughout `dotnet test`, so the Start-Process
-    # child stays alive too. The trap at the end ensures GaApi is killed
-    # even if dotnet test throws, so we don't leak a runaway process.
-    # The 180s deadline matches observed startup: GaApi loads voicing/
-    # embedding binary caches, Yarp config, and the governance watcher
-    # before accepting requests.
-    - name: Start GaApi + Run Playwright tests (single step — see ga#128)
+    # caused ga#128 (re-confirmed in PR #129's diagnostic): GaApi spawned
+    # via Start-Process gets killed when the launching pwsh exits at
+    # step end (Windows attaches child processes to the parent's job
+    # object, even with -WindowStyle Hidden). Single step keeps the
+    # pwsh alive throughout `dotnet test`, so the Start-Process child
+    # stays alive too. try/finally guarantees cleanup on test failure
+    # or runner timeout.
+    #
+    # ga#134 step 1 additions inside the merged step:
+    #   - ASPNETCORE_CONTENTROOT pinned to Apps/ga-server/GaApi so
+    #     ASP.NET resolves `wwwroot` correctly (PR #122 logs showed
+    #     "WebRootPath was not found: D:\a\ga\ga\wwwroot" — workspace
+    #     root, not the project folder, hiding chatbot-demo.html).
+    #   - CHATBOT_BASE_URL env var so ChatbotTestBase.BaseUrl matches
+    #     what GaApi actually serves (was hardcoded https://localhost:7001
+    #     placeholder that never matched any binding — see ga#134 thread).
+    - name: Start GaApi + Run Playwright tests (single step — see ga#128, ga#134)
       shell: pwsh
       run: |
         $apiDll = "Apps/ga-server/GaApi/bin/Release/net10.0/GaApi.dll"
@@ -159,20 +164,18 @@ jobs:
         }
         $env:ASPNETCORE_URLS = "http://localhost:5232"
         $env:ASPNETCORE_ENVIRONMENT = "CI"
+        $env:ASPNETCORE_CONTENTROOT = (Resolve-Path "Apps/ga-server/GaApi").Path
+        $env:CHATBOT_BASE_URL = "http://localhost:5232/chatbot-demo.html"
         $start = Get-Date
         $gaapiProc = Start-Process -NoNewWindow -PassThru -FilePath "dotnet" -ArgumentList $apiDll `
           -RedirectStandardOutput "gaapi-stdout.log" `
           -RedirectStandardError "gaapi-stderr.log"
-        Write-Host "GaApi spawned with PID $($gaapiProc.Id)"
+        Write-Host "GaApi spawned with PID $($gaapiProc.Id), ContentRoot=$($env:ASPNETCORE_CONTENTROOT), BaseUrl=$($env:CHATBOT_BASE_URL)"
 
-        # Liveness probe: any HTTP response = server up; only network
-        # errors (refused / timeout / DNS) keep polling. Background:
-        # ga#128 captured logs proving the previous 200-only probe
-        # missed a healthy GaApi returning 401 in CI's no-auth context.
-        # PowerShell Invoke-WebRequest throws on 4xx/5xx but
-        # $_.Exception.Response is non-null for HTTP errors and null
-        # for connection failures — that's how we separate "alive but
-        # rejecting" from "nothing listening yet."
+        # Liveness probe (401-blind). Any HTTP response = server up;
+        # only network errors keep polling. Background: ga#128 captured
+        # logs proving the previous 200-only probe missed a healthy
+        # GaApi returning 401 in CI's no-auth context.
         $deadline = $start.AddSeconds(180)
         $apiUp = $false
         while ((Get-Date) -lt $deadline -and -not $apiUp) {
@@ -203,9 +206,22 @@ jobs:
           exit 1
         }
 
-        # GaApi is alive in this same pwsh process. Run Playwright tests
-        # synchronously here. The try/finally ensures the API process is
-        # always cleaned up, even on test failure or runner-side timeout.
+        # Sanity-check static-file serving before Playwright. If
+        # chatbot-demo.html doesn't 200, ContentRoot is wrong and tests
+        # will all fail "selector not found" downstream — this gives
+        # actionable signal upstream.
+        try {
+          $page = Invoke-WebRequest -Uri "http://localhost:5232/chatbot-demo.html" -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+          Write-Host "chatbot-demo.html OK ($($page.StatusCode), $($page.Content.Length) bytes)"
+        } catch {
+          $resp = $_.Exception.Response
+          if ($resp -ne $null) {
+            Write-Host "::warning::chatbot-demo.html returned HTTP $([int]$resp.StatusCode); ContentRoot may still be wrong"
+          } else {
+            Write-Host "::warning::chatbot-demo.html network error: $($_.Exception.Message)"
+          }
+        }
+
         try {
           dotnet test Tests/GuitarAlchemistChatbot.Tests.Playwright/GuitarAlchemistChatbot.Tests.Playwright.csproj `
             --configuration Release `

--- a/Tests/GuitarAlchemistChatbot.Tests.Playwright/ChatbotTestBase.cs
+++ b/Tests/GuitarAlchemistChatbot.Tests.Playwright/ChatbotTestBase.cs
@@ -8,7 +8,16 @@ using Microsoft.Playwright.NUnit;
 /// </summary>
 public class ChatbotTestBase : PageTest
 {
-    protected const string BaseUrl = "https://localhost:7001"; // Update with actual URL
+    // GaApi serves chatbot-demo.html from Apps/ga-server/GaApi/wwwroot.
+    // 5232 = the http profile in GaApi's launchSettings.json. The previous
+    // value `https://localhost:7001` was a placeholder ("Update with actual
+    // URL" comment) that never matched any real binding — see ga#134.
+    // Override via env var so CI can pin the URL to whatever the workflow
+    // actually starts; default keeps local dev pointed at the canonical
+    // http profile.
+    protected static readonly string BaseUrl =
+        Environment.GetEnvironmentVariable("CHATBOT_BASE_URL")
+        ?? "http://localhost:5232/chatbot-demo.html";
     protected const int DefaultTimeout = 30000; // 30 seconds
 
     [SetUp]


### PR DESCRIPTION
## Summary

Three nested fixes for [ga#134](https://github.com/GuitarAlchemist/ga/issues/134) Playwright failure layer:

1. **Test BaseUrl** (`ChatbotTestBase.cs`): was hardcoded `https://localhost:7001` with a literal "Update with actual URL" comment — port 7001 doesn't match any GaApi binding (5232/7184/41167). Now reads from `CHATBOT_BASE_URL` env var with a working default of `http://localhost:5232/chatbot-demo.html`.

2. **GaApi ContentRoot** (`ci.yml`): GaApi launched from workspace root resolves `wwwroot` to `D:\a\ga\ga\wwwroot`, which doesn't exist. PR #122 captured logs: `WebRootPath was not found`. Real path is `Apps/ga-server/GaApi/wwwroot/chatbot-demo.html`. Setting `ASPNETCORE_CONTENTROOT` fixes static-file resolution.

3. **Merged-step pattern restored** (`ci.yml`): PR #130's keystone fix didn't survive the squash to main — main reverted to the separate-steps pattern that ga#128 documented as broken (process orphaned at step boundary). Re-applied with try/finally cleanup.

Plus a static-file **sanity probe** before Playwright runs — HTTP GETs `chatbot-demo.html` and emits `::warning::` if ContentRoot is still wrong. Gives actionable upstream signal instead of letting all 198 tests fail with selector-not-found downstream.

## Honest scope: this is step 1, not the whole fix

[ga#134](https://github.com/GuitarAlchemist/ga/issues/134) has a **Bug #6 layer below this** that this PR does NOT address: even with the URL working, `ChatbotTestBase` selectors (`input.form-control[placeholder*='Ask about']`, `button.btn-primary:has(i.fa-paper-plane)`) don't match the actual `chatbot-demo.html` classes (`chat-input`, `id="messageInput"`, custom `.send-btn`). The tests were never validated against the real page.

Expected CI signal after this PR:
- ✅ `chatbot-demo.html OK (200, N bytes)` in the sanity probe → ContentRoot correct
- ❌ Tests still fail, but with `selector not found` rather than `ERR_CONNECTION_REFUSED` — diagnostically clearer
- Will file Bug #6 separately for the test-vs-UI selector mismatch

## Test plan

- [ ] CI run shows `GaApi up after Ns (HTTP 401, ...)` (probe still works)
- [ ] CI run shows `chatbot-demo.html OK (200, N bytes)` (ContentRoot fix worked)
- [ ] Failure mode changes from `ERR_CONNECTION_REFUSED at https://localhost:7001/` to `selector not found` (URL routing fixed; test-UI mismatch surfaced)
- [ ] Backend Tests still fail with the 14 env-deps (pre-existing, separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)