### PR TITLE
feat(memory): one-shot legacy type=response → transcript-store migration

### DIFF
--- a/Apps/GaMemoryCli/Program.cs
+++ b/Apps/GaMemoryCli/Program.cs
@@ -236,7 +236,10 @@ static int RunMigrateTranscripts(string[] args)
     }
 
     // ── --apply path ─────────────────────────────────────────────────────
-    var stamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss");
+    // PR #176 review (correctness MED-2): include milliseconds so a same-
+    // second re-run after an aborted apply doesn't hit a backup-name
+    // collision against File.Copy's overwrite:false guard.
+    var stamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss-fff");
     var memoryBackup = memoryPath + ".bak-" + stamp;
     var transcriptBackup = File.Exists(transcriptPath) ? transcriptPath + ".bak-" + stamp : null;
 
@@ -262,6 +265,19 @@ static int RunMigrateTranscripts(string[] args)
     Console.WriteLine();
     Console.WriteLine("Done. Re-run `ga-memory migrate-transcripts` to verify it's a no-op.");
     Console.WriteLine($"Backups retained at {memoryBackup}" + (transcriptBackup is not null ? $" and {transcriptBackup}" : "") + " — delete after you've verified the chatbot still boots.");
+    // PR #176 review (correctness MED-3): document the recovery path. The
+    // two-file write isn't atomic — if the process is killed between the
+    // transcripts.json write and the memory.json write, transcripts have
+    // the legacy turns but memory.json still has the source response
+    // entries. Re-running --apply uses the deterministic-id check in
+    // LegacyResponseMigration.Plan to route them to EntriesAlreadyMigrated
+    // and drop them from memory.json. Don't restore from .bak — that
+    // discards correct work.
+    Console.WriteLine();
+    Console.WriteLine("If a crash interrupted this run (you see entries in both files), simply re-run");
+    Console.WriteLine("`ga-memory migrate-transcripts --apply` — the migration is idempotent and the");
+    Console.WriteLine("re-run will detect already-migrated entries and finish the drain from memory.json.");
+    Console.WriteLine("DO NOT restore from .bak in that case — that discards correct work.");
     return 0;
 }
 

--- a/Apps/GaMemoryCli/Program.cs
+++ b/Apps/GaMemoryCli/Program.cs
@@ -26,9 +26,10 @@ if (args.Length == 0)
 var command = args[0];
 return command switch
 {
-    "curate"  => await RunCurateAsync(args[1..]),
-    "diff"    => RunDiff(args[1..]),
-    "promote" => RunPromote(args[1..]),
+    "curate"               => await RunCurateAsync(args[1..]),
+    "diff"                 => RunDiff(args[1..]),
+    "promote"              => RunPromote(args[1..]),
+    "migrate-transcripts"  => RunMigrateTranscripts(args[1..]),
     "--help" or "-h" or "help" => PrintUsage(),
     _ => UnknownCommand(command),
 };
@@ -179,6 +180,110 @@ static int RunDiff(string[] args)
     return 0;
 }
 
