### PR TITLE
feat(chatbot): m7b5 + dim7 in ga_chord_info — first /chatbot-iterate canary

### DIFF
--- a/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs
@@ -44,12 +44,13 @@ public sealed partial class ChordMcpTools
     /// </summary>
     [McpServerTool(Name = "ga_chord_info"), Description(
         "Parse a chord symbol and return its notes, intervals, and quality. " +
-        "Examples: 'Cmaj7' returns C E G B; 'F#m' returns F# A C#; 'Bbdim' returns Bb Db Fb. " +
+        "Examples: 'Cmaj7' returns C E G B; 'F#m' returns F# A C#; 'Bbdim' returns Bb Db Fb; " +
+        "'Cdim7' returns C Eb Gb Bbb; 'Bm7b5' returns B D F A. " +
         "Use this whenever a user asks for the notes / intervals / construction of a named chord. " +
         "Supports major, minor (m/min), diminished (dim), augmented (aug), dominant 7 (just '7'), " +
-        "major 7 (maj7/M7), and minor 7 (m7/min7).")]
+        "major 7 (maj7/M7), minor 7 (m7/min7), diminished 7 (dim7), and half-diminished (m7b5).")]
     public ChordResult GetChordInfo(
-        [Description("The chord symbol — root note plus optional quality suffix. Examples: 'C', 'Cm', 'Cmaj7', 'F#dim', 'Bbm7', 'Aaug'.")]
+        [Description("The chord symbol — root note plus optional quality suffix. Examples: 'C', 'Cm', 'Cmaj7', 'F#dim', 'Bbm7', 'Aaug', 'Cdim7', 'Bm7b5'.")]
         string chordSymbol)
     {
         if (string.IsNullOrEmpty(chordSymbol) || chordSymbol.Length > MaxChordSymbolLength)
@@ -106,33 +107,47 @@ public sealed partial class ChordMcpTools
             "M7" => "major 7",
             _    => trimmed.ToLowerInvariant() switch
             {
-                ""                              => "major",
-                "maj" or "major"                => "major",
-                "m" or "min" or "minor"         => "minor",
-                "dim" or "diminished"           => "diminished",
-                "aug" or "augmented"            => "augmented",
-                "7" or "dominant" or "dom7"     => "dominant 7",
-                "maj7" or "major 7"             => "major 7",
-                "m7" or "min7" or "minor 7"     => "minor 7",
-                var other                       => other,
+                ""                                          => "major",
+                "maj" or "major"                            => "major",
+                "m" or "min" or "minor"                     => "minor",
+                "dim" or "diminished"                       => "diminished",
+                "aug" or "augmented"                        => "augmented",
+                "7" or "dominant" or "dom7"                 => "dominant 7",
+                "maj7" or "major 7"                         => "major 7",
+                "m7" or "min7" or "minor 7"                 => "minor 7",
+                "dim7" or "diminished 7" or "diminished7"   => "diminished 7",
+                "m7b5" or "min7b5" or "half-diminished"     => "half-diminished",
+                var other                                   => other,
             },
         };
     }
 
     private static ChordFormula GetFormula(string quality) => quality switch
     {
-        "minor"      => new("minor",      [0, 3, 7],     [0, 2, 4],    ["root", "minor third", "perfect fifth"]),
-        "diminished" => new("diminished", [0, 3, 6],     [0, 2, 4],    ["root", "minor third", "diminished fifth"]),
-        "augmented"  => new("augmented",  [0, 4, 8],     [0, 2, 4],    ["root", "major third", "augmented fifth"]),
-        "dominant 7" => new("dominant 7", [0, 4, 7, 10], [0, 2, 4, 6], ["root", "major third", "perfect fifth", "minor seventh"]),
-        "major 7"    => new("major 7",    [0, 4, 7, 11], [0, 2, 4, 6], ["root", "major third", "perfect fifth", "major seventh"]),
-        "minor 7"    => new("minor 7",    [0, 3, 7, 10], [0, 2, 4, 6], ["root", "minor third", "perfect fifth", "minor seventh"]),
-        _            => new("major",      [0, 4, 7],     [0, 2, 4],    ["root", "major third", "perfect fifth"]),
+        "minor"            => new("minor",            [0, 3, 7],     [0, 2, 4],    ["root", "minor third", "perfect fifth"]),
+        "diminished"       => new("diminished",       [0, 3, 6],     [0, 2, 4],    ["root", "minor third", "diminished fifth"]),
+        "augmented"        => new("augmented",        [0, 4, 8],     [0, 2, 4],    ["root", "major third", "augmented fifth"]),
+        "dominant 7"       => new("dominant 7",       [0, 4, 7, 10], [0, 2, 4, 6], ["root", "major third", "perfect fifth", "minor seventh"]),
+        "major 7"          => new("major 7",          [0, 4, 7, 11], [0, 2, 4, 6], ["root", "major third", "perfect fifth", "major seventh"]),
+        "minor 7"          => new("minor 7",          [0, 3, 7, 10], [0, 2, 4, 6], ["root", "minor third", "perfect fifth", "minor seventh"]),
+        // Diminished seventh: stacked minor thirds. Cdim7 = C Eb Gb Bbb (the
+        // seventh is enharmonically a major sixth, but the letter-step math
+        // forces the double-flat spelling). Letter steps 0,2,4,6 keep all four
+        // notes on consecutive odd letters from the root.
+        "diminished 7"     => new("diminished 7",     [0, 3, 6, 9],  [0, 2, 4, 6], ["root", "minor third", "diminished fifth", "diminished seventh"]),
+        // Half-diminished (m7b5): minor seventh with a flat fifth. Bm7b5 = B D F A.
+        // The classic ii° in a minor key (e.g. Bm7b5 in A minor).
+        "half-diminished"  => new("half-diminished",  [0, 3, 6, 10], [0, 2, 4, 6], ["root", "minor third", "diminished fifth", "minor seventh"]),
+        _                  => new("major",            [0, 4, 7],     [0, 2, 4],    ["root", "major third", "perfect fifth"]),
     };
 
     // Spell() delegates to the shared helper (PR #102) — see ChordSpelling.
 
