### PR TITLE
chore(quality): first scored routing-eval baseline — 66.2% accuracy

### DIFF
--- a/state/quality/README.md
+++ b/state/quality/README.md
@@ -12,9 +12,29 @@ state/quality/
 │   └── YYYY-MM-DD.json
 ├── voicing-analysis/        # Demos/VoicingAnalysisAudit output
 │   └── YYYY-MM-DD.json
-└── chatbot-qa/              # ga-chatbot qa --benchmark summary
-    └── YYYY-MM-DD.json
+├── chatbot-qa/              # ga-chatbot qa --benchmark summary
+│   └── YYYY-MM-DD.json
+└── routing-eval-YYYY-MM-DD.json   # SemanticIntentRouter F1 by intent
 ```
+
+## Routing eval
+
+Top-level `routing-eval-YYYY-MM-DD.json` files are produced by
+`Tests/Common/GA.Business.ML.Tests/Eval/RoutingEvalHarness.RunBaseline_EmitReport`
+(NUnit `[Explicit]` — requires a live Ollama at `localhost:11434` with
+`nomic-embed-text`). Each file records overall accuracy plus per-intent
+precision / recall / F1 against `Tests/.../Data/routing-eval-prompts.json`.
+
+Run a new baseline:
+
+```powershell
+dotnet test Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj `
+    --filter "FullyQualifiedName~RoutingEvalHarness.RunBaseline_EmitReport"
+```
+
+The baseline file gets overwritten if the date matches; rename the prior
+file (`routing-eval-2026-05-11.json` → `routing-eval-2026-05-11-pre-fix.json`)
+before a re-run if you want to compare two same-day runs.
 
 ## How new snapshots get added
 

