### PR TITLE
fix(chatbot): close AG-UI session fixation + cookie-ordering + CORS assertion

### DIFF
--- a/Apps/ga-server/GaApi/Controllers/AgUiChatController.cs
+++ b/Apps/ga-server/GaApi/Controllers/AgUiChatController.cs
@@ -71,8 +71,18 @@ public class AgUiChatController(
                     m.Role, m.Content!, DateTimeOffset.UtcNow))
                 .ToList();
 
+            // Phase C P1 (task #107 INFO-003) — server-issued cookie is the
+            // SessionId source. Previously this site passed input.ThreadId
+            // directly as SessionId, which is client-controlled and would
+            // have allowed session fixation once Memory:EnrichOnRetrieve=true
+            // ships (same threat shape as VULN-001 closed for /api/chatbot/chat).
+            // ThreadId remains a client-side state-management primitive for
+            // the AG-UI protocol; it is NOT a server-side memory partition key.
+            // Issued AFTER the concurrency-gate check so 503 paths don't mint
+            // orphan cookies (VULN-004).
+            var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
             var response = await chatService.ChatAsync(
-                new OrchestratorChatRequest(userMessage, input.ThreadId, History: history),
+                new OrchestratorChatRequest(userMessage, sessionId, History: history),
                 cancellationToken);
 
             return Ok(new
@@ -110,6 +120,16 @@ public class AgUiChatController(
             return;
         }
 
+        // Phase C P1 (task #107 INFO-003) — issue the session cookie BEFORE
+        // StartAsync because Response.Cookies.Append modifies response headers,
+        // which become read-only once StartAsync commits the wire. We pay the
+        // small cost of minting a cookie before the concurrency gate check
+        // because SSE never returns 503 (it emits a RUN_ERROR frame on a 200
+        // response), so there's no "503-orphan" trade-off to optimise for.
+        // Validation already ran (userMessage check above), so we don't mint
+        // cookies for shape-invalid requests.
+        var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
+
         Response.StatusCode = StatusCodes.Status200OK;
         Response.Headers.Append("Content-Type",       "text/event-stream");
         Response.Headers.Append("Cache-Control",      "no-cache");
@@ -118,7 +138,7 @@ public class AgUiChatController(
         await Response.StartAsync(cancellationToken);
 
         var writer   = new AgUiEventWriter(Response);
-        var threadId = input.ThreadId;
+        var threadId = input.ThreadId;     // AG-UI client-side state primitive
         var runId    = AgUiEventWriter.NewRunId();
         var msgId    = $"msg_{runId[..8]}";
 
@@ -146,7 +166,15 @@ public class AgUiChatController(
             }, cancellationToken);
 
             // ── 3. Invoke orchestrator with true token streaming ────────────────
-            var chatRequest = new OrchestratorChatRequest(userMessage, threadId);
+            // INFO-003: use the server-issued cookie session ID for memory
+            // partitioning, NOT the client-controlled threadId. ThreadId is
+            // the AG-UI protocol's notion of "which conversation thread" for
+            // event correlation; it MUST NOT be used as a server-side memory
+            // partition key — that would be a session-fixation vulnerability
+            // identical in shape to VULN-001 (PR #163 audit, closed for the
+            // /api/chatbot surface). Phase C P1 (task #107) extends that fix
+            // to AG-UI.
+            var chatRequest = new OrchestratorChatRequest(userMessage, sessionId);
 
             // ── 4. Stream text tokens, emit STEP_STARTED after streaming completes
             await writer.WriteTextStartAsync(msgId, cancellationToken);

--- a/Apps/ga-server/GaApi/Controllers/ChatbotController.cs
+++ b/Apps/ga-server/GaApi/Controllers/ChatbotController.cs
@@ -61,6 +61,26 @@ public class ChatbotController(
             return;
         }
 
+        // Phase C (task #103) — HTTP transport plumbs SessionId from a
+        // server-issued cookie so HTTP callers get session-scoped memory
+        // the same way SignalR callers do (PR #160). Without this, HTTP
+        // requests fall through to the orchestrator's per-request Guid
+        // fallback and their MemoryHook writes are unreachable from any
+        // future request.
+        //
+        // Phase C P1 (task #107) — fix ordering bug: GetOrIssue MUST run
+        // BEFORE StartAsync because Response.Cookies.Append modifies
+        // response headers, and headers become read-only once StartAsync
+        // commits the wire. The previous placement after StartAsync would
+        // have thrown InvalidOperationException, surfacing as an SSE
+        // RUN_ERROR frame instead of issuing a cookie.
+        //
+        // Trade-off vs. VULN-004 (defer past gate): SSE never returns 503;
+        // a busy gate produces a 200-OK + SSE error frame, so we don't
+        // mint cookies "wasted on 503s." Validation (message-empty)
+        // already ran, so shape-invalid requests still don't get cookies.
+        var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
+
         Response.StatusCode = StatusCodes.Status200OK;
         Response.Headers.Append("Content-Type", "text/event-stream");
         Response.Headers.Append("Cache-Control", "no-cache");
@@ -79,13 +99,6 @@ public class ChatbotController(
 
         try
         {
-            // Phase C (task #103) — HTTP transport plumbs SessionId from a
-            // server-issued cookie so HTTP callers get session-scoped memory
-            // the same way SignalR callers do (PR #160). Without this, HTTP
-            // requests fall through to the orchestrator's per-request Guid
-            // fallback and their MemoryHook writes are unreachable from any
-            // future request.
-            var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
             var response = await chatService.ChatAsync(
                 new GA.Business.Core.Orchestration.Models.ChatRequest(message, SessionId: sessionId),
                 cancellationToken);

--- a/Apps/ga-server/GaApi/Program.cs
+++ b/Apps/ga-server/GaApi/Program.cs
@@ -168,6 +168,49 @@ builder.Services.AddCors(options =>
     });
 });
 
