### PR TITLE
feat(chatbot): session-scoped MemoryStore — closes retrieval leak (Phase A)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -10,6 +10,8 @@ using GA.Business.ML.Agents.Skills;
 using GA.Domain.Services.Atonal.Grothendieck;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 /// <summary>
 /// The core GA chatbot plugin — bundles all built-in orchestrator skills and hooks.
@@ -61,7 +63,13 @@ public sealed class GaPlugin : IChatPlugin
         services.AddOrchestratorSkillIntent<ProgressionCompletionSkill>(ServiceLifetime.Scoped);
 
         // ── Persistent memory ────────────────────────────────────────────────
-        services.TryAddSingleton<MemoryStore>();
+        // Construct via factory so we can wire ILogger<MemoryStore> for the
+        // Load() IO-error surfacing introduced in PR #157 review rel-001.
+        // Without the logger the legacy parameterless ctor swallows
+        // permission-denied / disk-full silently — which historically looked
+        // identical to "memory forgot everything between restarts."
+        services.TryAddSingleton<MemoryStore>(sp =>
+            new MemoryStore(sp.GetService<ILogger<MemoryStore>>() ?? NullLogger<MemoryStore>.Instance));
 
         // ── Hooks (execute in registration order at each lifecycle point) ─────
         services.AddSingleton<IChatHook, PromptSanitizationHook>();

--- a/Common/GA.Business.ML/Agents/Hooks/ChatHookContext.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/ChatHookContext.cs
@@ -38,6 +38,28 @@ public sealed class ChatHookContext
     /// <summary>Optional session or user identifier for per-user policies.</summary>
     public string? UserId { get; init; }
 
+    /// <summary>
+    /// Optional per-conversation identifier. Set by the transport layer
+    /// (e.g. SignalR <c>Context.ConnectionId</c> in ChatbotHub, HTTP
+    /// session cookie in controllers) so downstream hooks can scope state
+    /// to one conversation rather than the whole process.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When null, hooks that depend on session scope (e.g.
+    /// <see cref="MemoryHook"/>) MUST default to a conservative global
+    /// behaviour rather than treating "no session" as a single shared
+    /// session — that's the leak documented in PR #151 review
+    /// (<c>Memory:EnrichOnRetrieve=false</c> default).
+    /// </para>
+    /// <para>
+    /// Distinct from <see cref="CorrelationId"/>: CorrelationId is one
+    /// Guid per request and changes between turns; SessionId is stable
+    /// across the turns of one conversation.
+    /// </para>
+    /// </remarks>
+    public string? SessionId { get; init; }
+
     /// <summary>DI service locator — available to stateful hooks that need services.</summary>
     public IServiceProvider? Services { get; init; }
 }

--- a/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
@@ -10,14 +10,27 @@ using Microsoft.Extensions.Logging;
 /// high-confidence responses as new memories.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Retrieval (request-time injection) defaults to OFF — opt in via