-    [GeneratedRegex(@"^(?<root>[A-Ga-g][#b]?)(?<quality>maj7|min7|m7|maj|min|m|dim|aug|7|M7|M)?$",
+    // Order matters in the alternation: longer prefixes first so `dim7` is
+    // tried before `dim` and `m7b5` before `m7`. Without this ordering, input
+    // "Cdim7" matches `dim` and leaves "7" unconsumed, failing the ^...$ anchor
+    // and the whole regex. Same for "Cm7b5" → matches `m` and fails on "7b5".
+    [GeneratedRegex(@"^(?<root>[A-Ga-g][#b]?)(?<quality>maj7|min7b5|min7|m7b5|m7|maj|min|m|dim7|dim|aug|7|M7|M)?$",
         RegexOptions.CultureInvariant)]
     private static partial Regex ChordSymbolRegex();
 

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs
@@ -161,7 +161,6 @@ public class ChordMcpToolsTests
 
     [TestCase("Csus4")]
     [TestCase("C9")]
-    [TestCase("Am7b5")]
     [TestCase("Cadd9")]
     [TestCase("C/E")]
     public void GetChordInfo_OutOfScopeSymbols_ReturnError(string symbol)
@@ -184,5 +183,56 @@ public class ChordMcpToolsTests
         var result = MakeTool().GetChordInfo("C");
 
         Assert.That(result.Intervals, Is.EqualTo(new[] { "root", "major third", "perfect fifth" }));
+    }
+
+    // Diminished seventh (dim7) — stacked minor thirds. Cdim7's seventh is a
+    // double-flat B because letter-step math forces the consecutive-odd-letters
+    // spelling: C-E-G-B with each lowered (Eb-Gb-Bbb). Adim7 / Bbdim7 also
+    // pinned because they exercise different enharmonic paths.
+    [TestCase("Cdim7",  "C",  "diminished 7", new[] { "C",  "Eb", "Gb", "Bbb" })]
+    [TestCase("Adim7",  "A",  "diminished 7", new[] { "A",  "C",  "Eb", "Gb"  })]
+    [TestCase("Bbdim7", "Bb", "diminished 7", new[] { "Bb", "Db", "Fb", "Abb" })]
+    [TestCase("F#dim7", "F#", "diminished 7", new[] { "F#", "A",  "C",  "Eb"  })]
+    public void GetChordInfo_DiminishedSeventh_ReturnsCorrectNotes(
+        string symbol, string expectedRoot, string expectedQuality, string[] expectedNotes)
+    {
+        var result = MakeTool().GetChordInfo(symbol);
+
+        Assert.That(result.Error,   Is.Null,                 $"valid input must not produce an Error for {symbol}");
+        Assert.That(result.Root,    Is.EqualTo(expectedRoot));
+        Assert.That(result.Quality, Is.EqualTo(expectedQuality));
+        Assert.That(result.Notes,   Is.EqualTo(expectedNotes), $"notes mismatch for {symbol}");
+    }
+
+    // Half-diminished (m7b5) — minor seventh with a flat fifth. Classic ii° in
+    // a minor key: Bm7b5 = B D F A is the ii° of A minor. Am7b5 was previously
+    // in the OutOfScope regression list (now removed alongside this addition).
+    [TestCase("Cm7b5",  "C",  "half-diminished", new[] { "C",  "Eb", "Gb", "Bb" })]
+    [TestCase("Bm7b5",  "B",  "half-diminished", new[] { "B",  "D",  "F",  "A"  })]
+    [TestCase("F#m7b5", "F#", "half-diminished", new[] { "F#", "A",  "C",  "E"  })]
+    [TestCase("Am7b5",  "A",  "half-diminished", new[] { "A",  "C",  "Eb", "G"  })]
+    public void GetChordInfo_HalfDiminished_ReturnsCorrectNotes(
+        string symbol, string expectedRoot, string expectedQuality, string[] expectedNotes)
+    {
+        var result = MakeTool().GetChordInfo(symbol);
+
+        Assert.That(result.Error,   Is.Null,                 $"valid input must not produce an Error for {symbol}");
+        Assert.That(result.Root,    Is.EqualTo(expectedRoot));
+        Assert.That(result.Quality, Is.EqualTo(expectedQuality));
+        Assert.That(result.Notes,   Is.EqualTo(expectedNotes), $"notes mismatch for {symbol}");
+    }
+
+    [TestCase("min7b5", "half-diminished")]
+    public void GetChordInfo_AlternateQualityForms_NormalizeToCanonical(string suffix, string expectedCanonical)
+    {
+        // The verbose form `min7b5` is uncommon but legal — pin it so a future
+        // refactor of NormalizeQuality doesn't silently drop it. The full word
+        // `diminished7` is NOT in the regex on purpose — `dim7` is the only
+        // canonical short form for the regex; the NormalizeQuality switch
+        // accepts the full word as defensive code if the regex ever expands.
+        var result = MakeTool().GetChordInfo("C" + suffix);
+
+        Assert.That(result.Error,   Is.Null);
+        Assert.That(result.Quality, Is.EqualTo(expectedCanonical));
     }
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
@@ -9,6 +9,17 @@ using Moq;
 [TestFixture]
 public class SemanticIntentRouterTests
 {
+    // No-op hint provider so tests exercise pure cosine routing without
+    // boost interference. The DefaultRoutingHintProvider has surface-pattern
+    // boosts that the embedding-similarity tests below specifically don't want
+    // to entangle with — those are covered separately in DefaultRoutingHintProviderTests.
+    private sealed class EmptyHintProvider : IRoutingHintProvider
+    {
+        public static readonly EmptyHintProvider Instance = new();
+        public IReadOnlyDictionary<string, float> GetDeltas(string query) =>
+            new Dictionary<string, float>();
+    }
+
     private sealed class StubIntent(
         string id,
         string description,
@@ -77,6 +88,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("are 0146 and 0137 z-related?", Services(algebraIntent));
@@ -106,6 +118,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("what are the modes", Services(algebra, modes));
@@ -130,6 +143,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance) { MinConfidence = 0.5f };
 
         var match = await router.RouteAsync("what is for breakfast", Services(algebra));
@@ -144,6 +158,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             textEmbeddings: null,
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("anything", Services(algebra));
@@ -158,6 +173,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder([]),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("anything", Services(bareIntent));
@@ -171,6 +187,7 @@ public class SemanticIntentRouterTests
         var algebra = new StubIntent("algebra", "set theory", ["z-related"]);
         var router = new SemanticIntentRouter(
             StubEmbedder([]),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         Assert.That(await router.RouteAsync("",      Services(algebra)), Is.Null);
@@ -200,6 +217,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             mock.Object,
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var sp = Services(algebra);
@@ -241,6 +259,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync(
@@ -297,6 +316,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync(
@@ -330,6 +350,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("List the diatonic modes please", Services(modes));

--- a/skills/chord-info/SKILL.md
+++ b/skills/chord-info/SKILL.md
@@ -52,7 +52,7 @@ It returns a structured result:
 
 - `Symbol` — chord symbol echoed back.
 - `Root` — root note in canonical case (e.g. `"F#"`).
-- `Quality` — long form: `"major"`, `"minor"`, `"diminished"`, `"augmented"`, `"dominant 7"`, `"major 7"`, `"minor 7"`.
+- `Quality` — long form: `"major"`, `"minor"`, `"diminished"`, `"augmented"`, `"dominant 7"`, `"major 7"`, `"minor 7"`, `"diminished 7"`, `"half-diminished"`.
 - `Notes` — array of chord tones in ascending order.
 - `Intervals` — interval names for each note (e.g. `["root", "major third", "perfect fifth"]`).
 - `Error` — non-null only when the input could not be parsed.
@@ -68,6 +68,8 @@ It returns a structured result:
 | `C7`, `Cdom7` | `"dominant 7"` |
 | `Cmaj7`, `CM7` | `"major 7"` |
 | `Cm7`, `Cmin7` | `"minor 7"` |
+| `Cdim7` | `"diminished 7"` |
+| `Cm7b5`, `Cmin7b5` | `"half-diminished"` |
 
 ## Mapping user phrasings to arguments
 
@@ -76,6 +78,8 @@ It returns a structured result:
 - *"Spell a B7 chord"* → `chordSymbol="B7"`.
 - *"Notes in an F minor chord"* → `chordSymbol="Fm"`.
 - *"What's in a Cmaj7?"* → `chordSymbol="Cmaj7"`.
+- *"Spell a B half-diminished"* → `chordSymbol="Bm7b5"`.
+- *"What's a C diminished 7th?"* → `chordSymbol="Cdim7"`.
 
 ## Phrasing the answer
 
@@ -88,12 +92,12 @@ If `Error` is non-null, surface the message verbatim and ask the user to clarify
 ## When to ask for clarification
 
 - User names a key rather than a chord (e.g. *"what notes are in C major key"* — vs *"C major chord"*) → that's a scale-info question; defer to the scale-info skill, do NOT call `ga_chord_info`.
-- User asks for a chord quality this tool doesn't support (sus2, sus4, 9th, 11th, 13th, slash chords, altered dominants like 7b5 or 7#9) — the tool will return an Error. Decline cleanly: *"I can spell major / minor / diminished / augmented triads and major/minor/dominant sevenths. For altered or extended chords I'd need different tooling."*
+- User asks for a chord quality this tool doesn't support (sus2, sus4, 9th, 11th, 13th, slash chords, altered dominants like 7b5 or 7#9) — the tool will return an Error. Decline cleanly: *"I can spell major / minor / diminished / augmented triads, major/minor/dominant sevenths, diminished sevenths (dim7) and half-diminished (m7b5). For altered or extended chords beyond those I'd need different tooling."*
 
 ## Out of scope
 
 - **Extended chords** (9, 11, 13) — not yet supported.
-- **Altered / suspended / add chords** (sus2, sus4, add9, 7b5, 7#9, m7b5, etc.) — not supported.
+- **Altered / suspended / add chords** (sus2, sus4, add9, 7b5, 7#9, etc.) — not supported. *(m7b5 and dim7 ARE supported as of 2026-05-10.)*
 - **Slash chords** (C/E, Am/G) — not supported; pass just the upper chord and explain the bass note in prose.
 - **Chord identification from a note set** (*"what chord is C E G?"*) — not yet exposed; that would be a separate `ga_chord_identify(notes)` tool.
 


### PR DESCRIPTION
## Summary

First end-to-end run of `/chatbot-iterate` against the new Chatbot Track in `BACKLOG.md`. Picks the smallest P0 item (`m7b5-dim7-chord-info`) to **validate the L2 loop** and close a known consistency gap.

**Gap:** `m7b5` and `dim7` are valid suffixes in `ga_chord_substitutions` and `ga_chord_compare`, but `ga_chord_info` rejected them. The chord-info SKILL.md correctly declined, but the agent response felt broken when an adjacent tool accepted the same input.

**Refs:** Chatbot Track item `m7b5-dim7-chord-info` (P0, ready) in `BACKLOG.md`.

## What changed

| File | What |
|---|---|
| `Common/GA.Business.ML/Agents/Mcp/ChordMcpTools.cs` | Regex alternation order, NormalizeQuality cases, GetFormula entries for `diminished 7` + `half-diminished`, updated tool/parameter `[Description]` |
| `Tests/Common/GA.Business.ML.Tests/Unit/ChordMcpToolsTests.cs` | Removed `Am7b5` from out-of-scope set; added 4-row `DiminishedSeventh` + 4-row `HalfDiminished` positive cases + alt-form normalization |
| `skills/chord-info/SKILL.md` | Quality list, suffix table, decline message, out-of-scope note, two new example phrasings |
| `Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs` | **Drive-by** — test project failed to compile on origin/main: `SemanticIntentRouter` ctor gained `IRoutingHintProvider` in a recent change, 10 call sites weren't updated. Added `EmptyHintProvider` stub returning no deltas. Not part of the chatbot item — surfaced because test project must build to run my new chord tests |

## Music-theory pinning

Both new formulas use letter-steps `[0, 2, 4, 6]` so all four notes spell on consecutive odd letters from the root, producing the textbook enharmonics:

- **Cdim7** = C – Eb – Gb – **Bbb** (double-flat seventh)
- **Bbdim7** = Bb – Db – Fb – **Abb**
- **Bm7b5** = B – D – F – A (the classic ii° of A minor)
- **Cm7b5** = C – Eb – Gb – Bb

## Test plan

- [x] `dotnet build Common/GA.Business.ML/GA.Business.ML.csproj -c Debug` — 0 errors, 101 (pre-existing) warnings
- [x] `dotnet test --filter "FullyQualifiedName~ChordMcpToolsTests"` — 40/40 passing
- [x] `dotnet test --filter "FullyQualifiedName~SemanticIntentRouterTests"` — 11/11 passing (regression check after the drive-by fix)
- [ ] CI green
- [ ] **`/octo:review`** — multi-LLM review (correctness + security)
- [ ] **Demerzel QA Architect Tribunal** — music-theory verdict via `Demerzel/pipelines/qa-architect-cycle.ixql`

## Iron Law gate plan

Per `.claude/skills/chatbot-iterate/SKILL.md`:

> ANY PR touching `Common/GA.Business.ML/**/Mcp/**` REQUIRES Demerzel tribunal verdict + multi-LLM review BEFORE merge. The "feedback_multi_llm_review_pays_off" memory documents that multi-LLM review caught 9 real bugs in PR #151 alone that local tests missed.

This PR touches that path. **Both gates required.** Please run `/octo:review` against this PR before merging.

## Manual smoke

The agent should now answer:

> User: "What notes are in Bm7b5?"
> Agent: "A **Bm7b5** chord (half-diminished) contains **B – D – F – A** (root, minor third, diminished fifth, minor seventh)."

vs. previously returning a parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)