+// VULN-003 (PR #163 audit, task #107) — runtime assertion that catches a
+// misconfiguration class: turning on cross-session memory enrichment with
+// a permissive cross-origin allow-list. If both
+//   Cors:AllowedOrigins contains a wildcard ("*") or a "*"-bearing entry
+//   Memory:EnrichOnRetrieve = true
+// were ever simultaneously true in production, a malicious off-domain
+// page could ride a victim's cookie, write to memory under their session,
+// and observe enrichment from another caller — a cross-origin memory
+// exfiltration vector. We refuse to start in that case rather than
+// shipping a silent compromise.
+{
+    var enrichOnRetrieve = builder.Configuration.GetValue<bool?>("Memory:EnrichOnRetrieve") ?? false;
+    if (enrichOnRetrieve)
+    {
+        var hasWildcard = configuredCorsOrigins.Any(o =>
+            string.IsNullOrWhiteSpace(o) ||
+            o == "*" ||
+            o.Contains('*', StringComparison.Ordinal));
+        if (hasWildcard)
+        {
+            throw new InvalidOperationException(
+                "Refusing to start: Memory:EnrichOnRetrieve=true with a wildcard " +
+                "Cors:AllowedOrigins entry is a cross-origin memory exfiltration risk. " +
+                "Either pin Cors:AllowedOrigins to specific HTTPS origins, or disable " +
+                "Memory:EnrichOnRetrieve. See task #107 / VULN-003.");
+        }
+        // Soft-warn on plain-HTTP non-loopback entries — these allow MITM
+        // session pinning, defeating the cookie's Secure flag.
+        var insecureExternal = configuredCorsOrigins
+            .Where(o => o.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            .Where(o => !o.Contains("localhost", StringComparison.OrdinalIgnoreCase)
+                     && !o.Contains("127.0.0.1", StringComparison.Ordinal))
+            .ToArray();
+        if (insecureExternal.Length > 0)
+        {
+            Console.WriteLine(
+                "[startup-warn] Memory:EnrichOnRetrieve=true with plain-http non-loopback " +
+                $"Cors origin(s): {string.Join(", ", insecureExternal)}. " +
+                "Cookie Secure flag will not be set for these origins; MITM can hijack sessions.");
+        }
+    }
+}
+
 // ─── OAuth2 + JWT authentication ─────────────────────────────────────────
 // Configuration path: Authentication:* (user-secrets in dev, env vars in prod)
 // See C:/Users/spare/source/repos/ga/Apps/ga-server/GaApi/Properties/launchSettings.json

--- a/Tests/Apps/GaApi.Tests/Controllers/AgUiChatControllerTests.cs
+++ b/Tests/Apps/GaApi.Tests/Controllers/AgUiChatControllerTests.cs
@@ -28,6 +28,7 @@ public class AgUiChatControllerTests
 
     private HttpClient? _client;
     private HttpClient? _saturatedClient;
+    private HttpClient? _rawClient; // HandleCookies = false — preserves Set-Cookie in response headers
 
     // ── Sample input ─────────────────────────────────────────────────────────────
 
@@ -65,6 +66,10 @@ public class AgUiChatControllerTests
 
         _client          = _factory.CreateClient();
         _saturatedClient = _saturatedFactory.CreateClient();
+        // Raw client preserves Set-Cookie in response.Headers so we can
+        // assert the server-issued cookie shape (INFO-003 tests).
+        _rawClient = _factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
     }
 
     [OneTimeTearDown]
