### PR TITLE
feat(memory): Dreams-lite curator over MemoryStore (Phase 1 v0.1) — recovered

### DIFF
--- a/AllProjects.slnx
+++ b/AllProjects.slnx
@@ -7,6 +7,7 @@
     <Folder Name="/Apps/">
         <Project Path="Apps/GaChatbotCli/GaChatbotCli.csproj" />
         <Project Path="Apps/GaCli/GaCli.fsproj" />
+        <Project Path="Apps/GaMemoryCli/GaMemoryCli.csproj" />
         <Project Path="Apps/GaQaMcp/GaQaMcp.csproj" />
     </Folder>
     <Folder Name="/Backend/" />

--- a/Apps/GaMemoryCli/GaMemoryCli.csproj
+++ b/Apps/GaMemoryCli/GaMemoryCli.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>GaMemoryCli</AssemblyName>
+    <RootNamespace>GaMemoryCli</RootNamespace>
+    <NoWarn>$(NoWarn);SKEXP0001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\GA.Business.ML\GA.Business.ML.csproj" />
+    <!-- AnthropicProvider is the only blessed way to obtain an IChatClient
+         backed by the Anthropic SDK. The SDK is isolated in this project; do
+         NOT add the Anthropic package directly. -->
+    <ProjectReference Include="..\..\Common\GA.Providers.Anthropic\GA.Providers.Anthropic.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Apps/GaMemoryCli/Program.cs
+++ b/Apps/GaMemoryCli/Program.cs
@@ -1,0 +1,282 @@
+/// <summary>
+/// GaMemoryCli — Dreams-lite curator over the chatbot MemoryStore.
+///
+/// Usage:
+///   dotnet run --project Apps/GaMemoryCli -- curate [--instructions "..."]
+///   dotnet run --project Apps/GaMemoryCli -- diff   &lt;candidate-path&gt;
+///   dotnet run --project Apps/GaMemoryCli -- promote &lt;candidate-path&gt;
+///
+/// Set ANTHROPIC_API_KEY before `curate`. `diff` and `promote` are offline.
+/// See docs/plans/2026-05-10-feat-dreams-lite-memory-curator-plan.md.
+/// </summary>
+
+using System.Text.Json;
+using GA.Business.ML.Agents.Memory;
+using GA.Business.ML.Agents.Memory.Curator;
+using GA.Providers.Anthropic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+if (args.Length == 0)
+{
+    PrintUsage();
+    return 1;
+}
+
+var command = args[0];
+return command switch
+{
+    "curate"  => await RunCurateAsync(args[1..]),
+    "diff"    => RunDiff(args[1..]),
+    "promote" => RunPromote(args[1..]),
+    "--help" or "-h" or "help" => PrintUsage(),
+    _ => UnknownCommand(command),
+};
+
+// ── Commands ──────────────────────────────────────────────────────────────
+
+static async Task<int> RunCurateAsync(string[] args)
+{
+    string? instructions = null;
+    for (var i = 0; i < args.Length; i++)
+    {
+        if (args[i] == "--instructions" && i + 1 < args.Length)
+            instructions = args[++i];
+    }
+
+    var storePath = MemoryStore.DefaultStorePath;
+    if (!File.Exists(storePath))
+    {
+        Console.Error.WriteLine($"No store at {storePath} — nothing to curate.");
+        return 2;
+    }
+
+    var entries = LoadEntries(storePath);
+    Console.WriteLine($"Loaded {entries.Count} entries from {storePath}.");
+
+    var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+    if (!AnthropicProvider.IsAvailable(config))
+    {
+        Console.Error.WriteLine(
+            "ANTHROPIC_API_KEY is not set. Curation needs a real model — refusing to run.");
+        return 3;
+    }
+
+    var chatClient = AnthropicProvider.CreateChatClient(config, AnthropicProvider.DefaultModel);
+    var curator = new MemoryCurator(chatClient,
+        LoggerFactory.Create(b => b.AddSimpleConsole()).CreateLogger<MemoryCurator>());
+
+    var runId = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss") + "-" + Guid.NewGuid().ToString("N")[..6];
+    var ledgerDir = Path.Combine(
+        Directory.GetCurrentDirectory(), "state", "quality", "memory-curator",
+        DateTimeOffset.UtcNow.ToString("yyyy-MM-dd"));
+    Directory.CreateDirectory(ledgerDir);
+
+    var startedAt = DateTimeOffset.UtcNow;
+    MemoryCurationResult result;
+    try
+    {
+        result = await curator.CurateAsync(new MemoryCurationRequest(
+            ExistingEntries: entries,
+            RecentTranscripts: [],  // v0.1: no transcript plumbing yet
+            Instructions: instructions));
+    }
+    catch (MemoryCurationException ex)
+    {
+        WriteLedgerFailure(ledgerDir, runId, startedAt, storePath, entries.Count, ex);
+        Console.Error.WriteLine($"Curation refused: {ex.Message}");
+        return 4;
+    }
+
+    var candidatePath = Path.Combine(ledgerDir, $"memory.v2-candidate-{runId}.json");
+    File.WriteAllText(candidatePath,
+        JsonSerializer.Serialize(result.CandidateEntries, new JsonSerializerOptions { WriteIndented = true }));
+
+    WriteLedgerSuccess(ledgerDir, runId, startedAt, storePath, entries.Count,
+        candidatePath, result);
+
+    Console.WriteLine();
+    Console.WriteLine($"Candidate written: {candidatePath}");
+    PrintDiffSummary(result.Diff);
+    Console.WriteLine();
+    Console.WriteLine($"Review with: ga-memory diff {candidatePath}");
+    Console.WriteLine($"Promote with: ga-memory promote {candidatePath}");
+    return 0;
+}
+
+static int RunDiff(string[] args)
+{
+    if (args.Length == 0)
+    {
+        Console.Error.WriteLine("Usage: ga-memory diff <candidate-path>");
+        return 1;
+    }
+
+    var candidatePath = args[0];
+    if (!File.Exists(candidatePath))
+    {
+        Console.Error.WriteLine($"Candidate not found: {candidatePath}");
+        return 2;
+    }
+
+    // Locate the ledger entry by sibling pattern: run-<id>.json next to the candidate.
+    var runId = ExtractRunId(candidatePath);
+    var ledgerPath = Path.Combine(Path.GetDirectoryName(candidatePath)!, $"run-{runId}.json");
+    if (!File.Exists(ledgerPath))
+    {
+        Console.Error.WriteLine($"Ledger entry not found at {ledgerPath} — cannot show diff.");
+        return 3;
+    }
+
+    var ledger = JsonSerializer.Deserialize<JsonElement>(File.ReadAllText(ledgerPath));
+    if (ledger.TryGetProperty("result", out var resultElem) &&
+        resultElem.TryGetProperty("diffSummary", out var summary))
+    {
+        Console.WriteLine("Diff summary:");
+        foreach (var p in summary.EnumerateObject())
+            Console.WriteLine($"  {p.Name,-10} {p.Value.GetInt32()}");
+    }
+    else
+    {
+        Console.Error.WriteLine("Ledger missing diffSummary.");
+        return 4;
+    }
+    return 0;
+}
+
+static int RunPromote(string[] args)
+{
+    if (args.Length == 0)
+    {
+        Console.Error.WriteLine("Usage: ga-memory promote <candidate-path>");
+        return 1;
+    }
+
+    var candidatePath = args[0];
+    if (!File.Exists(candidatePath))
+    {
+        Console.Error.WriteLine($"Candidate not found: {candidatePath}");
+        return 2;
+    }
+
+    var livePath = MemoryStore.DefaultStorePath;
+    var backupPath = livePath + ".bak-" + DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss");
+
+    Console.WriteLine($"About to promote:");
+    Console.WriteLine($"  live store : {livePath}");
+    Console.WriteLine($"  candidate  : {candidatePath}");
+    Console.WriteLine($"  backup     : {backupPath}");
+    Console.Write("Proceed? [y/N] ");
+    var confirm = Console.ReadLine()?.Trim();
+    if (!string.Equals(confirm, "y", StringComparison.OrdinalIgnoreCase))
+    {
+        Console.WriteLine("Aborted.");
+        return 0;
+    }
+
+    if (File.Exists(livePath))
+        File.Move(livePath, backupPath);
+    File.Copy(candidatePath, livePath);
+
+    Console.WriteLine($"Promoted. Backup at {backupPath} — keep until you've verified the new store is working.");
+    return 0;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+static int PrintUsage()
+{
+    Console.WriteLine("ga-memory — Dreams-lite curator over the chatbot MemoryStore");
+    Console.WriteLine();
+    Console.WriteLine("Commands:");
+    Console.WriteLine("  curate [--instructions \"...\"]   Run the curator, write a candidate");
+    Console.WriteLine("  diff <candidate-path>           Show the diff summary for a candidate");
+    Console.WriteLine("  promote <candidate-path>        Atomic swap (with .bak backup)");
+    Console.WriteLine();
+    Console.WriteLine("Env:");
+    Console.WriteLine("  ANTHROPIC_API_KEY              required for `curate` (Sonnet 4.6 by default)");
+    return 0;
+}
+
+static int UnknownCommand(string cmd)
+{
+    Console.Error.WriteLine($"Unknown command: {cmd}");
+    PrintUsage();
+    return 1;
+}
+
+static IReadOnlyList<MemoryEntry> LoadEntries(string storePath)
+{
+    var json = File.ReadAllText(storePath);
+    var entries = JsonSerializer.Deserialize<List<MemoryEntry>>(json,
+        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    return entries ?? new List<MemoryEntry>();
+}
+
+static void PrintDiffSummary(CurationDiff diff)
+{
+    Console.WriteLine();
+    Console.WriteLine("Diff:");
+    Console.WriteLine($"  kept     {diff.Kept.Count}");
+    Console.WriteLine($"  merged   {diff.Merged.Count}");
+    Console.WriteLine($"  replaced {diff.Replaced.Count}");
+    Console.WriteLine($"  new      {diff.NewItems.Count}");
+    Console.WriteLine($"  dropped  {diff.Dropped.Count}");
+}
+
+static string ExtractRunId(string candidatePath)
+{
+    // memory.v2-candidate-<id>.json → <id>
+    var name = Path.GetFileNameWithoutExtension(candidatePath);
+    const string prefix = "memory.v2-candidate-";
+    return name.StartsWith(prefix, StringComparison.Ordinal)
+        ? name[prefix.Length..]
+        : name;
+}
+
+static void WriteLedgerSuccess(
+    string ledgerDir, string runId, DateTimeOffset startedAt,
+    string storePath, int entryCount, string candidatePath, MemoryCurationResult result)
+{
+    var ledger = new
+    {
+        runId,
+        startedAt,
+        completedAt = DateTimeOffset.UtcNow,
+        status = "completed",
+        modelId = result.ModelId,
+        inputs = new { storePath, entryCount, transcriptCount = 0, instructionsLength = 0 },
+        result = new
+        {
+            candidatePath,
+            diffSummary = new
+            {
+                kept     = result.Diff.Kept.Count,
+                merged   = result.Diff.Merged.Count,
+                replaced = result.Diff.Replaced.Count,
+                newItems = result.Diff.NewItems.Count,
+                dropped  = result.Diff.Dropped.Count,
+            },
+            tokens = new { input = result.InputTokens, output = result.OutputTokens },
+        },
+    };
+    File.WriteAllText(Path.Combine(ledgerDir, $"run-{runId}.json"),
+        JsonSerializer.Serialize(ledger, new JsonSerializerOptions { WriteIndented = true }));
+}
+
+static void WriteLedgerFailure(
+    string ledgerDir, string runId, DateTimeOffset startedAt,
+    string storePath, int entryCount, MemoryCurationException ex)
+{
+    var ledger = new
+    {
+        runId,
+        startedAt,
+        completedAt = DateTimeOffset.UtcNow,
+        status = "failed",
+        inputs = new { storePath, entryCount, transcriptCount = 0, instructionsLength = 0 },
+        error = new { type = "validation_failed", message = ex.Message },
+    };
+    File.WriteAllText(Path.Combine(ledgerDir, $"run-{runId}.json"),
+        JsonSerializer.Serialize(ledger, new JsonSerializerOptions { WriteIndented = true }));
+}

--- a/Common/GA.Business.ML/Agents/Memory/Curator/CurationDiff.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/CurationDiff.cs
@@ -1,0 +1,45 @@
+namespace GA.Business.ML.Agents.Memory.Curator;
+
+/// <summary>
+/// Structured audit trail of what the curator did. Every output entry's
+/// origin must trace to one or more input entries (or to a transcript
+/// reference if it's a <see cref="NewItems"/> insight). Operator review
+/// compares input → output via this diff rather than re-reading the whole
+/// store.
+/// </summary>
+/// <remarks>
+/// The curator MUST refuse to emit an output entry that doesn't appear in
+/// at least one of: <see cref="Kept"/>, <see cref="Merged"/>,
+/// <see cref="Replaced"/>, <see cref="NewItems"/>. The validator in
+/// <see cref="MemoryCurator"/> rejects a response that breaks this rule —
+/// see "NEVER invents facts" rule in the curation prompt.
+/// </remarks>
+public sealed record CurationDiff(
+    IReadOnlyList<string> Kept,
+    IReadOnlyList<MergeOp> Merged,
+    IReadOnlyList<ReplaceOp> Replaced,
+    IReadOnlyList<NewOp> NewItems,
+    IReadOnlyList<DropOp> Dropped);
+
+/// <summary>Output key produced by merging two or more input entries into one.</summary>
+/// <param name="OutputKey">Key of the resulting output entry.</param>
+/// <param name="InputKeys">Keys of the input entries collapsed into <see cref="OutputKey"/>.</param>
+/// <param name="Rationale">One-sentence explanation grounded in the input content.</param>
+public sealed record MergeOp(string OutputKey, IReadOnlyList<string> InputKeys, string Rationale);
+
+/// <summary>An output entry that replaces an older (now-stale) input entry.</summary>
+/// <param name="OutputKey">Key of the surviving output entry.</param>
+/// <param name="SupersededKey">Key of the input entry that has been superseded.</param>
+/// <param name="Rationale">Why the older entry is now stale (timestamp + content reference).</param>
+public sealed record ReplaceOp(string OutputKey, string SupersededKey, string Rationale);
+
+/// <summary>An emergent insight derived from transcript patterns (not present in the input store).</summary>
+/// <param name="OutputKey">Key of the new output entry.</param>
+/// <param name="SupportingTranscriptRefs">Session IDs and turn indexes the curator cites.</param>
+/// <param name="Rationale">Why the pattern justifies storing this as durable memory.</param>
+public sealed record NewOp(string OutputKey, IReadOnlyList<string> SupportingTranscriptRefs, string Rationale);
+
+/// <summary>An input entry dropped from the output (e.g., one-off debugging note).</summary>
+/// <param name="InputKey">Key of the dropped input entry.</param>
+/// <param name="Rationale">Why the entry is not worth preserving.</param>
+public sealed record DropOp(string InputKey, string Rationale);

--- a/Common/GA.Business.ML/Agents/Memory/Curator/CurationPromptBuilder.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/CurationPromptBuilder.cs
@@ -1,0 +1,85 @@
+namespace GA.Business.ML.Agents.Memory.Curator;
+
+using System.Text;
+using System.Text.Json;
+
+/// <summary>
+/// Builds the prompt that defines the curator's contract. Kept separate from
+/// <see cref="MemoryCurator"/> so the prompt can be A/B-tested independently
+/// — prompt churn is expected; orchestration is stable.
+/// </summary>
+/// <remarks>
+/// The contract is intentionally narrow: produce JSON, every output entry
+/// must trace to an input or transcript, session scope must be preserved.
+/// Violating any of these makes the response unparseable by the validator
+/// in <see cref="MemoryCurator"/> — the curator returns a failure rather
+/// than emitting a corrupt candidate.
+/// </remarks>
+internal static class CurationPromptBuilder
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = false,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public const string SystemPrompt = """
+        You are a memory curator. You receive an existing MemoryStore (JSON array
+        of entries with keys: Key, Type, Content, Tags, Timestamp, SessionId) and
+        optional past chat transcripts. Produce a NEW MemoryStore that:
+
+        1. Merges duplicate entries (same fact stated different ways) into one.
+        2. Replaces entries contradicted by later evidence — use Timestamp to
+           decide which is later. The newer wins.
+        3. Surfaces new memory entries when transcripts show a recurring pattern
+           that is not already captured.
+        4. NEVER invents facts not grounded in the inputs.
+        5. Preserves SessionId scope. NEVER move a session-scoped entry to
+           global (SessionId=null), nor a global entry to a session.
+
+        Respond with a SINGLE JSON object and NOTHING ELSE — no prose, no
+        markdown fences. The object has exactly two keys:
+
+        {
+          "entries": [
+            { "Key": "...", "Type": "...", "Content": "...",
+              "Tags": ["..."], "Timestamp": "ISO-8601",
+              "SessionId": "..." or null }
+          ],
+          "diff": {
+            "kept":     ["inputKey1", "inputKey2"],
+            "merged":   [{ "outputKey": "...", "inputKeys": ["..."],
+                           "rationale": "..." }],
+            "replaced": [{ "outputKey": "...", "supersededKey": "...",
+                           "rationale": "..." }],
+            "newItems": [{ "outputKey": "...",
+                           "supportingTranscriptRefs": ["sessionId:turnIndex"],
+                           "rationale": "..." }],
+            "dropped":  [{ "inputKey": "...", "rationale": "..." }]
+          }
+        }
+
+        Every Key in `entries` MUST appear in exactly one of `kept`,
+        `merged.outputKey`, `replaced.outputKey`, or `newItems.outputKey`.
+        Every input Key MUST appear in exactly one of `kept`,
+        `merged.inputKeys`, `replaced.supersededKey`, or `dropped.inputKey`.
+        Rationales must be one sentence each, grounded in the inputs.
+        """;
+
+    public static string BuildUserMessage(MemoryCurationRequest request)
+    {
+        var sb = new StringBuilder(capacity: 4096);
+        sb.AppendLine("EXISTING MEMORY STORE:");
+        sb.AppendLine(JsonSerializer.Serialize(request.ExistingEntries, JsonOpts));
+        sb.AppendLine();
+        sb.AppendLine("RECENT CHAT TRANSCRIPTS:");
+        sb.AppendLine(JsonSerializer.Serialize(request.RecentTranscripts, JsonOpts));
+        if (!string.IsNullOrWhiteSpace(request.Instructions))
+        {
+            sb.AppendLine();
+            sb.AppendLine("OPERATOR INSTRUCTIONS:");
+            sb.AppendLine(request.Instructions);
+        }
+        return sb.ToString();
+    }
+}

--- a/Common/GA.Business.ML/Agents/Memory/Curator/IChatTranscriptStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/IChatTranscriptStore.cs
@@ -1,0 +1,50 @@
+namespace GA.Business.ML.Agents.Memory.Curator;
+
+/// <summary>
+/// Header-only interface (v0.1) — the production transcript-capture story is
+/// not yet wired. Memory curator depends on this contract so v0.2 can drop in
+/// a real implementation without changing curator code.
+/// </summary>
+/// <remarks>
+/// For v0.1 spike runs, tests and the CLI pass a hand-written fixture
+/// implementation (e.g. <see cref="FixtureChatTranscriptStore"/>). For v0.2,
+/// the production implementation will read from whatever transcript log the
+/// chatbot persists per <see cref="Hooks.ChatHookContext"/> session.
+/// </remarks>
+public interface IChatTranscriptStore
+{
+    /// <summary>
+    /// Returns up to <paramref name="maxSessions"/> recent chat session
+    /// transcripts. Order is newest-first. Empty list is a legitimate
+    /// answer (no transcripts available — the curator will operate over
+    /// the memory store alone).
+    /// </summary>
+    Task<IReadOnlyList<ChatTranscript>> GetRecentAsync(
+        int maxSessions,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Plain transcript record handed to the curator. Order of <see cref="Turns"/>
+/// is chronological within a session.
+/// </summary>
+public sealed record ChatTranscript(
+    string SessionId,
+    DateTimeOffset StartedAt,
+    IReadOnlyList<TranscriptTurn> Turns);
+
+/// <summary>One conversational turn — user or assistant — within a transcript.</summary>
+public sealed record TranscriptTurn(string Role, string Content, DateTimeOffset Timestamp);
+
+/// <summary>
+/// In-memory fixture for v0.1. Tests and the CLI pre-load this with the
+/// transcripts they want the curator to consider.
+/// </summary>
+public sealed class FixtureChatTranscriptStore(IReadOnlyList<ChatTranscript> transcripts) : IChatTranscriptStore
+{
+    public Task<IReadOnlyList<ChatTranscript>> GetRecentAsync(
+        int maxSessions,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<ChatTranscript>>(
+            transcripts.Take(maxSessions).ToList());
+}

--- a/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurationRequest.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurationRequest.cs
@@ -1,0 +1,24 @@
+namespace GA.Business.ML.Agents.Memory.Curator;
+
+/// <summary>
+/// Input to <see cref="MemoryCurator.CurateAsync(MemoryCurationRequest, CancellationToken)"/>.
+/// Mirrors the shape of Anthropic Dreams' input: an existing store + optional
+/// past sessions + optional free-text instructions narrowing the scope.
+/// </summary>
+/// <param name="ExistingEntries">
+/// Snapshot of the live <see cref="MemoryStore"/> entries. The curator never
+/// mutates this list — output is a new candidate list.
+/// </param>
+/// <param name="RecentTranscripts">
+/// Past chat transcripts the curator may mine for emergent insights. Empty
+/// is fine — the curator can still dedupe / collapse based on
+/// <paramref name="ExistingEntries"/> alone.
+/// </param>
+/// <param name="Instructions">
+/// Optional operator hints (≤4096 chars to match Dreams' limit). For example:
+/// "Focus on user preferences; ignore one-off debugging notes."
+/// </param>
+public sealed record MemoryCurationRequest(
+    IReadOnlyList<MemoryEntry> ExistingEntries,
+    IReadOnlyList<ChatTranscript> RecentTranscripts,
+    string? Instructions = null);

--- a/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurationResult.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurationResult.cs
@@ -1,0 +1,22 @@
+namespace GA.Business.ML.Agents.Memory.Curator;
+
+/// <summary>
+/// Output of a successful curation run. Mirrors Dreams' "completed" status
+/// shape: candidate entries + an audit-trail diff + usage telemetry.
+/// </summary>
+/// <param name="CandidateEntries">
+/// The new MemoryEntry set proposed by the curator. NOT yet written to disk;
+/// caller decides whether to persist (operator review then promote).
+/// </param>
+/// <param name="Diff">Structured trace of how the candidate derives from the input.</param>
+/// <param name="ModelId">Which model produced this result (audit / cost attribution).</param>
+/// <param name="InputTokens">Reported by the model (0 if the provider didn't surface usage).</param>
+/// <param name="OutputTokens">Same.</param>
+/// <param name="GeneratedAt">When the curator finished.</param>
+public sealed record MemoryCurationResult(
+    IReadOnlyList<MemoryEntry> CandidateEntries,
+    CurationDiff Diff,
+    string ModelId,
+    long InputTokens,
+    long OutputTokens,
+    DateTimeOffset GeneratedAt);

--- a/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurator.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurator.cs
@@ -1,0 +1,254 @@
+namespace GA.Business.ML.Agents.Memory.Curator;
+
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Periodic curation pass over the chatbot <see cref="MemoryStore"/>. Modeled
+/// on Anthropic's Dreams Research Preview — same intent (merge duplicates,
+/// replace stale entries, surface insights), local implementation (uses our
+/// existing <see cref="IChatClient"/> rather than the managed-agents API).
+///
+/// See <c>docs/plans/2026-05-10-feat-dreams-lite-memory-curator-plan.md</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Two-way door.</b> The curator never mutates its input. It produces a
+/// candidate <see cref="MemoryCurationResult"/> that the operator (or a
+/// promote command) decides to persist or discard.
+/// </para>
+/// <para>
+/// <b>Validation gate.</b> Even with a strong prompt, an LLM can return
+/// malformed JSON or a diff that fails the trace-to-input rule. The
+/// validator below rejects such responses with
+/// <see cref="MemoryCurationException"/> — the candidate is never written.
+/// </para>
+/// </remarks>
+public sealed class MemoryCurator(IChatClient chatClient, ILogger<MemoryCurator>? logger = null)
+{
+    public const string DefaultModelId = "claude-sonnet-4-6";
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false,
+    };
+
+    /// <summary>
+    /// Runs one curation pass. Returns the candidate entries + diff. Does not
+    /// touch the live <see cref="MemoryStore"/> on disk.
+    /// </summary>
+    /// <exception cref="MemoryCurationException">
+    /// The model response was unparseable, or the diff failed the trace-to-
+    /// input audit (an output key with no matching input/transcript).
+    /// </exception>
+    public async Task<MemoryCurationResult> CurateAsync(
+        MemoryCurationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, CurationPromptBuilder.SystemPrompt),
+            new(ChatRole.User,   CurationPromptBuilder.BuildUserMessage(request)),
+        };
+
+        var response = await chatClient.GetResponseAsync(messages, cancellationToken: cancellationToken);
+        var responseText = response.Messages.LastOrDefault()?.Text ?? "";
+
+        if (string.IsNullOrWhiteSpace(responseText))
+            throw new MemoryCurationException("Curator response was empty.");
+
+        // Strip optional ```json``` fences (some providers wrap JSON even when
+        // told not to — defensive parsing, not contract relaxation).
+        var cleaned = StripCodeFence(responseText);
+
+        CuratorPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<CuratorPayload>(cleaned, JsonOpts);
+        }
+        catch (JsonException ex)
+        {
+            throw new MemoryCurationException(
+                $"Curator response was not valid JSON: {ex.Message}", ex);
+        }
+
+        if (payload is null || payload.Entries is null || payload.Diff is null)
+            throw new MemoryCurationException("Curator response missing 'entries' or 'diff'.");
+
+        var diff = ToCurationDiff(payload.Diff);
+        var candidateEntries = payload.Entries
+            .Select(ToMemoryEntry)
+            .ToList();
+
+        ValidateTraceability(request, candidateEntries, diff);
+        ValidateSessionScopePreserved(request, candidateEntries, diff);
+
+        logger?.LogInformation(
+            "MemoryCurator produced {OutCount} candidate entries from {InCount} inputs " +
+            "({Kept} kept, {Merged} merged, {Replaced} replaced, {New} new, {Dropped} dropped).",
+            candidateEntries.Count, request.ExistingEntries.Count,
+            diff.Kept.Count, diff.Merged.Count, diff.Replaced.Count,
+            diff.NewItems.Count, diff.Dropped.Count);
+
+        return new MemoryCurationResult(
+            CandidateEntries: candidateEntries,
+            Diff: diff,
+            ModelId: response.ModelId ?? DefaultModelId,
+            InputTokens: response.Usage?.InputTokenCount ?? 0,
+            OutputTokens: response.Usage?.OutputTokenCount ?? 0,
+            GeneratedAt: DateTimeOffset.UtcNow);
+    }
+
+    // ── Validation ───────────────────────────────────────────────────────
+
+    private static void ValidateTraceability(
+        MemoryCurationRequest request,
+        IReadOnlyList<MemoryEntry> candidate,
+        CurationDiff diff)
+    {
+        var inputKeys = request.ExistingEntries.Select(e => e.Key).ToHashSet(StringComparer.Ordinal);
+
+        // Every output entry must appear in exactly one of: kept, merged.outputKey,
+        // replaced.outputKey, newItems.outputKey.
+        var accountedOutputKeys = new HashSet<string>(diff.Kept, StringComparer.Ordinal);
+        foreach (var m in diff.Merged)     accountedOutputKeys.Add(m.OutputKey);
+        foreach (var r in diff.Replaced)   accountedOutputKeys.Add(r.OutputKey);
+        foreach (var n in diff.NewItems)   accountedOutputKeys.Add(n.OutputKey);
+
+        foreach (var entry in candidate)
+        {
+            if (!accountedOutputKeys.Contains(entry.Key))
+                throw new MemoryCurationException(
+                    $"Output entry '{entry.Key}' is not referenced in the diff. " +
+                    "Every output entry must trace to an input or transcript.");
+        }
+
+        // Every input key must appear in exactly one of: kept, merged.inputKeys,
+        // replaced.supersededKey, dropped.inputKey.
+        var accountedInputKeys = new HashSet<string>(diff.Kept, StringComparer.Ordinal);
+        foreach (var m in diff.Merged)   foreach (var ik in m.InputKeys) accountedInputKeys.Add(ik);
+        foreach (var r in diff.Replaced) accountedInputKeys.Add(r.SupersededKey);
+        foreach (var d in diff.Dropped)  accountedInputKeys.Add(d.InputKey);
+
+        foreach (var key in inputKeys)
+        {
+            if (!accountedInputKeys.Contains(key))
+                throw new MemoryCurationException(
+                    $"Input entry '{key}' is missing from the diff. " +
+                    "Every input key must appear in exactly one of kept/merged/replaced/dropped.");
+        }
+    }
+
+    private static void ValidateSessionScopePreserved(
+        MemoryCurationRequest request,
+        IReadOnlyList<MemoryEntry> candidate,
+        CurationDiff diff)
+    {
+        // Build a lookup of input Key → SessionId so we can check whether
+        // a kept/merged/replaced output's session scope matches its source.
+        var inputScopeByKey = request.ExistingEntries
+            .GroupBy(e => e.Key, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First().SessionId, StringComparer.Ordinal);
+
+        var candidateByKey = candidate
+            .GroupBy(e => e.Key, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+        foreach (var key in diff.Kept)
+        {
+            if (inputScopeByKey.TryGetValue(key, out var inScope) &&
+                candidateByKey.TryGetValue(key, out var outEntry) &&
+                !string.Equals(inScope, outEntry.SessionId, StringComparison.Ordinal))
+            {
+                throw new MemoryCurationException(
+                    $"Kept entry '{key}' changed SessionId scope from " +
+                    $"'{inScope ?? "global"}' to '{outEntry.SessionId ?? "global"}'. " +
+                    "Session scope must be preserved.");
+            }
+        }
+
+        foreach (var merge in diff.Merged)
+        {
+            if (!candidateByKey.TryGetValue(merge.OutputKey, out var outEntry)) continue;
+            // All inputs in a merge must share a session scope, and the output
+            // must inherit it. Cross-scope merges leak.
+            var inScopes = merge.InputKeys
+                .Select(k => inputScopeByKey.TryGetValue(k, out var s) ? s : null)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            if (inScopes.Count > 1)
+                throw new MemoryCurationException(
+                    $"Merged entry '{merge.OutputKey}' collapses inputs from different SessionId scopes " +
+                    $"({string.Join(", ", inScopes.Select(s => s ?? "global"))}). " +
+                    "Cross-scope merges leak — refuse.");
+            if (inScopes.Count == 1 && !string.Equals(inScopes[0], outEntry.SessionId, StringComparison.Ordinal))
+                throw new MemoryCurationException(
+                    $"Merged entry '{merge.OutputKey}' changed scope from " +
+                    $"'{inScopes[0] ?? "global"}' to '{outEntry.SessionId ?? "global"}'.");
+        }
+    }
+
+    // ── JSON mapping ─────────────────────────────────────────────────────
+
+    private static string StripCodeFence(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            var firstNewline = trimmed.IndexOf('\n');
+            if (firstNewline > 0) trimmed = trimmed[(firstNewline + 1)..];
+            if (trimmed.EndsWith("```", StringComparison.Ordinal))
+                trimmed = trimmed[..^3];
+        }
+        return trimmed.Trim();
+    }
+
+    private static MemoryEntry ToMemoryEntry(CuratorEntry e) =>
+        new(e.Key, e.Type, e.Content, e.Tags ?? [], e.Timestamp, e.SessionId);
+
+    private static CurationDiff ToCurationDiff(CuratorDiff d) =>
+        new(
+            Kept:     d.Kept     ?? [],
+            Merged:   (d.Merged   ?? []).Select(m => new MergeOp(m.OutputKey, m.InputKeys ?? [], m.Rationale ?? "")).ToList(),
+            Replaced: (d.Replaced ?? []).Select(r => new ReplaceOp(r.OutputKey, r.SupersededKey, r.Rationale ?? "")).ToList(),
+            NewItems: (d.NewItems ?? []).Select(n => new NewOp(n.OutputKey, n.SupportingTranscriptRefs ?? [], n.Rationale ?? "")).ToList(),
+            Dropped:  (d.Dropped  ?? []).Select(p => new DropOp(p.InputKey, p.Rationale ?? "")).ToList());
+
+    // Plain DTOs for deserialization — keep flexible (nullable) so a missing
+    // section fails in the validator with a useful message instead of a
+    // cryptic JsonException.
+    private sealed record CuratorPayload(
+        IReadOnlyList<CuratorEntry>? Entries,
+        CuratorDiff? Diff);
+
+    private sealed record CuratorEntry(
+        string Key,
+        string Type,
+        string Content,
+        string[]? Tags,
+        DateTimeOffset Timestamp,
+        string? SessionId);
+
+    private sealed record CuratorDiff(
+        IReadOnlyList<string>? Kept,
+        IReadOnlyList<CuratorMerge>? Merged,
+        IReadOnlyList<CuratorReplace>? Replaced,
+        IReadOnlyList<CuratorNew>? NewItems,
+        IReadOnlyList<CuratorDrop>? Dropped);
+
+    private sealed record CuratorMerge(string OutputKey, IReadOnlyList<string>? InputKeys, string? Rationale);
+    private sealed record CuratorReplace(string OutputKey, string SupersededKey, string? Rationale);
+    private sealed record CuratorNew(string OutputKey, IReadOnlyList<string>? SupportingTranscriptRefs, string? Rationale);
+    private sealed record CuratorDrop(string InputKey, string? Rationale);
+}
+
+/// <summary>Thrown when the curator's response can't be safely turned into a candidate.</summary>
+public sealed class MemoryCurationException : Exception
+{
+    public MemoryCurationException(string message) : base(message) { }
+    public MemoryCurationException(string message, Exception inner) : base(message, inner) { }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryCuratorTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryCuratorTests.cs
@@ -1,0 +1,326 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Text.Json;
+using GA.Business.ML.Agents.Memory;
+using GA.Business.ML.Agents.Memory.Curator;
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Tests for <see cref="MemoryCurator"/> — the Dreams-lite curation pass.
+/// Uses a stub <see cref="IChatClient"/> that returns hand-crafted JSON
+/// payloads, so we exercise the curator's parsing + validation gates
+/// without hitting a real LLM.
+/// </summary>
+/// <remarks>
+/// See <c>docs/plans/2026-05-10-feat-dreams-lite-memory-curator-plan.md</c>.
+/// The validator is load-bearing: it's what makes the curator safe to point
+/// at production stores. Each test pins one validator rule.
+/// </remarks>
+[TestFixture]
+public class MemoryCuratorTests
+{
+    // ─── Happy path ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task CurateAsync_HappyPath_MergesDuplicates()
+    {
+        var inputs = new List<MemoryEntry>
+        {
+            new("pref-guitar-1", "preference", "user plays Strat",       [], T(0), SessionId: null),
+            new("pref-guitar-2", "preference", "user plays Stratocaster",[], T(1), SessionId: null),
+            new("focus-1",       "focus",      "user is studying bebop", [], T(2), SessionId: null),
+        };
+
+        var stub = new StubChatClient(JsonSerializer.Serialize(new
+        {
+            entries = new[]
+            {
+                new { Key = "pref-guitar",   Type = "preference", Content = "user plays a Fender Stratocaster",
+                      Tags = Array.Empty<string>(), Timestamp = T(1), SessionId = (string?)null },
+                new { Key = "focus-1",       Type = "focus",      Content = "user is studying bebop",
+                      Tags = Array.Empty<string>(), Timestamp = T(2), SessionId = (string?)null },
+            },
+            diff = new
+            {
+                kept     = new[] { "focus-1" },
+                merged   = new[] { new { outputKey = "pref-guitar", inputKeys = new[] { "pref-guitar-1", "pref-guitar-2" },
+                                         rationale = "Same instrument stated two ways." } },
+                replaced = Array.Empty<object>(),
+                newItems = Array.Empty<object>(),
+                dropped  = Array.Empty<object>(),
+            },
+        }));
+
+        var curator = new MemoryCurator(stub);
+        var result = await curator.CurateAsync(
+            new MemoryCurationRequest(inputs, [], null));
+
+        Assert.That(result.CandidateEntries, Has.Count.EqualTo(2));
+        Assert.That(result.Diff.Merged, Has.Count.EqualTo(1));
+        Assert.That(result.Diff.Merged[0].InputKeys, Is.EquivalentTo(new[] { "pref-guitar-1", "pref-guitar-2" }));
+        Assert.That(result.Diff.Kept, Does.Contain("focus-1"));
+    }
+
+    [Test]
+    public async Task CurateAsync_HappyPath_ReplacesStale()
+    {
+        // Models a real replacement: one input ("focus") whose content is
+        // now stale, replaced by a new output ("focus-current") with revised
+        // content. The output is NOT a verbatim copy of any input.
+        var inputs = new List<MemoryEntry>
+        {
+            new("focus", "focus", "user focuses on bebop", [], T(0), SessionId: null),
+        };
+
+        var stub = new StubChatClient(JsonSerializer.Serialize(new
+        {
+            entries = new[]
+            {
+                new { Key = "focus-current", Type = "focus",
+                      Content = "user focuses on fingerstyle (changed from bebop per recent sessions)",
+                      Tags = Array.Empty<string>(), Timestamp = T(10), SessionId = (string?)null },
+            },
+            diff = new
+            {
+                kept     = Array.Empty<string>(),
+                merged   = Array.Empty<object>(),
+                replaced = new[] { new { outputKey = "focus-current", supersededKey = "focus",
+                                         rationale = "Recent sessions show fingerstyle, not bebop." } },
+                newItems = Array.Empty<object>(),
+                dropped  = Array.Empty<object>(),
+            },
+        }));
+
+        var result = await new MemoryCurator(stub).CurateAsync(
+            new MemoryCurationRequest(inputs, [], null));
+
+        Assert.That(result.CandidateEntries, Has.Count.EqualTo(1));
+        Assert.That(result.Diff.Replaced, Has.Count.EqualTo(1));
+        Assert.That(result.Diff.Replaced[0].SupersededKey, Is.EqualTo("focus"));
+        Assert.That(result.Diff.Replaced[0].OutputKey, Is.EqualTo("focus-current"));
+    }
+
+    // ─── Validator: trace to input ───────────────────────────────────────
+
+    [Test]
+    public void CurateAsync_OutputEntryNotInDiff_Throws()
+    {
+        // An output entry that never appears in kept/merged/replaced/newItems —
+        // the curator must reject this rather than silently accepting an
+        // ungrounded fact (covers "NEVER invents facts" rule).
+        var inputs = new List<MemoryEntry>
+        {
+            new("real", "fact", "real input", [], T(0), SessionId: null),
+        };
+
+        var stub = new StubChatClient(JsonSerializer.Serialize(new
+        {
+            entries = new[]
+            {
+                new { Key = "real",          Type = "fact", Content = "real input",
+                      Tags = Array.Empty<string>(), Timestamp = T(0), SessionId = (string?)null },
+                new { Key = "hallucinated",  Type = "fact", Content = "made up",
+                      Tags = Array.Empty<string>(), Timestamp = T(1), SessionId = (string?)null },
+            },
+            diff = new
+            {
+                kept     = new[] { "real" },
+                merged   = Array.Empty<object>(),
+                replaced = Array.Empty<object>(),
+                newItems = Array.Empty<object>(),
+                dropped  = Array.Empty<object>(),
+            },
+        }));
+
+        Assert.That(async () => await new MemoryCurator(stub).CurateAsync(
+                new MemoryCurationRequest(inputs, [], null)),
+            Throws.TypeOf<MemoryCurationException>()
+                  .With.Message.Contains("hallucinated"));
+    }
+
+    [Test]
+    public void CurateAsync_InputKeyMissingFromDiff_Throws()
+    {
+        // Every input must be accounted for. If an input vanishes silently
+        // (not in kept/merged/replaced/dropped), the curator hid a deletion —
+        // refuse.
+        var inputs = new List<MemoryEntry>
+        {
+            new("a", "fact", "first",  [], T(0), SessionId: null),
+            new("b", "fact", "second", [], T(1), SessionId: null),
+        };
+
+        var stub = new StubChatClient(JsonSerializer.Serialize(new
+        {
+            entries = new[]
+            {
+                new { Key = "a", Type = "fact", Content = "first", Tags = Array.Empty<string>(),
+                      Timestamp = T(0), SessionId = (string?)null },
+            },
+            diff = new
+            {
+                kept     = new[] { "a" },
+                merged   = Array.Empty<object>(),
+                replaced = Array.Empty<object>(),
+                newItems = Array.Empty<object>(),
+                dropped  = Array.Empty<object>(), // <-- "b" missing
+            },
+        }));
+
+        Assert.That(async () => await new MemoryCurator(stub).CurateAsync(
+                new MemoryCurationRequest(inputs, [], null)),
+            Throws.TypeOf<MemoryCurationException>()
+                  .With.Message.Contains("'b'"));
+    }
+
+    // ─── Validator: session-scope preservation ───────────────────────────
+
+    [Test]
+    public void CurateAsync_KeptEntryChangesScope_Throws()
+    {
+        var inputs = new List<MemoryEntry>
+        {
+            new("scoped", "fact", "session A's fact", [], T(0), SessionId: "session-A"),
+        };
+
+        var stub = new StubChatClient(JsonSerializer.Serialize(new
+        {
+            entries = new[]
+            {
+                new { Key = "scoped", Type = "fact", Content = "session A's fact",
+                      Tags = Array.Empty<string>(), Timestamp = T(0), SessionId = (string?)null }, // <-- promoted to global
+            },
+            diff = new
+            {
+                kept     = new[] { "scoped" },
+                merged   = Array.Empty<object>(),
+                replaced = Array.Empty<object>(),
+                newItems = Array.Empty<object>(),
+                dropped  = Array.Empty<object>(),
+            },
+        }));
+
+        Assert.That(async () => await new MemoryCurator(stub).CurateAsync(
+                new MemoryCurationRequest(inputs, [], null)),
+            Throws.TypeOf<MemoryCurationException>()
+                  .With.Message.Contains("scope"));
+    }
+
+    [Test]
+    public void CurateAsync_MergesAcrossSessionScopes_Throws()
+    {
+        // Cross-scope merges leak — session A's preference must NEVER merge
+        // with session B's preference into a single output entry, even if
+        // the content is identical.
+        var inputs = new List<MemoryEntry>
+        {
+            new("a-pref", "preference", "wants jazz",   [], T(0), SessionId: "session-A"),
+            new("b-pref", "preference", "wants jazz",   [], T(1), SessionId: "session-B"),
+        };
+
+        var stub = new StubChatClient(JsonSerializer.Serialize(new
+        {
+            entries = new[]
+            {
+                new { Key = "ab-pref", Type = "preference", Content = "wants jazz",
+                      Tags = Array.Empty<string>(), Timestamp = T(1), SessionId = (string?)null },
+            },
+            diff = new
+            {
+                kept     = Array.Empty<string>(),
+                merged   = new[] { new { outputKey = "ab-pref", inputKeys = new[] { "a-pref", "b-pref" },
+                                         rationale = "Identical preference content." } },
+                replaced = Array.Empty<object>(),
+                newItems = Array.Empty<object>(),
+                dropped  = Array.Empty<object>(),
+            },
+        }));
+
+        Assert.That(async () => await new MemoryCurator(stub).CurateAsync(
+                new MemoryCurationRequest(inputs, [], null)),
+            Throws.TypeOf<MemoryCurationException>()
+                  .With.Message.Contains("scope"));
+    }
+
+    // ─── Robustness: malformed response handling ─────────────────────────
+
+    [Test]
+    public void CurateAsync_NonJsonResponse_Throws()
+    {
+        var stub = new StubChatClient("Sure, here's the curation: ...");
+
+        Assert.That(async () => await new MemoryCurator(stub).CurateAsync(
+                new MemoryCurationRequest([], [], null)),
+            Throws.TypeOf<MemoryCurationException>());
+    }
+
+    [Test]
+    public async Task CurateAsync_JsonWrappedInCodeFence_ParsesAnyway()
+    {
+        // Some providers wrap JSON in ```json ... ``` even when told not to.
+        // Curator strips this defensively (doesn't change the contract).
+        var fenced = "```json\n" +
+            JsonSerializer.Serialize(new
+            {
+                entries = Array.Empty<object>(),
+                diff = new
+                {
+                    kept = Array.Empty<string>(),
+                    merged = Array.Empty<object>(),
+                    replaced = Array.Empty<object>(),
+                    newItems = Array.Empty<object>(),
+                    dropped = Array.Empty<object>(),
+                },
+            }) +
+            "\n```";
+        var stub = new StubChatClient(fenced);
+
+        var result = await new MemoryCurator(stub).CurateAsync(
+            new MemoryCurationRequest([], [], null));
+
+        Assert.That(result.CandidateEntries, Is.Empty);
+    }
+
+    [Test]
+    public void CurateAsync_EmptyResponse_Throws()
+    {
+        var stub = new StubChatClient("");
+
+        Assert.That(async () => await new MemoryCurator(stub).CurateAsync(
+                new MemoryCurationRequest([], [], null)),
+            Throws.TypeOf<MemoryCurationException>().With.Message.Contains("empty"));
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private static DateTimeOffset T(int seconds) =>
+        new(2026, 5, 10, 0, 0, seconds, TimeSpan.Zero);
+}
+
+/// <summary>
+/// Stub IChatClient that always returns the same JSON payload. No real LLM
+/// call. Used by every test in <see cref="MemoryCuratorTests"/>.
+/// </summary>
+file sealed class StubChatClient(string responseJson) : IChatClient
+{
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, responseJson))
+        {
+            ModelId = "stub-model",
+        };
+        return Task.FromResult(response);
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException();
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+    public void Dispose() { }
+}

