### PR TITLE
fix(chatbot): register IChatClientFactory in AddGuitarAlchemistAI

### DIFF
--- a/Common/GA.Business.ML/Extensions/ServiceCollectionExtensions.cs
+++ b/Common/GA.Business.ML/Extensions/ServiceCollectionExtensions.cs
@@ -135,6 +135,13 @@ public static class MlServiceCollectionExtensions
         services.AddTransient<BenchmarkRunner>();
         // services.AddTransient<GA.Domain.Services.AI.Benchmarks.IBenchmark, AI.Benchmarks.VoicingQualityBenchmark>();
 
+        // Provider-neutral chat client factory — required by SkillMdDrivenSkill.
+        // The matching registration in AiServiceExtensions.AddGuitarAlchemistAi
+        // (lowercase) only fires when callers use that helper; GaApi calls this
+        // uppercase variant, so the singleton needs to be registered here too or
+        // SkillMdPlugin lookups crash at first chatbot request.
+        services.TryAddSingleton<IChatClientFactory, DefaultChatClientFactory>();
+
         return services;
     }
 

--- a/Tests/Common/GA.Business.ML.Tests/Unit/AddGuitarAlchemistAiRegistrationTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/AddGuitarAlchemistAiRegistrationTests.cs
@@ -1,0 +1,47 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Extensions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+/// <summary>
+/// Regression guard for the DI bootstrap that GaApi actually invokes.
+/// <see cref="MlServiceCollectionExtensions.AddGuitarAlchemistAI"/> (uppercase
+/// <c>AI</c>) and <see cref="AiServiceExtensions.AddGuitarAlchemistAi"/>
+/// (lowercase <c>Ai</c>) drifted: the lowercase variant registered
+/// <see cref="IChatClientFactory"/>; the uppercase one didn't. Once the
+/// canonical <c>skills/</c> directory had real SKILL.md files,
+/// <see cref="GA.Business.ML.Agents.Plugins.SkillMdPlugin"/> demanded the
+/// factory inside <c>IEnumerable&lt;IOrchestratorSkill&gt;</c> resolution and
+/// every chatbot endpoint started returning HTTP 500. This fixture pins the
+/// requirement that <c>AddGuitarAlchemistAI</c> registers the factory.
+/// </summary>
+[TestFixture]
+public class AddGuitarAlchemistAiRegistrationTests
+{
+    [Test]
+    public void AddGuitarAlchemistAI_RegistersIChatClientFactory()
+    {
+        var services = new ServiceCollection();
+
+        // DefaultChatClientFactory's ctor pulls IConfiguration + IChatClient —
+        // provide stubs so the resolve doesn't fail on dependencies unrelated
+        // to the assertion under test.
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton<IChatClient>(_ => new Mock<IChatClient>().Object);
+
+        services.AddGuitarAlchemistAI();
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetService<IChatClientFactory>();
+
+        Assert.That(factory, Is.Not.Null,
+            "GaApi calls AddGuitarAlchemistAI (uppercase). If this throws, " +
+            "every chatbot endpoint will 500 once SkillMdPlugin finds a " +
+            "SKILL.md to register, because SkillMdDrivenSkill needs " +
+            "IChatClientFactory.");
+        Assert.That(factory, Is.InstanceOf<DefaultChatClientFactory>());
+    }
+}

--- a/docs/plans/2026-05-06-skills-orchestration-architecture.md
+++ b/docs/plans/2026-05-06-skills-orchestration-architecture.md
@@ -159,6 +159,37 @@ Tasks:
 
 **Why this is partial one-way**: once a skill consumes `ga_dsl_eval`, downgrading the contract (renaming closures, restructuring args) becomes a coordinated change. Adding closures stays additive.
 
