### PR TITLE
fix(ga-react-components): Prime Radiant 504s + ag-grid CSS 404s on tunneled origin

### DIFF
--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/IxqlGridPanel.tsx
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/IxqlGridPanel.tsx
@@ -10,8 +10,15 @@
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import type { ColDef, RowClickedEvent, GridReadyEvent, GridApi } from 'ag-grid-community';
-import 'ag-grid-community/styles/ag-grid.css';
-import 'ag-grid-community/styles/ag-theme-alpine.css';
+// AG Grid v33+ removed `styles/ag-grid.css` and `styles/ag-theme-alpine.css`
+// in favor of the JS Theming API (themeQuartz is the default). Importing
+// those static CSS paths produces 404s in dev (Vite proxies node_modules
+// requests verbatim) and broke Prime Radiant rendering on Cloudflare-
+// tunneled origins. Default theme works without any import; if Alpine
+// styling is required, use the new API:
+//   import { themeAlpine } from 'ag-grid-community';
+//   <AgGridReact theme={themeAlpine} ... />
+// See https://www.ag-grid.com/react-data-grid/theming/
 
 import type { PanelSpec, CompiledProjectionField } from './IxqlWidgetSpec';
 import { applyProjection } from './IxqlWidgetSpec';

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -443,7 +443,26 @@ export default defineConfig({
         },
     },
     optimizeDeps: {
-        include: ['prop-types'],
+        // Pre-bundle heavy deps at dev-server startup so first-request
+        // doesn't hit a multi-second esbuild transform — that pause
+        // exceeds Cloudflare Tunnel's per-request timeout for our
+        // demos.guitaralchemist.com origin and causes 504 cascades on
+        // Prime Radiant routes (3d-force-graph, three postprocessing,
+        // signalr, ag-grid all timed out + dynamic-import-fail).
+        // Adding them here makes Vite pre-bundle on `vite` boot, so
+        // the tunnel sees fast cache hits instead of cold transforms.
+        include: [
+            'prop-types',
+            '3d-force-graph',
+            'three',
+            'three/examples/jsm/postprocessing/UnrealBloomPass.js',
+            'three/examples/jsm/postprocessing/ShaderPass.js',
+            'three/examples/jsm/loaders/STLLoader.js',
+            '@microsoft/signalr',
+            'ag-grid-community',
+            'ag-grid-react',
+            'react-dom',
+        ],
     },
     resolve: {
         alias: {


### PR DESCRIPTION
## Summary

User reported https://demos.guitaralchemist.com/test/prime-radiant as broken (blank white page). Browser console pasted by user gave the exact diagnosis — two independent bugs:

### 1. Vite dep pre-bundling timing out via Cloudflare Tunnel (504 cascade)

\`\`\`
GET /node_modules/.vite/deps/3d-force-graph.js?v=0c79fa77 net::ERR_ABORTED 504
GET /node_modules/.vite/deps/three_examples_jsm_postprocessing_UnrealBloomPass__js.js  504
GET /node_modules/.vite/deps/@microsoft_signalr.js  504
GET /node_modules/.vite/deps/ag-grid-react.js  504
GET /node_modules/.vite/deps/react-dom.js  504
... (cascading)
Uncaught TypeError: Failed to fetch dynamically imported module: /src/components/PrimeRadiant/index.ts
\`\`\`

On first request the dev server's esbuild bundles each dep on-demand; multi-second per dep exceeds Cloudflare Tunnel's per-request timeout. Listing them in `optimizeDeps.include` makes Vite pre-bundle on boot, so the tunneled origin sees cached responses instead of cold transforms.

### 2. AG Grid v34 doesn't ship legacy CSS file paths

\`\`\`
GET /node_modules/ag-grid-community/styles/ag-grid.css  404
GET /node_modules/ag-grid-community/styles/ag-theme-alpine.css  404
\`\`\`

`node_modules/ag-grid-community/styles/` doesn't exist in v34.2.0 (verified). Removed in v33 in favor of JS Theming API. Dropped the broken imports + left a pointer comment for the new `themeAlpine`/`themeQuartz` API.

## Test plan (local)

\`\`\`
cd ReactComponents/ga-react-components
npx vite optimize --force   # rebuilds .vite/deps with new include list
# restart Vite dev server
# reload https://demos.guitaralchemist.com/test/prime-radiant
\`\`\`

Expected after restart:
- [ ] No 504s on `/node_modules/.vite/deps/*` in browser console
- [ ] No 404s on `/node_modules/ag-grid-community/styles/*`
- [ ] `PrimeRadiantTest` renders ForceRadiant + panels (no longer blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)