### PR TITLE
fix(chatbot): SC-001 — gate MemoryMcpTools.MemoryWrite + filter MCP-origin from retrieval

### DIFF
--- a/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
@@ -89,11 +89,13 @@ public sealed class MemoryHook(
         // filter shipped, retrieval injection refuses to surface those
         // entries into a future session's prompt. The McpOriginTag is
         // applied automatically on every MemoryMcpTools.MemoryWrite that
-        // gets through the flag gate. See
-        // docs/solutions/security/2026-05-11-sc-001-mcp-write-injection.md.
-        const string McpOriginTag = "origin:mcp-tool";
+        // gets through the flag gate.
+        //
+        // Per PR #161 review F-1: reference Memory.MemoryMcpTools.McpOriginTag
+        // (the source of truth) rather than a local literal — a rename
+        // there must not silently regress this filter.
         var filtered = matches
-            .Where(m => !m.Tags.Contains(McpOriginTag, StringComparer.Ordinal))
+            .Where(m => !m.Tags.Contains(Memory.MemoryMcpTools.McpOriginTag, StringComparer.Ordinal))
             .ToList();
         var filteredOutCount = matches.Count - filtered.Count;
         if (filteredOutCount > 0)
@@ -102,7 +104,7 @@ public sealed class MemoryHook(
                 "MemoryHook: filtered {Count} '{Tag}' entries from retrieval (SC-001 defense). " +
                 "If this fires frequently, audit MemoryMcpTools.MemoryWrite usage and consider " +
                 "setting Memory:AllowLlmGlobalWrite=false.",
-                filteredOutCount, McpOriginTag);
+                filteredOutCount, Memory.MemoryMcpTools.McpOriginTag);
         }
         if (filtered.Count == 0) return Task.FromResult(HookResult.Continue);
 
