### PR TITLE
feat(governance): Demerzel integration — Tier 1 status emit + Tier 2 directives + Tier 3 contract

### DIFF
--- a/.claude/skills/chatbot-iterate/SKILL.md
+++ b/.claude/skills/chatbot-iterate/SKILL.md
@@ -50,9 +50,11 @@ have been satisfied.
 
 ## Process
 
-### Step 0: Killswitch check
+### Step 0: Killswitch + governance-directives check
 
-Before doing ANYTHING, check the loop killswitch:
+Before doing ANYTHING, check the two halt signals.
+
+**A. Local killswitch** (operator-owned):
 
 ```powershell
 if (Test-Path state/.loop-halted) {
@@ -62,10 +64,7 @@ if (Test-Path state/.loop-halted) {
 }
 ```
 
-If `state/.loop-halted` exists, exit cleanly with the sentinel's
-reason. Do NOT pick a new item. Do NOT touch the working tree.
-This is the L4 kill switch — when set, every fresh iteration
-refuses to start. To resume:
+To resume:
 
 ```powershell
 pwsh Scripts/loop-killswitch.ps1 -Reset
@@ -76,6 +75,34 @@ Status check (read-only):
 ```powershell
 pwsh Scripts/loop-killswitch.ps1 -Status
 ```
+
+**B. Demerzel governance directives** (Tier 2 integration —
+governance-owned). Demerzel writes
+`state/governance/directives.json` per
+`docs/schemas/governance-directives.schema.json` to pause the whole
+Chatbot Track, pause a specific slug, or order a rollback of a
+specific PR. Check before picking the next item:
+
+```powershell
+pwsh Scripts/check-governance-directives.ps1 -Slug <selected-slug>
+```
+
+Exit codes:
+- `0` clear — proceed
+- `2` blocked — directive targets this scope; do NOT iterate. Surface
+  the reason to the user and STOP.
+- `3` invalid — directives file malformed. Treat as conservatively
+  blocked; flag for Demerzel-side fix.
+
+Composition: the local killswitch AND the governance directive both
+must clear. EITHER can block. The local sentinel is faster to set
+(operator on this host); governance directives travel from Demerzel's
+clock — both are valid stop signals.
+
+Source-of-truth contract: `docs/schemas/governance-directives.schema.json`
++ the loop-status emitter at `Scripts/project-sync.ps1` (Tier 1, GA →
+Demerzel) that lets Demerzel see what GA's been doing before issuing
+directives back.
 
 ### Step 1: Identify the next chatbot item
 

--- a/Scripts/check-governance-directives.ps1
+++ b/Scripts/check-governance-directives.ps1
@@ -1,0 +1,138 @@
+# Reads state/governance/directives.json (Tier 2 Demerzel integration) and
+# determines whether /chatbot-iterate's current iteration should proceed.
+#
+# Schema: docs/schemas/governance-directives.schema.json.
+#
+# Called by /chatbot-iterate Step 0 alongside the killswitch sentinel check.
+# Composition: ANY block-class directive that targets the current scope is
+# sufficient to refuse the iteration. Advisory directives surface a warning
+# but don't refuse.
+#
+# Exit codes:
+#   0 = clear (no directives, or only advisories — proceed)
+#   2 = blocked (one or more directives target the current scope)
+#   3 = file present but invalid (schema violation or unparseable JSON)
+#
+# Usage from /chatbot-iterate:
+#   pwsh Scripts/check-governance-directives.ps1 -Slug memory-session-scope -Json
+#
+# Stand-alone:
+#   pwsh Scripts/check-governance-directives.ps1            # check whole-track
+#   pwsh Scripts/check-governance-directives.ps1 -Slug X    # check one slug
+
+[CmdletBinding()]
+param(
+    [string]$Slug,
+    [int]$Pr,
+    [switch]$Json,
+    [string]$RepoRoot = (Resolve-Path .).Path,
+    [int]$StaleDays = 7
+)
+
+$ErrorActionPreference = 'Stop'
+
+$directivesFile = Join-Path $RepoRoot 'state/governance/directives.json'
+
+function Emit {
+    param([int]$ExitCode, [string]$State, [string]$Reason, [array]$Blocks, [array]$Advisories)
+    if ($Json) {
+        $obj = [ordered]@{
+            state       = $State
+            reason      = $Reason
+            blocks      = $Blocks
+            advisories  = $Advisories
+            exitCode    = $ExitCode
+        }
+        $obj | ConvertTo-Json -Depth 5 -Compress
+    } else {
+        $colour = switch ($State) {
+            'clear'   { 'Green' }
+            'blocked' { 'Red' }
+            'invalid' { 'Magenta' }
+            default   { 'Yellow' }
+        }
+        Write-Host ''
+        Write-Host "Governance directives: $State" -ForegroundColor $colour
+        if ($Reason) { Write-Host "  $Reason" -ForegroundColor DarkGray }
+        if ($Blocks -and $Blocks.Count -gt 0) {
+            Write-Host '  Blocking:' -ForegroundColor Red
+            foreach ($b in $Blocks) {
+                Write-Host ("    [{0}] {1}" -f $b.type, $b.reason) -ForegroundColor Red
+                if ($b.verdictId) { Write-Host ("      verdict: {0}" -f $b.verdictId) -ForegroundColor DarkGray }
+            }
+        }
+        if ($Advisories -and $Advisories.Count -gt 0) {
+            Write-Host '  Advisories:' -ForegroundColor Yellow
+            foreach ($a in $Advisories) {
+                Write-Host ("    {0}" -f $a.reason) -ForegroundColor Yellow
+            }
+        }
+        Write-Host ''
+    }
+    exit $ExitCode
+}
+
+# No file present = no directives = clear
+if (-not (Test-Path $directivesFile)) {
+    Emit 0 'clear' 'No state/governance/directives.json present.' @() @()
+}
+
+# Parse + validate basic shape
+$doc = $null
+try { $doc = Get-Content $directivesFile -Raw | ConvertFrom-Json } catch { }
+if (-not $doc) {
+    Emit 3 'invalid' "Couldn't parse $directivesFile as JSON." @() @()
+}
+if (-not $doc.schemaVersion -or -not $doc.directives) {
+    Emit 3 'invalid' 'Directives file missing required fields (schemaVersion, directives).' @() @()
+}
+
+# Staleness sanity check — refuse stale files
+if ($doc.issuedAt) {
+    try {
+        $issued = [datetime]::Parse($doc.issuedAt).ToUniversalTime()
+        $ageDays = ((Get-Date).ToUniversalTime() - $issued).TotalDays
+        if ($ageDays -gt $StaleDays) {
+            Emit 0 'clear' ("Directives file is {0:N1} days old (> {1}-day stale cutoff). Treating as unset." -f $ageDays, $StaleDays) @() @()
+        }
+    } catch { }
+}
+
+# Apply each directive
+$now = (Get-Date).ToUniversalTime()
+$blocks = @()
+$advisories = @()
+foreach ($d in $doc.directives) {
+    # Expiry check
+    if ($d.expiresAt) {
+        try {
+            $exp = [datetime]::Parse($d.expiresAt).ToUniversalTime()
+            if ($now -gt $exp) { continue }
+        } catch { }
+    }
+
+    # Does this directive target the current scope?
+    $targets = $false
+    if ($d.scope.chatbotTrack -eq $true) { $targets = $true }
+    if ($Slug -and $d.scope.slug -eq $Slug) { $targets = $true }
+    if ($Pr -gt 0 -and $d.scope.pr -eq $Pr) { $targets = $true }
+    if (-not $targets) { continue }
+
+    # Classify
+    if ($d.type -eq 'advisory') {
+        $advisories += $d
+    } else {
+        $blocks += $d
+    }
+}
+
+if ($blocks.Count -gt 0) {
+    $reason = ("{0} blocking directive(s) target this iteration scope." -f $blocks.Count)
+    Emit 2 'blocked' $reason $blocks $advisories
+}
+
+if ($advisories.Count -gt 0) {
+    Emit 0 'clear' ("{0} advisory directive(s); proceeding with warning." -f $advisories.Count) @() $advisories
+}
+
+Emit 0 'clear' 'No directives target this iteration scope.' @() @()

--- a/Scripts/project-sync.ps1
+++ b/Scripts/project-sync.ps1
@@ -1,0 +1,296 @@
+# Tier 1 Demerzel integration — read-only loop-status emitter.
+#
+# Aggregates GA's /chatbot-iterate state into a single
+# state/governance/ga-loop-status.json that Demerzel governance can
+# poll. Schema: docs/schemas/ga-loop-status.schema.json.
+#
+# Sources:
+#   - BACKLOG.md (Chatbot Track section)
+#   - gh pr list --search "head:chatbot/" --state open
+#   - state/chatbot-reviews/<pr>.json (Agent-tool review verdicts)
+#   - state/quality/gate-ledger.jsonl (post-merge cohort data)
+#   - state/quality/verdicts/<repo>/pr-<n>/*.json (Demerzel tribunal verdicts when present)
+#   - state/.loop-halted (kill switch state)
+#
+# Output: state/governance/ga-loop-status.json (atomically overwritten).
+#
+# This is the Tier 1 integration: GA writes, Demerzel reads. Tier 2 adds
+# the reverse direction (Demerzel writes governance directives that
+# /chatbot-iterate Step 0 reads).
+#
+# Usage:
+#   pwsh Scripts/project-sync.ps1                # emit snapshot
+#   pwsh Scripts/project-sync.ps1 -Verbose       # with progress
+#   pwsh Scripts/project-sync.ps1 -DryRun        # print to stdout, don't write
+#   pwsh Scripts/project-sync.ps1 -LastN 20      # include more ledger rows
+#
+# Safe to run on a cron: every minute is fine, the script is read-only
+# against the repo and atomic on the output.
+
+[CmdletBinding()]
+param(
+    [int]$LastN = 10,
+    [switch]$DryRun,
+    [string]$RepoRoot = (Resolve-Path .).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Read-JsonOrNull {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $null }
+    try { return Get-Content $Path -Raw | ConvertFrom-Json } catch { return $null }
+}
+
+function Parse-ChatbotTrack {
+    param([string]$BacklogPath)
+    if (-not (Test-Path $BacklogPath)) { return @() }
+    $content = Get-Content $BacklogPath -Raw
+
+    # Find the "Chatbot Track" section between its heading and the next H2.
+    $match = [regex]::Match($content,
+        '(?s)## Chatbot Track.*?(?=\n## (?!#)|\z)')
+    if (-not $match.Success) { return @() }
+    $section = $match.Value
+
+    # Match each item: - [ ] **`slug`** [status] — summary
+    $items = @()
+    foreach ($lineMatch in [regex]::Matches($section,
+        '(?m)^- \[(?<done>[ x])\] \*\*`(?<slug>[^`]+)`\*\* \[(?<status>[^\]]+)\][^—]*— (?<summary>[^\r\n]+)')) {
+        $statusRaw = $lineMatch.Groups['status'].Value.Trim()
+        # Normalise: "blocked: ..." → "blocked"
+        $status = ($statusRaw -split ':')[0].Trim().ToLowerInvariant()
+        if ($lineMatch.Groups['done'].Value -eq 'x') { $status = 'shipped' }
+        # Determine priority from the surrounding H3 (P0 / P1 / P2 / Scheduled / Parked)
+        $beforeText = $section.Substring(0, $lineMatch.Index)
+        $priority = if ($beforeText -match '###\s*P0[^#]*$') { 'P0' }
+                    elseif ($beforeText -match '###\s*P1[^#]*$') { 'P1' }
+                    elseif ($beforeText -match '###\s*P2[^#]*$') { 'P2' }
+                    else { 'P2' }  # scheduled / parked default to P2 bucket
+        # Tribunal-required if summary mentions "Tribunal: REQUIRED"
+        $tribunalRequired = ($lineMatch.Value -match 'Tribunal:\s*REQUIRED')
+        $items += [ordered]@{
+            slug             = $lineMatch.Groups['slug'].Value
+            priority         = $priority
+            status           = $status
+            summary          = ($lineMatch.Groups['summary'].Value.Trim() -replace '\s+', ' ')
+            tribunalRequired = $tribunalRequired
+        }
+    }
+    return $items
+}
+
+function Get-OpenChatbotPRs {
+    param([string]$RepoRoot)
+    try {
+        $raw = & gh pr list --state open --json number,title,headRefName,createdAt,labels,mergeable,statusCheckRollup --limit 50 2>$null
+        if (-not $raw) { return @() }
+        $all = $raw | ConvertFrom-Json
+    } catch { return @() }
+
+    $result = @()
+    foreach ($pr in $all) {
+        $labels = @($pr.labels | ForEach-Object { $_.name })
+        # Heuristic: include if branch is chatbot/* OR has auto-merge-eligible label
+        $isChatbot = $pr.headRefName -like 'chatbot/*' -or ($labels -contains 'auto-merge-eligible')
+        if (-not $isChatbot) { continue }
+
+        # CI tally
+        $passed = 0; $failed = 0; $pending = 0
+        $failedNames = @()
+        foreach ($c in $pr.statusCheckRollup) {
+            $conc = if ($c.conclusion) { $c.conclusion } else { $c.status }
+            switch ($conc) {
+                'SUCCESS'         { $passed++ }
+                'NEUTRAL'         { $passed++ }
+                'FAILURE'         { $failed++; if ($c.name) { $failedNames += $c.name } }
+                'TIMED_OUT'       { $failed++ }
+                'CANCELLED'       { $failed++ }
+                'STARTUP_FAILURE' { $failed++ }
+                'IN_PROGRESS'     { $pending++ }
+                'QUEUED'          { $pending++ }
+                'PENDING'         { $pending++ }
+                'WAITING'         { $pending++ }
+            }
+        }
+
+        # Review verdict (if produced by chatbot-review-write.ps1)
+        $verdictPath = Join-Path $RepoRoot "state/chatbot-reviews/$($pr.number).json"
+        $verdict = $null
+        if (Test-Path $verdictPath) {
+            try {
+                $v = Get-Content $verdictPath -Raw | ConvertFrom-Json
+                $verdict = [ordered]@{
+                    verdict    = $v.verdict
+                    mechanism  = $v.mechanism
+                    reviewedAt = $v.reviewedAt
+                }
+            } catch { }
+        }
+
+        $result += [ordered]@{
+            number        = $pr.number
+            title         = $pr.title
+            branch        = $pr.headRefName
+            createdAt     = $pr.createdAt
+            labels        = $labels
+            mergeable     = $pr.mergeable
+            ci            = [ordered]@{ passed=$passed; failed=$failed; pending=$pending; failedNames=@($failedNames | Select-Object -Unique) }
+            reviewVerdict = $verdict
+        }
+    }
+    return $result
+}
+
+function Read-LedgerSummary {
+    param([string]$RepoRoot, [int]$LastN)
+    $ledger = Join-Path $RepoRoot 'state/quality/gate-ledger.jsonl'
+    if (-not (Test-Path $ledger)) {
+        return [ordered]@{
+            totalRows = 0
+            lastNRows = @()
+            decisionCounts = [ordered]@{
+                'merged-clean' = 0
+                'merged-with-followup' = 0
+                'merged-with-revert' = 0
+                'open' = 0
+                'abandoned' = 0
+            }
+        }
+    }
+    $rows = @(Get-Content $ledger | ForEach-Object { try { $_ | ConvertFrom-Json } catch { } } | Where-Object { $_ })
+    $counts = @{}
+    foreach ($d in @('merged-clean','merged-with-followup','merged-with-revert','open','abandoned')) { $counts[$d] = 0 }
+    foreach ($r in $rows) { if ($r.decision -and $counts.ContainsKey($r.decision)) { $counts[$r.decision]++ } }
+    return [ordered]@{
+        totalRows = $rows.Count
+        lastNRows = @($rows | Select-Object -Last $LastN)
+        decisionCounts = [ordered]@{
+            'merged-clean'         = [int]$counts['merged-clean']
+            'merged-with-followup' = [int]$counts['merged-with-followup']
+            'merged-with-revert'   = [int]$counts['merged-with-revert']
+            'open'                 = [int]$counts['open']
+            'abandoned'            = [int]$counts['abandoned']
+        }
+    }
+}
+
+function Read-TribunalVerdicts {
+    param([string]$RepoRoot, $OpenPRs, $TribunalRequiredSlugs)
+    $owner = ''; $repo = ''
+    try {
+        $remote = & git remote get-url origin 2>$null
+        if ($remote -match '[:/]([^/]+)/([^/]+?)(?:\.git)?$') {
+            $owner = $Matches[1]; $repo = $Matches[2]
+        }
+    } catch { }
+    $verdictsDir = Join-Path $RepoRoot "state/quality/verdicts/$owner/$repo"
+
+    $completed = @()
+    if (Test-Path $verdictsDir) {
+        Get-ChildItem -Path $verdictsDir -Directory -Filter 'pr-*' -ErrorAction SilentlyContinue | ForEach-Object {
+            $prNum = ($_.Name -replace '^pr-','')
+            $latest = Get-ChildItem $_.FullName -Filter '*.json' -ErrorAction SilentlyContinue |
+                      Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if ($latest) {
+                $v = Read-JsonOrNull $latest.FullName
+                if ($v) {
+                    $completed += [ordered]@{
+                        pr          = [int]$prNum
+                        verdict     = ($v.verdict ?? 'unknown')
+                        verdictId   = ($v.verdictId ?? '')
+                        completedAt = ($v.completedAt ?? $latest.LastWriteTimeUtc.ToString('o'))
+                    }
+                }
+            }
+        }
+    }
+
+    $completedPrs = @($completed | ForEach-Object { $_.pr })
+    $pending = @()
+    foreach ($pr in $OpenPRs) {
+        # Heuristic: a PR is "pending tribunal" if its branch matches a
+        # tribunal-required slug from the Chatbot Track AND no verdict
+        # has been written yet.
+        $matchesTrack = $false
+        foreach ($slug in $TribunalRequiredSlugs) {
+            if ($pr.branch -like "*$slug*") { $matchesTrack = $true; break }
+        }
+        if ($matchesTrack -and ($pr.number -notin $completedPrs)) {
+            $ageDays = [Math]::Round(((Get-Date) - [datetime]$pr.createdAt).TotalDays, 2)
+            $pending += [ordered]@{
+                pr      = [int]$pr.number
+                branch  = $pr.branch
+                ageDays = $ageDays
+            }
+        }
+    }
+
+    return [ordered]@{ pendingTribunal = $pending; completedTribunal = $completed }
+}
+
+# ---- Gather state ----
+
+$repoInfo = [ordered]@{
+    owner   = ''
+    name    = ''
+    branch  = ($null)
+    headSha = ($null)
+}
+try {
+    $remote = & git remote get-url origin 2>$null
+    if ($remote -match '[:/]([^/]+)/([^/]+?)(?:\.git)?$') {
+        $repoInfo.owner = $Matches[1]
+        $repoInfo.name  = $Matches[2]
+    }
+    $repoInfo.branch  = (& git branch --show-current 2>$null)
+    $repoInfo.headSha = (& git rev-parse HEAD 2>$null)
+} catch { }
+
+$loopState = [ordered]@{
+    halted            = $false
+    killswitchReason  = $null
+}
+$sentinel = Join-Path $RepoRoot 'state/.loop-halted'
+if (Test-Path $sentinel) {
+    $loopState.halted = $true
+    $reasonLine = Get-Content $sentinel | Where-Object { $_ -like 'REASON:*' } | Select-Object -First 1
+    if ($reasonLine) { $loopState.killswitchReason = ($reasonLine -replace '^REASON:\s*','') }
+}
+
+$track = @(Parse-ChatbotTrack -BacklogPath (Join-Path $RepoRoot 'BACKLOG.md'))
+$openPRs = @(Get-OpenChatbotPRs -RepoRoot $RepoRoot)
+$ledgerSummary = Read-LedgerSummary -RepoRoot $RepoRoot -LastN $LastN
+$tribunalRequiredSlugs = @($track | Where-Object { $_.tribunalRequired } | ForEach-Object { $_.slug })
+$tribunal = Read-TribunalVerdicts -RepoRoot $RepoRoot -OpenPRs $openPRs -TribunalRequiredSlugs $tribunalRequiredSlugs
+
+# ---- Assemble ----
+
+$snapshot = [ordered]@{
+    schemaVersion = '0.1'
+    emittedAt     = (Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ' -AsUTC)
+    repo          = $repoInfo
+    loop          = $loopState
+    backlog       = [ordered]@{ chatbotTrack = $track }
+    openPRs       = $openPRs
+    ledger        = $ledgerSummary
+    verdicts      = $tribunal
+}
+
+$json = $snapshot | ConvertTo-Json -Depth 8
+
+if ($DryRun) {
+    Write-Output $json
+    exit 0
+}
+
+$outDir  = Join-Path $RepoRoot 'state/governance'
+if (-not (Test-Path $outDir)) { New-Item -ItemType Directory -Path $outDir -Force | Out-Null }
+$outPath = Join-Path $outDir 'ga-loop-status.json'
+$tmpPath = "$outPath.tmp"
+Set-Content -Path $tmpPath -Value $json -Encoding UTF8
+Move-Item -Path $tmpPath -Destination $outPath -Force
+
+Write-Host ("Loop status emitted: {0}" -f $outPath) -ForegroundColor Green
+Write-Host ("  track items: {0}; open PRs: {1}; ledger rows: {2}; pending tribunal: {3}; completed tribunal: {4}; halted: {5}" -f `
+    $track.Count, $openPRs.Count, $ledgerSummary.totalRows, $tribunal.pendingTribunal.Count, $tribunal.completedTribunal.Count, $loopState.halted) -ForegroundColor DarkGray

--- a/docs/automation/chatbot-loop.md
+++ b/docs/automation/chatbot-loop.md
@@ -236,6 +236,9 @@ After the 2026-05-10 session that authored this document:
 | Gate ledger writer | ✅ shipped (`gate-ledger-write.ps1` + schema) |
 | Cost tally | ✅ shipped (`octo-cost-tally.ps1`) |
 | Loop killswitch | ✅ shipped (`loop-killswitch.ps1`) |
+| **Tier 1 Demerzel integration** (GA → Demerzel status emission) | ✅ shipped (`project-sync.ps1` + `ga-loop-status.schema.json`) |
+| **Tier 2 Demerzel integration** (Demerzel → GA directives) | ✅ shipped (`check-governance-directives.ps1` + `governance-directives.schema.json` + SKILL.md Step 0) |
+| **Tier 3 Demerzel integration** (Demerzel orchestrates the loop) | 🟡 contract drafted (`docs/contracts/2026-05-10-ga-loop-driver.contract.md`); Demerzel-side `ga-loop-driver.ixql` pipeline not yet written |
 | L3 default-on enablement | ❌ blocked on remaining checklist items (5 clean auto-merges, production canary, CI env fix) |
 | L4 dark factory | ❌ blocked on remaining checklist items (telemetry pipeline, triage skill, scheduler, anomaly detection) |
 

--- a/docs/contracts/2026-05-10-ga-loop-driver.contract.md
+++ b/docs/contracts/2026-05-10-ga-loop-driver.contract.md
@@ -1,0 +1,190 @@
+# Contract: Demerzel `ga-loop-driver` pipeline (Tier 3)
+
+> **Status:** v0.1 draft — 2026-05-10. **Not frozen.** Tier 3 of the
+> GA ↔ Demerzel integration ladder. Tier 1 (status emission) and
+> Tier 2 (directives) shipped 2026-05-10 in GA. Tier 3 requires
+> matching work on the Demerzel side.
+
+## What this contract describes
+
+A Demerzel pipeline (`Demerzel/pipelines/ga-loop-driver.ixql`, to be
+written by the Demerzel team) that orchestrates GA's
+`/chatbot-iterate` from Demerzel's scheduler instead of from a Claude
+Code session. The result: the loop runs from Demerzel's clock, not
+from a human invoking `/chatbot-iterate` interactively.
+
+Mirrors the shape of `Demerzel/pipelines/qa-architect-cycle.ixql`
+that already exists for the QA Architect Tribunal (Phase 1 fires
+`trig_01WdRGSqgxah5PD46wg8u4Qq` on 2026-05-18 per memory
+`project_qa_architect_tribunal`).
+
+## Pre-requisites (already shipped on the GA side)
+
+| Component | Status | File |
+|---|---|---|
+| Loop status emitter (Tier 1) | ✅ | `Scripts/project-sync.ps1` |
+| Loop status schema | ✅ | `docs/schemas/ga-loop-status.schema.json` |
+| Governance directives reader (Tier 2) | ✅ | `Scripts/check-governance-directives.ps1` |
+| Governance directives schema | ✅ | `docs/schemas/governance-directives.schema.json` |
+| `/chatbot-iterate` Step 0 reads directives | ✅ | `.claude/skills/chatbot-iterate/SKILL.md` |
+| Gate liveness check | ✅ | `Scripts/octo-gate-liveness.ps1` |
+| Auto-merge decision | ✅ | `Scripts/octo-auto-merge-decision.ps1` |
+| Gate ledger writer | ✅ | `Scripts/gate-ledger-write.ps1` |
+| Loop killswitch | ✅ | `Scripts/loop-killswitch.ps1` |
+
+## Pre-requisites (Demerzel-side, NOT yet implemented)
+
+The Demerzel team is responsible for:
+
+1. **Polling `state/governance/ga-loop-status.json`** at a configurable
+   cadence (recommend: 60–300 s). The repo is at `../ga/` from the
+   Demerzel repo per the cross-repo convention in `CLAUDE.md`.
+2. **Writing `state/governance/directives.json`** to control GA's loop
+   in response to the status it observes (e.g. pause the track when
+   the QA Tribunal verdict comes back negative).
+3. **Triggering `/chatbot-iterate` execution** when a Track item is
+   ready and Demerzel has approved spending the budget. Mechanism
+   options below.
+
+## Trigger mechanism options (Demerzel-side decision)
+
+Three patterns, ordered by coupling:
+
+### Option 1: GitHub Actions dispatch (loosest coupling)
+
+Demerzel calls `gh workflow run chatbot-iterate.yml -f slug=<slug>`
+against the GA repo. GA hosts a workflow that runs the loop in a
+runner. Pros: zero GA-process modifications. Cons: runner costs;
+runner must have Anthropic + OpenAI auth.
+
+### Option 2: ACP RPC to a local GA daemon
+
+A long-running GA-side daemon (extension of `GaApi`) exposes an
+ACP endpoint at `port: 8201` accepting `{ "command":
+"chatbot-iterate", "slug": "<slug>", "verdictBinding": "<id>" }`.
+Demerzel calls it via ACP from `qa-architect-cycle.ixql`. The daemon
+invokes the same Claude Code skill machinery as the interactive
+session. Pros: matches the existing Demerzel-ACP pattern at
+port 8200. Cons: requires a new GaApi endpoint.
+
+### Option 3: File-watch + spawn
+
+Demerzel writes a `state/governance/iterations/<verdictId>.request.json`
+file. A GA-side watcher (extending the existing
+`GovernanceWatcherService`) picks it up, spawns
+`pwsh -c 'claude code ... /chatbot-iterate <slug>'` in headless mode,
+and writes the result back to `<verdictId>.result.json`. Pros: zero
+new endpoints; reuses existing watcher infra. Cons: headless Claude
+Code needs explicit budget + auth flags.
+
+**Recommendation:** Option 2 (ACP) once the Demerzel team's QA
+Tribunal Phase 1 stabilises. Until then, Option 3 (file-watch) gives
+us a working integration with no new ports.
+
+## State machine the pipeline owns
+
+```
+   ┌─────────────────────────────────────────────────┐
+   │  Demerzel poll loop (ga-loop-driver.ixql)        │
+   │                                                  │
+   │  every <interval>:                              │
+   │    1. read GA's ga-loop-status.json             │
+   │    2. apply governance rules:                   │
+   │       - pause if rolling regression rate > 0    │
+   │       - pause if cost-ledger > budget           │
+   │       - pause if Track is empty                 │
+   │    3. write directives.json if any pause fires  │
+   │    4. if no pause + at least one ready P0/P1:   │
+   │         pick highest-priority ready slug        │
+   │         trigger /chatbot-iterate (Option 1/2/3) │
+   │    5. when iteration completes:                 │
+   │         match returned verdict to GA's          │
+   │         state/quality/verdicts/                 │
+   │         emit Demerzel tribunal verdict          │
+   │         update its own state                    │
+   └─────────────────────────────────────────────────┘
+```
+
+## Governance rules the pipeline should enforce
+
+These are the rules Demerzel's IXQL evaluates against
+`ga-loop-status.json`. Numbers are recommendations; tune as data
+accumulates.
+
+| Signal | Threshold | Directive issued |
+|---|---|---|
+| `ledger.decisionCounts."merged-with-revert"` over last 5 PRs | ≥ 2 | `track-pause`, reason: "regression rate exceeded" |
+| Slug's last 3 ledger rows show ≥ 1 revert | | `item-pause` on that slug |
+| Cost ledger 30-day total | > budget | `track-pause`, reason: "monthly budget exhausted" |
+| `verdicts.pendingTribunal[].ageDays` | > 7 | `advisory` per PR, reason: "tribunal stuck — manual escalation" |
+| Demerzel's own QA Architect verdict on a PR | = REJECT | `rollback-ordered` on that PR |
+| `loop.halted` | = true | No action — operator already paused locally; just observe |
+
+## Identity / authority boundaries
+
+- **GA writes** `ga-loop-status.json` only. Read-only on `directives.json`.
+- **Demerzel writes** `directives.json` only. Read-only on `ga-loop-status.json`.
+- **Operator overrides Demerzel** via `pwsh Scripts/loop-killswitch.ps1`
+  — sets the local sentinel which composes with directives. The operator's
+  kill is ALWAYS sufficient.
+- **Demerzel cannot override the operator** — if both halt signals are
+  set, both must lift before iteration resumes. This is by design.
+
+## Verdict-binding contract
+
+When Demerzel-driven iteration produces a PR, the iteration result
+includes the Demerzel verdict ID that authorised it. That verdict ID
+goes into:
+
+- The PR body (so reviewers see "authorised by Demerzel
+  verdict `<id>`")
+- The gate-ledger row (`tribunal.verdictId`)
+- The Agent-tool review verdict file's `notes` field
+
+Closes the audit loop: every Demerzel-driven merge can be traced back
+to the verdict that authorised it. Operator-driven (interactive
+`/chatbot-iterate`) merges have no `verdictId` and that's the audit
+signal that distinguishes the two modes.
+
+## Out of scope for this contract
+
+- **Cross-repo coordination.** Demerzel itself orchestrates GA + ix +
+  tars + Seldon. This contract is the GA <-> Demerzel slice only.
+- **Multi-host loops.** If GA's loop runs on multiple machines, the
+  loop-status emitter would need to namespace by host. Current shape
+  assumes one canonical GA instance.
+- **Real-time push.** Both directions are file-polling; latency floor
+  is the poll interval. A SignalR push channel would cut latency but
+  adds a connection lifetime concern. Defer until polling latency is
+  a real bottleneck.
+
+## Schedule
+
+Tier 3 is gated on:
+
+1. QA Architect Tribunal Phase 1 firing successfully (2026-05-18 per
+   memory `project_qa_architect_tribunal`)
+2. Demerzel team confirming this contract shape via their own review
+   (their pipeline owns implementation; GA owns the contract)
+3. At least one Track item shipped via `/chatbot-iterate` with a
+   verdict in the ledger (PR #155 or #157 — the first two canaries)
+
+Once those three line up, the Demerzel team writes
+`Demerzel/pipelines/ga-loop-driver.ixql` against this contract, and
+the loop transitions from operator-driven (L2-with-label) toward
+governance-driven (L3+).
+
+## Cross-references
+
+- GA-side schemas: `docs/schemas/ga-loop-status.schema.json`,
+  `docs/schemas/governance-directives.schema.json`
+- GA-side scripts: `Scripts/project-sync.ps1`,
+  `Scripts/check-governance-directives.ps1`
+- Skill that consumes both: `.claude/skills/chatbot-iterate/SKILL.md`
+- Memory: `project_qa_architect_tribunal` (Phase 1 trigger),
+  `project_acp_agents_2026_03_29` (ACP pattern for Option 2),
+  `feedback_multi_llm_review_pays_off` (gate ROI evidence)
+- Demerzel-side reference shape:
+  `Demerzel/pipelines/qa-architect-cycle.ixql` (existing)
+- The 4-level ladder this Tier 3 sits at the top of:
+  `docs/automation/chatbot-loop.md`

--- a/docs/schemas/ga-loop-status.schema.json
+++ b/docs/schemas/ga-loop-status.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GA Loop Status (Demerzel integration — Tier 1, read-only)",
+  "description": "Snapshot of /chatbot-iterate's current state, emitted by Scripts/project-sync.ps1 so Demerzel governance can poll it without coupling to internal GA mechanics. One-way: GA writes, Demerzel reads. Tier 2 adds the reverse direction via docs/schemas/governance-directives.schema.json.\n\nStorage: state/governance/ga-loop-status.json (single file, atomically overwritten).",
+  "type": "object",
+  "required": ["schemaVersion", "emittedAt", "repo", "loop", "backlog", "openPRs", "ledger", "verdicts"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "0.1",
+      "description": "Bumped on breaking schema changes. v0.1 = first Demerzel-readable emission (2026-05-10)."
+    },
+    "emittedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of this snapshot."
+    },
+    "repo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "name", "branch", "headSha"],
+      "properties": {
+        "owner": { "type": "string" },
+        "name": { "type": "string" },
+        "branch": { "type": "string", "description": "Current branch when the snapshot was emitted." },
+        "headSha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" }
+      }
+    },
+    "loop": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["halted", "killswitchReason"],
+      "properties": {
+        "halted": {
+          "type": "boolean",
+          "description": "True if state/.loop-halted sentinel is present (kill switch engaged)."
+        },
+        "killswitchReason": {
+          "anyOf": [ { "type": "string" }, { "type": "null" } ],
+          "description": "Contents of state/.loop-halted's REASON line, or null if not halted."
+        }
+      }
+    },
+    "backlog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chatbotTrack"],
+      "properties": {
+        "chatbotTrack": {
+          "type": "array",
+          "description": "Items parsed from the 'Chatbot Track' section of BACKLOG.md. Order reflects priority ordering in the source.",
+          "items": {
+            "type": "object",
+            "required": ["slug", "priority", "status"],
+            "additionalProperties": false,
+            "properties": {
+              "slug": { "type": "string", "description": "kebab-case identifier (e.g. memory-session-scope)" },
+              "priority": { "type": "string", "enum": ["P0", "P1", "P2"] },
+              "status": {
+                "type": "string",
+                "enum": ["ready", "blocked", "scheduled", "parked", "shipped"]
+              },
+              "summary": { "type": "string", "description": "One-line description from the BACKLOG entry." },
+              "tribunalRequired": {
+                "type": "boolean",
+                "description": "Whether the path-hints classifier flags this as needing the QA Architect Tribunal."
+              }
+            }
+          }
+        }
+      }
+    },
+    "openPRs": {
+      "type": "array",
+      "description": "Currently-open PRs that came out of /chatbot-iterate (heuristic: branch starts with 'chatbot/' or PR has 'auto-merge-eligible' label).",
+      "items": {
+        "type": "object",
+        "required": ["number", "title", "branch", "createdAt"],
+        "additionalProperties": false,
+        "properties": {
+          "number": { "type": "integer" },
+          "title": { "type": "string" },
+          "branch": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "labels": { "type": "array", "items": { "type": "string" } },
+          "mergeable": {
+            "type": "string",
+            "enum": ["MERGEABLE", "CONFLICTING", "UNKNOWN"]
+          },
+          "ci": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "passed": { "type": "integer", "minimum": 0 },
+              "failed": { "type": "integer", "minimum": 0 },
+              "pending": { "type": "integer", "minimum": 0 },
+              "failedNames": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "reviewVerdict": {
+            "anyOf": [
+              { "type": "null" },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "verdict": { "type": "string", "enum": ["pass", "nits-only", "blocking", "abstain"] },
+                  "mechanism": { "type": "string" },
+                  "reviewedAt": { "type": "string", "format": "date-time" }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ledger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["totalRows", "lastNRows", "decisionCounts"],
+      "properties": {
+        "totalRows": { "type": "integer", "minimum": 0 },
+        "lastNRows": {
+          "type": "array",
+          "description": "Most recent N rows from state/quality/gate-ledger.jsonl (N=10 by default). Demerzel uses these to assess gate ROI over time.",
+          "items": { "type": "object" }
+        },
+        "decisionCounts": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "merged-clean":         { "type": "integer", "minimum": 0 },
+            "merged-with-followup": { "type": "integer", "minimum": 0 },
+            "merged-with-revert":   { "type": "integer", "minimum": 0 },
+            "open":                 { "type": "integer", "minimum": 0 },
+            "abandoned":            { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "verdicts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pendingTribunal", "completedTribunal"],
+      "properties": {
+        "pendingTribunal": {
+          "type": "array",
+          "description": "PRs that touched tribunal-required paths (per check-chatbot-tribunal-gate.ps1) but have not yet produced a Demerzel verdict at state/quality/verdicts/.",
+          "items": {
+            "type": "object",
+            "required": ["pr"],
+            "additionalProperties": false,
+            "properties": {
+              "pr": { "type": "integer" },
+              "branch": { "type": "string" },
+              "ageDays": { "type": "number", "minimum": 0 }
+            }
+          }
+        },
+        "completedTribunal": {
+          "type": "array",
+          "description": "PRs with a tribunal verdict file present.",
+          "items": {
+            "type": "object",
+            "required": ["pr", "verdict"],
+            "additionalProperties": false,
+            "properties": {
+              "pr": { "type": "integer" },
+              "verdict": { "type": "string" },
+              "verdictId": { "type": "string" },
+              "completedAt": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/governance-directives.schema.json
+++ b/docs/schemas/governance-directives.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Governance Directives (Demerzel → GA, Tier 2)",
+  "description": "Demerzel governance writes this file to direct GA's /chatbot-iterate loop. Read by Step 0 of the skill alongside state/.loop-halted. Both signals compose: ANY non-empty directive that targets the current iteration is sufficient to block.\n\nThis is the reverse direction of state/governance/ga-loop-status.json. One-way reverse: Demerzel writes here, GA reads. No GA ack — Demerzel infers ack by polling ga-loop-status.json's emittedAt + halted state.\n\nStorage: state/governance/directives.json (single file). Demerzel atomically overwrites.",
+  "type": "object",
+  "required": ["schemaVersion", "issuedAt", "directives"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "0.1",
+      "description": "Bumped on breaking changes. v0.1 = 2026-05-10."
+    },
+    "issuedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC. /chatbot-iterate ignores directives older than 7 days (sanity check against stale files)."
+    },
+    "issuedBy": {
+      "type": "string",
+      "description": "Identifier for the issuing Demerzel pipeline / verdict ID. For audit trail."
+    },
+    "directives": {
+      "type": "array",
+      "description": "Active directives. Empty array means no governance blocks — equivalent to no file present.",
+      "items": {
+        "type": "object",
+        "required": ["type", "scope", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["track-pause", "item-pause", "rollback-ordered", "advisory"],
+            "description": "track-pause = halt ALL iterations until lifted. item-pause = skip the named slug only. rollback-ordered = revert the named PR via gh + flip ledger row. advisory = log a warning but don't block."
+          },
+          "scope": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "What the directive applies to. Exactly one of {chatbotTrack, slug, pr} must be set.",
+            "properties": {
+              "chatbotTrack": {
+                "type": "boolean",
+                "description": "True = applies to the whole Chatbot Track (use with track-pause)."
+              },
+              "slug": {
+                "type": "string",
+                "description": "BACKLOG.md Chatbot Track slug (e.g. memory-session-scope)."
+              },
+              "pr": {
+                "type": "integer",
+                "description": "PR number (use with rollback-ordered)."
+              }
+            }
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 8,
+            "description": "Human-readable reason that surfaces in /chatbot-iterate's refusal message and Slack/log."
+          },
+          "verdictId": {
+            "type": "string",
+            "description": "Demerzel verdict that produced this directive — links to state/quality/verdicts/.../<verdictId>.json."
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Optional ISO 8601 UTC. If present, directive auto-lifts after this time. If absent, directive holds until file is rewritten."
+          }
+        }
+      }
+    }
+  }
+}

--- a/state/governance/.gitignore
+++ b/state/governance/.gitignore
@@ -1,0 +1,7 @@
+# Runtime artifacts emitted by Scripts/project-sync.ps1 and similar.
+# Schema lives in docs/schemas/; check-in not useful since timestamps
+# change every run.
+ga-loop-status.json
+ga-loop-status.json.tmp
+directives.json
+directives.json.tmp


### PR DESCRIPTION
## Summary

Three-tier integration between GA's `/chatbot-iterate` autonomy loop and the Demerzel governance project board.

| Tier | Direction | Status |
|---|---|---|
| **1 — Loop status emission** | GA → Demerzel (read-only) | ✅ shipped here |
| **2 — Governance directives** | Demerzel → GA (read-only) | ✅ shipped here |
| **3 — Pipeline orchestration** | Demerzel drives the loop | 🟡 GA-side contract drafted; Demerzel-side `ga-loop-driver.ixql` pending |

## What's in the diff

| File | Purpose |
|---|---|
| `Scripts/project-sync.ps1` | Aggregates Chatbot Track + open PRs + ledger + tribunal verdicts + killswitch into `state/governance/ga-loop-status.json` |
| `docs/schemas/ga-loop-status.schema.json` | Tier 1 contract (GA emits, Demerzel reads) |
| `Scripts/check-governance-directives.ps1` | Reads `state/governance/directives.json`; exits 0 / 2 / 3 |
| `docs/schemas/governance-directives.schema.json` | Tier 2 contract (Demerzel writes, GA reads) |
| `.claude/skills/chatbot-iterate/SKILL.md` | Step 0 now checks BOTH killswitch + directives |
| `docs/contracts/2026-05-10-ga-loop-driver.contract.md` | Tier 3 contract — what Demerzel's `ga-loop-driver.ixql` pipeline should do |
| `docs/automation/chatbot-loop.md` | Status table extended with the three tiers |
| `state/governance/.gitignore` | Runtime artifacts excluded; schemas live in `docs/schemas/` |

## Verified end-to-end

**Tier 1 emitter:**

```
$ pwsh Scripts/project-sync.ps1
Loop status emitted: state/governance/ga-loop-status.json
  track items: 16; open PRs: 2; ledger rows: 0; pending tribunal: 2;
  completed tribunal: 0; halted: False
```

PR #157 (this session's memory-session-scope canary) and PR #155 (the m7b5/dim7 canary) both appear in `openPRs[]` with their CI counts and (for #157) the Agent-tool review verdict.

**Tier 2 reader:** clear / blocked / JSON-output modes all behave correctly with a fabricated `track-pause` directive (smoke-tested + cleaned).

**Tier 3 contract:** draft v0.1. Three options for the Demerzel-side trigger mechanism documented (`gh workflow dispatch`, ACP RPC at port 8201, file-watch). Recommended: ACP once QA Tribunal Phase 1 stabilises (fires `trig_01WdRGSqgxah5PD46wg8u4Qq` on 2026-05-18).

## Identity / authority boundaries

- **GA writes** `ga-loop-status.json` only.
- **Demerzel writes** `directives.json` only.
- **Operator's local killswitch** (`Scripts/loop-killswitch.ps1`) composes with directives — EITHER blocks, BOTH must clear to resume.
- **Operator > Demerzel.** The local sentinel always wins.

## Gate plan

This PR does NOT touch chatbot-core paths (`Common/GA.Business.ML/Agents/Mcp/`, MCP, DSL, etc.) per `Scripts/check-chatbot-tribunal-gate.ps1`. Tribunal NOT required; multi-LLM review recommended but not mandatory.

PR scope is governance/infrastructure — orthogonal to PR #157 (memory-session-scope) and PR #155 (m7b5/dim7 chord-info). All three can land independently.

## Test plan

- [x] `pwsh Scripts/project-sync.ps1` produces valid JSON conforming to schema
- [x] `pwsh Scripts/check-governance-directives.ps1` returns clear / blocked / invalid correctly across all three modes
- [ ] CI green
- [ ] Demerzel team review of the Tier 3 contract draft before they start implementation

## Followups (Demerzel-side, not in this PR)

1. Write `Demerzel/pipelines/ga-loop-driver.ixql` against the contract draft (pre-req: QA Tribunal Phase 1 stable 2026-05-18+)
2. Implement the chosen trigger mechanism (recommend ACP at port 8201)
3. Implement the governance rules table — when to issue directives based on observed status

🤖 Generated with [Claude Code](https://claude.com/claude-code)