### PR TITLE
feat(skills): CommonTonesSkill — second Path B canary (rebased)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -53,6 +53,7 @@ public sealed class GaPlugin : IChatPlugin
         // skills follows the TransposeSkill/DiatonicChordsSkill template:
         // 1) skills/<name>/SKILL.md, 2) <Name>Skill.cs, 3) register here.
         services.AddOrchestratorSkillIntent<TransposeSkill>();
+        services.AddOrchestratorSkillIntent<CommonTonesSkill>();
         services.AddOrchestratorSkillIntent<DiatonicChordsSkill>();
 
         // Skills using IChatClient are Scoped (IChatClient lifetime is Scoped).

--- a/Common/GA.Business.ML/Agents/Skills/CommonTonesSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/CommonTonesSkill.cs
@@ -1,0 +1,43 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using GA.Business.ML.Agents.Plugins;
+using GA.Business.ML.Extensions;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Finds the notes shared between two chords and describes their interval
+/// role in each. Second Path B canary (Phase 2b — transpose was first).
+/// The inherited <see cref="SkillMdDrivenWrapperBase"/> owns Lazy plumbing,
+/// exception handling, and Evidence stamping; this class only declares
+/// routing metadata + the closure target.
+/// </summary>
+public sealed class CommonTonesSkill(
+    IMcpToolsProvider toolsProvider,
+    IChatClientFactory chatClientFactory,
+    ILoggerFactory loggerFactory)
+    : SkillMdDrivenWrapperBase(toolsProvider, chatClientFactory, loggerFactory)
+{
+    protected override string SkillFolderName       => "common-tones";
+    protected override string ResponseAgentId       => AgentIds.Theory;
+    protected override string ClosureName           => "domain.commonTones";
+    protected override string DegradedResponseText  => "I couldn't compute the common tones for those chords right now. Please try again.";
+
+    public override string Name        => "CommonTones";
+
+    public override string Description =>
+        "Finds notes shared between two chords and describes their interval role " +
+        "in each (root / 3rd / 5th / 7th / extension). Used for pivot-chord choice, " +
+        "smooth voice leading, and modulation prep. Routes through ga_dsl_eval to " +
+        "the domain.commonTones closure; the closure handles the role-mapping that " +
+        "LLMs fumble on extended/altered chords.";
+
+    public override IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What notes do Cmaj7 and Am7 share?",
+        "Common tones between G and D7",
+        "What's shared between Cmaj9 and Em7?",
+        "Pivot tones from F to Bb7",
+        "Notes in common between Dm7 and G7",
+        "What do C major and A minor share?",
+    ];
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/CommonTonesSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/CommonTonesSkillTests.cs
@@ -1,0 +1,148 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Plugins;
+using GA.Business.ML.Agents.Skills;
+using GA.Business.ML.Extensions;
+using GA.Business.ML.Skills;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+/// <summary>
+/// Verification harness for <see cref="CommonTonesSkill"/> — the second
+/// Path B canary (Phase 2b of
+/// <c>docs/plans/2026-05-06-skills-orchestration-architecture.md</c>;
+/// transpose was first, PR #146 / #151). Mirrors
+/// <c>TransposeSkillTests</c>: the wrapper owns routing metadata,
+/// <c>ExecuteAsync</c> goes through the LLM-in-the-loop pass via a fake
+/// <see cref="IChatClient"/>.
+/// </summary>
+[TestFixture]
+public class CommonTonesSkillTests
+{
+    private const string SkillMdFolder = "common-tones";
+
+    private static IChatClientFactory FactoryFor(IChatClient client)
+    {
+        var mock = new Mock<IChatClientFactory>();
+        mock.Setup(f => f.Create(It.IsAny<string>())).Returns(client);
+        return mock.Object;
+    }
+
+    private static IChatClient FakeClient(string responseText)
+    {
+        var mock = new Mock<IChatClient>();
+        mock.Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+        return mock.Object;
+    }
+
+    private static IMcpToolsProvider EmptyTools()
+    {
+        var mock = new Mock<IMcpToolsProvider>();
+        mock.Setup(p => p.GetToolsAsync(It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<IReadOnlyList<AIFunction>>(Array.Empty<AIFunction>()));
+        return mock.Object;
+    }
+
+    private static CommonTonesSkill MakeSkill(string responseText = "C and E are shared between Cmaj7 (root, 3rd) and Am7 (3rd, 5th).")
+    {
+        var factory = FactoryFor(FakeClient(responseText));
+        return new CommonTonesSkill(EmptyTools(), factory, NullLoggerFactory.Instance);
+    }
+
+    [Test]
+    public void HasSubstantiveDescription()
+    {
+        var skill = MakeSkill();
+
+        Assert.That(skill.Description, Is.Not.Null.And.Not.Empty);
+        Assert.That(skill.Description.Length, Is.GreaterThan(50),
+            "Description fuels SemanticIntentRouter similarity match — needs more than a one-liner");
+    }
+
+    [Test]
+    public void HasAtLeast3ExamplePrompts()
+    {
+        var skill = MakeSkill();
+
+        Assert.That(skill.ExamplePrompts, Has.Count.GreaterThanOrEqualTo(3),
+            "common-tones must declare >=3 example prompts for routing diversity");
+    }
+
+    [Test]
+    public void CanHandle_AlwaysFalse()
+    {
+        var skill = MakeSkill();
+
+        Assert.That(skill.CanHandle("what notes do Cmaj7 and Am7 share"), Is.False,
+            "tool-driven skill — semantic-routing only; no legacy-regex shadow");
+        Assert.That(skill.CanHandle("any random message"), Is.False);
+        Assert.That(skill.CanHandle(string.Empty), Is.False);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DelegatesToSkillMdDrivenSkill_AndPassesResultThrough()
+    {
+        const string fakeAnswer = "C and E are shared between Cmaj7 (root, 3rd) and Am7 (3rd, 5th).";
+        var skill = MakeSkill(responseText: fakeAnswer);
+
+        var response = await skill.ExecuteAsync("common tones between Cmaj7 and Am7");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.AgentId, Is.EqualTo(AgentIds.Theory));
+            Assert.That(response.Result, Is.EqualTo(fakeAnswer),
+                "Path B: response.Result is the LLM's text, not SKILL.md body");
+            Assert.That(response.Evidence, Has.Some.Contains($"skills/{SkillMdFolder}"));
+            Assert.That(response.Evidence, Has.Some.Contains("ga_dsl_eval"));
+        });
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DoesNotEmitSkillMdBodyVerbatim()
+    {
+        // Regression guard against accidentally reverting to the
+        // markdown-emitter pattern (the failure mode flagged in the
+        // 2026-05-06 Phase 2 finding).
+        var skill = MakeSkill(responseText: "C, E");
+
+        var skillsDir = SkillMdPlugin.ResolveSkillsPath();
+        var path = Path.Combine(skillsDir, SkillMdFolder, "SKILL.md");
+        var skillMd = SkillMdParser.TryParse(path);
+        Assert.That(skillMd, Is.Not.Null);
+
+        var response = await skill.ExecuteAsync("test");
+
+        Assert.That(response.Result, Is.Not.EqualTo(skillMd!.Body),
+            "Path B: ExecuteAsync MUST go through the LLM, not echo the body");
+    }
+
+    [Test]
+    public void Name_MatchesExpected()
+    {
+        var skill = MakeSkill();
+
+        Assert.That(skill.Name, Is.EqualTo("CommonTones"));
+    }
+
+    [Test]
+    public void SkillMd_FrontmatterDeclaresGaDslEvalAllowedTool()
+    {
+        // Architectural invariant of the Phase 2b canary: SKILL.md routes
+        // through ga_dsl_eval to the domain.commonTones closure, NOT a
+        // fictional ga_common_tones keyhole tool.
+        var skillsDir = SkillMdPlugin.ResolveSkillsPath();
+        var path = Path.Combine(skillsDir, SkillMdFolder, "SKILL.md");
+        var content = File.ReadAllText(path);
+
+        Assert.That(content, Does.Contain("ga_dsl_eval"));
+        Assert.That(content, Does.Contain("domain.commonTones"));
+        Assert.That(content, Does.Not.Contain("ga_common_tones"),
+            "old fictional ga_common_tones keyhole tool must NOT remain in the body");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillParityMatrixTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillParityMatrixTests.cs
@@ -101,6 +101,12 @@ public class SkillParityMatrixTests
             typeof(GA.Business.ML.Agents.Skills.DiatonicChordsSkill),
             ["ga_dsl_eval"], "dsl-eval"),
 
+        // Tool-driven skill graduated 2026-05-07 — second Path B canary.
+        // Routes through ga_dsl_eval to the domain.commonTones closure.
+        new("common-tones",          "common-tones",
+            typeof(GA.Business.ML.Agents.Skills.CommonTonesSkill),
+            ["ga_dsl_eval"], "dsl-eval"),
+
         // MCP-tool-driven skills (SKILL.md → ga_* tool → IOrchestratorSkill)
         new("interval",              "interval",
             typeof(GA.Business.ML.Agents.Skills.IntervalSkill),

--- a/skills/common-tones/SKILL.md
+++ b/skills/common-tones/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: "common-tones"
+description: "Finds notes shared between TWO chords and describes their interval role in each (root / 3rd / 5th / 7th / extension). Used for pivot-chord choice, smooth voice leading, and modulation prep. Calls the deterministic `domain.commonTones` closure via the `ga_dsl_eval` MCP tool — never compute pivot tones from training data, since LLMs fumble extension intervals on altered chords."
+triggers:
+  - "common tones"
+  - "common tone"
+  - "shared notes"
+  - "pivot tone"
+  - "pivot chord"
+  - "notes in common"
+  - "what do these chords share"
+  - "what notes do x and y share"
+license: internal
+compatibility:
+  agent-framework: ">=1.0.0-preview"
+  microsoft-extensions-ai: ">=10.5.1"
+metadata:
+  authoring-style: "tool-driven"
+  origin: "graduated 2026-05-06 — second canary for ga_dsl_eval (Phase 2b)"
+  evidence-kinds:
+    - tool_call
+allowed-tools:
+  - ga_dsl_eval
+last_verified: 2026-05-06
+---
+
+# Common Tones Between Two Chords
+
+When a user asks what notes two chords share, call **`ga_dsl_eval`** with closure name **`domain.commonTones`**. Don't compute the intersection mentally — the closure returns each shared note's interval role in BOTH chords (root / 3rd / 5th / 7th / 9th / 11th / 13th), and that role-mapping is exactly what the LLM gets wrong on extended/altered chords.
+
+## Why this skill uses `ga_dsl_eval` (not a keyhole tool)
+
+This is the second canary for the DSL-eval pattern (PR #146 was the first, transpose). The `domain.commonTones` closure is already in `GaClosureRegistry` — exposed because its category is `Domain`. See `docs/contracts/2026-05-06-ga-dsl-eval-contract.md` (v0.1).
+
+## Calling the tool
+
+Method: `ga_dsl_eval`
+
+Args (flat key-value, all values as strings):
+
+- `closureName` = `"domain.commonTones"`
+- `args.chord1` — first chord symbol, e.g. `"Cmaj7"`, `"F#m7"`.
+- `args.chord2` — second chord symbol.
+
+Example invocation:
+
+```
+ga_dsl_eval(closureName: "domain.commonTones",
+            args: { "chord1": "Cmaj7", "chord2": "Am7" })
+```
+
+Returns a `DslEvalResult`. Read `Result` for the formatted shared-notes string (or `ResultJson` for the same value as a JSON-quoted string). On failure, read `Error.Code` and `Error.Message`.
+
+## Mapping user phrasings
+
+- *"What notes do Cmaj7 and Am7 share?"* → `args = { "chord1": "Cmaj7", "chord2": "Am7" }`
+- *"Common tones between G and D7"* → `args = { "chord1": "G", "chord2": "D7" }`
+- *"Pivot tones from F to Bb7"* → `args = { "chord1": "F", "chord2": "Bb7" }`
+- *"What's shared between Cmaj9 and Em7?"* → `args = { "chord1": "Cmaj9", "chord2": "Em7" }`
+
+## Phrasing the answer
+
+The closure returns a formatted string already. Surface it verbatim, then add a one-line interpretive hook tailored to the user's apparent intent (pivot, voice leading, modulation prep). Example:
+
+> **Cmaj7 and Am7** share these notes:
+> - C → root of Cmaj7, minor third of Am7
+> - E → major third of Cmaj7, perfect fifth of Am7
+> - G → perfect fifth of Cmaj7, minor seventh of Am7
+>
+> Three common tones — that's why Am7 is the canonical relative-vi substitute for C. Swap them anywhere in a progression with minimal harmonic disturbance.
+
+If the closure returns *"X and Y share no common tones"*, surface that and explain what it means: harmonically distant chords (often a tritone-related pair, an altered-dominant against a parallel major, or genuinely opposing modal centres). Suggest checking interval distance via the `interval` skill or using `chord-substitution` to find a related pair.
+
+## When to refuse / clarify
+
+- **Single chord** — that's a `chord-info` question (notes of one chord). Defer.
+- **Three or more chords** — out of scope for v0.1 (closure takes pairs). Either compute pairwise (Cmaj7-Am7, Am7-F, Cmaj7-F) or ask the user which pair matters most.
+- **Unparseable chord symbol** — the closure returns a `ParseError` naming which chord (`chord1` or `chord2`) failed; surface the error and ask for the correct symbol.
+
+## Out of scope
+
+- **N-way common tones (N ≥ 3)** — closure takes pairs only. Wrap with multiple calls if you need a 3-way intersection (compute pairwise, then intersect the result sets in prose).
+- **Voice-leading optimisation** — separate skill (BACKLOG #139 gap, not yet shipped). Common tones are a sub-step of voice leading; this skill returns the intersection, not the optimal motion of all voices.
+- **Modulation suggestions** — knowing the common tones is foundational, but choosing a destination key for modulation is a richer query. Defer to `key-identification` for analysing existing progressions.
+
+## Cross-reference
+
+- MCP tool surface: `ga_dsl_eval` in `Common/GA.Business.ML/Agents/Mcp/DslEvalMcpTools.cs`
+- Closure: `domain.commonTones` in `Common/GA.Business.DSL/Closures/BuiltinClosures/DomainClosures.fs` (line ~489)
+- Contract: `docs/contracts/2026-05-06-ga-dsl-eval-contract.md` (v0.1)
+- Plan: `docs/plans/2026-05-06-skills-orchestration-architecture.md` (Phase 2b — second canary)
+- Sibling: `transpose` (first DSL-eval canary, PR #146)


### PR DESCRIPTION
## Summary

Recreates PR #148 cleanly off main. The original branch was conflicted because PR #151 landed (a) the \`IChatClientFactory\` DI fix it depended on, (b) the \`SkillMdDrivenWrapperBase\` that supersedes its inlined \`Lazy\` plumbing, and (c) the test pattern that supersedes its byte-verbatim assertion. Rebasing was messier than recreating.

## What's in scope

- \`skills/common-tones/SKILL.md\` (verbatim from #148 — only the C# was stale)
- \`CommonTonesSkill.cs\` extending the new \`SkillMdDrivenWrapperBase\` (≈40 lines, just metadata)
- \`CommonTonesSkillTests.cs\` mirroring the post-PR-151 \`TransposeSkillTests\` pattern
- \`GaPlugin.cs\` registration line
- \`SkillParityMatrixTests.cs\` row

## Multi-LLM review (ce-correctness-reviewer)

Confirmed:
- Four \`protected override\` properties line up with \`SkillMdDrivenWrapperBase\` abstract contract
- SKILL.md unambiguously documents \"TWO chords\" matching \`domain.commonTones\` \`InputSchema = [chord1; chord2]\`
- 7 tests mirror \`TransposeSkillTests\` 1:1
- Parity-matrix row consistent with frontmatter + GaPlugin registration

One low-impact stylistic nit deferred (SKILL.md L63 \"verbatim\" instruction vs reformatted example at L65-70).

## Test plan

- [x] \`dotnet test --filter \"FullyQualifiedName~CommonTonesSkillTests|SkillParityMatrixTests\"\` → 52 passed, 7 skipped, 0 failed
- [ ] CI green
- [ ] Live soak: prompt \"common tones between Cmaj7 and Am7\" routes to \`skill.commontones\` and answers correctly via \`ga_dsl_eval(domain.commonTones)\`

## Closes

Closes #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)