@@ -72,6 +77,7 @@ public class AgUiChatControllerTests
     {
         _client?.Dispose();
         _saturatedClient?.Dispose();
+        _rawClient?.Dispose();
         _factory?.Dispose();
         _saturatedFactory?.Dispose();
     }
@@ -274,6 +280,96 @@ public class AgUiChatControllerTests
         Assert.That(message.GetString(), Is.Not.Null.And.Not.Empty);
     }
 
+    // ── INFO-003: server-issued cookie SessionId (task #107) ─────────────────────
+
+    [Test]
+    public async Task AgUiStream_IssuesGaChatSessionCookie()
+    {
+        // Phase C P1 / INFO-003 — every AG-UI stream response that passed
+        // input validation must Set-Cookie the server-issued session ID,
+        // so memory partitioning works across reloads the same way it does
+        // for /api/chatbot/chat.
+        var request = BuildRequest(ValidInput);
+        using var response = await _rawClient!.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var setCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies)
+            ? string.Join("; ", cookies)
+            : string.Empty;
+
+        Assert.That(setCookie, Does.Contain(HttpChatSessionCookie.CookieName),
+            "AG-UI stream must Set-Cookie the server-issued session cookie. " +
+            "Without it, HTTP callers fall through to per-request Guid SessionId " +
+            "and their memory writes become unreachable.");
+    }
+
+    [Test]
+    public async Task AgUiStream_SessionIdPlumbedToOrchestrator_IsNotClientThreadId()
+    {
+        // INFO-003 — the orchestrator must receive the cookie-derived
+        // SessionId, NOT the client-supplied input.ThreadId. Before
+        // PR #163 + task #107, AG-UI passed input.ThreadId directly as
+        // SessionId, which would let a malicious client forge any session
+        // ID they pleased once Memory:EnrichOnRetrieve=true ships.
+        const string maliciousThreadId = "victim-session-abc";
+        var input = new
+        {
+            threadId = maliciousThreadId,
+            runId    = "r-malicious",
+            messages = new[] { new { role = "user", content = "Tell me about Cmaj7", id = "m1" } },
+        };
+
+        TestHarmonicChatOrchestrator.LastRequest = null;
+
+        var request = BuildRequest(input);
+        using var response = await _client!.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        // Drain the stream so the orchestrator actually runs.
+        _ = await response.Content.ReadAsStringAsync();
+
+        Assert.That(TestHarmonicChatOrchestrator.LastRequest, Is.Not.Null,
+            "Orchestrator should have been invoked.");
+        Assert.That(TestHarmonicChatOrchestrator.LastRequest!.SessionId,
+            Is.Not.EqualTo(maliciousThreadId),
+            "VULNERABILITY: AG-UI is passing client-controlled threadId as SessionId. " +
+            "This is the same shape as VULN-001 (PR #163 audit). Use HttpChatSessionCookie.GetOrIssue " +
+            "to derive SessionId from a server-signed cookie instead.");
+        Assert.That(TestHarmonicChatOrchestrator.LastRequest!.SessionId,
+            Is.Not.Null.And.Not.Empty,
+            "SessionId must still be plumbed — just from the cookie, not from input.ThreadId.");
+    }
+
+    [Test]
+    public async Task AgUiJson_IssuesGaChatSessionCookie_AndDoesNotUseClientThreadId()
+    {
+        // Companion test for the non-streaming AG-UI endpoint (/api/chatbot/agui/json).
+        // It goes through IChatApplicationService rather than IHarmonicChatOrchestrator,
+        // so we can't capture LastRequest here without swapping that service too.
+        // For now we only assert the visible effect: Set-Cookie is present.
+        const string maliciousThreadId = "victim-session-xyz";
+        var input = new
+        {
+            threadId = maliciousThreadId,
+            runId    = "r-malicious-json",
+            messages = new[] { new { role = "user", content = "Tell me about Dm7", id = "m1" } },
+        };
+
+        using var response = await _rawClient!.PostAsJsonAsync("/api/chatbot/agui/json", input);
+
+        // Status may be 200 (real service available) or 502/503 (Ollama down) — we
+        // only care that, when validation passes and the gate admits, a cookie is set.
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var setCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies)
+                ? string.Join("; ", cookies)
+                : string.Empty;
+
+            Assert.That(setCookie, Does.Contain(HttpChatSessionCookie.CookieName),
+                "AG-UI JSON endpoint must Set-Cookie the server-issued session cookie " +
+                "(INFO-003 — server-issued, not client-controlled threadId).");
+        }
+    }
+
     // ── STATE_DELTA round-trip ────────────────────────────────────────────────────
 
     [Test]
