### PR TITLE
feat(memory): audit channel for dropped MemoryHook responses

### DIFF
--- a/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
@@ -45,6 +45,20 @@ public sealed class MemoryHook(
     // process, not per request. 0 = not yet logged; 1 = already logged.
     private int _loggedNullSessionId;
 
+    // ── Audit counters (PR #174 follow-up: dropped-response visibility) ──
+    // OnResponseSent silently skips writes when Confidence < 0.7 OR
+    // Result.Length < 100. Without an audit channel operators can't
+    // distinguish "MemoryHook is working but the chatbot rarely meets
+    // threshold" from "MemoryHook is broken." These counters surface the
+    // distribution via Information logs (once per reason on first hit, then
+    // every <see cref="AuditSummaryInterval"/> drops) and Debug logs on
+    // every drop. No behavior change — observability only.
+    private long _droppedLowConfidence;
+    private long _droppedShortContent;
+    private int  _loggedFirstLowConfidence;
+    private int  _loggedFirstShortContent;
+    private const int AuditSummaryInterval = 100;
+
     /// <summary>
     /// Searches memory for context relevant to the incoming message and prepends it.
     /// Off by default; enable with <c>Memory:EnrichOnRetrieve=true</c>.
@@ -125,8 +139,24 @@ public sealed class MemoryHook(
     /// </summary>
     public Task<HookResult> OnResponseSent(ChatHookContext ctx, CancellationToken ct = default)
     {
-        if (ctx.Response is not { Confidence: >= 0.7f } response) return Task.FromResult(HookResult.Continue);
-        if (response.Result.Length < 100) return Task.FromResult(HookResult.Continue);
+        // PR #174 follow-up: each threshold drop records an audit entry so
+        // operators can see why responses aren't reaching the transcript
+        // store. The structure of the guard chain is preserved (still two
+        // sequential early-returns) — only the side-effect is new.
+        if (ctx.Response is not { Confidence: >= 0.7f } response)
+        {
+            // Distinguish "no response at all" (genuinely nothing to write)
+            // from "response present but below confidence threshold" (a
+            // real drop). Only the latter is audit-worthy.
+            if (ctx.Response is not null)
+                RecordDrop("low-confidence", $"confidence={ctx.Response.Confidence:F2}");
+            return Task.FromResult(HookResult.Continue);
+        }
+        if (response.Result.Length < 100)
+        {
+            RecordDrop("short-content", $"length={response.Result.Length}");
+            return Task.FromResult(HookResult.Continue);
+        }
 
         // Per PR #161 review F-4 (preventative): refuse to write when
         // SessionId is null. ProductionOrchestrator currently always sets
@@ -205,4 +235,58 @@ public sealed class MemoryHook(
     /// assistant turns to bound storage cost — PR #174 review HIGH-2.
     /// </summary>
     private const int TurnContentCap = 2000;
+
+    /// <summary>
+    /// Records that <see cref="OnResponseSent"/> dropped a response without
+    /// writing it. Drives the audit-log channel: Information on first
+    /// occurrence per reason (rate-limited via
+    /// <see cref="Interlocked.CompareExchange(ref int, int, int)"/>), an
+    /// Information summary every <see cref="AuditSummaryInterval"/> drops,
+    /// and Debug on every individual drop.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Counters are per-process (instance-scoped). They reset on restart
+    /// — sufficient for "is this hook silently swallowing everything?"
+    /// triage but not for long-running quality trend analysis. Exporting
+    /// the counters to OpenTelemetry / Prometheus is a future iteration;
+    /// for now the log channel is the operator-facing surface.
+    /// </para>
+    /// </remarks>
+    private void RecordDrop(string reason, string detail)
+    {
+        long count;
+        bool firstForReason;
+
+        if (reason == "low-confidence")
+        {
+            count          = Interlocked.Increment(ref _droppedLowConfidence);
+            firstForReason = Interlocked.CompareExchange(ref _loggedFirstLowConfidence, 1, 0) == 0;
+        }
+        else  // "short-content"
+        {
+            count          = Interlocked.Increment(ref _droppedShortContent);
+            firstForReason = Interlocked.CompareExchange(ref _loggedFirstShortContent, 1, 0) == 0;
+        }
+
+        if (firstForReason)
+        {
+            logger.LogInformation(
+                "MemoryHook audit: first response dropped for reason '{Reason}' ({Detail}). " +
+                "Future drops for this reason will be summarized every {Interval} occurrences. " +
+                "Per-drop detail is at Debug level. This first-hit message logs once per " +
+                "reason per process — restart the process to see it again.",
+                reason, detail, AuditSummaryInterval);
+        }
+        else if (count % AuditSummaryInterval == 0)
+        {
+            logger.LogInformation(
+                "MemoryHook audit: {Reason} drops = {Count} since process start.",
+                reason, count);
+        }
+
+        logger.LogDebug(
+            "MemoryHook drop: reason={Reason} detail={Detail} count={Count}",
+            reason, detail, count);
+    }
 }

--- a/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
@@ -53,10 +53,21 @@ public sealed class MemoryHook(
     // distribution via Information logs (once per reason on first hit, then
     // every <see cref="AuditSummaryInterval"/> drops) and Debug logs on
     // every drop. No behavior change — observability only.
+    //
+    // PR #177 review (correctness MED-1): first-hit and 100th-drop summary
+    // gate on the post-increment count value directly (count == 1 / count %
+    // 100 == 0). The Interlocked.Increment returns a unique value per
+    // caller, so exactly one thread observes count == 1 and exactly one
+    // thread per 100-band observes count % 100 == 0. This eliminates the
+    // CAS-vs-Increment race that the previous CompareExchange-gated design
+    // could hit under singleton-shared concurrent OnResponseSent calls.
+    //
+    // NOTE: this hook is registered AddSingleton (see GaPlugin.cs). If that
+    // lifetime ever changes to Scoped/Transient, the counters reset per
+    // request and the first-hit log fires on every dropped response. The
+    // singleton invariant is load-bearing for the audit channel.
     private long _droppedLowConfidence;
     private long _droppedShortContent;
-    private int  _loggedFirstLowConfidence;
-    private int  _loggedFirstShortContent;
     private const int AuditSummaryInterval = 100;
 
     /// <summary>
@@ -148,13 +159,18 @@ public sealed class MemoryHook(
             // Distinguish "no response at all" (genuinely nothing to write)
             // from "response present but below confidence threshold" (a
             // real drop). Only the latter is audit-worthy.
+            //
+            // PR #177 review (reliability MED-1/MED-2): pass the raw float
+            // through so the detail string is materialized ONLY when the
+            // first-hit or summary log actually fires — saves an allocation
+            // per dropped response on the hot path.
             if (ctx.Response is not null)
-                RecordDrop("low-confidence", $"confidence={ctx.Response.Confidence:F2}");
+                RecordLowConfidenceDrop(ctx.Response.Confidence);
             return Task.FromResult(HookResult.Continue);
         }
         if (response.Result.Length < 100)
         {
-            RecordDrop("short-content", $"length={response.Result.Length}");
+            RecordShortContentDrop(response.Result.Length);
             return Task.FromResult(HookResult.Continue);
         }
 
@@ -253,30 +269,50 @@ public sealed class MemoryHook(
     /// for now the log channel is the operator-facing surface.
     /// </para>
     /// </remarks>
-    private void RecordDrop(string reason, string detail)
+    private void RecordLowConfidenceDrop(float confidence)
     {
-        long count;
-        bool firstForReason;
+        var count = Interlocked.Increment(ref _droppedLowConfidence);
+        EmitAuditLogs("low-confidence", count, "confidence", confidence);
+    }
 
-        if (reason == "low-confidence")
-        {
-            count          = Interlocked.Increment(ref _droppedLowConfidence);
-            firstForReason = Interlocked.CompareExchange(ref _loggedFirstLowConfidence, 1, 0) == 0;
-        }
-        else  // "short-content"
-        {
-            count          = Interlocked.Increment(ref _droppedShortContent);
-            firstForReason = Interlocked.CompareExchange(ref _loggedFirstShortContent, 1, 0) == 0;
-        }
+    private void RecordShortContentDrop(int length)
+    {
+        var count = Interlocked.Increment(ref _droppedShortContent);
+        EmitAuditLogs("short-content", count, "length", length);
+    }
 
-        if (firstForReason)
+    /// <summary>
+    /// Shared log-emission tail for both drop reasons. Split out from
+    /// <see cref="RecordLowConfidenceDrop"/> and
+    /// <see cref="RecordShortContentDrop"/> to keep them branchless on the
+    /// hot path (PR #177 review reliability MED-1/MED-2: avoid per-call
+    /// string allocation for the detail; let ILogger's structured args
+    /// defer formatting until a sink actually consumes the message).
+    /// </summary>
+    /// <remarks>
+    /// Two reasons today (<c>low-confidence</c> and <c>short-content</c>)
+    /// get explicit named methods rather than a string-tagged dispatch.
+    /// That makes adding a third reason a deliberate change to this file
+    /// (PR #177 review reliability MED-Reason-Drift) rather than a silent
+    /// bucketing into one of the existing counters.
+    /// </remarks>
+    private void EmitAuditLogs(string reason, long count, string detailKey, object detailValue)
+    {
+        // PR #177 review (correctness MED-1): gate first-hit and summary on
+        // the post-increment count value itself. Interlocked.Increment
+        // returns a unique value per caller, so exactly one thread observes
+        // count == 1 (the winner of the first race) and exactly one thread
+        // per 100-band observes count % 100 == 0. No CompareExchange needed
+        // — and no race window where another thread can win the first-hit
+        // CAS with a higher count than 1.
+        if (count == 1)
         {
             logger.LogInformation(
-                "MemoryHook audit: first response dropped for reason '{Reason}' ({Detail}). " +
+                "MemoryHook audit: first response dropped for reason '{Reason}' ({DetailKey}={DetailValue}). " +
                 "Future drops for this reason will be summarized every {Interval} occurrences. " +
                 "Per-drop detail is at Debug level. This first-hit message logs once per " +
                 "reason per process — restart the process to see it again.",
-                reason, detail, AuditSummaryInterval);
+                reason, detailKey, detailValue, AuditSummaryInterval);
         }
         else if (count % AuditSummaryInterval == 0)
         {
@@ -285,8 +321,16 @@ public sealed class MemoryHook(
                 reason, count);
         }
 
-        logger.LogDebug(
-            "MemoryHook drop: reason={Reason} detail={Detail} count={Count}",
-            reason, detail, count);
+        // PR #177 review reliability MED-2: gate behind IsEnabled so the
+        // per-drop debug call doesn't allocate the args array under
+        // production logging filters. The IsEnabled call is a single
+        // virtual dispatch; the args array allocation otherwise lives on
+        // the hot path.
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(
+                "MemoryHook drop: reason={Reason} {DetailKey}={DetailValue} count={Count}",
+                reason, detailKey, detailValue, count);
+        }
     }
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryHookAuditChannelTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryHookAuditChannelTests.cs
@@ -1,0 +1,222 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Collections.Concurrent;
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Hooks;
+using GA.Business.ML.Agents.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// Pins the dropped-response audit channel (PR #174 follow-up). The hook
+/// silently skips writes when <see cref="AgentResponse.Confidence"/> &lt; 0.7
+/// OR <see cref="AgentResponse.Result"/> length &lt; 100. Without an audit
+/// log, operators can't tell whether "no entries in the transcript store"
+/// means "MemoryHook is broken" or "the chatbot rarely meets threshold."
+/// </summary>
+/// <remarks>
+/// Behavior contract pinned here:
+/// <list type="bullet">
+/// <item>First drop per reason logs at Information.</item>
+/// <item>Every 100 drops per reason logs a summary at Information.</item>
+/// <item>Every drop logs at Debug (regardless of count).</item>
+/// <item>Confidence floor and content-length floor are tracked as distinct reasons.</item>
+/// <item>Successful writes (above both thresholds) emit no audit messages.</item>
+/// <item>Null Response is not counted as a drop — there's nothing to drop.</item>
+/// </list>
+/// </remarks>
+[TestFixture]
+public class MemoryHookAuditChannelTests
+{
+    private string _tempDir = string.Empty;
+    private string _memoryPath = string.Empty;
+    private string _transcriptPath = string.Empty;
+    private MemoryStore _store = null!;
+    private ChatTranscriptStore _transcriptStore = null!;
+    private RecordingLogger<MemoryHook> _logger = null!;
+    private MemoryHook _hook = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir        = Path.Combine(Path.GetTempPath(), $"ga-audit-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _memoryPath     = Path.Combine(_tempDir, "memory.json");
+        _transcriptPath = Path.Combine(_tempDir, "transcripts.json");
+        _store          = new MemoryStore(_memoryPath);
+        _transcriptStore = new ChatTranscriptStore(_transcriptPath);
+
+        // EnrichOnRetrieve=false — these tests exercise OnResponseSent only;
+        // we don't need the retrieval branch enabled.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Memory:EnrichOnRetrieve"] = "false",
+            })
+            .Build();
+
+        _logger = new RecordingLogger<MemoryHook>();
+        _hook = new MemoryHook(_store, _transcriptStore, config, _logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Test]
+    public async Task LowConfidence_Drop_LogsFirstHitAtInformation()
+    {
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.5f, contentLength: 200));
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        Assert.That(infos, Has.Count.EqualTo(1),
+            "First-hit message should fire once at Information.");
+        Assert.That(infos[0].Message, Does.Contain("low-confidence"));
+        Assert.That(infos[0].Message, Does.Contain("first response dropped"));
+    }
+
+    [Test]
+    public async Task ShortContent_Drop_LogsFirstHitAtInformation()
+    {
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.95f, contentLength: 50));
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        Assert.That(infos, Has.Count.EqualTo(1));
+        Assert.That(infos[0].Message, Does.Contain("short-content"));
+    }
+
+    [Test]
+    public async Task LowConfidence_SubsequentDrops_DoNotLogFirstHitAgain()
+    {
+        // First drop: fires the first-hit Information message.
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.5f, contentLength: 200));
+        // 50 more drops: none should fire another first-hit message.
+        for (var i = 0; i < 50; i++)
+            await _hook.OnResponseSent(MakeCtx(confidence: 0.5f, contentLength: 200));
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        Assert.That(infos, Has.Count.EqualTo(1),
+            "First-hit log should be rate-limited to once per process per reason.");
+    }
+
+    [Test]
+    public async Task LowConfidence_SummaryFires_EveryHundredDrops()
+    {
+        // 100 drops total -> 1 first-hit + 1 summary at count=100.
+        for (var i = 0; i < 100; i++)
+            await _hook.OnResponseSent(MakeCtx(confidence: 0.5f, contentLength: 200));
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        Assert.That(infos, Has.Count.EqualTo(2));
+        Assert.That(infos[0].Message, Does.Contain("first response dropped"));
+        Assert.That(infos[1].Message, Does.Contain("low-confidence drops = 100"));
+    }
+
+    [Test]
+    public async Task LowConfidence_AndShortContent_TrackedIndependently()
+    {
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.5f,  contentLength: 200));
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.95f, contentLength: 50));
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        Assert.That(infos, Has.Count.EqualTo(2),
+            "Each reason should fire its own first-hit Information message.");
+        Assert.That(infos.Any(e => e.Message.Contains("low-confidence")));
+        Assert.That(infos.Any(e => e.Message.Contains("short-content")));
+    }
+
+    [Test]
+    public async Task SuccessfulWrite_AboveBothThresholds_EmitsNoAuditMessages()
+    {
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.95f, contentLength: 200, sessionId: "s1"));
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        Assert.That(infos, Is.Empty,
+            "A response that meets both thresholds should not produce an audit log entry.");
+        Assert.That(_logger.Entries.Where(e =>
+                e.Level == LogLevel.Debug && e.Message.Contains("drop")),
+            Is.Empty,
+            "Successful writes should not record a Debug drop either.");
+    }
+
+    [Test]
+    public async Task NullResponse_NotCountedAsDrop()
+    {
+        // ctx with Response==null: nothing to write, but it's NOT a "drop"
+        // — the audit channel should distinguish this from below-threshold.
+        var ctx = new ChatHookContext
+        {
+            OriginalMessage = "hi",
+            CurrentMessage  = "hi",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = "sess-A",
+            Response        = null,
+        };
+
+        await _hook.OnResponseSent(ctx);
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        Assert.That(infos, Is.Empty,
+            "Null Response is 'nothing to write,' not 'dropped because below threshold' — no audit log.");
+    }
+
+    [Test]
+    public async Task EveryDrop_EmitsDebugLog()
+    {
+        // Three drops, all at Debug level (regardless of summary cadence).
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.5f, contentLength: 200));
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.6f, contentLength: 200));
+        await _hook.OnResponseSent(MakeCtx(confidence: 0.95f, contentLength: 30));
+
+        var debugs = _logger.Entries
+            .Where(e => e.Level == LogLevel.Debug && e.Message.Contains("MemoryHook drop"))
+            .ToList();
+        Assert.That(debugs, Has.Count.EqualTo(3),
+            "Each drop must emit one Debug-level audit entry — that's the per-drop forensic channel.");
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private static ChatHookContext MakeCtx(
+        float confidence,
+        int contentLength,
+        string? sessionId = "sess-A") => new()
+    {
+        OriginalMessage = "hi",
+        CurrentMessage  = "hi",
+        CorrelationId   = Guid.NewGuid(),
+        SessionId       = sessionId,
+        Response = new AgentResponse
+        {
+            AgentId    = "test-agent",
+            Result     = new string('x', contentLength),
+            Confidence = confidence,
+        },
+    };
+
+    /// <summary>
+    /// Captures log entries in-memory for assertion. Thread-safe so the
+    /// 100-drop summary test can hit the logger concurrently without
+    /// racing on the entries list (we don't actually use parallelism in
+    /// these tests, but the cost of safety is zero).
+    /// </summary>
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public ConcurrentQueue<LogEntry> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Enqueue(new LogEntry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message);
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryHookAuditChannelTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryHookAuditChannelTests.cs
@@ -164,6 +164,33 @@ public class MemoryHookAuditChannelTests
     }
 
     [Test]