-/// <c>Memory:EnrichOnRetrieve=true</c>. The store is process-wide and not
-/// session-scoped, so injecting accumulated history into every anonymous
-/// request leaks chord references between unrelated conversations and
-/// breaks any skill that does regex-based parsing on the full message
-/// (ChordSubstitutionSkill saw "A" from a prior cached answer when the
-/// user asked about "G7"). Persistence still runs so the data is
-/// available once the feature is properly session-scoped.
+/// <c>Memory:EnrichOnRetrieve=true</c>.
+/// </para>
+/// <para>
+/// <b>Session scoping (2026-05-10):</b> Search and Write now pass the
+/// caller's <see cref="ChatHookContext.SessionId"/> through to
+/// <see cref="MemoryStore"/>, which filters entries to the matching
+/// session plus global ones. The leak that motivated the OFF default
+/// — "injecting accumulated history into every anonymous request leaks
+/// chord references between unrelated conversations" — is fixed at the
+/// storage layer.
+/// </para>
+/// <para>
+/// However, the flag still defaults OFF until the transport layer
+/// (ChatbotHub for SignalR, controllers for HTTP) actually populates
+/// <see cref="ChatHookContext.SessionId"/>. When SessionId is null, this
+/// hook conservatively skips retrieval to preserve the existing safety
+/// posture — flipping the flag on without plumbing SessionId would
+/// regress to the leaky behaviour.
+/// </para>
 /// </remarks>
 public sealed class MemoryHook(
     MemoryStore memoryStore,
@@ -35,14 +48,30 @@ public sealed class MemoryHook(
     {
         if (!_enrichOnRetrieve) return Task.FromResult(HookResult.Continue);
 
-        var matches = memoryStore.Search(ctx.CurrentMessage);
+        // Safety belt: when SessionId isn't plumbed, refuse to retrieve. The
+        // alternative (treat null as a global session) replays the leak that
+        // the OFF default was protecting against. Operators see this gap by
+        // enabling EnrichOnRetrieve=true and observing "no memory injected"
+        // — that's the signal to wire SessionId into ChatHookContext from
+        // their transport layer.
+        if (ctx.SessionId is null)
+        {
+            logger.LogDebug(
+                "MemoryHook: skip retrieval — ChatHookContext.SessionId not set " +
+                "(transport layer hasn't plumbed it yet; see ChatHookContext.SessionId remarks).");
+            return Task.FromResult(HookResult.Continue);
+        }
+
+        var matches = memoryStore.Search(ctx.SessionId, ctx.CurrentMessage);
         if (matches.Count == 0) return Task.FromResult(HookResult.Continue);
 
         var contextBlock = string.Join("\n", matches.Take(3)
             .Select(m => $"[memory:{m.Key}] {m.Content}"));
 
         var enriched = $"[Relevant context from memory]\n{contextBlock}\n\n{ctx.CurrentMessage}";
-        logger.LogDebug("MemoryHook: injecting {Count} memory entries", matches.Count);
+        logger.LogDebug(
+            "MemoryHook: injecting {Count} memory entries for session {SessionId}",
+            matches.Count, ctx.SessionId);
         return Task.FromResult(HookResult.Mutate(enriched));
     }
 
@@ -55,15 +84,27 @@ public sealed class MemoryHook(
         if (ctx.Response is not { Confidence: >= 0.7f } response) return Task.FromResult(HookResult.Continue);
         if (response.Result.Length < 100) return Task.FromResult(HookResult.Continue);
 
+        // Capture by value before fire-and-forget — ctx fields are not safe to
+        // close over because the orchestrator may reuse / mutate the context
+        // after this method returns.
+        var sessionId       = ctx.SessionId;
+        var correlationId   = ctx.CorrelationId;
+        var originalMessage = ctx.OriginalMessage;
+        var agentId         = response.AgentId;
+        var resultSnippet   = response.Result[..Math.Min(500, response.Result.Length)];
+
         // Fire-and-forget write — don't block the response pipeline
         _ = Task.Run(() =>
         {
             try
             {
-                var key = $"response_{ctx.CorrelationId:N}";
-                memoryStore.Write(key, "response",
-                    $"Q: {ctx.OriginalMessage}\nA: {response.Result[..Math.Min(500, response.Result.Length)]}",
-                    [response.AgentId]);
+                var key = $"response_{correlationId:N}";
+                memoryStore.Write(
+                    sessionId: sessionId,
+                    key: key,
+                    type: "response",
+                    content: $"Q: {originalMessage}\nA: {resultSnippet}",
+                    tags: [agentId]);
             }
             catch (Exception ex)
             {

--- a/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
@@ -40,6 +40,10 @@ public sealed class MemoryHook(
     private readonly bool _enrichOnRetrieve =
         configuration.GetValue<bool?>("Memory:EnrichOnRetrieve") ?? false;
 
+    // Rate-limit the "SessionId not plumbed" message — log once per
+    // process, not per request. 0 = not yet logged; 1 = already logged.
+    private int _loggedNullSessionId;
+
     /// <summary>
     /// Searches memory for context relevant to the incoming message and prepends it.
     /// Off by default; enable with <c>Memory:EnrichOnRetrieve=true</c>.
@@ -54,11 +58,25 @@ public sealed class MemoryHook(
         // enabling EnrichOnRetrieve=true and observing "no memory injected"
         // — that's the signal to wire SessionId into ChatHookContext from
         // their transport layer.
+        //
+        // LogInformation (not Debug) on purpose: this branch represents a
+        // config-vs-plumbing mismatch (EnrichOnRetrieve=true but transport
+        // layer hasn't shipped SessionId yet — Phase B of PR #157). At
+        // default log levels Debug is filtered out, hiding the only
+        // breadcrumb explaining why retrieval is silently disabled. Rate-
+        // limited via the once-per-process flag below so we don't flood
+        // logs on a hot path.
         if (ctx.SessionId is null)
         {
-            logger.LogDebug(
-                "MemoryHook: skip retrieval — ChatHookContext.SessionId not set " +
-                "(transport layer hasn't plumbed it yet; see ChatHookContext.SessionId remarks).");
+            if (Interlocked.CompareExchange(ref _loggedNullSessionId, 1, 0) == 0)
+            {
+                logger.LogInformation(
+                    "MemoryHook: Memory:EnrichOnRetrieve=true but ChatHookContext.SessionId " +
+                    "is null. Retrieval is being skipped for safety until the transport layer " +
+                    "(ChatbotHub for SignalR, controllers for HTTP) plumbs a session identifier " +
+                    "into ChatHookContext.SessionId. See PR #157 Phase B. This message logs once " +
+                    "per process; subsequent skips are silent.");
+            }
             return Task.FromResult(HookResult.Continue);
         }
 

--- a/Common/GA.Business.ML/Agents/Memory/MemoryMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryMcpTools.cs
@@ -7,32 +7,65 @@ using System.ComponentModel;
 /// MCP tools for reading/writing persistent agent memory.
 /// Discovered by <see cref="Plugins.ChatPluginHost"/> via <see cref="GaPlugin.McpToolTypes"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Session scoping (2026-05-10):</b> these tools operate on the
+/// <em>global</em> memory partition (entries with SessionId=null). LLM
+/// callers don't have per-call access to the active SignalR ConnectionId
+/// — that's transport-layer context — so they cannot scope reads/writes
+/// to a session even if they wanted to.
+/// </para>
+/// <para>
+/// Treat the data the LLM writes via these tools as a SHARED knowledge
+/// pool: facts that should be visible to every session ("user prefers
+/// drop-D tuning examples", "this codebase uses .NET 10"). User-private
+/// conversation history is captured by <see cref="Hooks.MemoryHook"/>
+/// instead, which IS session-scoped because it reads
+/// <see cref="Hooks.ChatHookContext.SessionId"/>.
+/// </para>
+/// <para>
+/// Future plumbing could expose a session-scoped MCP variant by
+/// surfacing the current ChatHookContext via an async-local accessor,
+/// but that ships separately — keeping these tools un-scoped preserves
+/// backward compatibility with the existing SKILL.md instructions that
+/// rely on shared-knowledge semantics.
+/// </para>
+/// </remarks>
 [McpServerToolType]
 public sealed class MemoryMcpTools(MemoryStore store)
 {
     [McpServerTool]
-    [Description("Search agent memory by keyword. Returns matching entries.")]
+    [Description("Search the SHARED agent memory by keyword. Returns matching entries from the global knowledge pool (not session-private history). Use for cross-session facts like preferences or learned terminology.")]
     public IReadOnlyList<MemoryEntry> MemorySearch(string query, string? type = null)
-        => store.Search(query, type);
+        => store.Search(sessionId: MemoryStore.GlobalSessionId, query: query, type: type);
 
     [McpServerTool]
-    [Description("Write or update a memory entry.")]
+    [Description("Write or update a SHARED memory entry visible to every session. Use this for cross-session facts. Per-conversation context is captured automatically by the MemoryHook and is NOT written via this tool.")]
     public string MemoryWrite(string key, string type, string content, string[]? tags = null)
     {
-        store.Write(key, type, content, tags);
-        return $"Memory '{key}' saved.";
+        store.Write(sessionId: MemoryStore.GlobalSessionId, key: key, type: type, content: content, tags: tags);
+        return $"Memory '{key}' saved (global / shared scope).";
     }
 
     [McpServerTool]
-    [Description("Read a specific memory entry by key.")]
+    [Description("Read a SHARED memory entry by key. Returns null if not found in the global knowledge pool.")]
     public MemoryEntry? MemoryRead(string key)
-        => store.Read(key);
+        => store.Read(sessionId: MemoryStore.GlobalSessionId, key: key);
 
     [McpServerTool]
-    [Description("Get memory store statistics.")]
+    [Description("Get statistics for the SHARED memory partition (entries visible to every session).")]
     public object MemoryStats()
     {
-        var (total, byType) = store.Stats();
-        return new { total, byType };
+        var (total, byType) = store.Stats(MemoryStore.GlobalSessionId);
+        var grandTotal      = store.TotalEntriesAllSessions();
+        return new
+        {
+            total,
+            byType,
+            grandTotal,
+            note = grandTotal > total
+                ? $"{grandTotal - total} additional entries are session-scoped and not exposed via this tool."
+                : "all entries are in the global partition",
+        };
     }
 }

--- a/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
@@ -99,17 +99,36 @@ public sealed class MemoryStore
     /// location (<see cref="DefaultStorePath"/> = <c>~/.ga/memory.json</c>).
     /// Used by DI registration in <c>GaPlugin</c>.
     /// </summary>
-    public MemoryStore() : this(DefaultStorePath) { }
+    public MemoryStore() : this(DefaultStorePath, logger: null) { }
 
     /// <summary>
     /// Testable constructor — accepts an explicit store path so tests can
     /// isolate from the user's real <c>~/.ga/memory.json</c>. Production
-    /// callers should use the parameterless constructor.
+    /// callers should use the parameterless constructor (or the DI-friendly
+    /// <see cref="MemoryStore(ILogger{MemoryStore})"/> overload when a
+    /// logger is available).
     /// </summary>
-    public MemoryStore(string storePath)
+    public MemoryStore(string storePath) : this(storePath, logger: null) { }
+
+    /// <summary>
+    /// DI-friendly constructor — uses the default store path but accepts
+    /// an ILogger so non-JSON Load() failures (permission denied, disk
+    /// full, etc.) surface in the operator's logs instead of silently
+    /// starting fresh. Without this, a permissions regression on
+    /// <c>~/.ga/memory.json</c> looks identical to "memory forgot
+    /// everything between restarts."
+    /// </summary>
+    public MemoryStore(ILogger<MemoryStore> logger) : this(DefaultStorePath, logger) { }
+
+    /// <summary>
+    /// Full constructor — explicit store path plus optional logger.
+    /// Tests use this with a temp path; production uses one of the
+    /// overloads above.
+    /// </summary>
+    public MemoryStore(string storePath, ILogger<MemoryStore>? logger)
     {
         _storePath = storePath ?? throw new ArgumentNullException(nameof(storePath));
-        _entries   = Load(_storePath);
+        _entries   = Load(_storePath, logger);
     }
 
     // Bounded so anonymous chatbot traffic at the public demo URL can't grow
@@ -256,7 +275,7 @@ public sealed class MemoryStore
         }
     }
 
-    private static ConcurrentDictionary<string, MemoryEntry> Load(string storePath)
+    private static ConcurrentDictionary<string, MemoryEntry> Load(string storePath, ILogger<MemoryStore>? logger = null)
     {
         var dict = new ConcurrentDictionary<string, MemoryEntry>();
         if (!File.Exists(storePath)) return dict;
@@ -276,24 +295,37 @@ public sealed class MemoryStore
                 }
             }
         }
-        catch (JsonException)
+        catch (JsonException jex)
         {
             // Corrupt file — rename it so operators see the loss instead of
             // silently starting fresh; preserves the bytes for postmortem.
+            string? corruptPath = null;
             try
             {
-                var corruptPath = storePath + $".corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss}";
+                corruptPath = storePath + $".corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss}";
                 File.Move(storePath, corruptPath, overwrite: false);
             }
             catch
             {
                 // Best-effort rename; don't block boot if it fails.
             }
+            // Surface the loss to the operator (PR #157 review rel-001):
+            // without this, "memory forgot everything between restarts"
+            // looks identical to a permissions regression.
+            logger?.LogWarning(jex,
+                "MemoryStore: {Path} contained invalid JSON — quarantined as {Corrupt} and starting fresh.",
+                storePath, corruptPath ?? "(rename failed)");
         }
-        catch
+        catch (Exception ex)
         {
             // Other IO errors (file locked, permission denied) — start fresh
-            // rather than crash boot.
+            // rather than crash boot, but DO log. The previous swallow-all
+            // behaviour hid permissions regressions for days (PR #157
+            // review rel-001).
+            logger?.LogWarning(ex,
+                "MemoryStore: failed to read {Path}; starting with empty store. " +
+                "Common causes: file permissions, locked-by-other-process, disk full.",
+                storePath);
         }
 
         return dict;

--- a/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
@@ -7,21 +7,64 @@ using Microsoft.Extensions.Logging;
 /// <summary>
 /// A single persistent memory entry.
 /// </summary>
+/// <param name="Key">Stable identifier within a session (or globally if SessionId is null).</param>
+/// <param name="Type">Entry category (e.g. "response", "fact", "preference").</param>
+/// <param name="Content">The memory payload.</param>
+/// <param name="Tags">Optional searchable tags.</param>
+/// <param name="Timestamp">When the entry was written (UTC).</param>
+/// <param name="SessionId">
+/// Session scope. Null = global entry (visible to every session — use for
+/// learned facts that should be shared, e.g. user-confirmed preferences).
+/// Non-null = scoped to the caller's session (typically a SignalR
+/// ConnectionId or HTTP session cookie). Entries written without a session
+/// scope by callers that don't plumb one yet still default to global —
+/// callers that DO plumb a session ID get isolation between users / tabs.
+/// Backward compat: entries written before this field existed deserialise
+/// with SessionId=null and are treated as global.
+/// </param>
 public sealed record MemoryEntry(
     string Key,
     string Type,
     string Content,
     string[] Tags,
-    DateTimeOffset Timestamp);
+    DateTimeOffset Timestamp,
+    string? SessionId = null);
 
 /// <summary>
 /// In-process agent memory backed by a JSON file at <c>~/.ga/memory.json</c>.
 /// Thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Session scoping (2026-05-10):</b> entries carry an optional
+/// <see cref="MemoryEntry.SessionId"/>. Read and Search filter to entries
+/// whose SessionId matches the caller's, plus entries with SessionId=null
+/// (global / shared knowledge). Write requires the caller to pass a
+/// SessionId explicitly — callers without a session pass null to write a
+/// global entry.
+/// </para>
+/// <para>
+/// The store's primary key is now <c>(SessionId, Key)</c>. Two sessions can
+/// both have a "response_xyz" entry without colliding; a global entry with
+/// the same key sits in a third slot. Backward-compat dictionary indexing
+/// uses a composite key string internally — callers stay on the (key,
+/// sessionId) surface.
+/// </para>
+/// <para>
+/// Closes the leak documented in <see cref="Hooks.MemoryHook"/> remarks:
+/// retrieval was OFF because the previous global store leaked between
+/// anonymous chatbot sessions. With this fix, retrieval can be re-enabled
+/// via <c>Memory:EnrichOnRetrieve=true</c> as long as the caller plumbs a
+/// session identifier into <see cref="Hooks.ChatHookContext.SessionId"/>.
+/// </para>
+/// </remarks>
 public sealed class MemoryStore
 {
-    private static readonly string StorePath =
+    /// <summary>Default on-disk location used by the parameterless constructor.</summary>
+    public static readonly string DefaultStorePath =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".ga", "memory.json");
+
+    private readonly string _storePath;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -29,6 +72,9 @@ public sealed class MemoryStore
         PropertyNameCaseInsensitive = true,
     };
 
+    // Composite key = "<sessionId><key>" so two sessions can have the
+    // same Key without colliding. Unit separator (U+001F) is illegal in
+    // session IDs and keys, so split-on-U+001F is unambiguous.
     private readonly ConcurrentDictionary<string, MemoryEntry> _entries;
 
     // Serializes Save() so concurrent Write() calls don't corrupt the JSON
@@ -39,9 +85,31 @@ public sealed class MemoryStore
     // for the serialize+write window so it's not a hot path.
     private readonly SemaphoreSlim _saveLock = new(1, 1);
 
-    public MemoryStore()
+    /// <summary>
+    /// SessionId value used by the storage layer to represent "global"
+    /// (no session scope). Callers can pass <see cref="GlobalSessionId"/>
+    /// or null interchangeably — both resolve to global.
+    /// </summary>
+    public const string? GlobalSessionId = null;
+
+    private const char KeySeparator = '';
+
+    /// <summary>
+    /// Production constructor — backs the store with the default on-disk
+    /// location (<see cref="DefaultStorePath"/> = <c>~/.ga/memory.json</c>).
+    /// Used by DI registration in <c>GaPlugin</c>.
+    /// </summary>
+    public MemoryStore() : this(DefaultStorePath) { }
+
+    /// <summary>
+    /// Testable constructor — accepts an explicit store path so tests can
+    /// isolate from the user's real <c>~/.ga/memory.json</c>. Production
+    /// callers should use the parameterless constructor.
+    /// </summary>
+    public MemoryStore(string storePath)
     {
-        _entries = Load();
+        _storePath = storePath ?? throw new ArgumentNullException(nameof(storePath));
+        _entries   = Load(_storePath);
     }
 
     // Bounded so anonymous chatbot traffic at the public demo URL can't grow
@@ -51,23 +119,29 @@ public sealed class MemoryStore
     public const int DefaultMaxEntries = 10_000;
 
     /// <summary>
-    /// Writes (upserts) a memory entry and persists to disk. Evicts oldest
+    /// Writes (upserts) a memory entry scoped to <paramref name="sessionId"/>.
+    /// Pass null for a global entry visible to every session. Evicts oldest
     /// entries when the store exceeds <see cref="DefaultMaxEntries"/>.
     /// </summary>
-    public void Write(string key, string type, string content, string[]? tags = null)
+    public void Write(string? sessionId, string key, string type, string content, string[]? tags = null)
     {
-        var entry = new MemoryEntry(key, type, content, tags ?? [], DateTimeOffset.UtcNow);
-        _entries[key] = entry;
+        ValidateKeyOrThrow(key);
+        ValidateSessionIdOrThrow(sessionId);
+
+        var entry = new MemoryEntry(key, type, content, tags ?? [], DateTimeOffset.UtcNow, sessionId);
+        _entries[CompositeKey(sessionId, key)] = entry;
 
         if (_entries.Count > DefaultMaxEntries)
         {
             // Evict the oldest 10% so this work runs amortised, not per-write.
             // ConcurrentDictionary snapshot is consistent enough for trimming.
+            // Eviction is GLOBAL across sessions on purpose — disk size cap is a
+            // host-level concern, not a per-session quota.
             var evictTarget = _entries.Count - (DefaultMaxEntries * 9 / 10);
             var oldest = _entries.Values
                 .OrderBy(e => e.Timestamp)
                 .Take(evictTarget)
-                .Select(e => e.Key)
+                .Select(e => CompositeKey(e.SessionId, e.Key))
                 .ToList();
             foreach (var k in oldest)
                 _entries.TryRemove(k, out _);
@@ -77,18 +151,28 @@ public sealed class MemoryStore
     }
 
     /// <summary>
-    /// Reads a single entry by key, or null if not found.
+    /// Reads a single entry by key for the given session. Returns the
+    /// session-scoped entry if one exists; otherwise falls through to a
+    /// global entry (SessionId=null) with the same key; otherwise null.
     /// </summary>
-    public MemoryEntry? Read(string key)
-        => _entries.TryGetValue(key, out var entry) ? entry : null;
+    public MemoryEntry? Read(string? sessionId, string key)
+    {
+        if (sessionId is not null && _entries.TryGetValue(CompositeKey(sessionId, key), out var scoped))
+            return scoped;
+        return _entries.TryGetValue(CompositeKey(null, key), out var global) ? global : null;
+    }
 
     /// <summary>
-    /// Case-insensitive substring search across content and tags.
+    /// Case-insensitive substring search across content and tags, filtered
+    /// to entries whose SessionId matches <paramref name="sessionId"/> OR is
+    /// null (global). Pass <paramref name="sessionId"/>=null to search only
+    /// global entries.
     /// </summary>
-    public IReadOnlyList<MemoryEntry> Search(string query, string? type = null, string[]? tags = null)
+    public IReadOnlyList<MemoryEntry> Search(string? sessionId, string query, string? type = null, string[]? tags = null)
     {
         var q = query.ToLowerInvariant();
         return _entries.Values
+            .Where(e => InScope(e, sessionId))
             .Where(e => type is null || e.Type.Equals(type, StringComparison.OrdinalIgnoreCase))
             .Where(e => tags is null || tags.Any(t => e.Tags.Contains(t, StringComparer.OrdinalIgnoreCase)))
             .Where(e => e.Content.Contains(q, StringComparison.OrdinalIgnoreCase)
@@ -99,19 +183,59 @@ public sealed class MemoryStore
     }
 
     /// <summary>
-    /// Returns summary statistics about the memory store.
+    /// Returns summary statistics for entries visible to <paramref name="sessionId"/>
+    /// (session-scoped + global). Pass null for global-only stats.
     /// </summary>
-    public (int TotalEntries, IReadOnlyDictionary<string, int> ByType) Stats()
+    public (int TotalEntries, IReadOnlyDictionary<string, int> ByType) Stats(string? sessionId = null)
     {
-        var byType = _entries.Values
+        var visible = _entries.Values.Where(e => InScope(e, sessionId)).ToList();
+        var byType = visible
             .GroupBy(e => e.Type)
             .ToDictionary(g => g.Key, g => g.Count());
-        return (_entries.Count, byType);
+        return (visible.Count, byType);
+    }
+
+    /// <summary>
+    /// Returns total entry count across ALL sessions. For host-level disk
+    /// budgeting / eviction monitoring — not for per-session UX.
+    /// </summary>
+    public int TotalEntriesAllSessions() => _entries.Count;
+
+    private static bool InScope(MemoryEntry entry, string? sessionId)
+    {
+        // Global entries (SessionId=null) are visible to every caller. Scoped
+        // entries are visible only when the caller's sessionId matches exactly.
+        if (entry.SessionId is null) return true;
+        if (sessionId is null) return false;
+        return string.Equals(entry.SessionId, sessionId, StringComparison.Ordinal);
+    }
+
+    private static string CompositeKey(string? sessionId, string key)
+        => $"{sessionId ?? string.Empty}{KeySeparator}{key}";
+
+    private static void ValidateKeyOrThrow(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Memory key cannot be empty.", nameof(key));
+        if (key.IndexOf(KeySeparator) >= 0)
+            throw new ArgumentException(
+                $"Memory key cannot contain the unit separator (U+001F).", nameof(key));
+    }
+
+    private static void ValidateSessionIdOrThrow(string? sessionId)
+    {
+        if (sessionId is null) return;
+        if (string.IsNullOrWhiteSpace(sessionId))
+            throw new ArgumentException(
+                "SessionId must be either null (global) or a non-empty string.", nameof(sessionId));
+        if (sessionId.IndexOf(KeySeparator) >= 0)
+            throw new ArgumentException(
+                $"SessionId cannot contain the unit separator (U+001F).", nameof(sessionId));
     }
 
     private void Save()
     {
-        var dir = Path.GetDirectoryName(StorePath)!;
+        var dir = Path.GetDirectoryName(_storePath)!;
         if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
 
         // Snapshot under the lock so concurrent Writes that mutate _entries
@@ -122,9 +246,9 @@ public sealed class MemoryStore
         try
         {
             var json    = JsonSerializer.Serialize(_entries.Values.ToList(), JsonOpts);
-            var tmpPath = StorePath + ".tmp";
+            var tmpPath = _storePath + ".tmp";
             File.WriteAllText(tmpPath, json);
-            File.Move(tmpPath, StorePath, overwrite: true);
+            File.Move(tmpPath, _storePath, overwrite: true);
         }
         finally
         {
@@ -132,19 +256,24 @@ public sealed class MemoryStore
         }
     }
 
-    private static ConcurrentDictionary<string, MemoryEntry> Load()
+    private static ConcurrentDictionary<string, MemoryEntry> Load(string storePath)
     {
         var dict = new ConcurrentDictionary<string, MemoryEntry>();
-        if (!File.Exists(StorePath)) return dict;
+        if (!File.Exists(storePath)) return dict;
 
         try
         {
-            var json = File.ReadAllText(StorePath);
+            var json = File.ReadAllText(storePath);
             var entries = JsonSerializer.Deserialize<List<MemoryEntry>>(json, JsonOpts);
             if (entries is not null)
             {
                 foreach (var e in entries)
-                    dict[e.Key] = e;
+                {
+                    // Pre-session-scope entries deserialise with SessionId=null
+                    // because the field didn't exist on disk. That's the
+                    // intended migration path: legacy entries become global.
+                    dict[CompositeKey(e.SessionId, e.Key)] = e;
+                }
             }
         }
         catch (JsonException)
@@ -153,8 +282,8 @@ public sealed class MemoryStore
             // silently starting fresh; preserves the bytes for postmortem.
             try
             {
-                var corruptPath = StorePath + $".corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss}";
-                File.Move(StorePath, corruptPath, overwrite: false);
+                var corruptPath = storePath + $".corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss}";
+                File.Move(storePath, corruptPath, overwrite: false);
             }
             catch
             {

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryStoreSessionScopeTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryStoreSessionScopeTests.cs
@@ -1,0 +1,257 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Text.Json;
+using GA.Business.ML.Agents.Memory;
+
+/// <summary>
+/// Tests for the session-scoping fix that closes the leak documented in
+/// PR #151 review and BACKLOG.md Chatbot Track item "memory-session-scope".
+/// </summary>
+/// <remarks>
+/// Uses a temp directory so the user's real <c>~/.ga/memory.json</c> is
+/// never touched. Each test instantiates its own MemoryStore against a
+/// freshly-deleted path.
+/// </remarks>
+[TestFixture]
+public class MemoryStoreSessionScopeTests
+{
+    private string _tempDir = string.Empty;
+    private string _tempStorePath = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ga-memstore-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _tempStorePath = Path.Combine(_tempDir, "memory.json");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ─── Core isolation guarantees ─────────────────────────────────────
+
+    [Test]
+    public void Write_SessionScopedEntry_NotVisibleToOtherSession()
+    {
+        // The leak this whole feature exists to close: session A writes a
+        // chord reference, session B should NOT see it in any retrieval.
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: "sessionA", key: "k1", type: "response",
+            content: "user asked about Cmaj7 over Dm");
+
+        var resultsForB = store.Search(sessionId: "sessionB", query: "Cmaj7");
+
+        Assert.That(resultsForB, Is.Empty,
+            "Session B must not see entries written by session A — that's the leak the feature flag was protecting against.");
+    }
+
+    [Test]
+    public void Write_SessionScopedEntry_VisibleToOwnSession()
+    {
+        // Negative test for the isolation guarantee: it shouldn't hide
+        // entries from their OWN session.
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: "sessionA", key: "k1", type: "response",
+            content: "user asked about Cmaj7 over Dm");
+
+        var resultsForA = store.Search(sessionId: "sessionA", query: "Cmaj7");
+
+        Assert.That(resultsForA, Has.Count.EqualTo(1));
+        Assert.That(resultsForA[0].SessionId, Is.EqualTo("sessionA"));
+    }
+
+    [Test]
+    public void Write_GlobalEntry_VisibleAcrossAllSessions()
+    {
+        // Entries written with SessionId=null are the "shared knowledge"
+        // partition — visible to every session. MemoryMcpTools uses this.
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: null, key: "global-fact", type: "fact",
+            content: "User prefers DADGAD tuning examples.");
+
+        var fromA = store.Search(sessionId: "sessionA", query: "DADGAD");
+        var fromB = store.Search(sessionId: "sessionB", query: "DADGAD");
+        var fromAnon = store.Search(sessionId: null, query: "DADGAD");
+
+        Assert.That(fromA, Has.Count.EqualTo(1));
+        Assert.That(fromB, Has.Count.EqualTo(1));
+        Assert.That(fromAnon, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Write_SameKeyDifferentSessions_DoesNotCollide()
+    {
+        // Two sessions can both have a "response_xyz" entry — they sit in
+        // separate compositeKey slots and don't overwrite each other.
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: "sessionA", key: "shared-key", type: "response", content: "A's content");
+        store.Write(sessionId: "sessionB", key: "shared-key", type: "response", content: "B's content");
+
+        var fromA = store.Read(sessionId: "sessionA", key: "shared-key");
+        var fromB = store.Read(sessionId: "sessionB", key: "shared-key");
+
+        Assert.That(fromA!.Content, Is.EqualTo("A's content"));
+        Assert.That(fromB!.Content, Is.EqualTo("B's content"));
+    }
+
+    // ─── Read fallback semantics ───────────────────────────────────────
+
+    [Test]
+    public void Read_FallsBackToGlobalWhenSessionSpecificMissing()
+    {
+        // If sessionA doesn't have a "user-pref" entry but a global one
+        // exists, Read returns the global as a fallback — matches the
+        // "shared knowledge augments per-session" intent.
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: null, key: "user-pref", type: "fact", content: "global preference");
+
+        var result = store.Read(sessionId: "sessionA", key: "user-pref");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Content, Is.EqualTo("global preference"));
+        Assert.That(result.SessionId, Is.Null);
+    }
+
+    [Test]
+    public void Read_PrefersSessionScopedOverGlobal()
+    {
+        // When both exist, the session-scoped entry wins. Lets a user
+        // "override" a global default for their conversation.
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: null, key: "user-pref", type: "fact", content: "global value");
+        store.Write(sessionId: "sessionA", key: "user-pref", type: "fact", content: "sessionA override");
+
+        var fromA       = store.Read(sessionId: "sessionA", key: "user-pref");
+        var fromB       = store.Read(sessionId: "sessionB", key: "user-pref");
+        var fromGlobal  = store.Read(sessionId: null, key: "user-pref");
+
+        Assert.That(fromA!.Content,      Is.EqualTo("sessionA override"));
+        Assert.That(fromB!.Content,      Is.EqualTo("global value"));
+        Assert.That(fromGlobal!.Content, Is.EqualTo("global value"));
+    }
+
+    // ─── Search filtering ──────────────────────────────────────────────
+
+    [Test]
+    public void Search_ReturnsGlobalPlusOwnSession_NotOtherSessions()
+    {
+        // The composite filter: matching content + (matching sessionId OR
+        // null sessionId). Three distinct entries, three distinct sessions.
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: null,        key: "g1", type: "fact",     content: "shared dim7 reference");
+        store.Write(sessionId: "sessionA",  key: "a1", type: "response", content: "A's dim7 conversation");
+        store.Write(sessionId: "sessionB",  key: "b1", type: "response", content: "B's dim7 conversation");
+
+        var fromA = store.Search(sessionId: "sessionA", query: "dim7");
+
+        Assert.That(fromA, Has.Count.EqualTo(2),
+            "Session A should see its own + the global, but NOT session B's.");
+        Assert.That(fromA.Any(e => e.Key == "b1"), Is.False,
+            "Cross-session leak: session B's entry surfaced in session A's search.");
+        Assert.That(fromA.Any(e => e.Key == "a1"), Is.True);
+        Assert.That(fromA.Any(e => e.Key == "g1"), Is.True);
+    }
+
+    [Test]
+    public void Stats_FilterBySession_OnlyCountsVisibleEntries()
+    {
+        var store = new MemoryStore(_tempStorePath);
+        store.Write(sessionId: null,       key: "g1", type: "fact",     content: "x");
+        store.Write(sessionId: "sessionA", key: "a1", type: "response", content: "x");
+        store.Write(sessionId: "sessionA", key: "a2", type: "response", content: "x");
+        store.Write(sessionId: "sessionB", key: "b1", type: "response", content: "x");
+
+        var (totalA, _) = store.Stats(sessionId: "sessionA");
+
+        Assert.That(totalA, Is.EqualTo(3), "A sees its 2 entries + the global; not B's.");
+        Assert.That(store.TotalEntriesAllSessions(), Is.EqualTo(4),
+            "Grand total still reflects all 4 entries — host-level budget concerns operate on this.");
+    }
+
+    // ─── Persistence + backward compat ─────────────────────────────────
+
+    [Test]
+    public void BackwardCompat_LegacyEntryWithoutSessionId_LoadsAsGlobal()
+    {
+        // Simulate a memory.json written before SessionId existed:
+        // serialise a list of entries where SessionId is intentionally
+        // absent from the JSON. New MemoryStore should load them as
+        // SessionId=null, treating them as global.
+        Directory.CreateDirectory(Path.GetDirectoryName(_tempStorePath)!);
+        const string legacyJson = @"[
+            { ""Key"": ""legacy1"", ""Type"": ""fact"", ""Content"": ""older entry"", ""Tags"": [], ""Timestamp"": ""2026-05-01T00:00:00+00:00"" },
+            { ""Key"": ""legacy2"", ""Type"": ""response"", ""Content"": ""another"", ""Tags"": [""auto""], ""Timestamp"": ""2026-05-02T00:00:00+00:00"" }
+        ]";
+        File.WriteAllText(_tempStorePath, legacyJson);
+
+        var store = new MemoryStore(_tempStorePath);
+
+        var fromAnySession = store.Search(sessionId: "any-new-session", query: "entry");
+        Assert.That(fromAnySession, Has.Count.EqualTo(1),
+            "Legacy entry without SessionId should be globally visible.");
+
+        var direct = store.Read(sessionId: null, key: "legacy1");
+        Assert.That(direct, Is.Not.Null);
+        Assert.That(direct!.SessionId, Is.Null,
+            "Legacy entry's SessionId deserialises to null (global).");
+    }
+
+    [Test]
+    public void Write_Persists_AndIsolationSurvivesReload()
+    {
+        // Smoke test: write some session-scoped entries, reload the store
+        // from disk, confirm session boundaries are preserved.
+        var store1 = new MemoryStore(_tempStorePath);
+        store1.Write(sessionId: "sessionA", key: "k1", type: "response", content: "A only");
+        store1.Write(sessionId: "sessionB", key: "k1", type: "response", content: "B only");
+        store1.Write(sessionId: null,       key: "k1", type: "fact",     content: "global");
+
+        var store2 = new MemoryStore(_tempStorePath);
+
+        Assert.That(store2.Read("sessionA", "k1")!.Content, Is.EqualTo("A only"));
+        Assert.That(store2.Read("sessionB", "k1")!.Content, Is.EqualTo("B only"));
+        Assert.That(store2.Read(null,       "k1")!.Content, Is.EqualTo("global"));
+    }
+
+    // ─── Defensive validation ──────────────────────────────────────────
+
+    [Test]
+    public void Write_RejectsEmptyKey()
+    {
+        var store = new MemoryStore(_tempStorePath);
+        Assert.That(() => store.Write("sessionA", "", "fact", "x"), Throws.ArgumentException);
+        Assert.That(() => store.Write("sessionA", "   ", "fact", "x"), Throws.ArgumentException);
+    }
+
+    [Test]
+    public void Write_RejectsKeyContainingUnitSeparator()
+    {
+        // The composite-key encoding uses U+001F as the delimiter. Allowing
+        // it in the key would let a malicious / sloppy caller forge a
+        // different session's entry.
+        var store = new MemoryStore(_tempStorePath);
+        Assert.That(() => store.Write("sessionA", "evilkey", "fact", "x"), Throws.ArgumentException);
+    }
+
+    [Test]
+    public void Write_RejectsEmptySessionId_ButAllowsNull()
+    {
+        var store = new MemoryStore(_tempStorePath);
+        Assert.That(() => store.Write("", "k", "fact", "x"), Throws.ArgumentException,
+            "Empty string is not a valid session ID; pass null for global instead.");
+        Assert.That(() => store.Write("   ", "k", "fact", "x"), Throws.ArgumentException);
+        Assert.That(() => store.Write(null, "k", "fact", "x"), Throws.Nothing,
+            "null is the explicit signal for 'global entry'.");
+    }
+
+    [Test]
+    public void Write_RejectsSessionIdContainingUnitSeparator()
+    {
+        var store = new MemoryStore(_tempStorePath);
+        Assert.That(() => store.Write("evilsession", "k", "fact", "x"), Throws.ArgumentException);
+    }
+}


