### PR TITLE
docs(solutions): MemoryHook conflates transcript log with durable memory

### DIFF
--- a/Apps/GaMemoryCli/Program.cs
+++ b/Apps/GaMemoryCli/Program.cs
@@ -38,11 +38,24 @@ return command switch
 static async Task<int> RunCurateAsync(string[] args)
 {
     string? instructions = null;
+    // Type-filter default: skip "response" entries. The chatbot's MemoryHook
+    // writes one per chat turn — these are transient logs, not durable
+    // knowledge. The curator is designed for fact / preference / focus
+    // entries (the kind that benefit from merging duplicates + replacing
+    // stale values). Operator can opt back in with --include-responses.
+    // Discovered 2026-05-11: 100% of a real ~/.ga/memory.json was type=
+    // response, dominating the curator input with content it has no useful
+    // curation to do on.
+    var includeResponses = false;
+    var excludeTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "response" };
     for (var i = 0; i < args.Length; i++)
     {
         if (args[i] == "--instructions" && i + 1 < args.Length)
             instructions = args[++i];
+        else if (args[i] == "--include-responses")
+            includeResponses = true;
     }
+    if (includeResponses) excludeTypes.Remove("response");
 
     var storePath = MemoryStore.DefaultStorePath;
     if (!File.Exists(storePath))
@@ -51,8 +64,26 @@ static async Task<int> RunCurateAsync(string[] args)
         return 2;
     }
 
-    var entries = LoadEntries(storePath);
-    Console.WriteLine($"Loaded {entries.Count} entries from {storePath}.");
+    var allEntries = LoadEntries(storePath);
+    var entries = allEntries.Where(e => !excludeTypes.Contains(e.Type)).ToList();
+    var skipped = allEntries.Count - entries.Count;
+    Console.WriteLine(
+        $"Loaded {allEntries.Count} entries from {storePath}" +
+        (skipped > 0
+            ? $" (filtered {skipped} entries with excluded types: {string.Join(", ", excludeTypes)}; " +
+              "pass --include-responses to keep them)"
+            : ""));
+
+    if (entries.Count == 0)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Nothing left to curate after type filtering. This usually means the");
+        Console.WriteLine("store is dominated by transient 'response' entries — the curator is");
+        Console.WriteLine("designed for durable memory (fact / preference / focus). Either:");
+        Console.WriteLine("  • Wait for the chatbot to accumulate non-response memory entries, or");
+        Console.WriteLine("  • Pass --include-responses to curate them anyway (not recommended).");
+        return 0;
+    }
 
     var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
     if (!AnthropicProvider.IsAvailable(config))
@@ -193,7 +224,11 @@ static int PrintUsage()
     Console.WriteLine("ga-memory — Dreams-lite curator over the chatbot MemoryStore");
     Console.WriteLine();
     Console.WriteLine("Commands:");
-    Console.WriteLine("  curate [--instructions \"...\"]   Run the curator, write a candidate");
+    Console.WriteLine("  curate [--instructions \"...\"] [--include-responses]");
+    Console.WriteLine("                                  Run the curator, write a candidate.");
+    Console.WriteLine("                                  By default skips type=response entries");
+    Console.WriteLine("                                  (transient chat logs). Pass");
+    Console.WriteLine("                                  --include-responses to curate them.");
     Console.WriteLine("  diff <candidate-path>           Show the diff summary for a candidate");
     Console.WriteLine("  promote <candidate-path>        Atomic swap (with .bak backup)");
     Console.WriteLine();

