### PR TITLE
feat(eval): routing harness v0.3 — grow labeled corpus to 5 prompts per intent

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Data/routing-eval-prompts.json
+++ b/Tests/Common/GA.Business.ML.Tests/Data/routing-eval-prompts.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.1",
-  "description": "Labeled prompt set for SemanticIntentRouter evaluation. v0.1.1: dropped skill.fretspan (regex-routed in production, not semantic), relabeled 'G mixolydian' from scaleinfo→modes, rephrased the progressionmood prompt to match production's transform semantics. Each entry pairs a user-style prompt with the intent ID it SHOULD route to. The harness routes the prompt through SemanticIntentRouter (with real embeddings + DefaultRoutingHintProvider) and compares the chosen intent against expectedIntentId.\n\nKNOWN GAPS (v0.1 → v0.2): per Agent-tool review on PR #162, stub IIntent registry diverges from production for several intents (F3). Reflect-loading from production DI is tracked as a follow-up task. Until that lands, baseline is for HARNESS validation only, NOT regression gating.",
+  "version": "0.3.0",
+  "description": "Labeled prompt set for SemanticIntentRouter evaluation. v0.3 (task #106): grew labeled corpus to ≥5 prompts per intent (was avg 1.7/intent at v0.1.1). New prompts tagged 'v0.3-seed' — drafted by the harness author as plausible candidates; some routing-ambiguity is expected. Operator should spot-check after the first v0.3 eval run and either confirm or relabel any seed whose routing diverges from human intuition.\n\nIntent count: 16 (unchanged from v0.2). Total prompt count: 80 (27 existing + 53 v0.3 seeds).\n\nHISTORY:\n  v0.1.0: initial 27 prompts, average 1.7/intent — insufficient for stable per-intent F1.\n  v0.1.1: dropped skill.fretspan (regex-routed in production, not semantic), relabeled 'G mixolydian' from scaleinfo→modes, rephrased the progressionmood prompt to match production's transform semantics.\n  v0.2  : harness reflect-loads production IIntent set (PR #168). Corpus unchanged.\n  v0.3  : grew labeled corpus to ≥5 prompts per intent. Per-intent F1 now has enough support to be statistically meaningful.\n\nKNOWN GAPS: still missing labeled prompts for AlgebraIntent, TabOptimizeIntent, TabAnalyzeIntent, VoicingIntent (the four non-skill intents that live in GA.Business.Core.Orchestration). The v0.2 harness doesn't load them either, so this is consistent.",
   "lastUpdated": "2026-05-11",
   "intentIdsCovered": [
     "skill.chordinfo",
@@ -23,30 +23,98 @@
   "prompts": [
     { "id": "ci-1",  "prompt": "what notes are in Cmaj7?",                              "expectedIntentId": "skill.chordinfo",          "tags": ["common"] },
     { "id": "ci-2",  "prompt": "spell a Bbdim chord",                                   "expectedIntentId": "skill.chordinfo",          "tags": ["common"] },
+    { "id": "ci-3",  "prompt": "tell me about Dm7",                                     "expectedIntentId": "skill.chordinfo",          "tags": ["v0.3-seed"] },
+    { "id": "ci-4",  "prompt": "spell an Eb7#9 chord",                                  "expectedIntentId": "skill.chordinfo",          "tags": ["v0.3-seed", "jargon"] },
+    { "id": "ci-5",  "prompt": "what makes a chord a major seventh",                    "expectedIntentId": "skill.chordinfo",          "tags": ["v0.3-seed", "conceptual"] },
+
     { "id": "si-1",  "prompt": "notes in the A natural minor scale",                    "expectedIntentId": "skill.scaleinfo",          "tags": ["common"] },
+    { "id": "si-2",  "prompt": "notes of the harmonic minor scale",                     "expectedIntentId": "skill.scaleinfo",          "tags": ["v0.3-seed"] },
+    { "id": "si-3",  "prompt": "scale tones for D melodic minor",                       "expectedIntentId": "skill.scaleinfo",          "tags": ["v0.3-seed"] },
+    { "id": "si-4",  "prompt": "what's in the G major scale",                           "expectedIntentId": "skill.scaleinfo",          "tags": ["v0.3-seed"] },
+    { "id": "si-5",  "prompt": "spell out C natural minor",                             "expectedIntentId": "skill.scaleinfo",          "tags": ["v0.3-seed"] },
+
     { "id": "mo-1",  "prompt": "what are the modes of the major scale",                 "expectedIntentId": "skill.modes",              "tags": ["common"] },
     { "id": "mo-2",  "prompt": "list the seven modes",                                  "expectedIntentId": "skill.modes",              "tags": ["common"] },
     { "id": "mo-3",  "prompt": "what notes are in G mixolydian",                        "expectedIntentId": "skill.modes",              "tags": ["modal-overlap", "relabeled-v0.1.1"] },
+    { "id": "mo-4",  "prompt": "explain the Lydian mode",                               "expectedIntentId": "skill.modes",              "tags": ["v0.3-seed"] },
+    { "id": "mo-5",  "prompt": "what is the third mode of major",                       "expectedIntentId": "skill.modes",              "tags": ["v0.3-seed"] },
+
     { "id": "in-1",  "prompt": "interval between C and G",                              "expectedIntentId": "skill.interval",           "tags": ["common"] },
     { "id": "in-2",  "prompt": "what's a perfect fifth",                                "expectedIntentId": "skill.interval",           "tags": ["common"] },
+    { "id": "in-3",  "prompt": "interval from F to Bb",                                 "expectedIntentId": "skill.interval",           "tags": ["v0.3-seed"] },
+    { "id": "in-4",  "prompt": "what is a minor third up from D",                       "expectedIntentId": "skill.interval",           "tags": ["v0.3-seed"] },
+    { "id": "in-5",  "prompt": "name the interval D to A",                              "expectedIntentId": "skill.interval",           "tags": ["v0.3-seed"] },
+
     { "id": "cs-1",  "prompt": "what chord can substitute for G7",                      "expectedIntentId": "skill.chordsubstitution", "tags": ["common"] },
     { "id": "cs-2",  "prompt": "tritone substitution for D7",                           "expectedIntentId": "skill.chordsubstitution", "tags": ["jargon"] },
+    { "id": "cs-3",  "prompt": "good substitute for the V chord",                       "expectedIntentId": "skill.chordsubstitution", "tags": ["v0.3-seed"] },
+    { "id": "cs-4",  "prompt": "alternative chord for Cmaj7",                           "expectedIntentId": "skill.chordsubstitution", "tags": ["v0.3-seed"] },
+    { "id": "cs-5",  "prompt": "modal interchange substitutes for C major",             "expectedIntentId": "skill.chordsubstitution", "tags": ["v0.3-seed", "jargon"] },
+
     { "id": "bc-1",  "prompt": "easy chords for beginners",                             "expectedIntentId": "skill.beginnerchords",     "tags": ["common"] },
     { "id": "bc-2",  "prompt": "first chords to learn on guitar",                       "expectedIntentId": "skill.beginnerchords",     "tags": ["common"] },
+    { "id": "bc-3",  "prompt": "what chords should I learn first",                      "expectedIntentId": "skill.beginnerchords",     "tags": ["v0.3-seed"] },
+    { "id": "bc-4",  "prompt": "simple chord shapes for a new guitarist",               "expectedIntentId": "skill.beginnerchords",     "tags": ["v0.3-seed"] },
+    { "id": "bc-5",  "prompt": "starter chords for an absolute beginner",               "expectedIntentId": "skill.beginnerchords",     "tags": ["v0.3-seed"] },
+
     { "id": "pm-1",  "prompt": "how do I make this minor progression sound brighter",   "expectedIntentId": "skill.progressionmood",    "tags": ["common", "transform-semantics"] },
+    { "id": "pm-2",  "prompt": "make C G Am F sound darker",                            "expectedIntentId": "skill.progressionmood",    "tags": ["v0.3-seed", "transform-semantics"] },
+    { "id": "pm-3",  "prompt": "darken a vi-IV-I-V progression",                        "expectedIntentId": "skill.progressionmood",    "tags": ["v0.3-seed", "roman-numeral"] },
+    { "id": "pm-4",  "prompt": "brighten up a minor key tune",                          "expectedIntentId": "skill.progressionmood",    "tags": ["v0.3-seed"] },
+    { "id": "pm-5",  "prompt": "give this progression a sadder feel",                   "expectedIntentId": "skill.progressionmood",    "tags": ["v0.3-seed"] },
+
     { "id": "co-1",  "prompt": "circle of fifths positions",                            "expectedIntentId": "skill.circleoffifths",     "tags": ["common"] },
+    { "id": "co-2",  "prompt": "explain the circle of fifths",                          "expectedIntentId": "skill.circleoffifths",     "tags": ["v0.3-seed"] },
+    { "id": "co-3",  "prompt": "show me the circle of fourths",                         "expectedIntentId": "skill.circleoffifths",     "tags": ["v0.3-seed"] },
+    { "id": "co-4",  "prompt": "what key is across the circle from D",                  "expectedIntentId": "skill.circleoffifths",     "tags": ["v0.3-seed"] },
+    { "id": "co-5",  "prompt": "neighboring keys on the circle of fifths",              "expectedIntentId": "skill.circleoffifths",     "tags": ["v0.3-seed"] },
+
     { "id": "pr-1",  "prompt": "give me a 20 minute practice routine",                  "expectedIntentId": "skill.practiceroutine",    "tags": ["common"] },
+    { "id": "pr-2",  "prompt": "design a practice plan for me",                         "expectedIntentId": "skill.practiceroutine",    "tags": ["v0.3-seed"] },
+    { "id": "pr-3",  "prompt": "what should I practice today",                          "expectedIntentId": "skill.practiceroutine",    "tags": ["v0.3-seed"] },
+    { "id": "pr-4",  "prompt": "build a 30 minute practice schedule",                   "expectedIntentId": "skill.practiceroutine",    "tags": ["v0.3-seed"] },
+    { "id": "pr-5",  "prompt": "give me a daily practice outline",                      "expectedIntentId": "skill.practiceroutine",    "tags": ["v0.3-seed"] },
+
     { "id": "ge-1",  "prompt": "essential chords for blues guitar",                     "expectedIntentId": "skill.genreessentials",    "tags": ["common"] },
+    { "id": "ge-2",  "prompt": "essential scales for jazz guitar",                      "expectedIntentId": "skill.genreessentials",    "tags": ["v0.3-seed"] },
+    { "id": "ge-3",  "prompt": "country guitar starter chords",                         "expectedIntentId": "skill.genreessentials",    "tags": ["v0.3-seed", "starter-overlap"] },
+    { "id": "ge-4",  "prompt": "must-know progressions for rock",                       "expectedIntentId": "skill.genreessentials",    "tags": ["v0.3-seed"] },
+    { "id": "ge-5",  "prompt": "key chords in funk music",                              "expectedIntentId": "skill.genreessentials",    "tags": ["v0.3-seed"] },
+
     { "id": "wc-1",  "prompt": "what can you do",                                       "expectedIntentId": "skill.whatcanyoudo",       "tags": ["meta"] },
     { "id": "wc-2",  "prompt": "what are your capabilities",                            "expectedIntentId": "skill.whatcanyoudo",       "tags": ["meta"] },
+    { "id": "wc-3",  "prompt": "help me figure out what to ask",                        "expectedIntentId": "skill.whatcanyoudo",       "tags": ["v0.3-seed", "meta"] },
+    { "id": "wc-4",  "prompt": "what features does this chatbot have",                  "expectedIntentId": "skill.whatcanyoudo",       "tags": ["v0.3-seed", "meta"] },
+    { "id": "wc-5",  "prompt": "show me what you know",                                 "expectedIntentId": "skill.whatcanyoudo",       "tags": ["v0.3-seed", "meta"] },
+
     { "id": "tr-1",  "prompt": "transpose C major up a perfect fifth",                  "expectedIntentId": "skill.transpose",          "tags": ["common"] },
     { "id": "tr-2",  "prompt": "transpose this progression down a half step",           "expectedIntentId": "skill.transpose",          "tags": ["common", "requires-context"] },
+    { "id": "tr-3",  "prompt": "transpose C-Am-F-G to G major",                         "expectedIntentId": "skill.transpose",          "tags": ["v0.3-seed"] },
+    { "id": "tr-4",  "prompt": "shift this progression up a whole step",                "expectedIntentId": "skill.transpose",          "tags": ["v0.3-seed"] },
+    { "id": "tr-5",  "prompt": "bring D minor down to A minor",                         "expectedIntentId": "skill.transpose",          "tags": ["v0.3-seed"] },
+
     { "id": "ct-1",  "prompt": "common tones between Cmaj7 and Am7",                    "expectedIntentId": "skill.commontones",        "tags": ["common"] },
+    { "id": "ct-2",  "prompt": "shared notes between G7 and Cmaj7",                     "expectedIntentId": "skill.commontones",        "tags": ["v0.3-seed"] },
+    { "id": "ct-3",  "prompt": "which pitches do Dm and Bbmaj share",                   "expectedIntentId": "skill.commontones",        "tags": ["v0.3-seed"] },
+    { "id": "ct-4",  "prompt": "common tones for F and G7",                             "expectedIntentId": "skill.commontones",        "tags": ["v0.3-seed"] },
+    { "id": "ct-5",  "prompt": "overlapping notes in Cmaj7 and Em7",                    "expectedIntentId": "skill.commontones",        "tags": ["v0.3-seed"] },
+
     { "id": "dc-1",  "prompt": "diatonic chords in C major",                            "expectedIntentId": "skill.diatonicchords",     "tags": ["common"] },
     { "id": "dc-2",  "prompt": "what chords are in the key of D",                       "expectedIntentId": "skill.diatonicchords",     "tags": ["common"] },
+    { "id": "dc-3",  "prompt": "what is the IV chord in A major",                       "expectedIntentId": "skill.diatonicchords",     "tags": ["v0.3-seed", "roman-numeral"] },
+    { "id": "dc-4",  "prompt": "list the chords in G major",                            "expectedIntentId": "skill.diatonicchords",     "tags": ["v0.3-seed"] },
+    { "id": "dc-5",  "prompt": "diatonic seventh chords in E minor",                    "expectedIntentId": "skill.diatonicchords",     "tags": ["v0.3-seed"] },
+
     { "id": "ki-1",  "prompt": "what key is this progression in C G Am F",              "expectedIntentId": "skill.keyidentification", "tags": ["common"] },
     { "id": "ki-2",  "prompt": "identify the key of Am F C G",                          "expectedIntentId": "skill.keyidentification", "tags": ["minor-tonic"] },
+    { "id": "ki-3",  "prompt": "what key is C F G C in",                                "expectedIntentId": "skill.keyidentification", "tags": ["v0.3-seed"] },
+    { "id": "ki-4",  "prompt": "tell me the key of Em Am D G",                          "expectedIntentId": "skill.keyidentification", "tags": ["v0.3-seed", "minor-tonic"] },
+    { "id": "ki-5",  "prompt": "find the tonic of A E F#m D",                           "expectedIntentId": "skill.keyidentification", "tags": ["v0.3-seed"] },
+
     { "id": "pc-1",  "prompt": "what chord comes next after C Am F",                    "expectedIntentId": "skill.progressioncompletion", "tags": ["common"] },
-    { "id": "pc-2",  "prompt": "suggest a chord to finish this progression",            "expectedIntentId": "skill.progressioncompletion", "tags": ["common"] }
+    { "id": "pc-2",  "prompt": "suggest a chord to finish this progression",            "expectedIntentId": "skill.progressioncompletion", "tags": ["common"] },
+    { "id": "pc-3",  "prompt": "complete this: C Am F",                                 "expectedIntentId": "skill.progressioncompletion", "tags": ["v0.3-seed"] },
+    { "id": "pc-4",  "prompt": "what should come after G C in this song",               "expectedIntentId": "skill.progressioncompletion", "tags": ["v0.3-seed"] },
+    { "id": "pc-5",  "prompt": "predict the next chord in I V vi",                      "expectedIntentId": "skill.progressioncompletion", "tags": ["v0.3-seed", "roman-numeral"] }
   ]
 }