+    public async Task ConcurrentDrops_ExactlyOneFirstHit_AndCorrectSummaryCount()
+    {
+        // PR #177 review (correctness MED-1) regression pin: under
+        // concurrent OnResponseSent, the previous CompareExchange-gated
+        // design could let one thread win the first-hit CAS with count=100
+        // while another thread saw count=1 with firstForReason=false, both
+        // suppressing the count=100 summary AND attributing wrong detail
+        // to the first-hit log. The fixed design gates on count == 1
+        // directly so exactly one thread observes the first hit. Run 500
+        // parallel drops — expect exactly 1 first-hit + 5 summaries.
+        const int total = 500;
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, total),
+            new ParallelOptions { MaxDegreeOfParallelism = 16 },
+            async (_, _) => await _hook.OnResponseSent(MakeCtx(confidence: 0.5f, contentLength: 200)));
+
+        var infos = _logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        var firstHits = infos.Count(e => e.Message.Contains("first response dropped"));
+        var summaries = infos.Count(e => e.Message.Contains("low-confidence drops ="));
+
+        Assert.That(firstHits, Is.EqualTo(1),
+            "Exactly one thread must observe count == 1 (no CAS race) — got first-hits = " + firstHits);
+        Assert.That(summaries, Is.EqualTo(total / 100),
+            $"Summary log must fire at every 100-multiple (5 times for total={total}).");
+    }
+
+    [Test]
     public async Task EveryDrop_EmitsDebugLog()
     {
         // Three drops, all at Debug level (regardless of summary cadence).


### PR DESCRIPTION
## Summary

Closes the PR #174 review follow-up: `MemoryHook.OnResponseSent` silently skips writes when `Confidence < 0.7` OR `Result.Length < 100`. Without an audit channel, operators couldn't distinguish "MemoryHook is working but the chatbot rarely meets threshold" from "MemoryHook is broken."

**Observability only — no behavior change.** The two early-return guards retain their structure; only the side-effect (`RecordDrop`) is new.

## Behavior contract (pinned by 8 unit tests)

| Event | Log Level | Cadence |
|---|---|---|
| First drop per reason | Information | Once per process per reason (rate-limited via `Interlocked.CompareExchange`) |
| Every 100th drop | Information | Summary with running count |
| Every drop | Debug | Per-drop forensic line |
| Null `Response` | (none) | Not counted as a drop — genuinely nothing to write |
| Successful write | (none) | No audit emission |

Two reasons tracked independently — confidence floor and content-length floor each get their own first-hit log + summary cadence.

## Test plan

- [x] 8 unit tests covering first-hit cadence, summary cadence, debug-per-drop, two-reason isolation, null-response exclusion, successful-write silence
- [x] 23/23 across full `MemoryHook` test surface (Session-Plumbing + SC-001 + Audit-Channel) green
- [x] Build green

## Future iteration

Export the counters to OpenTelemetry / Prometheus so the operator surface lives beyond process restart. Today the log channel is the only surface; the counters are per-instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)