--- a/ReactComponents/ga-react-components/src/pages/GaussianSplatTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/GaussianSplatTest.tsx
@@ -1,15 +1,32 @@
 /**
  * Gaussian Splat viewer — native Three.js renderer (no iframe, no PlayCanvas).
  *
- * Loads a .compressed.ply from SuperSplat's CDN by scene id and renders it via
- * @mkkellogg/gaussian-splats-3d on top of our own Three.js canvas. SuperSplat's
- * newer SOG format (WebP textures + meta.json) isn't decodable by the lib yet,
- * so SOG scenes display a friendly fallback message — see PR #478 upstream.
+ * Three source kinds:
+ *   - superspl-id: probes SuperSplat CDN /v1../v9 for compressed PLY / SOG.
+ *   - direct-url:  any http(s) URL pointing at .ply / .compressed.ply /
+ *                  .splat / .ksplat; format detected from extension.
+ *   - local-file:  user-picked file (any of the above) loaded via blob URL.
+ *
+ * Renders via @mkkellogg/gaussian-splats-3d. SuperSplat's newer SOG format
+ * (WebP textures + meta.json) isn't decodable by the lib yet, so SOG scenes
+ * surface a friendly fallback — see PR #478 upstream.
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
-import { Box, Button, Chip, LinearProgress, Paper, Stack, TextField, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  LinearProgress,
+  Paper,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { DemoErrorBoundary } from '../components/Common/DemoErrorBoundary';
 
 interface ScenePreset {
@@ -24,22 +41,69 @@ const PRESETS: ScenePreset[] = [
 ];
 const DEFAULT_SCENE_ID = PRESETS[0].id;
 const SUPERSPLAT_CDN = 'https://d28zzqy0iyovbz.cloudfront.net';
-
-// SuperSplat re-encodes scenes under per-scene version paths (v1..v9). v1 and
-// v7 cover the bulk of scenes I've sampled; the rest are tried as fallbacks.
 const VERSION_PATHS = ['v1', 'v7', 'v2', 'v3', 'v4', 'v5', 'v6', 'v8', 'v9'];
 
-interface ResolvedScene {
-  format: 'ply' | 'sog';
-  version: string;
-  url: string; // populated for ply only
+// ───────────────────────────── source types ─────────────────────────────
+
+type SplatSource =
+  | { kind: 'superspl-id'; sceneId: string }
+  | { kind: 'direct-url';  url: string; label: string }
+  | { kind: 'local-file';  file: File; objectUrl: string; label: string };
+
+function sourceKey(s: SplatSource): string {
+  switch (s.kind) {
+    case 'superspl-id': return `superspl:${s.sceneId}`;
+    case 'direct-url':  return `url:${s.url}`;
+    case 'local-file':  return `file:${s.objectUrl}`;
+  }
 }
 
-function extractSceneId(input: string): string {
+function sourceLabel(s: SplatSource): string {
+  switch (s.kind) {
+    case 'superspl-id': return s.sceneId;
+    case 'direct-url':  return s.label;
+    case 'local-file':  return s.label;
+  }
+}
+
+function parseInputToSource(input: string): SplatSource {
   const trimmed = input.trim();
-  if (!trimmed) return DEFAULT_SCENE_ID;
-  const match = trimmed.match(/scene\/([a-zA-Z0-9-]+)/);
-  return match ? match[1] : trimmed;
+  if (!trimmed) return { kind: 'superspl-id', sceneId: DEFAULT_SCENE_ID };
+
+  // SuperSplat scene URL: https://superspl.at/scene/<id>
+  const m = trimmed.match(/superspl\.at\/scene\/([a-zA-Z0-9-]+)/i);
+  if (m) return { kind: 'superspl-id', sceneId: m[1] };
+
+  // Direct URL — let the lib fetch it.
+  if (/^https?:\/\//i.test(trimmed)) {
+    const filename = trimmed.split('/').pop()?.split('?')[0] || trimmed;
+    return { kind: 'direct-url', url: trimmed, label: filename };
+  }
+
+  // Bare alphanumeric: treat as a SuperSplat scene id.
+  if (/^[a-zA-Z0-9-]+$/.test(trimmed)) {
+    return { kind: 'superspl-id', sceneId: trimmed };
+  }
+
+  // Anything else: assume it's a URL fragment / unusual scheme.
+  return { kind: 'direct-url', url: trimmed, label: trimmed };
+}
+
+// Format hint for the lib; for non-SuperSplat blob/data URLs we have to be
+// explicit because the lib can't sniff format without an extension.
+type LibFormatKey = 'Ply' | 'KSplat' | 'Splat';
+function detectFormatFromName(name: string): LibFormatKey | undefined {
+  const n = name.toLowerCase();
+  if (n.endsWith('.compressed.ply') || n.endsWith('.ply')) return 'Ply';
+  if (n.endsWith('.ksplat')) return 'KSplat';
+  if (n.endsWith('.splat'))  return 'Splat';
+  return undefined;
+}
+
+interface SuperSplatResolution {
+  format: 'ply' | 'sog';
+  version: string;
+  url: string; // for ply only
 }
 
 async function probe(url: string): Promise<boolean> {
@@ -51,7 +115,7 @@ async function probe(url: string): Promise<boolean> {
   }
 }
 
-async function resolveScene(sceneId: string): Promise<ResolvedScene | null> {
+async function resolveSuperSplatScene(sceneId: string): Promise<SuperSplatResolution | null> {
   for (const v of VERSION_PATHS) {
     const plyUrl = `${SUPERSPLAT_CDN}/${sceneId}/${v}/scene.compressed.ply`;
     const sogUrl = `${SUPERSPLAT_CDN}/${sceneId}/${v}/meta.json`;
@@ -62,25 +126,66 @@ async function resolveScene(sceneId: string): Promise<ResolvedScene | null> {
   return null;
 }
 
+// ───────────────────────────── component ─────────────────────────────
+
 const GaussianSplatTest: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<GaussianSplats3D.Viewer | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // Tracks the object URL of the currently displayed local file so we can
+  // revoke it when a new source replaces it. URLs from earlier files would
+  // otherwise leak the file's memory until the page is closed.
+  const lastObjectUrlRef = useRef<string | null>(null);
 
   const [draftInput, setDraftInput] = useState(`https://superspl.at/scene/${DEFAULT_SCENE_ID}`);
-  const [sceneId, setSceneId] = useState(DEFAULT_SCENE_ID);
+  const [source, setSource] = useState<SplatSource>({ kind: 'superspl-id', sceneId: DEFAULT_SCENE_ID });
   const [loading, setLoading] = useState(true);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
+  const replaceSource = useCallback((next: SplatSource) => {
+    setSource((prev) => {
+      // Revoke any previous blob URL we created; ignore URLs we didn't make.
+      if (lastObjectUrlRef.current && lastObjectUrlRef.current !== (next.kind === 'local-file' ? next.objectUrl : null)) {
+        try { URL.revokeObjectURL(lastObjectUrlRef.current); } catch { /* already revoked */ }
+        lastObjectUrlRef.current = null;
+      }
+      if (next.kind === 'local-file') lastObjectUrlRef.current = next.objectUrl;
+      // Avoid no-op state updates that would refire effects unnecessarily.
+      if (sourceKey(prev) === sourceKey(next)) return prev;
+      return next;
+    });
+  }, []);
+
   const handleLoad = useCallback(() => {
-    const next = extractSceneId(draftInput);
-    if (next !== sceneId) setSceneId(next);
-  }, [draftInput, sceneId]);
+    replaceSource(parseInputToSource(draftInput));
+  }, [draftInput, replaceSource]);
 
   const handlePreset = useCallback((preset: ScenePreset) => {
     setDraftInput(`https://superspl.at/scene/${preset.id}`);
-    if (preset.id !== sceneId) setSceneId(preset.id);
-  }, [sceneId]);
+    replaceSource({ kind: 'superspl-id', sceneId: preset.id });
+  }, [replaceSource]);
+
+  const handleFile = useCallback((file: File) => {
+    const objectUrl = URL.createObjectURL(file);
+    setDraftInput(file.name);
+    replaceSource({ kind: 'local-file', file, objectUrl, label: file.name });
+  }, [replaceSource]);
+
+  const onFileInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    // Allow re-picking the same file later.
+    e.target.value = '';
+  }, [handleFile]);
+
+  // Revoke any outstanding blob URL when the page unmounts.
+  useEffect(() => () => {
+    if (lastObjectUrlRef.current) {
+      try { URL.revokeObjectURL(lastObjectUrlRef.current); } catch { /* already revoked */ }
+      lastObjectUrlRef.current = null;
+    }
+  }, []);
 
   // Gotchas this hook exists to work around — keep this comment, the wins
   // here cost a session of experimentation:
@@ -128,6 +233,7 @@ const GaussianSplatTest: React.FC = () => {
     };
 
     let cancelled = false;
+    const key = sourceKey(source);
     setLoading(true);
     setProgress(0);
     setError(null);
@@ -135,10 +241,11 @@ const GaussianSplatTest: React.FC = () => {
     loadChainRef.current = loadChainRef.current
       .catch(() => undefined)
       .then(async () => {
-        if (lastLoadedRef.current === sceneId) {
+        if (lastLoadedRef.current === key) {
           if (!cancelled) setLoading(false);
           return;
         }
+
         const clearLoadedSplat = async () => {
           const existing = viewerRef.current;
           if (!existing || lastLoadedRef.current === null) return;
@@ -147,45 +254,76 @@ const GaussianSplatTest: React.FC = () => {
           lastLoadedRef.current = null;
         };
 
-        const resolved = await resolveScene(sceneId);
-        if (!resolved) {
-          await clearLoadedSplat();
-          if (!cancelled) {
-            setError(`Scene ${sceneId} not found on the SuperSplat CDN under any known version path (v1–v9).`);
-            setLoading(false);
+        // Resolve to a concrete URL + format hint per source kind.
+        let url: string;
+        let formatKey: LibFormatKey | undefined;
+
+        if (source.kind === 'superspl-id') {
+          const resolved = await resolveSuperSplatScene(source.sceneId);
+          if (!resolved) {
+            await clearLoadedSplat();
+            if (!cancelled) {
+              setError(`Scene ${source.sceneId} not found on the SuperSplat CDN under any known version path (v1–v9).`);
+              setLoading(false);
+            }
+            return;
           }
-          return;
-        }
-        if (resolved.format === 'sog') {
-          await clearLoadedSplat();
-          if (!cancelled) {
-            setError(
-              `Scene ${sceneId} (${resolved.version}) uses SuperSplat's newer SOG format (WebP textures + meta.json). ` +
-              `The Three.js renderer here (@mkkellogg/gaussian-splats-3d 0.4.7) only supports the older compressed PLY. ` +
-              `SOG support is in flight upstream — see github.com/mkkellogg/GaussianSplats3D/pull/478.`
-            );
-            setLoading(false);
+          if (resolved.format === 'sog') {
+            await clearLoadedSplat();
+            if (!cancelled) {
+              setError(
+                `Scene ${source.sceneId} (${resolved.version}) uses SuperSplat's newer SOG format (WebP textures + meta.json). ` +
+                `The Three.js renderer here (@mkkellogg/gaussian-splats-3d 0.4.7) only supports the older compressed PLY. ` +
+                `SOG support is in flight upstream — see github.com/mkkellogg/GaussianSplats3D/pull/478.`
+              );
+              setLoading(false);
+            }
+            return;
           }
-          return;
+          url = resolved.url;
+          formatKey = 'Ply';
+        } else if (source.kind === 'direct-url') {
+          url = source.url;
+          formatKey = detectFormatFromName(source.label) ?? detectFormatFromName(source.url);
+        } else {
+          url = source.objectUrl;
+          formatKey = detectFormatFromName(source.label);
+          if (!formatKey) {
+            await clearLoadedSplat();
+            if (!cancelled) {
+              setError(
+                `Couldn't detect splat format from "${source.label}". Supported extensions: .ply, .compressed.ply, .splat, .ksplat.`
+              );
+              setLoading(false);
+            }
+            return;
+          }
         }
+
         const v = ensureViewer();
         try {
           if (lastLoadedRef.current !== null && v.getSceneCount?.() > 0) {
             await v.removeSplatScene(0);
           }
-          await v.addSplatScene(resolved.url, {
+          const sceneOptions: Record<string, unknown> = {
             progressiveLoad: false,
             showLoadingUI: false,
             // SuperSplat / COLMAP captures author +Y as gravity (down). Rotate
             // 180° around the X axis (quaternion x,y,z,w = 1,0,0,0) so subjects
-            // render right-side-up under Three.js's Y-up convention. Applies to
-            // the splat geometry itself so cached viewers also pick it up.
+            // render right-side-up under Three.js's Y-up convention.
             rotation: [1, 0, 0, 0],
             onProgress: (percent: number) => {
               if (!cancelled) setProgress(percent);
             },
-          });
-          lastLoadedRef.current = sceneId;
+          };
+          if (formatKey) {
+            const fmtEnum = (GaussianSplats3D as unknown as { SceneFormat?: Record<string, unknown> }).SceneFormat;
+            if (fmtEnum && fmtEnum[formatKey] !== undefined) {
+              sceneOptions.format = fmtEnum[formatKey];
+            }
+          }
+          await v.addSplatScene(url, sceneOptions);
+          lastLoadedRef.current = key;
           if (!cancelled) setLoading(false);
         } catch (err) {
           if (!cancelled) {
@@ -199,14 +337,17 @@ const GaussianSplatTest: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [sceneId]);
+  }, [source]);
+
+  const currentLabel = sourceLabel(source);
+  const isPresetSelected = (preset: ScenePreset) =>
+    source.kind === 'superspl-id' && source.sceneId === preset.id;
 
   return (
     <DemoErrorBoundary demoName="Gaussian Splat">
       <Box
         sx={{
           width: '100%',
-          // 100dvh respects mobile address-bar collapse; 100vh fallback for browsers without dvh.
           height: ['100vh', '100dvh'],
           bgcolor: '#05050d',
           display: 'flex',
@@ -225,8 +366,6 @@ const GaussianSplatTest: React.FC = () => {
             borderRadius: 0,
             borderBottom: '1px solid rgba(189,164,255,0.24)',
             display: 'flex',
-            // Stack rows on phones, single row on tablets+: header rows are
-            // title/badge, then presets, then URL+Load on narrow viewports.
             flexDirection: { xs: 'column', md: 'row' },
             alignItems: { xs: 'stretch', md: 'center' },
             gap: { xs: 0.75, md: 1.5 },
@@ -247,27 +386,29 @@ const GaussianSplatTest: React.FC = () => {
             spacing={0.75}
             sx={{ flexWrap: 'wrap', rowGap: 0.75, overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}
           >
-            {PRESETS.map((preset) => (
-              <Chip
-                key={preset.id}
-                label={preset.label}
-                clickable
-                onClick={() => handlePreset(preset)}
-                variant={preset.id === sceneId ? 'filled' : 'outlined'}
-                sx={{
-                  // Bigger touch target on phones (32px) vs desktop "small" (24px).
-                  height: { xs: 32, sm: 26 },
-                  fontSize: { xs: '0.8rem', sm: '0.75rem' },
-                  color: preset.id === sceneId ? '#0d0d18' : '#bda4ff',
-                  bgcolor: preset.id === sceneId ? '#bda4ff' : 'transparent',
-                  borderColor: 'rgba(189,164,255,0.4)',
-                  fontWeight: preset.id === sceneId ? 600 : 400,
-                  '&:hover': {
-                    bgcolor: preset.id === sceneId ? '#bda4ff' : 'rgba(189,164,255,0.12)',
-                  },
-                }}
-              />
-            ))}
+            {PRESETS.map((preset) => {
+              const selected = isPresetSelected(preset);
+              return (
+                <Chip
+                  key={preset.id}
+                  label={preset.label}
+                  clickable
+                  onClick={() => handlePreset(preset)}
+                  variant={selected ? 'filled' : 'outlined'}
+                  sx={{
+                    height: { xs: 32, sm: 26 },
+                    fontSize: { xs: '0.8rem', sm: '0.75rem' },
+                    color: selected ? '#0d0d18' : '#bda4ff',
+                    bgcolor: selected ? '#bda4ff' : 'transparent',
+                    borderColor: 'rgba(189,164,255,0.4)',
+                    fontWeight: selected ? 600 : 400,
+                    '&:hover': {
+                      bgcolor: selected ? '#bda4ff' : 'rgba(189,164,255,0.12)',
+                    },
+                  }}
+                />
+              );
+            })}
           </Stack>
           <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flex: 1, minWidth: 0 }}>
             <TextField
@@ -275,7 +416,7 @@ const GaussianSplatTest: React.FC = () => {
               value={draftInput}
               onChange={(e) => setDraftInput(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
-              placeholder="superspl.at scene URL or id"
+              placeholder="superspl.at URL, scene id, or direct .ply/.splat/.ksplat URL"
               sx={{
                 flex: 1,
                 minWidth: 0,
@@ -301,6 +442,29 @@ const GaussianSplatTest: React.FC = () => {
             >
               Load
             </Button>
+            <Tooltip title="Open a local .ply, .compressed.ply, .splat, or .ksplat file">
+              <IconButton
+                size="small"
+                onClick={() => fileInputRef.current?.click()}
+                sx={{
+                  color: '#bda4ff',
+                  border: '1px solid rgba(189,164,255,0.4)',
+                  borderRadius: 1,
+                  width: 36,
+                  height: 36,
+                }}
+                aria-label="Open local splat file"
+              >
+                <UploadFileIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".ply,.splat,.ksplat"
+              onChange={onFileInputChange}
+              style={{ display: 'none' }}
+            />
           </Box>
           <Typography
             variant="caption"
@@ -308,9 +472,16 @@ const GaussianSplatTest: React.FC = () => {
               color: '#8b949e',
               fontFamily: 'monospace',
               display: { xs: 'none', md: 'inline' },
+              maxWidth: 220,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
+            title={currentLabel}
           >
-            scene: {sceneId}
+            {source.kind === 'superspl-id' && `scene: ${source.sceneId}`}
+            {source.kind === 'direct-url'  && `url: ${currentLabel}`}
+            {source.kind === 'local-file'  && `file: ${currentLabel}`}
           </Typography>
         </Paper>
 
@@ -320,8 +491,6 @@ const GaussianSplatTest: React.FC = () => {
             sx={{
               position: 'absolute',
               inset: 0,
-              // touch-action: none lets the lib's OrbitControls own the gesture
-              // instead of the browser stealing it for scroll/zoom.
               touchAction: 'none',
               overscrollBehavior: 'contain',
               '& canvas': {
@@ -353,7 +522,7 @@ const GaussianSplatTest: React.FC = () => {
                 <LinearProgress variant="determinate" value={progress} />
               </Box>
               <Typography variant="caption" sx={{ color: '#8b949e' }}>
-                Streaming compressed PLY from SuperSplat CDN.
+                {source.kind === 'local-file' ? 'Decoding local splat file.' : 'Streaming splat data.'}
               </Typography>
             </Box>
           )}

--- a/ReactComponents/ga-react-components/src/pages/GaussianSplatTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/GaussianSplatTest.tsx
@@ -203,39 +203,61 @@ const GaussianSplatTest: React.FC = () => {
 
   return (
     <DemoErrorBoundary demoName="Gaussian Splat">
-      <Box sx={{ width: '100%', height: '100vh', bgcolor: '#05050d', display: 'flex', flexDirection: 'column', position: 'relative' }}>
+      <Box
+        sx={{
+          width: '100%',
+          // 100dvh respects mobile address-bar collapse; 100vh fallback for browsers without dvh.
+          height: ['100vh', '100dvh'],
+          bgcolor: '#05050d',
+          display: 'flex',
+          flexDirection: 'column',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
         <Paper
           elevation={0}
           sx={{
-            px: 2,
-            py: 1.25,
+            px: { xs: 1, sm: 2 },
+            py: { xs: 0.75, sm: 1.25 },
             bgcolor: 'rgba(5,5,13,0.92)',
             color: '#f5f0ff',
             borderRadius: 0,
             borderBottom: '1px solid rgba(189,164,255,0.24)',
             display: 'flex',
-            alignItems: 'center',
-            gap: 1.5,
+            // Stack rows on phones, single row on tablets+: header rows are
+            // title/badge, then presets, then URL+Load on narrow viewports.
+            flexDirection: { xs: 'column', md: 'row' },
+            alignItems: { xs: 'stretch', md: 'center' },
+            gap: { xs: 0.75, md: 1.5 },
             flexWrap: 'wrap',
             zIndex: 2,
           }}
         >
-          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-            Gaussian Splat Viewer
-          </Typography>
-          <Typography variant="caption" sx={{ color: '#bda4ff' }}>
-            Three.js · @mkkellogg/gaussian-splats-3d
-          </Typography>
-          <Stack direction="row" spacing={0.75}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              Gaussian Splat Viewer
+            </Typography>
+            <Typography variant="caption" sx={{ color: '#bda4ff', display: { xs: 'none', sm: 'inline' } }}>
+              Three.js · @mkkellogg/gaussian-splats-3d
+            </Typography>
+          </Box>
+          <Stack
+            direction="row"
+            spacing={0.75}
+            sx={{ flexWrap: 'wrap', rowGap: 0.75, overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}
+          >
             {PRESETS.map((preset) => (
               <Chip
                 key={preset.id}
                 label={preset.label}
-                size="small"
                 clickable
                 onClick={() => handlePreset(preset)}
                 variant={preset.id === sceneId ? 'filled' : 'outlined'}
                 sx={{
+                  // Bigger touch target on phones (32px) vs desktop "small" (24px).
+                  height: { xs: 32, sm: 26 },
+                  fontSize: { xs: '0.8rem', sm: '0.75rem' },
                   color: preset.id === sceneId ? '#0d0d18' : '#bda4ff',
                   bgcolor: preset.id === sceneId ? '#bda4ff' : 'transparent',
                   borderColor: 'rgba(189,164,255,0.4)',
@@ -247,33 +269,47 @@ const GaussianSplatTest: React.FC = () => {
               />
             ))}
           </Stack>
-          <TextField
-            size="small"
-            value={draftInput}
-            onChange={(e) => setDraftInput(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
-            placeholder="superspl.at scene URL or id"
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flex: 1, minWidth: 0 }}>
+            <TextField
+              size="small"
+              value={draftInput}
+              onChange={(e) => setDraftInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
+              placeholder="superspl.at scene URL or id"
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                '& .MuiOutlinedInput-root': {
+                  bgcolor: '#0d1117',
+                  color: 'rgba(255,255,255,0.87)',
+                  '& fieldset': { borderColor: '#30363d' },
+                  '&:hover fieldset': { borderColor: '#58a6ff' },
+                },
+                '& input::placeholder': { color: 'rgba(255,255,255,0.5)', opacity: 1 },
+              }}
+            />
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={handleLoad}
+              sx={{
+                color: '#bda4ff',
+                borderColor: 'rgba(189,164,255,0.4)',
+                minWidth: 64,
+                px: 1.5,
+              }}
+            >
+              Load
+            </Button>
+          </Box>
+          <Typography
+            variant="caption"
             sx={{
-              flex: 1,
-              minWidth: 240,
-              '& .MuiOutlinedInput-root': {
-                bgcolor: '#0d1117',
-                color: 'rgba(255,255,255,0.87)',
-                '& fieldset': { borderColor: '#30363d' },
-                '&:hover fieldset': { borderColor: '#58a6ff' },
-              },
-              '& input::placeholder': { color: 'rgba(255,255,255,0.5)', opacity: 1 },
+              color: '#8b949e',
+              fontFamily: 'monospace',
+              display: { xs: 'none', md: 'inline' },
             }}
-          />
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={handleLoad}
-            sx={{ color: '#bda4ff', borderColor: 'rgba(189,164,255,0.4)' }}
           >
-            Load
-          </Button>
-          <Typography variant="caption" sx={{ color: '#8b949e', fontFamily: 'monospace' }}>
             scene: {sceneId}
           </Typography>
         </Paper>
@@ -284,7 +320,16 @@ const GaussianSplatTest: React.FC = () => {
             sx={{
               position: 'absolute',
               inset: 0,
-              '& canvas': { display: 'block', width: '100%', height: '100%' },
+              // touch-action: none lets the lib's OrbitControls own the gesture
+              // instead of the browser stealing it for scroll/zoom.
+              touchAction: 'none',
+              overscrollBehavior: 'contain',
+              '& canvas': {
+                display: 'block',
+                width: '100%',
+                height: '100%',
+                touchAction: 'none',
+              },
             }}
           />
           {loading && !error && (
@@ -304,7 +349,7 @@ const GaussianSplatTest: React.FC = () => {
               <Typography variant="body2" sx={{ color: '#f5f0ff' }}>
                 Loading splat… {Math.round(progress)}%
               </Typography>
-              <Box sx={{ width: 280 }}>
+              <Box sx={{ width: { xs: '70vw', sm: 280 }, maxWidth: 320 }}>
                 <LinearProgress variant="determinate" value={progress} />
               </Box>
               <Typography variant="caption" sx={{ color: '#8b949e' }}>

--- a/docs/solutions/architecture/2026-05-11-memoryhook-conflates-transcript-log-with-durable-memory.md
+++ b/docs/solutions/architecture/2026-05-11-memoryhook-conflates-transcript-log-with-durable-memory.md
@@ -1,0 +1,124 @@
+---
+title: "MemoryHook conflates transcript log with durable memory store"
+date: 2026-05-11
+problem_type: "architecture"
+component: "GA.Business.ML.Agents.Hooks.MemoryHook / MemoryStore"
+symptoms:
+  - "`~/.ga/memory.json` is 100% `type=response` entries after normal chatbot use"
+  - "Memory curator (`ga-memory curate`) finds no curatable content because every entry is a transient chat log"
+  - "Retrieval injection (`Memory:EnrichOnRetrieve=true`) injects past Q&A pairs that are rarely useful as durable context"
+  - "The 10k-entry store cap evicts oldest entries by Timestamp — durable facts (if any are written) get evicted by sheer volume of response logs"
+tags:
+  - "chatbot"
+  - "memory"
+  - "memoryhook"
+  - "transcript-log"
+  - "curator"
+  - "architectural-conflation"
+severity: "medium"
+related_docs:
+  - "docs/plans/2026-05-10-feat-dreams-lite-memory-curator-plan.md"
+  - "docs/solutions/architecture/2026-05-07-process-wide-memory-store-leaks-into-anonymous-prompts.md"
+related_prs:
+  - "#157"
+  - "#160"
+  - "#163"
+  - "#166"
+  - "#170"
+  - "#171"
+---
+
+# MemoryHook conflates transcript log with durable memory store
+
+## Symptom
+
+Running the memory curator (PR #166) against `~/.ga/memory.json` (PR #170 end-to-end smoke):
+
+```
+$ ga-memory curate
+Loaded 86 entries from C:\Users\spare\.ga\memory.json
+```
+
+Type distribution of those 86 entries:
+
+```
+response             86
+```
+
+**100% of entries are `type=response`.** No `fact`, no `preference`, no `focus`, no durable knowledge. The curator was designed to merge duplicates, replace stale entries, and surface emergent insights from durable memory. Pure transient logs are the wrong shape — there's nothing to curate.
+
+## Root cause
+
+`Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs:125-177` writes a `type=response` entry on every chat turn that satisfies a confidence threshold:
+
+```csharp
+public Task<HookResult> OnResponseSent(ChatHookContext ctx, ...)
+{
+    if (ctx.Response is not { Confidence: >= 0.7f } response) return HookResult.Continue;
+    if (response.Result.Length < 100) return HookResult.Continue;
+    ...
+    memoryStore.Write(
+        sessionId: sessionId,
+        key: $"response_{correlationId:N}",
+        type: "response",
+        content: $"Q: {originalMessage}\nA: {resultSnippet}",
+        tags: [agentId]);
+}
+```
+
+This is a **transcript log**, not a **durable memory** entry. The store ends up storing:
+
+| What's there | What we want there |
+|---|---|
+| Every Q&A pair the chatbot has answered | User preferences (instrument, genre, level) |
+| Stamped with the responding agent's ID | Validated facts the user confirmed |
+| Truncated to 500 chars | Compact, durable nuggets |
+| Keyed by `correlationId` (one per request) | Keyed by topic / fact |
+
+The MemoryStore was originally designed as the durable knowledge backing — what the chatbot has *learned* about the user, not what it *said* to the user. The hook conflates the two.
+
+## Why this matters
+
+Three downstream effects:
+
+1. **Curator is useless on this data.** PR #170's smoke surfaced this — Sonnet 4.6 was given 86 transient entries to bookkeep. The diff-discipline gap that PR #170 documented (one entry unaccounted for) was partly because there was no useful curation to do, just exhaustive copying.
+
+2. **Retrieval injection is noisy.** When `Memory:EnrichOnRetrieve=true` eventually ships, the chatbot will inject past Q&A pairs into its own future prompts — "here's something I told someone earlier" — rather than durable preferences. That's barely useful at best, actively misleading at worst (stale answers re-injected).
+
+3. **Eviction destroys durable memory.** The 10k-entry cap evicts oldest by Timestamp. If a user takes the time to record a real preference ("I play fingerstyle"), and then has 10k chat turns, the preference is evicted by the volume of response logs.
+
+## Recommended fix path
+
+Three options ranked by scope:
+
+### Option A — Stop writing response entries automatically (smallest)
+
+Delete the auto-write in `OnResponseSent`. Persist only when an explicit signal is present (e.g., a hook-tagged "save this" or an MCP tool call). Pro: simplest, eliminates the conflation. Con: no transcript log at all — debuggability drop.
+
+### Option B — Split the store (medium)
+
+Two stores backing two purposes:
+- `MemoryStore` — durable memory (fact, preference, focus). Smaller, slower-growing, curator-eligible.
+- `ChatTranscriptStore` — Q&A logs (response). High-volume, separate file path, never queried by retrieval, IS the input for Phase 2 of the curator's `IChatTranscriptStore` slot.
+
+Pro: clean separation, matches the curator's existing two-input shape. Con: a new file, migration story for existing `~/.ga/memory.json` (mostly response entries that should move to the transcript store).
+
+### Option C — Smarter extraction (largest)
+
+`OnResponseSent` calls a small LLM ("did this response surface a durable fact about the user?") and only persists when yes. Pro: matches what ChatGPT's "improved memory" does. Con: another LLM call per response — cost + latency, and another model accuracy dependency.
+
+**Recommendation: Option B.** Aligns with the curator's existing architecture (transcript slot is already in `IChatTranscriptStore`). Lowest-friction migration. Sets up Option C as a future enhancement (the extraction step runs against the transcript store, writes high-confidence extractions to the memory store).
+
+## Workaround until the fix lands
+
+PR #171 adds a default type filter to `ga-memory curate` — skips `type=response` by default. Operator can opt in with `--include-responses` if they really want to curate transcripts. This is a **CLI-side workaround**, not the architectural fix.
+
+## Open follow-up
+
+- Audit what entry types the chatbot actually accumulates in production (probably still 100% response). If true → urgent for B.
+- Inventory other callers of `MemoryStore.Write` to see if any already write durable types. If yes → preserving those is a Option B migration constraint.
+- Decide whether to migrate existing response entries to a new transcript store on first-run, or just leave them (10k cap will age them out).
+
+## Why this wasn't caught earlier
+
+The audit-style test coverage (`MemoryHookSessionPlumbingTests`, `MemoryMcpToolsSC001Tests`) verifies *isolation* and *safety* — that one session's writes don't leak to another, that the SC-001 origin tag is honored. None of it asked the higher-level question: **is the hook writing the right *kind* of data?** That's exactly the kind of architectural concern a Dreams-style curator surfaces by running against the actual store. **Ship-and-verify worked as intended.**


### PR DESCRIPTION
Pure documentation PR — captures the architectural finding surfaced by PRs #170/#171 end-to-end smoke. 100% of a real ~/.ga/memory.json was type=response (transient chat logs), not durable memory. Doc covers three remediation options (A: stop auto-writing, B: split the store, C: LLM-extracted memory); recommends B as it aligns with the curator's existing IChatTranscriptStore slot. No code changes — architectural change deserves its own planning cycle. PR #171's CLI type filter is the workaround until B ships.

Why this wasn't caught earlier: existing tests verify isolation/safety, never the higher-level 'is this the right KIND of data?' question. Ship-and-verify worked as intended.

Refs: #157, #160, #163, #166, #170, #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)