### PR TITLE
fix(vite): pre-bundle @mui/x-tree-view to dodge tunnel 504 cascade

### DIFF
--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -462,6 +462,15 @@ export default defineConfig({
             'ag-grid-community',
             'ag-grid-react',
             'react-dom',
+            // @mui/x-tree-view ships many small ESM hook modules. On the
+            // tunneled origin (demos.guitaralchemist.com → Cloudflare →
+            // local Vite), each cold on-demand transform exceeds the
+            // per-request timeout and the browser sees net::ERR_FAILED
+            // on hooks like useApplyPropagationToSelectedItemsOnMount,
+            // useTreeViewApiRef, useRichTreeViewApiRef. Pre-bundling at
+            // boot avoids the cascade. NavigationPanel in
+            // EcosystemRoadmap is the current consumer.
+            '@mui/x-tree-view',
         ],
     },
     resolve: {

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SemanticIntentRouterTests.cs
@@ -9,6 +9,17 @@ using Moq;
 [TestFixture]
 public class SemanticIntentRouterTests
 {
+    // No-op hint provider so tests exercise pure cosine routing without
+    // boost interference. The DefaultRoutingHintProvider has surface-pattern
+    // boosts that the embedding-similarity tests below specifically don't want
+    // to entangle with — those are covered separately in DefaultRoutingHintProviderTests.
+    private sealed class EmptyHintProvider : IRoutingHintProvider
+    {
+        public static readonly EmptyHintProvider Instance = new();
+        public IReadOnlyDictionary<string, float> GetDeltas(string query) =>
+            new Dictionary<string, float>();
+    }
+
     private sealed class StubIntent(
         string id,
         string description,
@@ -77,6 +88,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("are 0146 and 0137 z-related?", Services(algebraIntent));
@@ -106,6 +118,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("what are the modes", Services(algebra, modes));
@@ -130,6 +143,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance) { MinConfidence = 0.5f };
 
         var match = await router.RouteAsync("what is for breakfast", Services(algebra));
@@ -144,6 +158,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             textEmbeddings: null,
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("anything", Services(algebra));
@@ -158,6 +173,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder([]),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("anything", Services(bareIntent));
@@ -171,6 +187,7 @@ public class SemanticIntentRouterTests
         var algebra = new StubIntent("algebra", "set theory", ["z-related"]);
         var router = new SemanticIntentRouter(
             StubEmbedder([]),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         Assert.That(await router.RouteAsync("",      Services(algebra)), Is.Null);
@@ -200,6 +217,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             mock.Object,
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var sp = Services(algebra);
@@ -241,6 +259,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync(
@@ -297,6 +316,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync(
@@ -330,6 +350,7 @@ public class SemanticIntentRouterTests
 
         var router = new SemanticIntentRouter(
             StubEmbedder(vectors),
+            EmptyHintProvider.Instance,
             NullLogger<SemanticIntentRouter>.Instance);
 
         var match = await router.RouteAsync("List the diatonic modes please", Services(modes));


### PR DESCRIPTION
## Symptom

`/test/ecosystem-roadmap` on `demos.guitaralchemist.com` surfaces the following console errors on first navigation:

```
node_modules/@mui/x-tree-view/esm/hooks/useApplyPropagationToSelectedItemsOnMount.js:1  Failed to load resource: net::ERR_FAILED
node_modules/@mui/x-tree-view/esm/hooks/useTreeViewApiRef.js:1  Failed to load resource: net::ERR_FAILED
node_modules/@mui/x-tree-view/esm/hooks/useRichTreeViewApiRef.js:1  Failed to load resource: net::ERR_FAILED
```

Direct `curl` to `localhost:5176` returns each file HTTP 200 cleanly. The errors only manifest via the Cloudflare tunnel.

## Root cause

Same class of bug as #149 (Prime Radiant 504s + ag-grid CSS 404s on tunneled origin). On a tunneled origin, Vite's per-request on-demand esbuild transform exceeds Cloudflare's per-request timeout and the browser sees `net::ERR_FAILED`. Fix is the same: pre-bundle the heavy package at dev-server boot via `optimizeDeps.include` so the tunnel hits a fast cache instead of a cold transform.

`@mui/x-tree-view` qualifies — it ships many small ESM hook modules and is imported by `NavigationPanel` in `EcosystemRoadmap`.

## Test plan

- [ ] CI green
- [ ] After deploy, hard-reload `https://demos.guitaralchemist.com/test/ecosystem-roadmap` and confirm zero `net::ERR_FAILED` console errors
- [ ] Verify the visualization still renders (the WebGPU canvas fix from `1b04d0c8` was independent of this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)