@@ -124,6 +126,24 @@ public sealed class MemoryHook(
     {
         if (ctx.Response is not { Confidence: >= 0.7f } response) return Task.FromResult(HookResult.Continue);
         if (response.Result.Length < 100) return Task.FromResult(HookResult.Continue);
+
+        // Per PR #161 review F-4 (preventative): refuse to write when
+        // SessionId is null. ProductionOrchestrator currently always sets
+        // it (req.SessionId ?? Guid.NewGuid().ToString("N")), so this
+        // branch is dormant today — but a future orchestrator refactor
+        // could pass null through. Without this guard, a null SessionId
+        // would land an entry in the global partition WITHOUT the
+        // origin:mcp-tool tag, defeating both layers of SC-001's defense.
+        // Mirror of the OnRequestReceived safety belt at line 65.
+        if (ctx.SessionId is null)
+        {
+            logger.LogWarning(
+                "MemoryHook: refused to persist response — SessionId is null. " +
+                "Writing here would land an entry in the global partition without the " +
+                "origin:mcp-tool tag, defeating SC-001's two-layer defense. Check the " +
+                "orchestrator's SessionId plumbing (PR #157 Phase B regression?).");
+            return Task.FromResult(HookResult.Continue);
+        }
 
         // Capture by value before fire-and-forget — ctx fields are not safe to
         // close over because the orchestrator may reuse / mutate the context

--- a/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
@@ -81,15 +81,38 @@ public sealed class MemoryHook(
         }
 
         var matches = memoryStore.Search(ctx.SessionId, ctx.CurrentMessage);
-        if (matches.Count == 0) return Task.FromResult(HookResult.Continue);
 
-        var contextBlock = string.Join("\n", matches.Take(3)
+        // SC-001 defense in depth: filter out entries that originated from
+        // MemoryMcpTools.MemoryWrite (LLM-callable). Even if the
+        // Memory:AllowLlmGlobalWrite flag is enabled (intentionally or by
+        // mistake), and even if a prompt-injected write landed before this
+        // filter shipped, retrieval injection refuses to surface those
+        // entries into a future session's prompt. The McpOriginTag is
+        // applied automatically on every MemoryMcpTools.MemoryWrite that
+        // gets through the flag gate. See
+        // docs/solutions/security/2026-05-11-sc-001-mcp-write-injection.md.
+        const string McpOriginTag = "origin:mcp-tool";
+        var filtered = matches
+            .Where(m => !m.Tags.Contains(McpOriginTag, StringComparer.Ordinal))
+            .ToList();
+        var filteredOutCount = matches.Count - filtered.Count;
+        if (filteredOutCount > 0)
+        {
+            logger.LogInformation(
+                "MemoryHook: filtered {Count} '{Tag}' entries from retrieval (SC-001 defense). " +
+                "If this fires frequently, audit MemoryMcpTools.MemoryWrite usage and consider " +
+                "setting Memory:AllowLlmGlobalWrite=false.",
+                filteredOutCount, McpOriginTag);
+        }
+        if (filtered.Count == 0) return Task.FromResult(HookResult.Continue);
+
+        var contextBlock = string.Join("\n", filtered.Take(3)
             .Select(m => $"[memory:{m.Key}] {m.Content}"));
 
         var enriched = $"[Relevant context from memory]\n{contextBlock}\n\n{ctx.CurrentMessage}";
         logger.LogDebug(
             "MemoryHook: injecting {Count} memory entries for session {SessionId}",
-            matches.Count, ctx.SessionId);
+            filtered.Count, ctx.SessionId);
         return Task.FromResult(HookResult.Mutate(enriched));
     }
 

--- a/Common/GA.Business.ML/Agents/Memory/MemoryMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryMcpTools.cs
@@ -61,19 +61,30 @@ public sealed class MemoryMcpTools(
     {
         if (!_allowLlmGlobalWrite)
         {
+            // Truncate attacker-controllable fields before logging — per PR
+            // #161 review F-11, an unbounded key from a prompt-injected
+            // tool call could flood the log file.
+            var safeKey  = (key  ?? string.Empty)[..Math.Min(256, (key  ?? string.Empty).Length)];
+            var safeType = (type ?? string.Empty)[..Math.Min(64,  (type ?? string.Empty).Length)];
             logger.LogInformation(
-                "MemoryMcpTools.MemoryWrite refused: Memory:AllowLlmGlobalWrite=false (default). " +
+                "MemoryMcpTools.MemoryWrite refused: AllowLlmGlobalWrite=false. " +
                 "Key='{Key}', Type='{Type}', ContentLength={Length}",
-                key, type, content?.Length ?? 0);
-            return
-                "Memory write refused: LLM-driven writes to the global memory pool are " +
-                "disabled by default (Memory:AllowLlmGlobalWrite=false). Per-conversation " +
-                "context is captured automatically by the MemoryHook and does not need this tool.";
+                safeKey, safeType, content?.Length ?? 0);
+            // Per PR #161 review F-6: terse refusal — no hints about the
+            // MemoryHook architecture or the exact config-key name.
+            // Operators see the full reason in the LogInformation above.
+            return "Memory write is not enabled.";
         }
 
         // Auto-tag with origin so MemoryHook can filter on retrieval —
         // defense in depth in case the flag is accidentally enabled.
-        var withOrigin = (tags ?? []).Concat([McpOriginTag]).ToArray();
+        // Per PR #161 review M1: dedup if the caller already supplied
+        // the origin tag (system-controlled tag, never trust caller's
+        // copy of it).
+        var withOrigin = (tags ?? [])
+            .Where(t => !string.Equals(t, McpOriginTag, StringComparison.Ordinal))
+            .Append(McpOriginTag)
+            .ToArray();
         store.Write(sessionId: MemoryStore.GlobalSessionId, key: key, type: type, content: content, tags: withOrigin);
         logger.LogInformation(
             "MemoryMcpTools.MemoryWrite accepted (AllowLlmGlobalWrite=true): key='{Key}' type='{Type}'",

--- a/Common/GA.Business.ML/Agents/Memory/MemoryMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryMcpTools.cs
@@ -1,5 +1,7 @@
 namespace GA.Business.ML.Agents.Memory;
 
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 
@@ -16,35 +18,67 @@ using System.ComponentModel;
 /// to a session even if they wanted to.
 /// </para>
 /// <para>
-/// Treat the data the LLM writes via these tools as a SHARED knowledge
-/// pool: facts that should be visible to every session ("user prefers
-/// drop-D tuning examples", "this codebase uses .NET 10"). User-private
-/// conversation history is captured by <see cref="Hooks.MemoryHook"/>
-/// instead, which IS session-scoped because it reads
-/// <see cref="Hooks.ChatHookContext.SessionId"/>.
+/// <b>SC-001 hardening (2026-05-11):</b> <see cref="MemoryWrite"/> is
+/// now <em>off by default</em> behind <c>Memory:AllowLlmGlobalWrite</c>.
+/// Without explicit operator opt-in, the LLM cannot write to the global
+/// partition. This closes the prompt-injection-to-cross-session-retrieval
+/// attack window that Phase A/B opened. Reads (Search/Read/Stats) remain
+/// enabled — they're inert without writers.
 /// </para>
 /// <para>
-/// Future plumbing could expose a session-scoped MCP variant by
-/// surfacing the current ChatHookContext via an async-local accessor,
-/// but that ships separately — keeping these tools un-scoped preserves
-/// backward compatibility with the existing SKILL.md instructions that
-/// rely on shared-knowledge semantics.
+/// When the flag IS opted in, every successful write is auto-tagged
+/// with <c>origin:mcp-tool</c> so <see cref="Hooks.MemoryHook"/>'s
+/// retrieval-injection path can filter these entries (defense in depth
+/// — even if the flag is mistakenly enabled, the retrieval surface
+/// stays safe).
 /// </para>
 /// </remarks>
 [McpServerToolType]
-public sealed class MemoryMcpTools(MemoryStore store)
+public sealed class MemoryMcpTools(
+    MemoryStore store,
+    IConfiguration configuration,
+    ILogger<MemoryMcpTools> logger)
 {
+    /// <summary>
+    /// Default-OFF config flag. Operators flip this only when they
+    /// understand the cross-session retrieval implications.
+    /// </summary>
+    private readonly bool _allowLlmGlobalWrite =
+        configuration.GetValue<bool?>("Memory:AllowLlmGlobalWrite") ?? false;
+
+    /// <summary>Tag automatically applied to MCP-tool-originated writes
+    /// so the retrieval path can identify and exclude them.</summary>
+    public const string McpOriginTag = "origin:mcp-tool";
+
     [McpServerTool]
     [Description("Search the SHARED agent memory by keyword. Returns matching entries from the global knowledge pool (not session-private history). Use for cross-session facts like preferences or learned terminology.")]
     public IReadOnlyList<MemoryEntry> MemorySearch(string query, string? type = null)
         => store.Search(sessionId: MemoryStore.GlobalSessionId, query: query, type: type);
 
     [McpServerTool]
-    [Description("Write or update a SHARED memory entry visible to every session. Use this for cross-session facts. Per-conversation context is captured automatically by the MemoryHook and is NOT written via this tool.")]
+    [Description("Write or update a SHARED memory entry. DISABLED BY DEFAULT — administrators must opt in via Memory:AllowLlmGlobalWrite=true to allow LLM-driven writes to the global pool. When disabled, returns a refusal message. When enabled, the entry is auto-tagged 'origin:mcp-tool' so retrieval hooks can filter it. Use sparingly for stable shared facts; per-conversation context belongs in session memory (handled automatically by the MemoryHook).")]
     public string MemoryWrite(string key, string type, string content, string[]? tags = null)
     {
-        store.Write(sessionId: MemoryStore.GlobalSessionId, key: key, type: type, content: content, tags: tags);
-        return $"Memory '{key}' saved (global / shared scope).";
+        if (!_allowLlmGlobalWrite)
+        {
+            logger.LogInformation(
+                "MemoryMcpTools.MemoryWrite refused: Memory:AllowLlmGlobalWrite=false (default). " +
+                "Key='{Key}', Type='{Type}', ContentLength={Length}",
+                key, type, content?.Length ?? 0);
+            return
+                "Memory write refused: LLM-driven writes to the global memory pool are " +
+                "disabled by default (Memory:AllowLlmGlobalWrite=false). Per-conversation " +
+                "context is captured automatically by the MemoryHook and does not need this tool.";
+        }
+
+        // Auto-tag with origin so MemoryHook can filter on retrieval —
+        // defense in depth in case the flag is accidentally enabled.
+        var withOrigin = (tags ?? []).Concat([McpOriginTag]).ToArray();
+        store.Write(sessionId: MemoryStore.GlobalSessionId, key: key, type: type, content: content, tags: withOrigin);
+        logger.LogInformation(
+            "MemoryMcpTools.MemoryWrite accepted (AllowLlmGlobalWrite=true): key='{Key}' type='{Type}'",
+            key, type);
+        return $"Memory '{key}' saved (global / shared scope, tagged '{McpOriginTag}').";
     }
 
     [McpServerTool]

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryMcpToolsSC001Tests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryMcpToolsSC001Tests.cs
@@ -1,0 +1,215 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Hooks;
+using GA.Business.ML.Agents.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// SC-001 closure tests — MemoryMcpTools.MemoryWrite must refuse LLM-driven
+/// writes to the global memory partition unless an operator explicitly
+/// opts in via <c>Memory:AllowLlmGlobalWrite=true</c>. When opted in, the
+/// write must be auto-tagged so MemoryHook's retrieval-injection path can
+/// filter it (defense in depth).
+/// </summary>
+/// <remarks>
+/// Background: PR #159 Agent-tool security review surfaced SC-001 as a
+/// HIGH-severity finding once <c>Memory:EnrichOnRetrieve=true</c> ships —
+/// without this gate, an anonymous user could prompt-inject the LLM into
+/// writing a poison entry that every future session's MemoryHook would
+/// inject into its prompts. These tests pin both layers of the defense.
+/// </remarks>
+[TestFixture]
+public class MemoryMcpToolsSC001Tests
+{
+    private string _tempDir = string.Empty;
+    private string _tempStorePath = string.Empty;
+    private MemoryStore _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir       = Path.Combine(Path.GetTempPath(), $"ga-mcp-sc001-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _tempStorePath = Path.Combine(_tempDir, "memory.json");
+        _store         = new MemoryStore(_tempStorePath);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ─── Layer 1: write gate ─────────────────────────────────────────────
+
+    [Test]
+    public void MemoryWrite_DefaultConfig_RefusesAndDoesNotPersist()
+    {
+        // Empty config → flag defaults to false → write must refuse.
+        var tools = NewToolsWith(allowLlmGlobalWrite: null);
+
+        var result = tools.MemoryWrite(
+            key: "fact_about_voicings",
+            type: "fact",
+            content: "Users prefer drop-2 voicings for jazz comping.");
+
+        Assert.That(result, Does.Contain("refused"),
+            "Refusal message must be returned to the LLM so it doesn't think the write succeeded.");
+        Assert.That(_store.TotalEntriesAllSessions(), Is.EqualTo(0),
+            "Nothing should have been persisted when the flag is default-off.");
+    }
+
+    [Test]
+    public void MemoryWrite_ExplicitlyDisabled_Refuses()
+    {
+        var tools = NewToolsWith(allowLlmGlobalWrite: false);
+
+        var result = tools.MemoryWrite("k1", "fact", "content");
+
+        Assert.That(result, Does.Contain("refused"));
+        Assert.That(_store.TotalEntriesAllSessions(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void MemoryWrite_OperatorOptIn_PersistsWithOriginTag()
+    {
+        var tools = NewToolsWith(allowLlmGlobalWrite: true);
+
+        var result = tools.MemoryWrite(
+            key: "fact_about_users",
+            type: "fact",
+            content: "Audience here is intermediate-to-advanced guitarists.",
+            tags: ["audience", "voice"]);
+
+        Assert.That(result, Does.Contain("saved"));
+        Assert.That(_store.TotalEntriesAllSessions(), Is.EqualTo(1),
+            "With the flag on, the write must persist exactly one entry.");
+
+        var stored = _store.Read(sessionId: null, key: "fact_about_users");
+        Assert.That(stored, Is.Not.Null);
+        Assert.That(stored!.Tags, Does.Contain(MemoryMcpTools.McpOriginTag),
+            "Auto-tag MUST be applied so MemoryHook can filter on retrieval.");
+        Assert.That(stored.Tags, Does.Contain("audience"),
+            "Caller-supplied tags must be preserved alongside the auto-tag.");
+        Assert.That(stored.Tags, Does.Contain("voice"));
+    }
+
+    [Test]
+    public void MemoryWrite_OperatorOptIn_NoCallerTags_StillTaggedWithOrigin()
+    {
+        var tools = NewToolsWith(allowLlmGlobalWrite: true);
+
+        tools.MemoryWrite("k1", "fact", "content");
+
+        var stored = _store.Read(sessionId: null, key: "k1");
+        Assert.That(stored!.Tags, Is.EqualTo(new[] { MemoryMcpTools.McpOriginTag }),
+            "Even when the caller passes no tags, origin:mcp-tool is applied so the filter still works.");
+    }
+
+    // ─── Layer 2: retrieval-injection filter ─────────────────────────────
+
+    [Test]
+    public async Task MemoryHook_FiltersOutMcpOriginEntries_FromRetrievalInjection()
+    {
+        // Pre-populate the global pool with a poisoned entry that matches
+        // a common query — simulates what would happen if the flag is on
+        // OR if a legacy entry from before this fix survived.
+        _store.Write(sessionId: null, key: "poison", type: "fact",
+            content: "Cmaj7 secretly contains the note F#.",
+            tags: [MemoryMcpTools.McpOriginTag]);
+        // Also write a legitimate session entry that matches.
+        _store.Write(sessionId: "sess-A", key: "real1", type: "response",
+            content: "Cmaj7 contains C, E, G, B — major seventh chord, no F# anywhere.");
+
+        var hook = NewHookWith(enrichOnRetrieve: true);
+        var ctx = new ChatHookContext
+        {
+            OriginalMessage = "Cmaj7",
+            CurrentMessage  = "Cmaj7",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = "sess-A",
+        };
+
+        var result = await hook.OnRequestReceived(ctx);
+
+        Assert.That(result.MutatedMessage, Is.Not.Null,
+            "The legitimate session entry should have been injected.");
+        Assert.That(result.MutatedMessage, Does.Contain("no F# anywhere"),
+            "Legitimate per-session entry should be retrieved.");
+        Assert.That(result.MutatedMessage, Does.Not.Contain("secretly contains the note F#"),
+            "MCP-origin global entry MUST NOT surface in retrieval injection — that's the SC-001 attack chain.");
+    }
+
+    [Test]
+    public async Task MemoryHook_NoMatchesAfterFiltering_SkipsInjection()
+    {
+        // Only an MCP-origin entry is in the pool. After filtering, nothing
+        // remains → hook returns Continue, no injection.
+        _store.Write(sessionId: null, key: "poison-only", type: "fact",
+            content: "completely fabricated chord theory claim about Cmaj7",
+            tags: [MemoryMcpTools.McpOriginTag]);
+
+        var hook = NewHookWith(enrichOnRetrieve: true);
+        var ctx = new ChatHookContext
+        {
+            OriginalMessage = "Cmaj7",
+            CurrentMessage  = "Cmaj7",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = "sess-A",
+        };
+
+        var result = await hook.OnRequestReceived(ctx);
+
+        Assert.That(result.MutatedMessage, Is.Null,
+            "When every match is filtered out, hook should produce no injection.");
+    }
+
+    [Test]
+    public async Task MemoryHook_NonMcpGlobalEntries_StillRetrievedNormally()
+    {
+        // Legitimate non-MCP global entries (e.g. server-side curated facts)
+        // remain visible to retrieval. The filter is specifically for the
+        // MCP-write attack vector, not "all global entries."
+        _store.Write(sessionId: null, key: "curated", type: "fact",
+            content: "All guitar voicings here assume standard tuning unless noted.",
+            tags: ["curated", "server-side"]);
+
+        var hook = NewHookWith(enrichOnRetrieve: true);
+        var ctx = new ChatHookContext
+        {
+            OriginalMessage = "voicings",
+            CurrentMessage  = "voicings",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = "sess-A",
+        };
+
+        var result = await hook.OnRequestReceived(ctx);
+
+        Assert.That(result.MutatedMessage, Is.Not.Null);
+        Assert.That(result.MutatedMessage, Does.Contain("standard tuning"),
+            "Non-MCP global entries (curated, server-side) must still surface — the filter targets only origin:mcp-tool.");
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private MemoryMcpTools NewToolsWith(bool? allowLlmGlobalWrite)
+    {
+        var values = new Dictionary<string, string?>();
+        if (allowLlmGlobalWrite.HasValue)
+            values["Memory:AllowLlmGlobalWrite"] = allowLlmGlobalWrite.Value ? "true" : "false";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        return new MemoryMcpTools(_store, config, NullLogger<MemoryMcpTools>.Instance);
+    }
+
+    private MemoryHook NewHookWith(bool enrichOnRetrieve)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["Memory:EnrichOnRetrieve"] = enrichOnRetrieve ? "true" : "false",
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        return new MemoryHook(_store, config, NullLogger<MemoryHook>.Instance);
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryMcpToolsSC001Tests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryMcpToolsSC001Tests.cs
@@ -55,8 +55,13 @@ public class MemoryMcpToolsSC001Tests
             type: "fact",
             content: "Users prefer drop-2 voicings for jazz comping.");
 
-        Assert.That(result, Does.Contain("refused"),
-            "Refusal message must be returned to the LLM so it doesn't think the write succeeded.");
+        // Per F-6 (PR #161 review): refusal is terse — does not name the
+        // config key or hint at MemoryHook architecture.
+        Assert.That(result, Does.Contain("not enabled"));
+        Assert.That(result, Does.Not.Contain("AllowLlmGlobalWrite"),
+            "Refusal must not name the config key — that's hint leakage to the LLM/attacker.");
+        Assert.That(result, Does.Not.Contain("MemoryHook"),
+            "Refusal must not name the hook — that's architecture leakage.");
         Assert.That(_store.TotalEntriesAllSessions(), Is.EqualTo(0),
             "Nothing should have been persisted when the flag is default-off.");
     }
@@ -68,8 +73,25 @@ public class MemoryMcpToolsSC001Tests
 
         var result = tools.MemoryWrite("k1", "fact", "content");
 
-        Assert.That(result, Does.Contain("refused"));
+        Assert.That(result, Does.Contain("not enabled"));
         Assert.That(_store.TotalEntriesAllSessions(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void MemoryWrite_OperatorOptIn_CallerSuppliedOriginTag_NotDuplicated()
+    {
+        // Per F-1/M1 (PR #161 review): the auto-tag is system-controlled.
+        // A caller who supplies origin:mcp-tool themselves (innocent or
+        // malicious) must not cause a duplicate in the stored Tags array.
+        var tools = NewToolsWith(allowLlmGlobalWrite: true);
+        tools.MemoryWrite("k1", "fact", "content with enough length for the persistence threshold and beyond",
+            tags: [MemoryMcpTools.McpOriginTag, "user-tag", MemoryMcpTools.McpOriginTag]);
+
+        var stored = _store.Read(sessionId: null, key: "k1");
+        Assert.That(stored, Is.Not.Null);
+        Assert.That(stored!.Tags.Count(t => t == MemoryMcpTools.McpOriginTag), Is.EqualTo(1),
+            "Auto-tag must be applied exactly once even if the caller already provided it.");
+        Assert.That(stored.Tags, Does.Contain("user-tag"));
     }
 
     [Test]
@@ -164,6 +186,40 @@ public class MemoryMcpToolsSC001Tests
 
         Assert.That(result.MutatedMessage, Is.Null,
             "When every match is filtered out, hook should produce no injection.");
+    }
+
+    [Test]
+    public async Task MemoryHook_OnResponseSent_RefusesWriteWhenSessionIdIsNull()
+    {
+        // Per F-4 (PR #161 review, preventative): if a future orchestrator
+        // refactor passes a null SessionId through to OnResponseSent, the
+        // hook must refuse to write rather than land an entry in the
+        // global partition WITHOUT the origin:mcp-tool tag (which would
+        // defeat SC-001's two-layer defense).
+        var hook = NewHookWith(enrichOnRetrieve: false);  // EnrichOnRetrieve doesn't gate OnResponseSent
+        var ctx = new ChatHookContext
+        {
+            OriginalMessage = "what's a Cmaj7?",
+            CurrentMessage  = "what's a Cmaj7?",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = null,
+            Response = new AgentResponse
+            {
+                AgentId    = "chord-info",
+                Result     = new string('x', 200),   // > 100 char threshold
+                Confidence = 0.95f,                  // > 0.7 threshold
+            },
+        };
+
+        await hook.OnResponseSent(ctx);
+
+        // Give the fire-and-forget Task.Run a chance to land if it were
+        // going to.
+        await Task.Delay(200);
+
+        Assert.That(_store.TotalEntriesAllSessions(), Is.EqualTo(0),
+            "OnResponseSent must REFUSE to write when SessionId is null — otherwise the entry " +
+            "lands in the global partition without origin:mcp-tool, defeating both SC-001 layers.");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Closes the HIGH-severity SC-001 finding from PR #159's Agent-tool security review. **Unblocks the `Memory:EnrichOnRetrieve=true` flag flip** by closing the prompt-injection vector that would otherwise let an anonymous user poison every future session's retrieval through the global memory pool.

Third L2 canary against a P0 Track item. Task #102.

## Threat model (per PR #159 SC-001)

Without this fix, after `Memory:EnrichOnRetrieve=true` ships:

1. Anonymous attacker connects to `/hubs/chatbot`
2. Crafts prompt to make the LLM call `MemoryWrite` via MCP with attacker-controlled content
3. Entry lands in global partition (sessionId=null)
4. Future anonymous user asks a related question
5. MemoryHook's `Search(victim_session, query)` includes global entries via `InScope`
6. Attacker-controlled content gets injected into victim's prompt as `[memory:...]`
7. Victim's LLM is grounded on poisoned text

Blast radius: hours-to-days, persists across server restart.

## Two-layer defense (security auditor options (a) + (c))

| Layer | What | File |
|---|---|---|
| 1 — Write gate | `Memory:AllowLlmGlobalWrite` config flag, **default false**. Refuses writes with a polite message to the LLM; logs the attempt at LogInformation. When opted in, auto-tags successful writes with `origin:mcp-tool`. | `MemoryMcpTools.cs` |
| 2 — Read filter | `OnRequestReceived` strips entries tagged `origin:mcp-tool` from retrieval-injection candidates. Defense in depth: even if Layer 1's flag is mistakenly enabled or legacy entries survived, retrieval refuses to surface MCP-originated content into future session prompts. | `MemoryHook.cs` |

An attacker must defeat BOTH layers to land a prompt-injection.

## Code-reviewer's plumb-001 / SD-001 still tracked

This PR does NOT touch HTTP controllers (task #103, Phase C). HTTP callers continue to get throwaway per-request sessions; the SC-001 fix is transport-neutral because it operates at the write and retrieval-injection layers.

## Test plan

- [x] `dotnet test` — **25/25 pass** (7 new SC-001 + 14 store + 4 hook plumbing)
- [x] Build clean
- [ ] CI green
- [ ] Agent-tool multi-LLM review (about to spawn)
- [ ] Demerzel QA Architect Tribunal — Phase 1 fires 2026-05-18

## Gate plan

Touches `Common/GA.Business.ML/Agents/Memory/` and `Common/GA.Business.ML/Agents/Hooks/` → **Tribunal: REQUIRED**.

Multi-LLM review concerns to focus on:
- Tag-forgery: can an attacker prompt-inject a `tags: []` arg that overrides the auto-tag? (Layer 1 uses `.Concat()` not replace — verify.)
- LLM social-engineering around the refusal message — does the polite refusal teach the LLM how to evade?
- Legacy entries: are there any pre-existing entries in `~/.ga/memory.json` that match `origin:mcp-tool` by coincidence?
- Flag-name collision: `Memory:AllowLlmGlobalWrite` — does this conflict with any existing config key?

## After merge

**`Memory:EnrichOnRetrieve=true` can now flip safely on the public demo.** Phase A (#157), Phase B (#160), and this PR (SC-001) together close the cross-session leak end-to-end:

- Storage layer: session-scoped (PR #157)
- Transport layer: SignalR plumbs ConnectionId (PR #160; HTTP path still task #103)
- Write surface: gated behind operator opt-in flag, auto-tagged when opted in
- Read surface: filters MCP-origin tag regardless of flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)