### PR DESCRIPTION
Closes task #106. Brings the labeled prompt set from 27 prompts (avg 1.7/intent) to **80 prompts (exactly 5/intent across all 16 intents)**. Per-intent F1 now has enough support to be statistically meaningful.

## What's in the diff

- 53 new prompts tagged `v0.3-seed` — drafted as plausible candidates
- Updated header description + lastUpdated date
- Bumped version to 0.3.0

## Phrasing strategy

- Mix of formal (`notes of the harmonic minor scale`) and colloquial (`tell me about Dm7`) wording
- Roman-numeral variants where realistic (`IV chord in A major`, `vi-IV-I-V`)
- Jargon coverage (`Eb7#9`, `tritone substitution`, `modal interchange`)
- Meta intent (`skill.whatcanyoudo`) gets non-overlapping framings (`help me figure out what to ask`, `what features does this chatbot have`)
- Avoided building in known-ambiguous prompts that would route 50/50 between two intents — those need operator decision before adding

## Per-intent counts (post-PR)

```
skill.beginnerchords             5
skill.chordinfo                  5
skill.chordsubstitution          5
skill.circleoffifths             5
skill.commontones                5
skill.diatonicchords             5
skill.genreessentials            5
skill.interval                   5
skill.keyidentification          5
skill.modes                      5
skill.practiceroutine            5
skill.progressioncompletion      5
skill.progressionmood            5
skill.scaleinfo                  5
skill.transpose                  5
skill.whatcanyoudo               5
```

## Review request

These are seeds, not gospel. After the first v0.3 baseline run lands, operator should spot-check any prompt that routes to something other than its `expectedIntentId`. If a seed is genuinely ambiguous, relabel it (or drop it) rather than blaming the router.

## Test plan

- [x] `node` JSON-parse check — 80 prompts, 16 intents, min 5/intent
- [x] `ProductionLikeRegistry_LoadsAllSkillIntents` (smoke test from PR #168) — passes
- [ ] `RunBaseline_EmitReport` against new corpus — `[Explicit]`, requires Ollama + tokens; defer to operator

## Out of scope

- AlgebraIntent / TabOptimizeIntent / TabAnalyzeIntent / VoicingIntent coverage. The v0.2 harness doesn't load these either (they live in `GA.Business.Core.Orchestration`, which the test project doesn't reference). Consistent gap; tracked for a future v0.4 that adds the cross-project reference.

Refs: task #106, PR #168, PR #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)