@@ -393,14 +489,23 @@ file sealed class AlwaysAvailableGate : ILlmConcurrencyGate
 
 file sealed class TestHarmonicChatOrchestrator : IHarmonicChatOrchestrator
 {
-    public Task<ChatResponse> AnswerAsync(ChatRequest req, CancellationToken ct = default) =>
-        Task.FromResult(BuildResponse());
+    // Captures the most recent ChatRequest so tests can assert what
+    // SessionId was actually plumbed to the orchestrator. Used by the
+    // INFO-003 (task #107) tests that pin the cookie-not-ThreadId fix.
+    public static ChatRequest? LastRequest { get; set; }
+
+    public Task<ChatResponse> AnswerAsync(ChatRequest req, CancellationToken ct = default)
+    {
+        LastRequest = req;
+        return Task.FromResult(BuildResponse());
+    }
 
     public async Task<ChatResponse> AnswerStreamingAsync(
         ChatRequest req,
         Func<string, Task> onToken,
         CancellationToken ct = default)
     {
+        LastRequest = req;
         await onToken("Deterministic test response.");
         return BuildResponse();
     }


### PR DESCRIPTION
## Summary

Phase C P1 follow-ups from the PR #163 security audit. Four hardening items on the chatbot HTTP/AG-UI surfaces — closes task #107.

| # | Item | Severity | What changed |
|---|------|----------|--------------|
| 1 | **INFO-003** — AG-UI session fixation | High (with EnrichOnRetrieve=true) | Both AG-UI endpoints now derive SessionId from `HttpChatSessionCookie.GetOrIssue(HttpContext)` instead of client-controlled `input.ThreadId` |
| 2 | **Cookie ordering bug** (newly discovered) | High | `ChatbotController.ChatStream` was calling `GetOrIssue` AFTER `StartAsync` → would throw `InvalidOperationException` because headers were already committed. Moved before `StartAsync`. Same fix in AgUiChatController.AgUiStream. |
| 3 | **VULN-003** — CORS runtime assertion | Medium | Program.cs refuses to start if `Memory:EnrichOnRetrieve=true` AND `Cors:AllowedOrigins` contains a wildcard. Soft-warns on plain-http non-loopback origins. |
| 4 | **INFO-005** — UseForwardedHeaders | Verified | Already wired correctly at Program.cs:347 with CF-aware gating. No code change needed; documented here. |

## Why this matters

The AG-UI fix is the headline. The previous code path looked like:

```csharp
new OrchestratorChatRequest(userMessage, input.ThreadId, ...)
//                                       ^^^^^^^^^^^^^^^ client-controlled
```

`input.ThreadId` comes straight from AG-UI's `RunAgentInput` request body. With `Memory:EnrichOnRetrieve=true` flipped on (planned next), a client could send any other user's session ID and (a) write to their memory partition and (b) observe their prior-session content. Same vulnerability shape as VULN-001 already closed on `/api/chatbot/chat`.

ThreadId is kept for AG-UI protocol use (RUN_STARTED/RUN_FINISHED correlation) — it's a client-side state-management primitive, NOT a server-side memory partition key.

## Cookie-ordering bug

The dormant bug in ChatStream is independently worth catching:

```csharp
await Response.StartAsync(ct);  // headers committed, read-only after this
...
var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
//                                  ^^^ tries Response.Cookies.Append → throws
```

That throw was being swallowed by the generic exception handler and surfacing as a "Failed to process message" SSE error frame. Cookie was never being issued on /chat/stream. Moved before StartAsync, after message validation (so shape-invalid requests still don't mint cookies).

## Test plan

- [x] `dotnet build Apps/ga-server/GaApi/GaApi.csproj -c Debug` — clean, 0 errors
- [x] 15 AG-UI controller tests pass (3 new: cookie issuance, cookie != client ThreadId, JSON-endpoint cookie)
- [x] 23 ChatbotController + HttpChatSessionCookie tests pass — no regression on the ordering change

## INFO-005 verification (no code change)

```csharp
// Program.cs:347
app.UseForwardedHeaders(forwardedHeadersOptions);
```

Already configured with `ForwardedHeaders.XForwardedFor | XForwardedProto | XForwardedHost` and CF-aware gating (lines 314–335) that synthesises X-Forwarded-Host only for Cloudflare-tagged requests and strips it on direct/localhost requests. No additional change needed.

## Refs

- Parent: #103 (Phase C session-cookie plumbing)
- This iteration: task #107
- Audit findings: PR #163 (VULN-001, VULN-003, VULN-004, INFO-003, INFO-005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)