+### Phase 2 finding (2026-05-06): canary emits docs, not answers
+
+Live retest of the transpose canary surfaced a precondition Phase 3 was
+silently assuming. The C# wrapper `TransposeSkill` is registered as
+`IIntent` (via `AddOrchestratorSkillIntent<T>`), so the
+`SemanticIntentRouter` considers it for routing. The matching
+`SkillMdDrivenSkill` instance built from `skills/transpose/SKILL.md` is
+registered only as `IOrchestratorSkill` — the router never sees it. So
+"transpose Cmaj7 up a perfect fifth" routes to the markdown-emitter
+wrapper at confidence 0.83 and the response is the SKILL.md *manual*,
+not `Gmaj7`. Anthropic + `ga_dsl_eval` is fully wired but never
+invoked.
+
+Phase 3's invocation-success metric needs the LLM-in-the-loop path
+actually live before it can measure anything. Two ways to land that:
+
+A. Make `SkillMdDrivenSkill` an `IIntent` too (register it via the
+   same adapter as the C# wrappers). Then drop the C# wrapper, since
+   it duplicates name/description/examples that already live in the
+   SKILL.md frontmatter. Same id collision risk — pick one or the
+   other per skill.
+
+B. Have the C# wrapper's `ExecuteAsync` delegate to a
+   `SkillMdDrivenSkill` built from the same `SKILL.md`, instead of
+   emitting the body verbatim. The wrapper keeps owning routing
+   metadata (so `IIntent` registration stays) and the SKILL.md
+   becomes the runtime system prompt for the LLM call.
+
+Pick before starting Phase 3 — measuring the markdown-emitter against
+the keyhole baseline measures the wrong thing.
+
 ### Phase 3 — Measure (one week soak)
 
 Goal: empirically decide whether the DSL pattern beats keyhole tools.


### PR DESCRIPTION
## Summary

- Restores `/api/chatbot/*` from HTTP 500 — `IChatClientFactory` was missing from the DI container the API actually uses.
- Adds a regression test that pins the contract so the two `AddGuitarAlchemist*` helpers can't drift apart again silently.
- Amends the skills-orchestration plan with the Phase 2 finding observed during live retest (markdown-emitter wins routing; Anthropic + `ga_dsl_eval` is wired but never invoked) — Phase 3's invocation-success metric measures nothing until that's resolved.

## Why this surfaced today

`MlServiceCollectionExtensions.AddGuitarAlchemistAI` (uppercase, called by GaApi) was never updated when Phase 1 of the chatbot migration introduced `IChatClientFactory`. The matching registration only landed in `AiServiceExtensions.AddGuitarAlchemistAi` (lowercase) which nothing in the app calls.

This was latent: `SkillMdPlugin` only demands the factory when `skills/` contains SKILL.md files with triggers. As catalog skills graduated through PRs #124, #126, #142, #143, and #146, the directory crossed that threshold. From there, every chatbot endpoint 500s during `IEnumerable<IOrchestratorSkill>` resolution:

```
System.InvalidOperationException: No service for type
'GA.Business.ML.Extensions.IChatClientFactory' has been registered.
  at SkillMdPlugin.<>c__DisplayClass5_0.<Register>b__0(IServiceProvider sp)
  at ... VisitIEnumerable ...
  at GaApi.Controllers.ChatbotController.GetStatus
```

Verified live against Ollama 0.23.1 (post-upgrade from broken 0.20.0 runner): chatbot endpoints went from 500 → 200 once the rebuilt GaApi picked up the registration. Transpose canary now routes via `orchestrator-skill-semantic` to `skill.transpose` at 0.83 confidence.

## Phase 2 finding (also in this PR)

Live retest exposed a precondition Phase 3 was silently assuming. The C# wrapper `TransposeSkill` is registered as `IIntent` (via `AddOrchestratorSkillIntent<T>`), so `SemanticIntentRouter` considers it. The `SkillMdDrivenSkill` instance built from `skills/transpose/SKILL.md` is registered only as `IOrchestratorSkill` — the router never sees it.

So "transpose Cmaj7 up a perfect fifth" routes to the markdown-emitter at 0.83 confidence and the response is the SKILL.md *manual*, not `Gmaj7`. Anthropic + `ga_dsl_eval` is fully wired but never invoked. Plan amendment documents two paths forward; pick before starting Phase 3.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~AddGuitarAlchemistAiRegistrationTests"` — passes locally (1/1).
- [x] Live: `curl /api/chatbot/status` returns 200 (was 500 before).
- [x] Live: `curl /api/chatbot/skills` returns 32 skills (was 500 before).
- [x] Live: transpose canary routes to `skill.transpose` via `orchestrator-skill-semantic`.
- [ ] CI green on full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)