### PR DESCRIPTION
## Summary

First end-to-end run of `/chatbot-iterate` using the autonomy mechanism shipped earlier today. Picks the P0 Chatbot Track item **`memory-session-scope`** — closing the leak that motivated `Memory:EnrichOnRetrieve=false` in PR #151.

## Problem

PR #151 disabled memory retrieval because the global `MemoryStore` was leaking chord references between unrelated anonymous chatbot conversations: `ChordSubstitutionSkill` saw "A" from a prior cached answer when a different user asked about "G7". The flag was a bandage; the real fix is **session-scoped storage** so retrieval can be turned back on safely.

## What changed (Phase A — storage layer)

| File | Change |
|---|---|
| `Common/GA.Business.ML/Agents/Memory/MemoryStore.cs` | Composite key `(SessionId, Key)`, internal U+001F-separated. `Read` prefers session-scoped, falls back to global. `Search` filters by `sessionId OR null`. New testable ctor. |
| `Common/GA.Business.ML/Agents/Memory/MemoryMcpTools.cs` | Explicit global-partition tool. `[Description]` attrs updated so LLM treats this as shared knowledge, not private memory. |
| `Common/GA.Business.ML/Agents/Hooks/ChatHookContext.cs` | New optional `SessionId` field (distinct from `CorrelationId`). |
| `Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs` | Passes `ctx.SessionId` to Search/Write. When SessionId is null (transport hasn't plumbed it yet), retrieval is **skipped** rather than treated as a shared session — safety-belt that preserves PR #151's posture until Phase B. |
| `Tests/Common/GA.Business.ML.Tests/Unit/MemoryStoreSessionScopeTests.cs` | New — 14 cases covering isolation, fallback, persistence-survives-reload, defensive validation. |

## Backward compatibility

Legacy `~/.ga/memory.json` entries (no `SessionId` field) deserialise with `SessionId=null`. They become the "shared knowledge" partition. No migration step needed.

## Phase split

- **Phase A (this PR):** storage-layer isolation. Retrieval STILL OFF by default.
- **Phase B (follow-up):** wire `Context.ConnectionId` (SignalR) and HTTP session cookie into `ChatHookContext.SessionId` from `ChatbotHub` + controllers. After Phase B lands, the operator can flip `Memory:EnrichOnRetrieve=true` and retrieval becomes safe.

The two-phase split keeps each PR reviewable independently. The leak is closed by Phase A; Phase B turns the feature back on.

## Test plan

- [x] `dotnet build Common/GA.Business.ML` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~MemoryStoreSessionScopeTests"` — **14/14 passed (74 ms)**
- [ ] CI green (modulo the known pre-existing Anthropic env failure on Backend Tests / build jobs)
- [ ] **Multi-LLM review** via Agent-tool subagents (`octo:droids:octo-code-reviewer` + `octo:droids:octo-security-auditor`) — see `feedback_multi_llm_review_pays_off` memory and `.claude/skills/chatbot-iterate/SKILL.md` Step 4
- [ ] Demerzel QA Architect Tribunal (when next scheduled)

## Iron Law gate plan

Per `.claude/skills/chatbot-iterate/SKILL.md` (post-2026-05-10 update): primary mechanism is **direct subagent dispatch via Agent tool** (orchestrated `/octo:review` has been silently dark on Windows). Two reviewers will be spawned in parallel before merge:

1. `octo:droids:octo-code-reviewer` — focus on session boundary correctness, composite-key collision risk, concurrency around `_entries` mutation during eviction, and backward-compat with legacy JSON.
2. `octo:droids:octo-security-auditor` — focus on U+001F escaping (is forging a "different session"'s entry possible?), the eviction policy under adversarial write pressure, the `~/.ga/memory.json` path resolution.

Verdict will be written to `state/chatbot-reviews/<pr>.json` per the schema and read by the auto-merge decision (Step 7).

## Manual smoke

Phase A is invisible to the chatbot end-user (retrieval still OFF). After Phase B + flag flip:

> User A (session abc): "What chord substitutes for G7?" → Agent answers with Db7 / Dm7 etc.
> User B (session xyz, separate connection): "What chord substitutes for Cmaj7?" → Agent answer must NOT reference G7-related content from session abc.

The new `Search_ReturnsGlobalPlusOwnSession_NotOtherSessions` test pins this guarantee at the unit level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)