### PR TITLE
feat(eval): routing harness v0.2 — reflect-load IIntent from production skills

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Eval/RoutingEvalHarness.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Eval/RoutingEvalHarness.cs
@@ -1,9 +1,17 @@
 namespace GA.Business.ML.Tests.Eval;
 
+using System.Reflection;
 using System.Text.Json;
+using GA.Business.ML.Agents;
 using GA.Business.ML.Agents.Intents;
+using GA.Business.ML.Agents.Plugins;
+using GA.Business.ML.Agents.Skills;
+using GA.Business.ML.Extensions;
+using GA.Domain.Services.Atonal.Grothendieck;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 /// <summary>
@@ -35,7 +43,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 /// </para>
 /// </remarks>
 [TestFixture]
-[Explicit("Requires live Ollama embedding endpoint. Run manually for baselines.")]
 public class RoutingEvalHarness
 {
     // Env-var overrides per PR #162 review F-7 — operators can point at
@@ -74,19 +81,79 @@ public class RoutingEvalHarness
 
     private static readonly string OutputDir = ResolveQualityDir();
 
+    /// <summary>
+    /// v0.2 smoke test (not [Explicit]) — pins that the reflection-load
+    /// registry constructs every production <c>IOrchestratorSkill</c> and
+    /// that the resulting <see cref="IIntent"/> set has ID values matching
+    /// the <c>skill.{name}</c> convention. Catches breakage when (a) a new
+    /// skill ctor adds a dependency we haven't stubbed, or (b) the
+    /// reflection scan stops finding skills (namespace move, build issue).
+    /// Runs without Ollama — fast, deterministic, in CI.
+    /// </summary>
     [Test]
+    [Category("Fast")]
+    public void ProductionLikeRegistry_LoadsAllSkillIntents()
+    {
+        var sp = BuildProductionLikeIntentRegistry();
+        var intents = sp.GetServices<IIntent>().ToList();
+
+        Assert.That(intents.Count, Is.GreaterThanOrEqualTo(15),
+            "Expected ≥15 IOrchestratorSkill-derived intents from GA.Business.ML " +
+            $"(PR #160 / 2026-05-06 graduation count). Found {intents.Count}.");
+
+        // FretSpanSkill intentionally has zero ExamplePrompts — it's
+        // dispatched by ProductionOrchestrator's CanHandle regex, not
+        // semantic routing. So "examples==0" is NOT malformed; "empty Id"
+        // or "missing skill. prefix" is.
+        var malformed = intents
+            .Where(i => string.IsNullOrWhiteSpace(i.Id) ||
+                        !i.Id.StartsWith("skill.", StringComparison.Ordinal))
+            .Select(i => $"id='{i.Id}'")
+            .ToList();
+
+        Assert.That(malformed, Is.Empty,
+            "Reflection-loaded intents have malformed shape (empty Id or missing " +
+            $"`skill.` prefix):\n  {string.Join("\n  ", malformed)}");
+
+        // Separate (informational) count of intents that have zero example
+        // prompts — these intents won't participate in semantic routing.
+        // Logged so changes to the production set are visible in test output.
+        var withoutExamples = intents.Where(i => i.ExamplePrompts.Count == 0).Select(i => i.Id).ToList();
+        TestContext.WriteLine(
+            $"Intents without ExamplePrompts (regex-routed in production): " +
+            $"{(withoutExamples.Count == 0 ? "(none)" : string.Join(", ", withoutExamples))}");
+
+        // Spot-check: a few known skill IDs must be present. If these miss,
+        // the reflection scan probably picked up the wrong assembly.
+        var ids = intents.Select(i => i.Id).ToHashSet(StringComparer.Ordinal);
+        foreach (var expected in new[] { "skill.chordinfo", "skill.modes", "skill.commontones" })
+        {
+            Assert.That(ids, Does.Contain(expected),
+                $"Expected production intent '{expected}' missing from reflection-loaded registry. " +
+                "Registry IDs: " + string.Join(", ", ids.OrderBy(x => x)));
+        }
+    }
+
+    [Test]
+    [Explicit("Requires live Ollama embedding endpoint. Run manually for baselines.")]
     public async Task RunBaseline_EmitReport()
     {
         var labeledPrompts = LoadLabeledPrompts();
         Assert.That(labeledPrompts.Prompts, Is.Not.Empty,
             $"Eval prompt set is empty at {DataPath} — cannot establish a baseline.");
 
-        // Build a minimal DI container with the intents the router routes
-        // among. We register stub IIntent instances mirroring the production
-        // skill IDs and their example prompts, so the harness measures the
-        // router's discrimination quality against a fixed intent corpus
-        // independent of skill implementation churn.
-        var services = BuildIntentRegistry();
+        // v0.2 (task #105) — reflect-load real IOrchestratorSkill implementations
+        // from the GA.Business.ML assembly and wrap them via SkillIntentAdapter,
+        // so the harness measures discrimination against the PRODUCTION example
+        // prompts rather than v0.1's hand-typed reconstruction. Set
+        // GA_EVAL_USE_STUB_REGISTRY=1 to opt back into the v0.1 stub registry
+        // for harness-validation runs (useful when comparing reflection-load
+        // metrics to the hand-typed baseline).
+        var services = string.Equals(
+            Environment.GetEnvironmentVariable("GA_EVAL_USE_STUB_REGISTRY"),
+            "1", StringComparison.Ordinal)
+            ? BuildIntentRegistry()
+            : BuildProductionLikeIntentRegistry();
 
         // Real embedder. If unreachable, fail fast with a clear message
         // rather than producing a meaningless all-null baseline.
@@ -284,6 +351,160 @@ public class RoutingEvalHarness
     private static void AddStubIntent(IServiceCollection sc, string id, string description, string[] examples)
     {
         sc.AddSingleton<IIntent>(new StubIntent(id, description, examples));
+    }
+
+    /// <summary>
+    /// v0.2 (task #105) — reflect-loads every concrete
+    /// <see cref="IOrchestratorSkill"/> implementation in the
+    /// <c>GA.Business.ML</c> assembly, instantiates each via DI with minimal
+    /// stubs for cross-cutting dependencies (logger, MCP tools, chat-client
+    /// factory, Grothendieck service), and wraps each in
+    /// <see cref="SkillIntentAdapter"/> so the router enumerates them as
+    /// <see cref="IIntent"/>. The harness now measures the router against
+    /// production <c>ExamplePrompts</c> values, not the v0.1 hand-typed
+    /// reconstruction that diverged for 8 of 17 intents.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why reflection (not project ref to Orchestration):</b> the
+    /// production <see cref="OrchestratorSkillIntent"/> adapter lives in
+    /// <c>GA.Business.Core.Orchestration</c>, which this test project does
+    /// not reference. <see cref="SkillIntentAdapter"/> below is a literal
+    /// re-implementation matching <c>OrchestratorSkillIntent</c>'s
+    /// <see cref="IIntent.Id"/>/<c>Description</c>/<c>ExamplePrompts</c>
+    /// projection (execute is a no-op since routing never executes).
+    /// </para>
+    /// <para>
+    /// <b>What this doesn't cover:</b> the four non-skill production
+    /// intents (<c>algebra</c>, <c>tab.optimize</c>, <c>tab.analyze</c>,
+    /// <c>skill.voicing</c>) registered directly in
+    /// <c>ChatbotOrchestrationExtensions</c>. None of them appear in the
+    /// v0.1 labeled prompt set, so excluding them doesn't change the
+    /// observed F1. If the labeled corpus grows to include them in v0.3,
+    /// add a project ref to <c>GA.Business.Core.Orchestration</c> here.
+    /// </para>
+    /// <para>
+    /// <b>Failure mode:</b> if a skill ctor depends on a service we don't
+    /// stub, instantiation throws and the test fails Inconclusive with a
+    /// list of unresolvable types — actionable signal, not silent skip.
+    /// </para>
+    /// </remarks>
+    private static IServiceProvider BuildProductionLikeIntentRegistry()
+    {
+        var sc = new ServiceCollection();
+
+        // Logging — every skill takes ILogger<TSelf>.
+        sc.AddLogging(b => b.AddProvider(NullLoggerProvider.Instance));
+
+        // Cross-cutting stubs for skill dependencies. Routing never invokes
+        // these — they're shape requirements for the ctors only.
+        sc.TryAddSingleton<IGrothendieckService, GrothendieckService>();
+        sc.TryAddSingleton<IMcpToolsProvider>(_ => new StubMcpToolsProvider());
+        sc.TryAddSingleton<IChatClientFactory>(_ => new StubChatClientFactory());
+        sc.TryAddSingleton<IChatClient>(_ => new StubChatClient());
+
+        // Reflect-discover every concrete IOrchestratorSkill in the
+        // GA.Business.ML assembly. (Skills implemented in host apps —
+        // GaApi's VoicingComfortSkill, etc. — aren't covered by this scan
+        // by design: they're host-specific and not part of the routed core.)
+        var skillTypes = typeof(IOrchestratorSkill).Assembly
+            .GetTypes()
+            .Where(t => !t.IsAbstract && !t.IsInterface &&
+                        typeof(IOrchestratorSkill).IsAssignableFrom(t) &&
+                        // Skip SkillMdDrivenSkill itself — it requires a parsed
+                        // SkillMd record and isn't routed directly; only its
+                        // wrappers (SkillMdDrivenWrapperBase descendants) are.
+                        t != typeof(SkillMdDrivenSkill))
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.That(skillTypes, Is.Not.Empty,
+            "Reflection found zero IOrchestratorSkill implementations in GA.Business.ML — " +
+            "either the namespace moved or the assembly load failed.");
+
+        foreach (var skillType in skillTypes)
+        {
+            // Register the skill type itself + an IIntent factory that
+            // resolves it through DI and wraps it. Singleton lifetime is
+            // fine for routing — the router never calls ExecuteAsync.
+            sc.AddSingleton(skillType);
+            sc.AddSingleton<IIntent>(sp =>
+            {
+                var skill = (IOrchestratorSkill)sp.GetRequiredService(skillType);
+                return new SkillIntentAdapter(skill);
+            });
+        }
+
+        var sp = sc.BuildServiceProvider();
+
+        // Eagerly resolve every IIntent so a missing dependency surfaces NOW
+        // (with the skill type name) rather than mid-route with an obscure
+        // null reference. Failure to resolve = test fails informatively.
+        var failures = new List<string>();
+        foreach (var skillType in skillTypes)
+        {
+            try { _ = sp.GetRequiredService(skillType); }
+            catch (Exception ex)
+            {
+                failures.Add($"{skillType.Name}: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        Assert.That(failures, Is.Empty,
+            "BuildProductionLikeIntentRegistry could not construct one or more skills. " +
+            "Add a stub for the missing dependency or exclude the skill explicitly:\n  " +
+            string.Join("\n  ", failures));
+
+        TestContext.WriteLine(
+            $"v0.2 production-like registry loaded {skillTypes.Count} skills via reflection.");
+        return sp;
+    }
+
+    /// <summary>
+    /// Local mirror of <c>OrchestratorSkillIntent</c> from
+    /// <c>GA.Business.Core.Orchestration</c>. Same Id/Description/Examples
+    /// projection so the router sees the exact production shape.
+    /// </summary>
+    private sealed class SkillIntentAdapter(IOrchestratorSkill skill) : IIntent
+    {
+        public string Id => $"skill.{skill.Name.ToLowerInvariant().Replace(' ', '-')}";
+        public string Description => skill.Description;
+        public IReadOnlyList<string> ExamplePrompts => skill.ExamplePrompts;
+        public Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default)
+            => Task.FromResult(new IntentResult("(no-op for eval)"));
+    }
+
+    // ─── Cross-cutting stubs ─────────────────────────────────────────────
+
+    private sealed class StubMcpToolsProvider : IMcpToolsProvider
+    {
+        public ValueTask<IReadOnlyList<AIFunction>> GetToolsAsync(CancellationToken ct = default) =>
+            ValueTask.FromResult<IReadOnlyList<AIFunction>>([]);
+    }
+
+    private sealed class StubChatClientFactory : IChatClientFactory
+    {
+        public IChatClient Create(string purpose) => new StubChatClient();
+    }
+
+    private sealed class StubChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException(
+                "StubChatClient.GetResponseAsync was invoked — routing must not execute " +
+                "ChatClient at routing time. Check the eval harness flow.");
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("StubChatClient.GetStreamingResponseAsync invoked unexpectedly.");
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
     }
 
     private sealed class StubIntent(string id, string description, IReadOnlyList<string> examples) : IIntent

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ProductionOrchestratorHookPlumbingTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ProductionOrchestratorHookPlumbingTests.cs
@@ -1,0 +1,116 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Static-analysis regression pin (task #104). Fails when a new
+/// <c>new ChatHookContext { ... }</c> initializer is added to
+/// <c>ProductionOrchestrator.cs</c> without plumbing <c>SessionId</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Background: PR #157 / PR #160 Phase B plumbed <c>SessionId</c> through
+/// every <c>ChatHookContext</c> instantiation in
+/// <c>ProductionOrchestrator</c> so the storage-layer isolation from
+/// PR #157 actually applies on every request path (skill, RAG, tab). A
+/// missing site silently regresses to a per-request Guid fallback, which
+/// looks correct in production but lets cross-session memory leak through
+/// any hook that observes <c>ctx.SessionId</c>.
+/// </para>
+/// <para>
+/// Why static analysis. The behavior is impossible to assert at the
+/// memory-store level (we already do that in
+/// <see cref="MemoryHookSessionPlumbingTests"/>) — that suite verifies the
+/// hook honors a SessionId when given one, not that every orchestrator
+/// path provides one. A runtime test would require most of the
+/// orchestrator's DI graph; cost/benefit doesn't justify it for this
+/// regression. The static pin catches the exact mistake: forgetting
+/// <c>SessionId =</c> in a new initializer.
+/// </para>
+/// <para>
+/// When this test fails. Either (a) you added a new
+/// <c>new ChatHookContext</c> site and forgot to plumb
+/// <c>SessionId = sessionId,</c> — fix the initializer, or (b) you
+/// deliberately removed a site — update <see cref="MinimumExpectedSites"/>
+/// downward AND document why in the commit message.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class ProductionOrchestratorHookPlumbingTests
+{
+    /// <summary>
+    /// Lower bound on the count of <c>new ChatHookContext</c> sites in
+    /// <c>ProductionOrchestrator.cs</c>. Set at the post-PR-#160 count.
+    /// If you legitimately remove a site, lower this number deliberately.
+    /// </summary>
+    private const int MinimumExpectedSites = 7;
+
+    private const string SourceRelativePath =
+        "Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs";
+
+    private static readonly Regex ChatHookContextInitializer =
+        new(@"new\s+ChatHookContext\s*\{([^}]*)\}", RegexOptions.Singleline);
+
+    private static readonly Regex SessionIdAssignment =
+        new(@"SessionId\s*=\s*\w");
+
+    [Test]
+    public void AllChatHookContextSites_PlumbSessionId()
+    {
+        var source = LoadOrchestratorSource();
+        var matches = ChatHookContextInitializer.Matches(source);
+
+        Assert.That(matches.Count, Is.GreaterThanOrEqualTo(MinimumExpectedSites),
+            $"Expected at least {MinimumExpectedSites} `new ChatHookContext` initializer " +
+            $"sites in ProductionOrchestrator.cs, found {matches.Count}. " +
+            "If a site was removed deliberately, lower MinimumExpectedSites and document why.");
+
+        var missing = new List<string>();
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var initBody = matches[i].Groups[1].Value;
+            if (!SessionIdAssignment.IsMatch(initBody))
+            {
+                var prefix = source[..matches[i].Index];
+                var lineNo = prefix.Count(c => c == '\n') + 1;
+                missing.Add($"site #{i + 1} (≈ line {lineNo})");
+            }
+        }
+
+        Assert.That(missing, Is.Empty,
+            "ChatHookContext sites missing `SessionId = ...` plumbing: " +
+            $"{string.Join(", ", missing)}. " +
+            "See PR #157 Phase B and PR #163 audit — session-scoped memory " +
+            "requires every hook ctx to carry the caller's SessionId. " +
+            "A missing site silently regresses to per-request Guid fallback, " +
+            "letting cross-session memory leak through any hook reading ctx.SessionId.");
+    }
+
+    private static string LoadOrchestratorSource()
+    {
+        var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
+        var sourcePath = Path.Combine(repoRoot, SourceRelativePath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.That(File.Exists(sourcePath), Is.True,
+            $"Could not locate ProductionOrchestrator.cs at {sourcePath}. " +
+            "If the file was moved, update SourceRelativePath.");
+        return File.ReadAllText(sourcePath);
+    }
+
+    /// <summary>
+    /// Walks up from the test-assembly directory until it finds
+    /// <c>AllProjects.slnx</c>, the repo root marker. Throws if not found
+    /// — keeps the test honest about its dependency on the source tree.
+    /// </summary>
+    private static string FindRepoRoot(string startDir)
+    {
+        var dir = new DirectoryInfo(startDir);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "AllProjects.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new InvalidOperationException(
+            $"Could not find repo root (AllProjects.slnx) walking up from {startDir}.");
+    }
+}


### PR DESCRIPTION
Closes task #105.

## What changed

Replaces v0.1's hand-typed stub registry (16 intents whose example prompts diverged from production for 8 of them, per PR #162 review F-3) with reflection-load of every concrete `IOrchestratorSkill` in `GA.Business.ML`. The harness now measures the deployed router's discrimination against production `ExamplePrompts` values, not the harness author's reconstruction.

## Why reflection (not project ref to Orchestration)

`OrchestratorSkillIntent` lives in `GA.Business.Core.Orchestration`, which this test project does not reference. `SkillIntentAdapter` (defined inline in the harness) is a literal re-implementation of `OrchestratorSkillIntent`'s `Id`/`Description`/`ExamplePrompts` projection — `Execute` is a no-op since routing never invokes it.

## What it covers

17 `IOrchestratorSkill` implementations from `GA.Business.ML.Agents.Skills.*`. 16 participate in semantic routing; `FretSpanSkill` has zero `ExamplePrompts` by design (regex-routed in production) — surfaced in test output, not flagged as malformed.

## What it doesn't cover (and why that's OK for v0.2)

Four non-skill intents in `GA.Business.Core.Orchestration` (`AlgebraIntent`, `TabOptimizeIntent`, `TabAnalyzeIntent`, `VoicingIntent`). None appear in the v0.1 labeled prompt set, so excluding them doesn't change observed F1. If v0.3 grows the corpus to include them, the next iteration can add the project reference.

## New smoke test (runs in CI without Ollama)

`ProductionLikeRegistry_LoadsAllSkillIntents`:
- Constructs every reflected skill via DI with stub cross-cutting deps
- Asserts ≥15 skill intents loaded
- Pins the `skill.{name}` ID convention
- Spot-checks known IDs (`skill.chordinfo`, `skill.modes`, `skill.commontones`)
- Catches "new skill ctor needs a stub we forgot" and "reflection scan can't find skills" early

## Opt-out

`GA_EVAL_USE_STUB_REGISTRY=1` keeps the v0.1 hand-typed registry — useful for harness-validation runs comparing reflection-load metrics against the prior baseline.

## Test plan

- [x] `dotnet build Tests/Common/GA.Business.ML.Tests` — 0 errors
- [x] `ProductionLikeRegistry_LoadsAllSkillIntents` (new smoke test) — passes
- [x] Full Memory + hook-plumbing + curator suite — 39/39 pass (no regression)
- [ ] End-to-end baseline run (`RunBaseline_EmitReport`) — still `[Explicit]`, needs live Ollama; defer to operator

Refs: task #105, PR #162 review F-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)