--- a/state/quality/routing-eval-2026-05-11.analysis.md
+++ b/state/quality/routing-eval-2026-05-11.analysis.md
@@ -1,0 +1,83 @@
+# Routing eval baseline 2026-05-11 — failure analysis
+
+**Overall: 53/80 correct = 66.2% accuracy** (router threshold 0.65, embedder
+`nomic-embed-text`, 17 production skills loaded via reflection).
+
+This is the **first scored baseline** for `SemanticIntentRouter`. Treat
+the file as a measurable starting point — every subsequent change to
+example prompts, hint-provider regexes, threshold, or embedder model
+should be benchmarked against this.
+
+## Per-intent F1 (sorted, worst first)
+
+| Intent | F1 | Notes |
+|---|---|---|
+| skill.genreessentials | **0.00** | All 5/5 misrouted — examples not discriminative against `beginnerchords`/`chordsubstitution`/`progressioncompletion`/`transpose` |
+| skill.transpose | **0.25** | 4/5 misrouted — prompts containing "progression" + "key" name collide with `progressioncompletion`/`diatonicchords` |
+| skill.chordinfo | 0.50 | `tell me about Dm7` → `modes`; `what makes a chord a major seventh` → `diatonicchords` |
+| skill.practiceroutine | 0.57 | 3/5 fall **below the 0.65 confidence threshold** — synonyms "schedule"/"outline" not in examples |
+| skill.diatonicchords | 0.60 | `IV chord in A major` → `chordinfo`; `list chords in G major` → `chordsubstitution` |
+| skill.scaleinfo | 0.67 | `what's in the G major scale` → `modes` |
+| skill.modes | 0.73 | `notes in G mixolydian` → `scaleinfo` (mirror of scaleinfo failure) |
+| skill.chordsubstitution | 0.73 | `alternative chord for Cmaj7` → `chordinfo` |
+| skill.interval | 0.75 | `what's a perfect fifth` → `circleoffifths`; `minor third up from D` → `scaleinfo` |
+| skill.whatcanyoudo | 0.75 | 2/5 fall below 0.65 threshold |
+| skill.progressioncompletion | 0.77 | over-greedy — catches transpose prompts |
+| skill.circleoffifths | 0.80 | `across the circle from D` → `keyidentification` |
+| skill.keyidentification | 0.80 | one transpose collision |
+| skill.beginnerchords | 0.83 | inflated FP from genreessentials prompts ("country guitar starter chords") |
+| skill.commontones | 0.89 | one chordinfo collision |
+| skill.progressionmood | 0.89 | one chordinfo collision |
+
+## Failure clusters (in order of leverage)
+
+### 1. `genreessentials` is invisible to the router (5 prompts, 6.25% of corpus)
+
+All five labeled prompts use "essential X for Y" / "starter X" / "must-know X
+for Y" / "key chords in Z" patterns. The skill's current examples don't
+cover these shapes. **Fix candidate**: rewrite examples to anchor on the
+genre tokens (blues, jazz, country, rock, funk) + the "for / in" preposition.
+
+### 2. Transpose vs progression-completion collision (4 prompts)
+
+Anything shaped like "transpose THIS PROGRESSION to/down/up Y" gets caught
+by `progressioncompletion` because both skills' examples lean heavily on
+"progression". **Fix candidate**: add a `transpose` regex hint to
+`DefaultRoutingHintProvider` matching `\b(transpose|shift|move)\b.*\b(up|down|to|into)\b` —
+deterministic short-circuit before semantic dispatch.
+
+### 3. Confidence-threshold floor catches 5 prompts (skill.practiceroutine x3 + skill.whatcanyoudo x2)
+
+These prompts use natural-language synonyms ("schedule", "outline",
+"figure out what to ask", "show me what you know") not in the skill's
+ExamplePrompts. They all return `(none)` at confidence < 0.65.
+**Two paths**: (a) expand example prompts to cover synonyms,
+(b) lower threshold per-intent for meta intents. (a) is safer.
+
+### 4. Chord vs scale/mode confusion (3 prompts)
+
+`tell me about Dm7` → `modes`, `what's in the G major scale` → `modes`,
+`notes in G mixolydian` → `scaleinfo`. The chord/scale boundary is
+genuinely fuzzy. **Fix candidate**: add positive examples that
+distinguish (e.g., chordinfo: `tell me about a chord`; scaleinfo:
+`tell me about a scale`).
+
+### 5. "in a key" overlap (3 prompts)
+
+`IV chord in A major`, `chords in the key of C`, `list the chords in G
+major` all route to chord-related intents but each to a different one.
+**Fix candidate**: standardize `diatonicchords` examples around "chords
+in [KEY] / [DEGREE] chord in [KEY] / what chords are in [KEY]".
+
+## Recommended follow-up PR ordering
+
+1. **Quick win PR — fix #1 + #2 + #5** (deterministic regex hints + 9 example-prompt edits across 4 skills). Target: +12 correct → ~81% accuracy. Re-run harness, commit `routing-eval-YYYY-MM-DD.json` showing the lift.
+2. **Threshold-tuning experiment** — try threshold 0.60 with confusion-matrix delta. Pick if it doesn't regress precision-sensitive intents.
+3. **Corpus expansion v0.4** — add 2-3 paraphrased prompts per intent (currently 5/intent → 7-8/intent). Watch for label drift.
+
+## Out of scope for the baseline PR
+
+- All of the above are **fixes**. The baseline PR (this one) is the
+  measurement infrastructure: harness already exists (PRs #168/#169),
+  this PR just adds the first scored artifact and the analysis note
+  pointing at where the next routing PR should aim.

--- a/state/quality/routing-eval-2026-05-11.json
+++ b/state/quality/routing-eval-2026-05-11.json
@@ -1,0 +1,1074 @@
+{
+  "schemaVersion": "0.1",
+  "generatedAt": "2026-05-11T21:26:19.8081205Z",
+  "routerConfig": {
+    "minConfidence": 0.65,
+    "embedder": "nomic-embed-text"
+  },
+  "totalPrompts": 80,
+  "overall": {
+    "Total": 80,
+    "Correct": 53,
+    "UnmatchedFallthrough": 5,
+    "Accuracy": 0.6625
+  },
+  "perIntent": {
+    "skill.chordinfo": {
+      "Support": 5,
+      "TruePositives": 3,
+      "FalsePositives": 4,
+      "FalseNegatives": 2,
+      "Precision": 0.42857142857142855,
+      "Recall": 0.6,
+      "F1": 0.5,
+      "Status": "measured"
+    },
+    "skill.scaleinfo": {
+      "Support": 5,
+      "TruePositives": 4,
+      "FalsePositives": 3,
+      "FalseNegatives": 1,
+      "Precision": 0.5714285714285714,
+      "Recall": 0.8,
+      "F1": 0.6666666666666666,
+      "Status": "measured"
+    },
+    "skill.modes": {
+      "Support": 5,
+      "TruePositives": 4,
+      "FalsePositives": 2,
+      "FalseNegatives": 1,
+      "Precision": 0.6666666666666666,
+      "Recall": 0.8,
+      "F1": 0.7272727272727272,
+      "Status": "measured"
+    },
+    "skill.interval": {
+      "Support": 5,
+      "TruePositives": 3,
+      "FalsePositives": 0,
+      "FalseNegatives": 2,
+      "Precision": 1,
+      "Recall": 0.6,
+      "F1": 0.7499999999999999,
+      "Status": "measured"
+    },
+    "skill.chordsubstitution": {
+      "Support": 5,
+      "TruePositives": 4,
+      "FalsePositives": 2,
+      "FalseNegatives": 1,
+      "Precision": 0.6666666666666666,
+      "Recall": 0.8,
+      "F1": 0.7272727272727272,
+      "Status": "measured"
+    },
+    "skill.beginnerchords": {
+      "Support": 5,
+      "TruePositives": 5,
+      "FalsePositives": 2,
+      "FalseNegatives": 0,
+      "Precision": 0.7142857142857143,
+      "Recall": 1,
+      "F1": 0.8333333333333333,
+      "Status": "measured"
+    },
+    "skill.progressionmood": {
+      "Support": 5,
+      "TruePositives": 4,
+      "FalsePositives": 0,
+      "FalseNegatives": 1,
+      "Precision": 1,
+      "Recall": 0.8,
+      "F1": 0.888888888888889,
+      "Status": "measured"
+    },
+    "skill.circleoffifths": {
+      "Support": 5,
+      "TruePositives": 4,
+      "FalsePositives": 1,
+      "FalseNegatives": 1,
+      "Precision": 0.8,
+      "Recall": 0.8,
+      "F1": 0.8000000000000002,
+      "Status": "measured"
+    },
+    "skill.practiceroutine": {
+      "Support": 5,
+      "TruePositives": 2,
+      "FalsePositives": 0,
+      "FalseNegatives": 3,
+      "Precision": 1,
+      "Recall": 0.4,
+      "F1": 0.5714285714285715,
+      "Status": "measured"
+    },
+    "skill.genreessentials": {
+      "Support": 5,
+      "TruePositives": 0,
+      "FalsePositives": 0,
+      "FalseNegatives": 5,
+      "Precision": 0,
+      "Recall": 0,
+      "F1": 0,
+      "Status": "measured"
+    },
+    "skill.whatcanyoudo": {
+      "Support": 5,
+      "TruePositives": 3,
+      "FalsePositives": 0,
+      "FalseNegatives": 2,
+      "Precision": 1,
+      "Recall": 0.6,
+      "F1": 0.7499999999999999,
+      "Status": "measured"
+    },
+    "skill.transpose": {
+      "Support": 5,
+      "TruePositives": 1,
+      "FalsePositives": 2,
+      "FalseNegatives": 4,
+      "Precision": 0.3333333333333333,
+      "Recall": 0.2,
+      "F1": 0.25,
+      "Status": "measured"
+    },
+    "skill.commontones": {
+      "Support": 5,
+      "TruePositives": 4,
+      "FalsePositives": 0,
+      "FalseNegatives": 1,
+      "Precision": 1,
+      "Recall": 0.8,
+      "F1": 0.888888888888889,
+      "Status": "measured"
+    },
+    "skill.diatonicchords": {
+      "Support": 5,
+      "TruePositives": 3,
+      "FalsePositives": 2,
+      "FalseNegatives": 2,
+      "Precision": 0.6,
+      "Recall": 0.6,
+      "F1": 0.6,
+      "Status": "measured"
+    },
+    "skill.keyidentification": {
+      "Support": 5,
+      "TruePositives": 4,
+      "FalsePositives": 1,
+      "FalseNegatives": 1,
+      "Precision": 0.8,
+      "Recall": 0.8,
+      "F1": 0.8000000000000002,
+      "Status": "measured"
+    },
+    "skill.progressioncompletion": {
+      "Support": 5,
+      "TruePositives": 5,
+      "FalsePositives": 3,
+      "FalseNegatives": 0,
+      "Precision": 0.625,
+      "Recall": 1,
+      "F1": 0.7692307692307693,
+      "Status": "measured"
+    }
+  },
+  "prompts": [
+    {
+      "Id": "ci-1",
+      "Prompt": "what notes are in Cmaj7?",
+      "Expected": "skill.chordinfo",
+      "Chosen": "skill.chordinfo",
+      "Confidence": 0.92115897,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "ci-2",
+      "Prompt": "spell a Bbdim chord",
+      "Expected": "skill.chordinfo",
+      "Chosen": "skill.chordinfo",
+      "Confidence": 0.8979752,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "ci-3",
+      "Prompt": "tell me about Dm7",
+      "Expected": "skill.chordinfo",
+      "Chosen": "skill.modes",
+      "Confidence": 0.7129854,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ci-4",
+      "Prompt": "spell an Eb7#9 chord",
+      "Expected": "skill.chordinfo",
+      "Chosen": "skill.chordinfo",
+      "Confidence": 0.80712485,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed",
+        "jargon"
+      ]
+    },
+    {
+      "Id": "ci-5",
+      "Prompt": "what makes a chord a major seventh",
+      "Expected": "skill.chordinfo",
+      "Chosen": "skill.diatonicchords",
+      "Confidence": 0.80769587,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed",
+        "conceptual"
+      ]
+    },
+    {
+      "Id": "si-1",
+      "Prompt": "notes in the A natural minor scale",
+      "Expected": "skill.scaleinfo",
+      "Chosen": "skill.scaleinfo",
+      "Confidence": 0.9280829,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "si-2",
+      "Prompt": "notes of the harmonic minor scale",
+      "Expected": "skill.scaleinfo",
+      "Chosen": "skill.scaleinfo",
+      "Confidence": 0.79404,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "si-3",
+      "Prompt": "scale tones for D melodic minor",
+      "Expected": "skill.scaleinfo",
+      "Chosen": "skill.scaleinfo",
+      "Confidence": 0.821083,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "si-4",
+      "Prompt": "what\u0027s in the G major scale",
+      "Expected": "skill.scaleinfo",
+      "Chosen": "skill.modes",
+      "Confidence": 0.85609615,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "si-5",
+      "Prompt": "spell out C natural minor",
+      "Expected": "skill.scaleinfo",
+      "Chosen": "skill.scaleinfo",
+      "Confidence": 0.7917001,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "mo-1",
+      "Prompt": "what are the modes of the major scale",
+      "Expected": "skill.modes",
+      "Chosen": "skill.modes",
+      "Confidence": 0.97804224,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "mo-2",
+      "Prompt": "list the seven modes",
+      "Expected": "skill.modes",
+      "Chosen": "skill.modes",
+      "Confidence": 0.834045,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "mo-3",
+      "Prompt": "what notes are in G mixolydian",
+      "Expected": "skill.modes",
+      "Chosen": "skill.scaleinfo",
+      "Confidence": 0.7594,
+      "Correct": false,
+      "Tags": [
+        "modal-overlap",
+        "relabeled-v0.1.1"
+      ]
+    },
+    {
+      "Id": "mo-4",
+      "Prompt": "explain the Lydian mode",
+      "Expected": "skill.modes",
+      "Chosen": "skill.modes",
+      "Confidence": 0.9062759,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "mo-5",
+      "Prompt": "what is the third mode of major",
+      "Expected": "skill.modes",
+      "Chosen": "skill.modes",
+      "Confidence": 0.7599073,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "in-1",
+      "Prompt": "interval between C and G",
+      "Expected": "skill.interval",
+      "Chosen": "skill.interval",
+      "Confidence": 0.95399445,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "in-2",
+      "Prompt": "what\u0027s a perfect fifth",
+      "Expected": "skill.interval",
+      "Chosen": "skill.circleoffifths",
+      "Confidence": 0.7367414,
+      "Correct": false,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "in-3",
+      "Prompt": "interval from F to Bb",
+      "Expected": "skill.interval",
+      "Chosen": "skill.interval",
+      "Confidence": 0.8870297,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "in-4",
+      "Prompt": "what is a minor third up from D",
+      "Expected": "skill.interval",
+      "Chosen": "skill.scaleinfo",
+      "Confidence": 0.7822146,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "in-5",
+      "Prompt": "name the interval D to A",
+      "Expected": "skill.interval",
+      "Chosen": "skill.interval",
+      "Confidence": 0.8479601,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "cs-1",
+      "Prompt": "what chord can substitute for G7",
+      "Expected": "skill.chordsubstitution",
+      "Chosen": "skill.chordsubstitution",
+      "Confidence": 0.83892983,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "cs-2",
+      "Prompt": "tritone substitution for D7",
+      "Expected": "skill.chordsubstitution",
+      "Chosen": "skill.chordsubstitution",
+      "Confidence": 0.88798326,
+      "Correct": true,
+      "Tags": [
+        "jargon"
+      ]
+    },
+    {
+      "Id": "cs-3",
+      "Prompt": "good substitute for the V chord",
+      "Expected": "skill.chordsubstitution",
+      "Chosen": "skill.chordsubstitution",
+      "Confidence": 0.81332636,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "cs-4",
+      "Prompt": "alternative chord for Cmaj7",
+      "Expected": "skill.chordsubstitution",
+      "Chosen": "skill.chordinfo",
+      "Confidence": 0.84093684,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "cs-5",
+      "Prompt": "modal interchange substitutes for C major",
+      "Expected": "skill.chordsubstitution",
+      "Chosen": "skill.chordsubstitution",
+      "Confidence": 0.7390118,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed",
+        "jargon"
+      ]
+    },
+    {
+      "Id": "bc-1",
+      "Prompt": "easy chords for beginners",
+      "Expected": "skill.beginnerchords",
+      "Chosen": "skill.beginnerchords",
+      "Confidence": 0.89739704,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "bc-2",
+      "Prompt": "first chords to learn on guitar",
+      "Expected": "skill.beginnerchords",
+      "Chosen": "skill.beginnerchords",
+      "Confidence": 0.8933455,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "bc-3",
+      "Prompt": "what chords should I learn first",
+      "Expected": "skill.beginnerchords",
+      "Chosen": "skill.beginnerchords",
+      "Confidence": 0.95299506,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "bc-4",
+      "Prompt": "simple chord shapes for a new guitarist",
+      "Expected": "skill.beginnerchords",
+      "Chosen": "skill.beginnerchords",
+      "Confidence": 0.8626401,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "bc-5",
+      "Prompt": "starter chords for an absolute beginner",
+      "Expected": "skill.beginnerchords",
+      "Chosen": "skill.beginnerchords",
+      "Confidence": 0.830715,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pm-1",
+      "Prompt": "how do I make this minor progression sound brighter",
+      "Expected": "skill.progressionmood",
+      "Chosen": "skill.progressionmood",
+      "Confidence": 0.8482656,
+      "Correct": true,
+      "Tags": [
+        "common",
+        "transform-semantics"
+      ]
+    },
+    {
+      "Id": "pm-2",
+      "Prompt": "make C G Am F sound darker",
+      "Expected": "skill.progressionmood",
+      "Chosen": "skill.progressionmood",
+      "Confidence": 0.8607227,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed",
+        "transform-semantics"
+      ]
+    },
+    {
+      "Id": "pm-3",
+      "Prompt": "darken a vi-IV-I-V progression",
+      "Expected": "skill.progressionmood",
+      "Chosen": "skill.progressionmood",
+      "Confidence": 0.81451225,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed",
+        "roman-numeral"
+      ]
+    },
+    {
+      "Id": "pm-4",
+      "Prompt": "brighten up a minor key tune",
+      "Expected": "skill.progressionmood",
+      "Chosen": "skill.chordinfo",
+      "Confidence": 0.7209605,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pm-5",
+      "Prompt": "give this progression a sadder feel",
+      "Expected": "skill.progressionmood",
+      "Chosen": "skill.progressionmood",
+      "Confidence": 0.76833844,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "co-1",
+      "Prompt": "circle of fifths positions",
+      "Expected": "skill.circleoffifths",
+      "Chosen": "skill.circleoffifths",
+      "Confidence": 0.8783361,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "co-2",
+      "Prompt": "explain the circle of fifths",
+      "Expected": "skill.circleoffifths",
+      "Chosen": "skill.circleoffifths",
+      "Confidence": 0.917666,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "co-3",
+      "Prompt": "show me the circle of fourths",
+      "Expected": "skill.circleoffifths",
+      "Chosen": "skill.circleoffifths",
+      "Confidence": 0.875373,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "co-4",
+      "Prompt": "what key is across the circle from D",
+      "Expected": "skill.circleoffifths",
+      "Chosen": "skill.keyidentification",
+      "Confidence": 0.8085134,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "co-5",
+      "Prompt": "neighboring keys on the circle of fifths",
+      "Expected": "skill.circleoffifths",
+      "Chosen": "skill.circleoffifths",
+      "Confidence": 0.8437756,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pr-1",
+      "Prompt": "give me a 20 minute practice routine",
+      "Expected": "skill.practiceroutine",
+      "Chosen": null,
+      "Confidence": 0,
+      "Correct": false,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "pr-2",
+      "Prompt": "design a practice plan for me",
+      "Expected": "skill.practiceroutine",
+      "Chosen": "skill.practiceroutine",
+      "Confidence": 0.7215876,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pr-3",
+      "Prompt": "what should I practice today",
+      "Expected": "skill.practiceroutine",
+      "Chosen": "skill.practiceroutine",
+      "Confidence": 0.70241785,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pr-4",
+      "Prompt": "build a 30 minute practice schedule",
+      "Expected": "skill.practiceroutine",
+      "Chosen": null,
+      "Confidence": 0,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pr-5",
+      "Prompt": "give me a daily practice outline",
+      "Expected": "skill.practiceroutine",
+      "Chosen": null,
+      "Confidence": 0,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ge-1",
+      "Prompt": "essential chords for blues guitar",
+      "Expected": "skill.genreessentials",
+      "Chosen": "skill.beginnerchords",
+      "Confidence": 0.71459174,
+      "Correct": false,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "ge-2",
+      "Prompt": "essential scales for jazz guitar",
+      "Expected": "skill.genreessentials",
+      "Chosen": "skill.chordsubstitution",
+      "Confidence": 0.700365,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ge-3",
+      "Prompt": "country guitar starter chords",
+      "Expected": "skill.genreessentials",
+      "Chosen": "skill.beginnerchords",
+      "Confidence": 0.75320107,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed",
+        "starter-overlap"
+      ]
+    },
+    {
+      "Id": "ge-4",
+      "Prompt": "must-know progressions for rock",
+      "Expected": "skill.genreessentials",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.6891813,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ge-5",
+      "Prompt": "key chords in funk music",
+      "Expected": "skill.genreessentials",
+      "Chosen": "skill.transpose",
+      "Confidence": 0.71533525,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "wc-1",
+      "Prompt": "what can you do",
+      "Expected": "skill.whatcanyoudo",
+      "Chosen": "skill.whatcanyoudo",
+      "Confidence": 0.8201942,
+      "Correct": true,
+      "Tags": [
+        "meta"
+      ]
+    },
+    {
+      "Id": "wc-2",
+      "Prompt": "what are your capabilities",
+      "Expected": "skill.whatcanyoudo",
+      "Chosen": "skill.whatcanyoudo",
+      "Confidence": 0.9460953,
+      "Correct": true,
+      "Tags": [
+        "meta"
+      ]
+    },
+    {
+      "Id": "wc-3",
+      "Prompt": "help me figure out what to ask",
+      "Expected": "skill.whatcanyoudo",
+      "Chosen": null,
+      "Confidence": 0,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed",
+        "meta"
+      ]
+    },
+    {
+      "Id": "wc-4",
+      "Prompt": "what features does this chatbot have",
+      "Expected": "skill.whatcanyoudo",
+      "Chosen": "skill.whatcanyoudo",
+      "Confidence": 0.91320884,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed",
+        "meta"
+      ]
+    },
+    {
+      "Id": "wc-5",
+      "Prompt": "show me what you know",
+      "Expected": "skill.whatcanyoudo",
+      "Chosen": null,
+      "Confidence": 0,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed",
+        "meta"
+      ]
+    },
+    {
+      "Id": "tr-1",
+      "Prompt": "transpose C major up a perfect fifth",
+      "Expected": "skill.transpose",
+      "Chosen": "skill.transpose",
+      "Confidence": 0.73667306,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "tr-2",
+      "Prompt": "transpose this progression down a half step",
+      "Expected": "skill.transpose",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.74104977,
+      "Correct": false,
+      "Tags": [
+        "common",
+        "requires-context"
+      ]
+    },
+    {
+      "Id": "tr-3",
+      "Prompt": "transpose C-Am-F-G to G major",
+      "Expected": "skill.transpose",
+      "Chosen": "skill.diatonicchords",
+      "Confidence": 0.8431992,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "tr-4",
+      "Prompt": "shift this progression up a whole step",
+      "Expected": "skill.transpose",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.7847122,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "tr-5",
+      "Prompt": "bring D minor down to A minor",
+      "Expected": "skill.transpose",
+      "Chosen": "skill.scaleinfo",
+      "Confidence": 0.8402884,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ct-1",
+      "Prompt": "common tones between Cmaj7 and Am7",
+      "Expected": "skill.commontones",
+      "Chosen": "skill.commontones",
+      "Confidence": 0.93789035,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "ct-2",
+      "Prompt": "shared notes between G7 and Cmaj7",
+      "Expected": "skill.commontones",
+      "Chosen": "skill.commontones",
+      "Confidence": 0.94378036,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ct-3",
+      "Prompt": "which pitches do Dm and Bbmaj share",
+      "Expected": "skill.commontones",
+      "Chosen": "skill.commontones",
+      "Confidence": 0.82350785,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ct-4",
+      "Prompt": "common tones for F and G7",
+      "Expected": "skill.commontones",
+      "Chosen": "skill.commontones",
+      "Confidence": 0.8965046,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ct-5",
+      "Prompt": "overlapping notes in Cmaj7 and Em7",
+      "Expected": "skill.commontones",
+      "Chosen": "skill.chordinfo",
+      "Confidence": 0.8900547,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "dc-1",
+      "Prompt": "diatonic chords in C major",
+      "Expected": "skill.diatonicchords",
+      "Chosen": "skill.diatonicchords",
+      "Confidence": 0.9583892,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "dc-2",
+      "Prompt": "what chords are in the key of D",
+      "Expected": "skill.diatonicchords",
+      "Chosen": "skill.diatonicchords",
+      "Confidence": 0.96443015,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "dc-3",
+      "Prompt": "what is the IV chord in A major",
+      "Expected": "skill.diatonicchords",
+      "Chosen": "skill.chordinfo",
+      "Confidence": 0.9679375,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed",
+        "roman-numeral"
+      ]
+    },
+    {
+      "Id": "dc-4",
+      "Prompt": "list the chords in G major",
+      "Expected": "skill.diatonicchords",
+      "Chosen": "skill.chordsubstitution",
+      "Confidence": 0.88730836,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "dc-5",
+      "Prompt": "diatonic seventh chords in E minor",
+      "Expected": "skill.diatonicchords",
+      "Chosen": "skill.diatonicchords",
+      "Confidence": 0.8226934,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ki-1",
+      "Prompt": "what key is this progression in C G Am F",
+      "Expected": "skill.keyidentification",
+      "Chosen": "skill.keyidentification",
+      "Confidence": 0.88022506,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "ki-2",
+      "Prompt": "identify the key of Am F C G",
+      "Expected": "skill.keyidentification",
+      "Chosen": "skill.keyidentification",
+      "Confidence": 0.9841621,
+      "Correct": true,
+      "Tags": [
+        "minor-tonic"
+      ]
+    },
+    {
+      "Id": "ki-3",
+      "Prompt": "what key is C F G C in",
+      "Expected": "skill.keyidentification",
+      "Chosen": "skill.keyidentification",
+      "Confidence": 1.001588,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "ki-4",
+      "Prompt": "tell me the key of Em Am D G",
+      "Expected": "skill.keyidentification",
+      "Chosen": "skill.keyidentification",
+      "Confidence": 0.92619485,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed",
+        "minor-tonic"
+      ]
+    },
+    {
+      "Id": "ki-5",
+      "Prompt": "find the tonic of A E F#m D",
+      "Expected": "skill.keyidentification",
+      "Chosen": "skill.transpose",
+      "Confidence": 0.6799444,
+      "Correct": false,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pc-1",
+      "Prompt": "what chord comes next after C Am F",
+      "Expected": "skill.progressioncompletion",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.96657485,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "pc-2",
+      "Prompt": "suggest a chord to finish this progression",
+      "Expected": "skill.progressioncompletion",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.7199988,
+      "Correct": true,
+      "Tags": [
+        "common"
+      ]
+    },
+    {
+      "Id": "pc-3",
+      "Prompt": "complete this: C Am F",
+      "Expected": "skill.progressioncompletion",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.800194,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pc-4",
+      "Prompt": "what should come after G C in this song",
+      "Expected": "skill.progressioncompletion",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.71939903,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed"
+      ]
+    },
+    {
+      "Id": "pc-5",
+      "Prompt": "predict the next chord in I V vi",
+      "Expected": "skill.progressioncompletion",
+      "Chosen": "skill.progressioncompletion",
+      "Confidence": 0.8223086,
+      "Correct": true,
+      "Tags": [
+        "v0.3-seed",
+        "roman-numeral"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Lands the first scored baseline for `SemanticIntentRouter` so every future routing change can be benchmarked. **Measurement-only — no code change.**

- `state/quality/routing-eval-2026-05-11.json` — 80 prompts × 17 production skills via the reflection-load harness (PRs #168/#169). Overall **53/80 = 66.2%**, per-intent F1 0.00–0.89.
- `state/quality/routing-eval-2026-05-11.analysis.md` — failure clusters + recommended ordering for the follow-up fix PR.
- `state/quality/README.md` — documents the file convention and how to re-run.

## Critical regressions surfaced

| Intent | F1 | Notes |
|---|---|---|
| `skill.genreessentials` | **0.00** | All 5/5 misrouted; examples not discriminative |
| `skill.transpose` | **0.25** | Collides with `progressioncompletion` |
| `skill.practiceroutine` | 0.57 | 3/5 fall below 0.65 confidence threshold |

Fix candidates in the analysis doc include a deterministic regex hint for transpose, rewriting genreessentials examples around genre tokens, and expanding practiceroutine synonyms.

## Test plan

- [x] `RoutingEvalHarness.RunBaseline_EmitReport` runs green against local Ollama (`nomic-embed-text`)
- [x] Output JSON validates against the existing `state/quality/` convention
- [x] No production code touched

## How to re-run

```powershell
dotnet test Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj `
    --filter "FullyQualifiedName~RoutingEvalHarness.RunBaseline_EmitReport"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)