--- a/docs/plans/2026-05-10-feat-dreams-lite-memory-curator-plan.md
+++ b/docs/plans/2026-05-10-feat-dreams-lite-memory-curator-plan.md
@@ -1,0 +1,133 @@
+---
+title: Dreams-lite — periodic curation pass over the chatbot MemoryStore
+date: 2026-05-10
+type: feat
+reversibility: two-way door (curation produces a candidate store; original is never mutated)
+revisit_trigger: when (a) Anthropic Dreams beta access lands AND our store fits its size budget, OR (b) curator output quality drops below the manual-review-acceptance bar three runs in a row
+status: draft
+---
+
+# Dreams-lite — periodic curation pass over the chatbot MemoryStore
+
+## Why this exists
+
+Anthropic's **Dreams** Research Preview (`dreaming-2026-04-21` beta) addresses a real pathology: managed-agent memory stores accumulate duplicates, contradictions, and stale entries over many sessions, and there's no built-in compaction step. Dreams runs an offline pipeline that reads a memory store + up to 100 session transcripts and produces a *new* store with duplicates merged, stale entries replaced, and emergent insights surfaced. The input is never mutated.
+
+Our `MemoryStore` (`Common/GA.Business.ML/Agents/Memory/MemoryStore.cs`) will hit the same pathology the moment `Memory:EnrichOnRetrieve=true` flips on. We already see the shape of the problem in two-day-old conversations: "user plays Strat" vs "user plays Stratocaster" gets stored as two facts; preferences that get overridden later (`"focus: bebop" → "focus: fingerstyle"`) both linger.
+
+Dreams the API isn't applicable directly because (a) it operates on Anthropic *managed-agents* memory stores (we use a file-backed `MemoryStore` instead) and (b) it's gated behind a Research Preview access form. But the **shape** of the pipeline is reproducible against any store, and we already have the dependencies (Anthropic API client via Microsoft.Extensions.AI, Claude Opus 4.7 access, JSON serialization).
+
+So: ship "dreams-lite" — a local analog wired to our existing infrastructure. Get the compounding-knowledge benefit now. Migrate to managed Dreams later if/when we adopt managed-agents API.
+
+## What it does
+
+A single command (or scheduled L2 step) that:
+
+1. Reads `~/.ga/memory.json` (current `MemoryStore` on disk).
+2. Reads the last N chat sessions from a transcript log (TBD — for v0.1, mock with hand-curated fixtures; v0.2 plumbs from production once chat-transcript logging exists).
+3. Sends both to Claude (Opus 4.7 or Sonnet 4.6) with a curation prompt that mirrors Dreams' contract:
+   - Merge duplicate entries (same fact stated different ways).
+   - Replace stale or contradicted entries with the latest value.
+   - Surface emergent insights (patterns across sessions).
+   - Never invent facts not grounded in inputs.
+4. Writes the candidate v2 store to `~/.ga/memory.v2-candidate-<timestamp>.json` (or a configurable path) — **never overwrites** the live store.
+5. Emits a diff summary (counts: kept, merged, replaced, new, dropped) and a structured ledger entry.
+6. Operator reviews → `ga-memory promote <candidate-path>` swaps the live store atomically (with backup of the previous one).
+
+The shape mirrors Dreams' "lifecycle" semantics: pending → running → completed/failed, with an `outputs[].memory_store_path` rather than a managed `memory_store_id`. Operator review is the audit gate. Same two-way door guarantee.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Common/GA.Business.ML/Agents/Memory/Curator/                       │
+│  ├─ MemoryCurator.cs              ← orchestrates the pass           │
+│  ├─ MemoryCurationRequest.cs      ← input record (store + sessions) │
+│  ├─ MemoryCurationResult.cs       ← output record (candidate + diff)│
+│  ├─ CurationPromptBuilder.cs      ← builds the system + user prompt │
+│  └─ CurationDiff.cs               ← kept/merged/replaced/new/dropped│
+├─────────────────────────────────────────────────────────────────────┤
+│  Apps/GaMemoryCli/ (new thin console host)                          │
+│  ├─ ga-memory curate              ← run pipeline, write candidate   │
+│  ├─ ga-memory diff <candidate>    ← show what changed               │
+│  └─ ga-memory promote <candidate> ← atomic swap with backup         │
+│  (separate project, NOT inside GaChatbotCli — curation has no       │
+│   IHarmonicChatOrchestrator dependency, only IChatClient + Store)   │
+├─────────────────────────────────────────────────────────────────────┤
+│  state/quality/memory-curator/<date>/                               │
+│  ├─ run-<id>.json                 ← ledger entry (input/output/diff)│
+│  └─ memory.v2-candidate-<id>.json ← candidate store                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Single dependency: existing `IChatClient` from `Microsoft.Extensions.AI` (we already inject Claude Opus 4.7 via this in `Common/GA.Business.ML/Agents/`).
+
+## Prompt contract
+
+The curation prompt is the load-bearing part. Draft (subject to iteration):
+
+```
+SYSTEM:
+You are a memory curator. You receive an existing MemoryStore (JSON array of
+MemoryEntry records: Key, Type, Content, Tags, Timestamp, SessionId) and
+optional past chat transcripts. Produce a NEW MemoryStore that:
+1. Merges duplicate entries (same fact stated different ways).
+2. Replaces entries contradicted by later evidence (use Timestamp).
+3. Surfaces new memory entries supported by recurring patterns in transcripts.
+4. NEVER invents facts not grounded in inputs.
+5. Preserves SessionId scope — never moves a session-scoped entry to global
+   or vice versa.
+
+Return a JSON object: { entries: [...], diff: { kept, merged, replaced, new, dropped } }.
+Every change in `diff` must reference the input Keys it derived from.
+
+USER:
+<existing store JSON>
+<session transcripts JSON>
+<operator instructions (optional, ≤2KB)>
+```
+
+The `diff` requirement is the audit trail — every output entry traces to inputs. Operator review compares input to output line-by-line via the `diff` keys, not by re-reading the whole store.
+
+## Acceptance criteria (Phase 1 — v0.1)
+
+- [ ] `MemoryCurator.CurateAsync(MemoryCurationRequest)` returns `MemoryCurationResult` with a candidate store and structured diff.
+- [ ] CLI `ga-memory curate` runs the pipeline against the live `~/.ga/memory.json` and writes a candidate file. **Never mutates the input file.**
+- [ ] CLI `ga-memory promote <candidate>` swaps stores atomically with a `.bak` of the prior live store.
+- [ ] Ledger entry written to `state/quality/memory-curator/<date>/run-<id>.json` (schema: `memory-curator-run.schema.json` — sibling to `gate-ledger.schema.json`).
+- [ ] Unit tests with fixture stores covering: duplicate merge, contradiction resolution, session-scope preservation, refusal to invent.
+- [ ] Smoke test against a real `~/.ga/memory.json` snapshot — operator confirms output quality is "merge-worthy" before we wire any automation.
+
+Not in scope for v0.1: production transcript ingestion (mock fixtures only); auto-promote; scheduled runs; UI surface; cross-session sensitive-data redaction. Each is its own phase.
+
+## Phasing
+
+| Phase | Scope | Out of scope |
+|---|---|---|
+| **0 — this plan** | One-page design + sign-off | Code |
+| **1 — v0.1 spike** | `MemoryCurator` + CLI + fixture tests + manual smoke | Production transcripts; scheduling |
+| **2 — v0.2 transcripts** | Plumb real chat-transcript log into curation input | Auto-promote |
+| **3 — v0.3 scheduled** | Optional L2 `/chatbot-iterate` step (weekly) with explicit operator-review gate before any promote | Removing the review gate |
+| **4 — v0.4 production** | Quality metric (curator-acceptance rate); SLOs; promote-on-green threshold | — |
+
+## One-way doors
+
+None at v0.1 — curator writes to a candidate file; original store untouched; promote is reversible via the `.bak`. The candidate JSON file is local; nothing leaves the workspace unless the operator manually shares it.
+
+## Open questions (need answers before Phase 1)
+
+1. **Model choice.** Opus 4.7 (better synthesis, ~5× cost) or Sonnet 4.6 (faster, cheaper, may miss subtle merges)? Recommendation: start with Sonnet 4.6 for cost; promote to Opus 4.7 if the diff quality is poor on the first three runs.
+2. **Where to inject the transcript dependency.** For v0.1 we use fixture JSON files; for v0.2 we need a `ChatTranscriptStore` that captures `ChatHookContext` history. Do we add this proactively in v0.1 even though it's not wired? Recommendation: yes — header-only interface so v0.2 is a drop-in.
+3. **Operator-review UI.** Plain CLI diff for v0.1. Should we plumb to Prime Radiant dashboard in v0.3? Recommendation: defer to v0.4 — terminal review is fine while we're calibrating the prompt.
+
+## Dreams-direct migration path (parallel option C)
+
+If Anthropic Dreams beta access lands and our `MemoryStore` size fits the input budget, we can also try the real Dreams API against `MEMORY.md` (Claude Code's auto-memory at `C:/Users/spare/.claude/projects/.../memory/`). That doesn't replace this plan — it's a *second* application of the same idea to a different memory store (Claude Code's, not GA's chatbot's). The prompt contract designed here is reusable as a Dreams `instructions` value.
+
+## Refs
+
+- Dreams docs: https://platform.claude.com/docs/en/managed-agents/dreams
+- Adjacent: `Common/GA.Business.ML/Agents/Memory/MemoryStore.cs` (target store)
+- Adjacent: `Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs` (writes that accumulate)
+- Adjacent: `docs/solutions/architecture/2026-05-07-process-wide-memory-store-leaks-into-anonymous-prompts.md` (why the store has session scoping)
+- Related: `BACKLOG.md` Chatbot Track (P1 items around memory)