+/// <summary>
+/// One-shot migration: drains legacy type=response entries from
+/// ~/.ga/memory.json into ~/.ga/transcripts.json. Default is dry-run;
+/// pass --apply to commit. Idempotent — re-running after --apply finds
+/// nothing to do. Backs up both files to <c>.bak-{stamp}</c> before
+/// writing. See <see cref="LegacyResponseMigration"/> for design notes.
+/// </summary>
+static int RunMigrateTranscripts(string[] args)
+{
+    var apply       = false;
+    var memoryPath  = MemoryStore.DefaultStorePath;
+    var transcriptPath = ChatTranscriptStore.DefaultStorePath;
+
+    for (var i = 0; i < args.Length; i++)
+    {
+        if (args[i] == "--apply") apply = true;
+        else if (args[i] == "--memory-path" && i + 1 < args.Length) memoryPath = args[++i];
+        else if (args[i] == "--transcripts-path" && i + 1 < args.Length) transcriptPath = args[++i];
+        else if (args[i] == "--dry-run") apply = false;   // explicit no-op alias for readability
+    }
+
+    if (!File.Exists(memoryPath))
+    {
+        Console.Error.WriteLine($"No memory store at {memoryPath} — nothing to migrate.");
+        return 2;
+    }
+
+    var memoryEntries = LoadEntries(memoryPath);
+    var existingTurns = LoadTranscriptTurns(transcriptPath);
+
+    var plan = LegacyResponseMigration.Plan(memoryEntries, existingTurns);
+
+    Console.WriteLine($"memory store : {memoryPath}  ({memoryEntries.Count} entries)");
+    Console.WriteLine($"transcripts  : {transcriptPath}  ({existingTurns.Count} turns)");
+    Console.WriteLine();
+    Console.WriteLine("Plan:");
+    Console.WriteLine($"  type=response → migrate    : {plan.EntriesToMigrate.Count}");
+    Console.WriteLine($"  type=response → already-migrated, will be dropped : {plan.EntriesAlreadyMigrated.Count}");
+    Console.WriteLine($"  non-response → keep        : {plan.EntriesToKeep.Count}");
+    Console.WriteLine($"  new transcript turns       : {plan.NewTranscriptTurns.Count} (SessionId='{LegacyResponseMigration.LegacySessionId}', Role='assistant')");
+
+    if (plan.IsNoOp)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Nothing to do — memory.json contains no type=response entries.");
+        return 0;
+    }
+
+    if (!apply)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Dry-run (no files written). Pass --apply to commit.");
+        return 0;
+    }
+
+    // ── --apply path ─────────────────────────────────────────────────────
+    var stamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss");
+    var memoryBackup = memoryPath + ".bak-" + stamp;
+    var transcriptBackup = File.Exists(transcriptPath) ? transcriptPath + ".bak-" + stamp : null;
+
+    Console.WriteLine();
+    Console.WriteLine("Backing up:");
+    File.Copy(memoryPath, memoryBackup, overwrite: false);
+    Console.WriteLine($"  {memoryPath} -> {memoryBackup}");
+    if (transcriptBackup is not null)
+    {
+        File.Copy(transcriptPath, transcriptBackup, overwrite: false);
+        Console.WriteLine($"  {transcriptPath} -> {transcriptBackup}");
+    }
+
+    // Merge existing + new transcript turns, write atomically.
+    var mergedTurns = existingTurns.Concat(plan.NewTranscriptTurns).ToList();
+    AtomicWrite(transcriptPath, JsonSerializer.Serialize(mergedTurns, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine($"Wrote {mergedTurns.Count} turns to {transcriptPath} (was {existingTurns.Count}).");
+
+    // Rewrite memory.json with the kept entries only.
+    AtomicWrite(memoryPath, JsonSerializer.Serialize(plan.EntriesToKeep, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine($"Wrote {plan.EntriesToKeep.Count} entries to {memoryPath} (was {memoryEntries.Count}; removed {memoryEntries.Count - plan.EntriesToKeep.Count}).");
+
+    Console.WriteLine();
+    Console.WriteLine("Done. Re-run `ga-memory migrate-transcripts` to verify it's a no-op.");
+    Console.WriteLine($"Backups retained at {memoryBackup}" + (transcriptBackup is not null ? $" and {transcriptBackup}" : "") + " — delete after you've verified the chatbot still boots.");
+    return 0;
+}
+
+static IReadOnlyList<TranscriptTurnEntry> LoadTranscriptTurns(string path)
+{
+    if (!File.Exists(path)) return [];
+    var json = File.ReadAllText(path);
+    var turns = JsonSerializer.Deserialize<List<TranscriptTurnEntry>>(json,
+        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    return turns ?? [];
+}
+
+static void AtomicWrite(string path, string content)
+{
+    var dir = Path.GetDirectoryName(path);
+    if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        Directory.CreateDirectory(dir);
+    var tmp = path + ".tmp";
+    File.WriteAllText(tmp, content);
+    File.Move(tmp, path, overwrite: true);
+}
+
 static int RunPromote(string[] args)
 {
     if (args.Length == 0)
@@ -231,6 +336,10 @@ static int PrintUsage()
     Console.WriteLine("                                  --include-responses to curate them.");
     Console.WriteLine("  diff <candidate-path>           Show the diff summary for a candidate");
     Console.WriteLine("  promote <candidate-path>        Atomic swap (with .bak backup)");
+    Console.WriteLine("  migrate-transcripts [--apply]   Drain legacy type=response entries from");
+    Console.WriteLine("                                  memory.json into transcripts.json. Default");
+    Console.WriteLine("                                  is dry-run; --apply commits with .bak backups.");
+    Console.WriteLine("                                  Idempotent; safe to re-run.");
     Console.WriteLine();
     Console.WriteLine("Env:");
     Console.WriteLine("  ANTHROPIC_API_KEY              required for `curate` (Sonnet 4.6 by default)");

--- a/Common/GA.Business.ML/Agents/Memory/LegacyResponseMigration.cs
+++ b/Common/GA.Business.ML/Agents/Memory/LegacyResponseMigration.cs
@@ -101,7 +101,14 @@ public static class LegacyResponseMigration
                 continue;
             }
 
-            var id = DeriveId(entry.Key, entry.Timestamp);
+            // PR #176 review (correctness LOW-DeriveId-Session): include
+            // the source SessionId. The historic store was empirically
+            // global (SessionId=null), but if a legacy file ever contains
+            // per-session entries sharing (Key, Timestamp) across different
+            // sessions, a (Key+Timestamp)-only hash would collide and
+            // silently drop content on ChatTranscriptStore.Load()'s dedupe.
+            // Costs nothing — closes a future-drift foot-gun.
+            var id = DeriveId(entry.SessionId, entry.Key, entry.Timestamp);
             if (existingIds.Contains(id))
             {
                 // Already migrated in a prior run — drop it from the source
@@ -134,15 +141,24 @@ public static class LegacyResponseMigration
 
     /// <summary>
     /// Deterministic transcript-turn id for a legacy memory entry. The
-    /// <c>(Key, Timestamp)</c> pair uniquely identifies a legacy entry —
-    /// the historic <see cref="MemoryStore"/> rejected duplicate keys with
-    /// the same SessionId, so collisions within the legacy partition are
-    /// impossible by construction.
+    /// <c>(SessionId, Key, Timestamp)</c> triple uniquely identifies a
+    /// legacy entry — MemoryStore's primary key is <c>(SessionId, Key)</c>,
+    /// so any two entries in the same source file are distinguishable
+    /// by that key plus their timestamp. Null SessionId (the global
+    /// partition) is normalized to the empty string in the hash payload
+    /// so global vs. session-scoped entries with the same Key/Timestamp
+    /// don't collide.
     /// </summary>
-    public static string DeriveId(string key, DateTimeOffset timestamp)
+    /// <remarks>
+    /// PR #176 review (correctness LOW-DeriveId-Session) added the
+    /// SessionId dimension. The historic store was empirically global,
+    /// but the hash now defends against any future legacy file with
+    /// per-session response entries.
+    /// </remarks>
+    public static string DeriveId(string? sessionId, string key, DateTimeOffset timestamp)
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
-        var payload = $"legacy|{key}|{timestamp:O}";
+        var payload = $"legacy|{sessionId ?? string.Empty}|{key}|{timestamp:O}";
         var bytes   = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
         return "legacy-" + Convert.ToHexString(bytes)[..24].ToLowerInvariant();
     }

--- a/Common/GA.Business.ML/Agents/Memory/LegacyResponseMigration.cs
+++ b/Common/GA.Business.ML/Agents/Memory/LegacyResponseMigration.cs
@@ -1,0 +1,185 @@
+namespace GA.Business.ML.Agents.Memory;
+
+using System.Security.Cryptography;
+using System.Text;
+
+/// <summary>
+/// One-shot migration that drains legacy <c>type=response</c> entries from
+/// <see cref="MemoryStore"/> into <see cref="ChatTranscriptStore"/>. Closes
+/// the architectural gap documented in
+/// <c>docs/solutions/architecture/2026-05-11-memoryhook-conflates-transcript-log-with-durable-memory.md</c>:
+/// every chatbot response prior to PR #174 landed in the durable memory file
+/// as <c>type=response</c>, but those rows are transient transcript content
+/// — not durable knowledge — and they crowd out real <c>fact</c> /
+/// <c>preference</c> / <c>focus</c> entries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Pure planning, no IO.</b> <see cref="Plan"/> takes the loaded entries
+/// and produces a <see cref="LegacyResponseMigrationPlan"/> describing what
+/// would change. Callers (the <c>ga-memory migrate-transcripts</c> CLI) own
+/// the read/write side-effects so the planning logic stays unit-testable.
+/// </para>
+/// <para>
+/// <b>Idempotent.</b> Migrated turns get a deterministic id derived from
+/// <c>SHA256("legacy|" + key + "|" + timestamp)[..24]</c> with a
+/// <c>"legacy-"</c> prefix. Re-running the plan against a transcripts file
+/// that already contains those ids produces an empty migration set —
+/// operators can safely re-invoke <c>migrate-transcripts --apply</c>.
+/// </para>
+/// <para>
+/// <b>Session bucket.</b> All legacy entries land in a single
+/// <see cref="LegacySessionId"/> bucket. The historic store was 100% global
+/// (SessionId=null), so there is no per-session information to recover.
+/// Bucketing under one synthetic session keeps the curator's cross-session
+/// <c>GetRecentAsync</c> from interleaving 86 ancient assistant turns into
+/// every live session's "most-recent" view.
+/// </para>
+/// <para>
+/// <b>Role.</b> All migrated turns are <c>"assistant"</c> — they came from
+/// <c>MemoryHook.OnResponseSent</c>, which only ever wrote the response
+/// text. The originating user prompts were never persisted in the legacy
+/// flow and are unrecoverable.
+/// </para>
+/// </remarks>
+public static class LegacyResponseMigration
+{
+    /// <summary>
+    /// Synthetic session id used for every migrated turn. Choosing a single
+    /// non-null value here (rather than null / null-by-design) preserves the
+    /// invariant that every <see cref="TranscriptTurnEntry.SessionId"/> is a
+    /// non-empty string — <see cref="ChatTranscriptStore.AppendTurn"/>
+    /// enforces this for live writes and the migration must not introduce
+    /// a class of entries that violates it.
+    /// </summary>
+    public const string LegacySessionId = "legacy-migrated";
+
+    /// <summary>
+    /// Type marker on the source entry that this migration drains. All other
+    /// types (<c>fact</c>, <c>preference</c>, <c>focus</c>, etc.) are durable
+    /// knowledge and must not be touched.
+    /// </summary>
+    public const string MigrateableType = "response";
+
+    /// <summary>
+    /// Builds a migration plan from the current contents of both stores. The
+    /// caller is responsible for loading <paramref name="memoryEntries"/>
+    /// and <paramref name="existingTranscriptTurns"/> from disk and for
+    /// persisting the plan's outputs.
+    /// </summary>
+    public static LegacyResponseMigrationPlan Plan(
+        IReadOnlyList<MemoryEntry> memoryEntries,
+        IReadOnlyList<TranscriptTurnEntry> existingTranscriptTurns)
+    {
+        ArgumentNullException.ThrowIfNull(memoryEntries);
+        ArgumentNullException.ThrowIfNull(existingTranscriptTurns);
+
+        var existingIds = existingTranscriptTurns
+            .Select(t => t.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var toMigrate    = new List<MemoryEntry>();
+        var toKeep       = new List<MemoryEntry>();
+        var newTurns     = new List<TranscriptTurnEntry>();
+        var alreadyDone  = new List<MemoryEntry>();
+
+        // Seed sequence numbers above the existing maximum so chronological
+        // tiebreaking via Sequence in ChatTranscriptStore.GetRecentAsync
+        // continues to work for both legacy and live turns. PR #174 review
+        // CR-H2 — sequence breaks Timestamp ties; new legacy turns sorted
+        // by their original Timestamp are safe even sharing the bucket.
+        var seqStart = existingTranscriptTurns.Count == 0
+            ? 0
+            : existingTranscriptTurns.Max(t => t.Sequence);
+
+        foreach (var entry in memoryEntries
+                     .OrderBy(e => e.Timestamp))   // chronological for deterministic Sequence ordering
+        {
+            if (!string.Equals(entry.Type, MigrateableType, StringComparison.OrdinalIgnoreCase))
+            {
+                toKeep.Add(entry);
+                continue;
+            }
+
+            var id = DeriveId(entry.Key, entry.Timestamp);
+            if (existingIds.Contains(id))
+            {
+                // Already migrated in a prior run — drop it from the source
+                // (so re-running --apply still completes the move), but do
+                // not re-emit a new transcript turn.
+                alreadyDone.Add(entry);
+                continue;
+            }
+
+            seqStart++;
+            newTurns.Add(new TranscriptTurnEntry(
+                Id:            id,
+                SessionId:     LegacySessionId,
+                Role:          "assistant",
+                Content:       entry.Content,
+                Timestamp:     entry.Timestamp,
+                Sequence:      seqStart,
+                CorrelationId: null,
+                AgentId:       null));
+            toMigrate.Add(entry);
+        }
+
+        return new LegacyResponseMigrationPlan(
+            EntriesToMigrate:          toMigrate,
+            EntriesToKeep:             toKeep,
+            EntriesAlreadyMigrated:    alreadyDone,
+            NewTranscriptTurns:        newTurns,
+            ExistingTranscriptTurns:   existingTranscriptTurns);
+    }
+
+    /// <summary>
+    /// Deterministic transcript-turn id for a legacy memory entry. The
+    /// <c>(Key, Timestamp)</c> pair uniquely identifies a legacy entry —
+    /// the historic <see cref="MemoryStore"/> rejected duplicate keys with
+    /// the same SessionId, so collisions within the legacy partition are
+    /// impossible by construction.
+    /// </summary>
+    public static string DeriveId(string key, DateTimeOffset timestamp)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        var payload = $"legacy|{key}|{timestamp:O}";
+        var bytes   = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return "legacy-" + Convert.ToHexString(bytes)[..24].ToLowerInvariant();
+    }
+}
+
+/// <summary>
+/// Outcome of <see cref="LegacyResponseMigration.Plan"/>. Holds every
+/// fragment the caller needs to execute the migration — the entries that
+/// will be removed from memory.json, the entries that will be kept, the
+/// new transcript turns to append, and a record of entries skipped because
+/// a prior run already migrated them.
+/// </summary>
+/// <param name="EntriesToMigrate">Source memory entries of type
+/// <c>response</c> that will be drained into the transcripts file.</param>
+/// <param name="EntriesToKeep">Source memory entries the migration leaves
+/// untouched — anything that is not type=response.</param>
+/// <param name="EntriesAlreadyMigrated">Source memory entries that map to
+/// transcript-turn ids already present in the transcripts file. These will
+/// be dropped from memory.json on --apply (the move is what finishes the
+/// migration) but no new transcript turn is emitted for them.</param>
+/// <param name="NewTranscriptTurns">Transcript turns that will be appended
+/// to the transcripts file. Sequence numbers are pre-assigned above the
+/// existing maximum.</param>
+/// <param name="ExistingTranscriptTurns">Snapshot of the transcripts file
+/// before migration. Useful for the writer to merge + atomic-rename.</param>
+public sealed record LegacyResponseMigrationPlan(
+    IReadOnlyList<MemoryEntry> EntriesToMigrate,
+    IReadOnlyList<MemoryEntry> EntriesToKeep,
+    IReadOnlyList<MemoryEntry> EntriesAlreadyMigrated,
+    IReadOnlyList<TranscriptTurnEntry> NewTranscriptTurns,
+    IReadOnlyList<TranscriptTurnEntry> ExistingTranscriptTurns)
+{
+    /// <summary>
+    /// True when running the plan would make zero changes. Lets the CLI
+    /// report "nothing to do — already migrated" without printing an empty
+    /// dry-run table.
+    /// </summary>
+    public bool IsNoOp =>
+        EntriesToMigrate.Count == 0 && EntriesAlreadyMigrated.Count == 0;
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/LegacyResponseMigrationTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/LegacyResponseMigrationTests.cs
@@ -98,7 +98,7 @@ public class LegacyResponseMigrationTests
         var entry = new MemoryEntry("response_x", "response", "answer", Tags: [], Timestamp: t0, SessionId: null);
 
         var priorTurn = new TranscriptTurnEntry(
-            Id:        LegacyResponseMigration.DeriveId(entry.Key, entry.Timestamp),
+            Id:        LegacyResponseMigration.DeriveId(entry.SessionId, entry.Key, entry.Timestamp),
             SessionId: LegacyResponseMigration.LegacySessionId,
             Role:      "assistant",
             Content:   "answer",
@@ -122,8 +122,8 @@ public class LegacyResponseMigrationTests
     {
         var ts = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
 
-        var id1 = LegacyResponseMigration.DeriveId("response_x", ts);
-        var id2 = LegacyResponseMigration.DeriveId("response_x", ts);
+        var id1 = LegacyResponseMigration.DeriveId(sessionId: null, "response_x", ts);
+        var id2 = LegacyResponseMigration.DeriveId(sessionId: null, "response_x", ts);
 
         Assert.That(id1, Is.EqualTo(id2));
         Assert.That(id1, Does.StartWith("legacy-"));
@@ -134,8 +134,8 @@ public class LegacyResponseMigrationTests
     public void DeriveId_DiffersForDifferentKeys()
     {
         var ts = DateTimeOffset.UtcNow;
-        var a = LegacyResponseMigration.DeriveId("response_a", ts);
-        var b = LegacyResponseMigration.DeriveId("response_b", ts);
+        var a = LegacyResponseMigration.DeriveId(sessionId: null, "response_a", ts);
+        var b = LegacyResponseMigration.DeriveId(sessionId: null, "response_b", ts);
         Assert.That(a, Is.Not.EqualTo(b));
     }
 
@@ -144,9 +144,26 @@ public class LegacyResponseMigrationTests
     {
         var t1 = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
         var t2 = t1.AddSeconds(1);
-        var a = LegacyResponseMigration.DeriveId("response_x", t1);
-        var b = LegacyResponseMigration.DeriveId("response_x", t2);
+        var a = LegacyResponseMigration.DeriveId(sessionId: null, "response_x", t1);
+        var b = LegacyResponseMigration.DeriveId(sessionId: null, "response_x", t2);
         Assert.That(a, Is.Not.EqualTo(b));
+    }
+
+    [Test]
+    public void DeriveId_DiffersForDifferentSessionIds()
+    {
+        // PR #176 review (LOW-DeriveId-Session) regression pin: even with
+        // identical (Key, Timestamp), two different SessionIds must produce
+        // distinct ids. Without this, per-session entries sharing a
+        // sub-second timestamp would collide and lose content on
+        // ChatTranscriptStore.Load()'s dictionary dedupe.
+        var ts = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var globalId  = LegacyResponseMigration.DeriveId(sessionId: null,         "k", ts);
+        var sessionA  = LegacyResponseMigration.DeriveId(sessionId: "session-A",  "k", ts);
+        var sessionB  = LegacyResponseMigration.DeriveId(sessionId: "session-B",  "k", ts);
+        Assert.That(globalId, Is.Not.EqualTo(sessionA));
+        Assert.That(sessionA, Is.Not.EqualTo(sessionB));
+        Assert.That(globalId, Is.Not.EqualTo(sessionB));
     }
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Unit/LegacyResponseMigrationTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/LegacyResponseMigrationTests.cs
@@ -1,0 +1,241 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Memory;
+
+/// <summary>
+/// Unit tests for <see cref="LegacyResponseMigration"/> — the one-shot
+/// drain of pre-PR-174 <c>type=response</c> memory entries into the
+/// transcript store. Pinned behaviors:
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item>Plan partitions correctly across mixed-type memory entries.</item>
+/// <item>Idempotency: a re-run with the prior turns already in the
+/// transcripts file drops the source entries without emitting duplicates.</item>
+/// <item>Deterministic id derivation across invocations.</item>
+/// <item>Sequence numbers continue above the existing maximum so the
+/// transcript store's tie-breaking sort remains correct.</item>
+/// <item>Non-response entries (durable knowledge — fact / preference / focus)
+/// are never touched.</item>
+/// </list>
+/// </remarks>
+[TestFixture]
+public class LegacyResponseMigrationTests
+{
+    [Test]
+    public void Plan_OnlyResponseEntries_MigratesAllAsAssistantTurns()
+    {
+        var t0 = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var entries = new[]
+        {
+            new MemoryEntry("response_a", "response", "answer about Cmaj7",
+                Tags: [], Timestamp: t0, SessionId: null),
+            new MemoryEntry("response_b", "response", "answer about scales",
+                Tags: ["topic:scales"], Timestamp: t0.AddMinutes(1), SessionId: null),
+        };
+
+        var plan = LegacyResponseMigration.Plan(entries, []);
+
+        Assert.That(plan.EntriesToMigrate.Count, Is.EqualTo(2));
+        Assert.That(plan.EntriesToKeep, Is.Empty);
+        Assert.That(plan.EntriesAlreadyMigrated, Is.Empty);
+        Assert.That(plan.NewTranscriptTurns.Count, Is.EqualTo(2));
+        Assert.That(plan.NewTranscriptTurns.All(t => t.Role == "assistant"));
+        Assert.That(plan.NewTranscriptTurns.All(
+            t => t.SessionId == LegacyResponseMigration.LegacySessionId));
+        Assert.That(plan.IsNoOp, Is.False);
+    }
+
+    [Test]
+    public void Plan_MixedTypes_OnlyResponseMigrated_DurableTypesPreserved()
+    {
+        var t0 = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var entries = new[]
+        {
+            new MemoryEntry("fact_audience",  "fact",       "intermediate guitarists",
+                Tags: [], Timestamp: t0, SessionId: null),
+            new MemoryEntry("response_x",     "response",   "answer",
+                Tags: [], Timestamp: t0.AddSeconds(1), SessionId: null),
+            new MemoryEntry("pref_voicings",  "preference", "drop-2",
+                Tags: [], Timestamp: t0.AddSeconds(2), SessionId: null),
+            new MemoryEntry("focus_jazz",     "focus",      "jazz comping",
+                Tags: [], Timestamp: t0.AddSeconds(3), SessionId: null),
+        };
+
+        var plan = LegacyResponseMigration.Plan(entries, []);
+
+        Assert.That(plan.EntriesToMigrate.Count, Is.EqualTo(1));
+        Assert.That(plan.EntriesToMigrate.Single().Key, Is.EqualTo("response_x"));
+        Assert.That(plan.EntriesToKeep.Select(e => e.Type),
+            Is.EquivalentTo(new[] { "fact", "preference", "focus" }),
+            "fact / preference / focus are durable knowledge — must be left untouched.");
+    }
+
+    [Test]
+    public void Plan_IsNoOp_WhenNoResponseEntries()
+    {
+        var entries = new[]
+        {
+            new MemoryEntry("fact_a", "fact", "durable", Tags: [], Timestamp: DateTimeOffset.UtcNow, SessionId: null),
+        };
+
+        var plan = LegacyResponseMigration.Plan(entries, []);
+
+        Assert.That(plan.IsNoOp, Is.True);
+        Assert.That(plan.EntriesToKeep.Count, Is.EqualTo(1));
+        Assert.That(plan.NewTranscriptTurns, Is.Empty);
+    }
+
+    [Test]
+    public void Plan_AlreadyMigrated_ReportedSeparately_AndNoDuplicateTurnEmitted()
+    {
+        // Idempotency contract: if a prior --apply run produced a transcript
+        // turn with the deterministic id, the current plan must not emit a
+        // duplicate. The source entry still belongs in EntriesToMigrate's
+        // "drop from memory.json" outcome — that's how a re-run finishes a
+        // partially-completed migration.
+        var t0 = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var entry = new MemoryEntry("response_x", "response", "answer", Tags: [], Timestamp: t0, SessionId: null);
+
+        var priorTurn = new TranscriptTurnEntry(
+            Id:        LegacyResponseMigration.DeriveId(entry.Key, entry.Timestamp),
+            SessionId: LegacyResponseMigration.LegacySessionId,
+            Role:      "assistant",
+            Content:   "answer",
+            Timestamp: t0,
+            Sequence:  1);
+
+        var plan = LegacyResponseMigration.Plan([entry], [priorTurn]);
+
+        Assert.That(plan.EntriesAlreadyMigrated.Count, Is.EqualTo(1),
+            "Entry whose deterministic id is already in transcripts must surface as already-migrated.");
+        Assert.That(plan.EntriesToMigrate, Is.Empty,
+            "Already-migrated entries must NOT also be in the new-migration list.");
+        Assert.That(plan.NewTranscriptTurns, Is.Empty,
+            "Idempotency: no duplicate transcript turn emitted.");
+        Assert.That(plan.IsNoOp, Is.False,
+            "Re-running with already-migrated entries is still actionable — the memory rows need removal.");
+    }
+
+    [Test]
+    public void DeriveId_IsDeterministic_AcrossCalls()
+    {
+        var ts = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+
+        var id1 = LegacyResponseMigration.DeriveId("response_x", ts);
+        var id2 = LegacyResponseMigration.DeriveId("response_x", ts);
+
+        Assert.That(id1, Is.EqualTo(id2));
+        Assert.That(id1, Does.StartWith("legacy-"));
+        Assert.That(id1.Length, Is.EqualTo("legacy-".Length + 24));
+    }
+
+    [Test]
+    public void DeriveId_DiffersForDifferentKeys()
+    {
+        var ts = DateTimeOffset.UtcNow;
+        var a = LegacyResponseMigration.DeriveId("response_a", ts);
+        var b = LegacyResponseMigration.DeriveId("response_b", ts);
+        Assert.That(a, Is.Not.EqualTo(b));
+    }
+
+    [Test]
+    public void DeriveId_DiffersForDifferentTimestamps()
+    {
+        var t1 = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var t2 = t1.AddSeconds(1);
+        var a = LegacyResponseMigration.DeriveId("response_x", t1);
+        var b = LegacyResponseMigration.DeriveId("response_x", t2);
+        Assert.That(a, Is.Not.EqualTo(b));
+    }
+
+    [Test]
+    public void Plan_NewTurnsSequencedAboveExistingMaximum()
+    {
+        // Existing transcripts already have Sequence values; new turns must
+        // start above the maximum so ChatTranscriptStore.GetRecentAsync's
+        // Timestamp+Sequence tie-break remains correct.
+        var t0 = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var existing = new[]
+        {
+            new TranscriptTurnEntry("existing-1", "live-session", "user",      "hi", t0.AddDays(-1), Sequence: 7),
+            new TranscriptTurnEntry("existing-2", "live-session", "assistant", "hello", t0.AddDays(-1).AddSeconds(1), Sequence: 12),
+        };
+        var entries = new[]
+        {
+            new MemoryEntry("response_a", "response", "old answer", Tags: [], Timestamp: t0, SessionId: null),
+        };
+
+        var plan = LegacyResponseMigration.Plan(entries, existing);
+
+        Assert.That(plan.NewTranscriptTurns.Single().Sequence, Is.GreaterThan(12),
+            "New legacy turn's Sequence must start above the existing max (12).");
+    }
+
+    [Test]
+    public void Plan_MigratedTurnsOrderedChronologicallyWithMonotonicSequence()
+    {
+        // Even when input order is jumbled, the emitted turns must be
+        // ordered by source Timestamp and have strictly-increasing Sequence.
+        // This guarantees the curator sees them in the natural order they
+        // were originally produced.
+        var t0 = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+        var entries = new[]
+        {
+            new MemoryEntry("c", "response", "third",  Tags: [], Timestamp: t0.AddMinutes(2), SessionId: null),
+            new MemoryEntry("a", "response", "first",  Tags: [], Timestamp: t0,                  SessionId: null),
+            new MemoryEntry("b", "response", "second", Tags: [], Timestamp: t0.AddMinutes(1), SessionId: null),
+        };
+
+        var plan = LegacyResponseMigration.Plan(entries, []);
+
+        Assert.That(plan.NewTranscriptTurns.Select(t => t.Content),
+            Is.EqualTo(new[] { "first", "second", "third" }));
+        var seqs = plan.NewTranscriptTurns.Select(t => t.Sequence).ToArray();
+        for (var i = 1; i < seqs.Length; i++)
+        {
+            Assert.That(seqs[i], Is.GreaterThan(seqs[i - 1]),
+                $"Sequence must be strictly increasing across migrated turns: {string.Join(",", seqs)}");
+        }
+    }
+
+    [Test]
+    public void Plan_PreservesContentAndTimestampVerbatim()
+    {
+        // Migration must not paraphrase or normalize content/timestamp —
+        // the value is a forensic record of what the chatbot said and when.
+        var ts = new DateTimeOffset(2026, 3, 1, 12, 34, 56, 789, TimeSpan.Zero);
+        var entry = new MemoryEntry("response_x", "response",
+            "Cmaj7 = C E G B", Tags: ["a", "b"], Timestamp: ts, SessionId: null);
+
+        var plan = LegacyResponseMigration.Plan([entry], []);
+        var turn = plan.NewTranscriptTurns.Single();
+
+        Assert.That(turn.Content,   Is.EqualTo("Cmaj7 = C E G B"));
+        Assert.That(turn.Timestamp, Is.EqualTo(ts));
+    }
+
+    [Test]
+    public void Plan_ResponseTypeMatchIsCaseInsensitive()
+    {
+        // Defensive: a few legacy entries may have "Response" or "RESPONSE"
+        // capitalization. We still want to migrate them.
+        var entries = new[]
+        {
+            new MemoryEntry("a", "Response", "answer1", Tags: [], Timestamp: DateTimeOffset.UtcNow, SessionId: null),
+            new MemoryEntry("b", "RESPONSE", "answer2", Tags: [], Timestamp: DateTimeOffset.UtcNow.AddSeconds(1), SessionId: null),
+            new MemoryEntry("c", "response", "answer3", Tags: [], Timestamp: DateTimeOffset.UtcNow.AddSeconds(2), SessionId: null),
+        };
+
+        var plan = LegacyResponseMigration.Plan(entries, []);
+
+        Assert.That(plan.EntriesToMigrate.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Plan_NullArguments_Throw()
+    {
+        Assert.That(() => LegacyResponseMigration.Plan(null!, []), Throws.InstanceOf<ArgumentNullException>());
+        Assert.That(() => LegacyResponseMigration.Plan([], null!), Throws.InstanceOf<ArgumentNullException>());
+    }
+}


### PR DESCRIPTION
## Summary

Closes the PR #174 follow-up: the user's `~/.ga/memory.json` contained 86 entries from before the Phase-2 split, **all of which were `type=response`** — transient chat logs miscategorized as durable memory. They crowd out real `fact`/`preference`/`focus` entries the curator and `EnrichOnRetrieve` are designed for.

## What changed

- **`LegacyResponseMigration`** (`Common/GA.Business.ML/Agents/Memory/LegacyResponseMigration.cs`) — pure planner, no IO. Derives deterministic transcript-turn ids from `SHA256("legacy|" + key + "|" + timestamp)` so the migration is idempotent across re-runs.
- **`ga-memory migrate-transcripts [--apply]`** subcommand — dry-run by default, `--apply` commits with `.bak-{stamp}` backups of both files. Drains every `type=response` entry into `transcripts.json` under `SessionId='legacy-migrated'` `Role='assistant'`. Non-response entries (fact / preference / focus / etc.) are untouched.
- **12 unit tests** covering partitioning, idempotency, deterministic id derivation, sequence ordering, chronological emission, case-insensitive type matching, null-arg defense.

## Test plan

End-to-end smoke against a temp copy of the real `~/.ga/memory.json`:

- [x] **dry-run** → 86 to migrate, 0 already done
- [x] **`--apply`** → 86 written to `transcripts.json`, 0 left in `memory.json`, backup made
- [x] **re-run** → "Nothing to do" (idempotency contract holds)
- [x] 12/12 unit tests green
- [x] Build green
- [x] No production write-path code touched — pure additive (new module + CLI subcommand)

## Why migrate (not delete)

The legacy entries are one-sided assistant responses without their originating user prompts, but the curator can still mine them for emergent patterns. Bucketing under a single `legacy-migrated` session keeps them out of live sessions' views (`GetRecentAsync` newest-first ordering already deprioritizes ancient timestamps).

## Operator playbook

```powershell
# 1. Inspect what would change (no writes)
dotnet run --project Apps/GaMemoryCli -- migrate-transcripts

# 2. Commit (creates .bak-{stamp} backups of both files)
dotnet run --project Apps/GaMemoryCli -- migrate-transcripts --apply

# 3. Verify idempotency
dotnet run --project Apps/GaMemoryCli -- migrate-transcripts
# expect: "Nothing to do — memory.json contains no type=response entries."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)