### PR TITLE
feat(chatbot): plumb SessionId through orchestrator — Phase B (re-targeted)

### DIFF
--- a/Apps/ga-server/GaApi/Hubs/ChatbotHub.cs
+++ b/Apps/ga-server/GaApi/Hubs/ChatbotHub.cs
@@ -116,8 +116,20 @@ public sealed class ChatbotHub(
 
         try
         {
+            // SessionId = Context.ConnectionId — the anonymous demo doesn't
+            // have an authenticated user identity, but SignalR's server-issued
+            // ConnectionId IS a 128-bit cryptographically-random per-tab handle
+            // (per Microsoft.AspNetCore.SignalR's default IConnectionIdGenerator).
+            // That's exactly what MemoryHook needs to scope retrieval per
+            // conversation rather than across every anonymous tab — see PR
+            // #157 Phase A (storage layer) for the leak this closes.
+            //
+            // After this Phase B change ships AND Memory:EnrichOnRetrieve=true
+            // is flipped in config, MemoryHook will scope reads/writes to
+            // (sessionId=connectionId) instead of skipping retrieval entirely.
             var response = await chatService.ChatAsync(
-                new ChatRequest(trimmedMessage), cancellationToken);
+                new ChatRequest(trimmedMessage, SessionId: connectionId),
+                cancellationToken);
 
             // Emit routing metadata to client. Grounding is included when the
             // intent that handled the request was deterministic-compute-backed

--- a/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
@@ -109,6 +109,7 @@ public class ProductionOrchestrator(
         var hookCtx = new ChatHookContext
         {
             CorrelationId   = correlationId,
+            SessionId       = sessionId,   // PR #157 Phase B — plumb session
             OriginalMessage = req.Message,
             CurrentMessage  = req.Message,
             Services        = services,
@@ -253,6 +254,7 @@ public class ProductionOrchestrator(
             OriginalMessage = req.Message,
             CurrentMessage  = req.Message,
             CorrelationId   = correlationId,
+            SessionId       = sessionId,   // PR #157 Phase B — plumb session
         };
 
         foreach (var hook in _hooks)
@@ -302,6 +304,7 @@ public class ProductionOrchestrator(
                 CurrentMessage   = message,
                 MatchedSkillName = pick.Intent.Id,
                 CorrelationId    = correlationId,
+                SessionId        = sessionId,   // PR #157 Phase B
             };
             foreach (var hook in _hooks)
             {
@@ -336,6 +339,7 @@ public class ProductionOrchestrator(
                 MatchedSkillName = pick.Intent.Id,
                 Response         = skillRespForHooks,
                 CorrelationId    = correlationId,
+                SessionId        = sessionId,   // PR #157 Phase B
             };
             foreach (var hook in _hooks)
                 await hook.OnAfterSkill(afterCtx, ct);
@@ -361,6 +365,7 @@ public class ProductionOrchestrator(
                 MatchedSkillName = pick.Intent.Id,
                 Response         = skillRespForHooks,
                 CorrelationId    = correlationId,
+                SessionId        = sessionId,   // PR #157 Phase B — load-bearing for MemoryHook session scope
             };
             foreach (var hook in _hooks)
                 await hook.OnResponseSent(sentCtx, ct);
@@ -463,6 +468,7 @@ public class ProductionOrchestrator(
             OriginalMessage = req.Message,
             CurrentMessage  = message,
             CorrelationId   = correlationId,
+            SessionId       = sessionId,   // PR #157 Phase B
             Response        = new AgentResponse
             {
                 AgentId    = routing.SelectedAgent.AgentId,
@@ -521,6 +527,7 @@ public class ProductionOrchestrator(
             OriginalMessage = req.Message,
             CurrentMessage  = message,
             CorrelationId   = correlationId,
+            SessionId       = sessionId,   // PR #157 Phase B — load-bearing for MemoryHook
             Response        = agentResponse,
         };
         foreach (var hook in _hooks)

--- a/Common/GA.Business.ML/Agents/Hooks/ChatHookContext.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/ChatHookContext.cs
@@ -57,6 +57,28 @@ public sealed class ChatHookContext
     /// Guid per request and changes between turns; SessionId is stable
     /// across the turns of one conversation.
     /// </para>
+    /// <para>
+    /// <b>SignalR rotation caveat (PR #159 review ux-001):</b> when the
+    /// transport is SignalR (<c>ChatbotHub</c>), SessionId =
+    /// <c>Context.ConnectionId</c>, which is a *per-physical-connection*
+    /// identifier. With <c>withAutomaticReconnect()</c> on the client,
+    /// a transient WebSocket drop opens a fresh negotiation and a fresh
+    /// ConnectionId. Treat SessionId as <i>connection-scoped, not
+    /// user-scoped</i>: a coffee-shop wifi blip rotates the session and
+    /// the user's prior turns become unreachable from MemoryHook.
+    /// Acceptable for the anonymous demo (where the alternative — a
+    /// stable client-supplied ID — would expand the trust boundary).
+    /// </para>
+    /// <para>
+    /// <b>HTTP controllers (PR #159 review plumb-001):</b> the HTTP chat
+    /// surfaces at <c>ChatbotController</c> (both GaApi and
+    /// GaChatbot.Api) do NOT plumb SessionId today — Phase B is
+    /// SignalR-only. The orchestrator falls back to a fresh Guid per
+    /// request so HTTP callers get throwaway per-request sessions whose
+    /// writes are unreachable from future retrieval. Tracked as Phase C
+    /// (task #103); do NOT flip <c>Memory:EnrichOnRetrieve=true</c>
+    /// expecting transport-uniform behaviour until Phase C ships.
+    /// </para>
     /// </remarks>
     public string? SessionId { get; init; }
 

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryHookSessionPlumbingTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryHookSessionPlumbingTests.cs
@@ -1,0 +1,202 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Hooks;
+using GA.Business.ML.Agents.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// Phase B regression tests — verify that <see cref="ChatHookContext.SessionId"/>
+/// actually flows from the orchestrator down into <see cref="MemoryStore.Write"/>'s
+/// sessionId argument. Without this, a future orchestrator refactor could silently
+/// drop SessionId from one of the seven ChatHookContext construction sites in
+/// ProductionOrchestrator and we'd regress to the cross-session-leak posture.
+/// </summary>
+/// <remarks>
+/// Tests use a temp store path so the user's real ~/.ga/memory.json is never
+/// touched. Each test builds its own MemoryHook with EnrichOnRetrieve=true so
+/// the retrieval branch isn't short-circuited.
+/// </remarks>
+[TestFixture]
+public class MemoryHookSessionPlumbingTests
+{
+    private string _tempDir = string.Empty;
+    private string _tempStorePath = string.Empty;
+    private MemoryStore _store = null!;
+    private MemoryHook _hook = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ga-memhook-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _tempStorePath = Path.Combine(_tempDir, "memory.json");
+        _store = new MemoryStore(_tempStorePath);
+
+        var configValues = new Dictionary<string, string?> { ["Memory:EnrichOnRetrieve"] = "true" };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(configValues).Build();
+        _hook = new MemoryHook(_store, config, NullLogger<MemoryHook>.Instance);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ─── OnResponseSent — write path uses ctx.SessionId ───────────────
+
+    [Test]
+    public async Task OnResponseSent_PersistsWithCtxSessionId()
+    {
+        // Setup: a context with an explicit SessionId — simulates what the
+        // orchestrator should pass after Phase B's plumbing.
+        var ctx = new ChatHookContext
+        {
+            OriginalMessage  = "what's a Cmaj7?",
+            CurrentMessage   = "what's a Cmaj7?",
+            CorrelationId    = Guid.NewGuid(),
+            SessionId        = "sess-from-orchestrator",
+            MatchedSkillName = "chord-info",
+            Response = new AgentResponse
+            {
+                AgentId    = "chord-info",
+                Result     = "Cmaj7 contains the notes C, E, G, and B — root, major third, perfect fifth, and major seventh respectively. " +
+                             "These four pitches together form the major seventh chord, the harmonic backbone of countless jazz progressions.",
+                Confidence = 0.95f,
+            },
+        };
+
+        await _hook.OnResponseSent(ctx);
+
+        // Give the fire-and-forget Task.Run a moment to flush.
+        await WaitForWriteAsync(expectedSessionId: "sess-from-orchestrator");
+
+        var sessionEntries = _store.Search(sessionId: "sess-from-orchestrator", query: "Cmaj7");
+        Assert.That(sessionEntries, Has.Count.EqualTo(1),
+            "ctx.SessionId must reach MemoryStore.Write — otherwise the leak is back.");
+        Assert.That(sessionEntries[0].SessionId, Is.EqualTo("sess-from-orchestrator"));
+    }
+
+    [Test]
+    public async Task OnResponseSent_DifferentSessions_DoNotSeeEachOthersWrites()
+    {
+        // Two sessions write through the hook; each should only see its own.
+        var sessA = MakeCtx("sess-A", "A asks about Cmaj7",
+            "Cmaj7 contains C E G B — root, major third, perfect fifth, major seventh. " +
+            "This is session A's conversation about the chord and what it sounds like in context.");
+        var sessB = MakeCtx("sess-B", "B asks about Dm7",
+            "Dm7 contains D F A C — root, minor third, perfect fifth, minor seventh. " +
+            "This is session B's conversation about a completely different chord, the ii in C major.");
+
+        await _hook.OnResponseSent(sessA);
+        await _hook.OnResponseSent(sessB);
+
+        await WaitForWriteAsync(expectedSessionId: "sess-A");
+        await WaitForWriteAsync(expectedSessionId: "sess-B");
+
+        var fromA = _store.Search(sessionId: "sess-A", query: "");
+        var fromB = _store.Search(sessionId: "sess-B", query: "");
+        var fromC = _store.Search(sessionId: "sess-C", query: ""); // a third, unrelated session
+
+        Assert.That(fromA, Has.Count.EqualTo(1), "Session A should see exactly its one entry.");
+        Assert.That(fromB, Has.Count.EqualTo(1), "Session B should see exactly its one entry.");
+        Assert.That(fromC, Is.Empty,
+            "An unrelated session must not see A's or B's writes — that's the leak Phase A+B closes.");
+        Assert.That(fromA[0].SessionId, Is.EqualTo("sess-A"));
+        Assert.That(fromB[0].SessionId, Is.EqualTo("sess-B"));
+    }
+
+    // ─── OnRequestReceived — retrieval path uses ctx.SessionId ─────────
+
+    [Test]
+    public async Task OnRequestReceived_WithSessionId_ScopesRetrievalToThatSession()
+    {
+        // Pre-populate the store with one entry per session, identical content.
+        _store.Write(sessionId: "sess-A", key: "k1", type: "response",
+            content: "this is A's previous conversation about voicings of Cmaj7");
+        _store.Write(sessionId: "sess-B", key: "k2", type: "response",
+            content: "this is B's previous conversation about voicings of Cmaj7");
+
+        var ctxA = new ChatHookContext
+        {
+            // Query is "Cmaj7" — a substring present in both A's and B's
+            // stored content. If isolation works, only A's entry is
+            // returned. If it doesn't, B's would surface too.
+            OriginalMessage = "Cmaj7",
+            CurrentMessage  = "Cmaj7",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = "sess-A",
+        };
+
+        var result = await _hook.OnRequestReceived(ctxA);
+
+        // The hook injects matching entries by mutating the message — verify that
+        // session A's entry showed up but session B's did NOT leak in.
+        Assert.That(result.MutatedMessage, Is.Not.Null,
+            "Hook should have found a memory match for session A and injected context.");
+        Assert.That(result.MutatedMessage, Does.Contain("A's previous conversation"),
+            "Session A's own memory should be in the injection.");
+        Assert.That(result.MutatedMessage, Does.Not.Contain("B's previous conversation"),
+            "Session B's memory MUST NOT leak into session A's request — that's the regression we're guarding against.");
+    }
+
+    [Test]
+    public async Task OnRequestReceived_WithoutSessionId_SkipsRetrievalConservatively()
+    {
+        // Pre-populate so retrieval WOULD find something if the hook didn't skip.
+        _store.Write(sessionId: "sess-A", key: "k1", type: "response",
+            content: "this content matches the query string");
+        _store.Write(sessionId: null, key: "k2", type: "fact",
+            content: "this content also matches the query string");
+
+        var ctxNoSession = new ChatHookContext
+        {
+            OriginalMessage = "tell me about content",
+            CurrentMessage  = "tell me about content",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = null,   // simulates "transport hasn't plumbed SessionId yet"
+        };
+
+        var result = await _hook.OnRequestReceived(ctxNoSession);
+
+        Assert.That(result.MutatedMessage, Is.Null,
+            "With SessionId=null, the hook MUST skip retrieval entirely (safety belt). " +
+            "Returning content from any session would replay the cross-session leak.");
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────
+
+    private ChatHookContext MakeCtx(string sessionId, string question, string answer) =>
+        new()
+        {
+            OriginalMessage  = question,
+            CurrentMessage   = question,
+            CorrelationId    = Guid.NewGuid(),
+            SessionId        = sessionId,
+            MatchedSkillName = "test",
+            Response = new AgentResponse
+            {
+                AgentId    = "test",
+                Result     = answer,
+                Confidence = 0.95f,
+            },
+        };
+
+    /// <summary>
+    /// Waits up to 2 seconds for the hook's fire-and-forget write to land.
+    /// Polls Search() rather than sleeping a fixed amount so the test is
+    /// fast on a hot machine and tolerant on a cold one.
+    /// </summary>
+    private async Task WaitForWriteAsync(string expectedSessionId, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_store.Search(sessionId: expectedSessionId, query: "").Count > 0) return;
+            await Task.Delay(25);
+        }
+        Assert.Fail($"Fire-and-forget Write for session '{expectedSessionId}' did not land within {timeoutMs}ms.");
+    }
+}


### PR DESCRIPTION
## Summary

**Replaces PR #159** (auto-closed when base branch `chatbot/memory-session-scope` was deleted on Phase A merge). Same diff, rebased onto `main` after PR #157 (Phase A) and #155 (m7b5/dim7) landed.

Phase B of `memory-session-scope`: plumbs `SessionId` from `ChatRequest` through `ProductionOrchestrator` (all 7 `ChatHookContext` construction sites) and wires SignalR `Context.ConnectionId` as the session ID in `ChatbotHub`.

## Same review verdict as PR #159

Already reviewed via Agent-tool subagents (`octo:droids:octo-code-reviewer` + `octo:droids:octo-security-auditor`). Verdict file: `state/chatbot-reviews/159.json` (carries over since PR# is referenced by review notes; will update on this new PR# after merge).

- **Code reviewer: approve-with-nits.** ux-001 (doc) + plumb-001 (Phase C HTTP follow-up) both addressed in commit `52a07cfb` (ChatHookContext XML doc). 4 verified-safe negative findings.
- **Security auditor: approve-with-nits.** 1 HIGH (SC-001 — MCP global-write prompt injection) is a re-frame of Phase A's MEMSTORE-003, MUST close before flipping `Memory:EnrichOnRetrieve=true`. Tracked as task #102. 6 of 8 original concerns refuted; PR itself doesn't introduce SC-001.

## What's in the diff (2 commits, same as #159)

| File | Change |
|---|---|
| `Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs` | All 7 `new ChatHookContext` blocks set `SessionId = sessionId` |
| `Apps/ga-server/GaApi/Hubs/ChatbotHub.cs` | `SendMessage` passes `Context.ConnectionId` as `ChatRequest.SessionId` |
| `Tests/Common/GA.Business.ML.Tests/Unit/MemoryHookSessionPlumbingTests.cs` | NEW — 4 cases |
| `Common/GA.Business.ML/Agents/Hooks/ChatHookContext.cs` | XML doc spells out SignalR-reconnect rotation + HTTP plumbing gap (Phase C / task #103) |

## Test results

```
dotnet test --filter "FullyQualifiedName~MemoryHookSessionPlumbingTests|MemoryStoreSessionScopeTests"
  Failed: 0, Passed: 18, Skipped: 0  (146 ms)
```

## Gate plan

- [x] Build clean
- [x] 18/18 unit tests pass
- [x] Agent-tool multi-LLM review (carried from #159)
- [ ] CI green (modulo pre-existing Anthropic env failures)
- [ ] Demerzel tribunal — Phase 1 fires `trig_01WdRGSqgxah5PD46wg8u4Qq` on 2026-05-18

## After merge

**Do NOT flip `Memory:EnrichOnRetrieve=true` until task #102 (SC-001) closes.** The flag flip turns on retrieval, at which point an anonymous prompt-injected `MemoryWrite` to the global partition surfaces in every future session's MemoryHook injection. The flip is gated, not the code merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)