--- a/docs/schemas/memory-curator-run.schema.json
+++ b/docs/schemas/memory-curator-run.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guitaralchemist.com/schemas/memory-curator-run.schema.json",
+  "title": "Memory curator run ledger entry",
+  "description": "One record per MemoryCurator.CurateAsync invocation. Written to state/quality/memory-curator/<date>/run-<id>.json. Audit trail for what the curator proposed and (if applicable) what the operator did with it.",
+  "type": "object",
+  "required": ["runId", "startedAt", "status", "inputs", "result"],
+  "properties": {
+    "runId": {
+      "type": "string",
+      "description": "Stable identifier for this run. ULID or UUID."
+    },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "completedAt": { "type": "string", "format": "date-time" },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "running", "completed", "failed", "canceled"],
+      "description": "Mirrors Dreams' lifecycle states."
+    },
+    "modelId": { "type": "string", "description": "e.g. claude-sonnet-4-6" },
+    "inputs": {
+      "type": "object",
+      "required": ["storePath", "entryCount", "transcriptCount"],
+      "properties": {
+        "storePath": { "type": "string", "description": "Absolute path to the input MemoryStore JSON file." },
+        "entryCount": { "type": "integer", "minimum": 0 },
+        "transcriptCount": { "type": "integer", "minimum": 0 },
+        "instructionsLength": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "result": {
+      "type": "object",
+      "required": ["candidatePath", "diffSummary"],
+      "properties": {
+        "candidatePath": {
+          "type": "string",
+          "description": "Absolute path to the candidate store JSON (NOT yet promoted)."
+        },
+        "diffSummary": {
+          "type": "object",
+          "required": ["kept", "merged", "replaced", "newItems", "dropped"],
+          "properties": {
+            "kept": { "type": "integer", "minimum": 0 },
+            "merged": { "type": "integer", "minimum": 0 },
+            "replaced": { "type": "integer", "minimum": 0 },
+            "newItems": { "type": "integer", "minimum": 0 },
+            "dropped": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "tokens": {
+          "type": "object",
+          "properties": {
+            "input": { "type": "integer", "minimum": 0 },
+            "output": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "promote": {
+      "type": "object",
+      "description": "Populated when the operator runs `ga-memory promote` against this run's candidate.",
+      "properties": {
+        "promotedAt": { "type": "string", "format": "date-time" },
+        "backupPath": { "type": "string", "description": "Path to the .bak of the prior live store." }
+      }
+    },
+    "error": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "description": "e.g. validation_failed, json_parse_failed, llm_error" },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Recovery of the curator work from PR #165, which was clobbered by a concurrent-surface force-push that reset its branch to PR #164's HEAD. PR #164 has now merged; this PR contains only the curator delta cleanly rebased on the new main.

Original PR: #165 (closed as superseded).
Original plan: docs/plans/2026-05-10-feat-dreams-lite-memory-curator-plan.md

## Summary

Local analog of Anthropic's [Dreams Research Preview](https://platform.claude.com/docs/en/managed-agents/dreams), applied to the chatbot MemoryStore.

- New module Common/GA.Business.ML/Agents/Memory/Curator/ — MemoryCurator + diff records + load-bearing validators (refuse hallucinations, no silent deletions, session-scope preservation)
- New CLI Apps/GaMemoryCli with curate / diff / promote subcommands
- 9 fixture tests pinning every validator rule + happy path + robustness
- Ledger schema docs/schemas/memory-curator-run.schema.json

## Why local (not managed Dreams)

Dreams operates on Anthropic managed-agents memory stores; we use a file-backed MemoryStore + Microsoft.Extensions.AI. Local analog ships with the same two-way-door safety (never mutates inputs, operator review before promote).

## Test plan

- [x] dotnet build clean across the new module + CLI
- [x] All 9 MemoryCuratorTests pass
- [x] All 37 Memory-related tests pass (no regression on storage layer / hook plumbing / SC-001)
- [x] dotnet run --project Apps/GaMemoryCli -- --help prints usage
- [x] Cherry-pick onto post-#164 main rebuilds clean (verified after this PR opened)
- [ ] End-to-end smoke against ~/.ga/memory.json — deferred

## One-way doors

None at v0.1. Operator review gate before any swap; promote is reversible via .bak.

Refs: tasks #108, #109, #110 — completed and ledger entries unchanged from PR #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)