### PR TITLE
feat(memory): RememberThis skill + MemoryWriteHook — first durable-memory writer

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -63,6 +63,14 @@ public sealed class GaPlugin : IChatPlugin
         services.AddOrchestratorSkillIntent<KeyIdentificationSkill>(ServiceLifetime.Scoped);
         services.AddOrchestratorSkillIntent<ProgressionCompletionSkill>(ServiceLifetime.Scoped);
 
+        // Durable-memory writer (2026-05-11) — first explicit "remember this"
+        // skill. Emits a MemoryWriteRequest on AgentResponse.Data; the new
+        // MemoryWriteHook below picks it up on OnResponseSent and writes via
+        // the caller's SessionId. Closes the loop on EnrichOnRetrieve — until
+        // this skill, MemoryStore had no fact/preference/focus writer at all
+        // (transcript turns post-PR #174 go to ChatTranscriptStore).
+        services.AddOrchestratorSkillIntent<RememberThisSkill>();
+
         // ── Persistent memory ────────────────────────────────────────────────
         // Construct via factory so we can wire ILogger<MemoryStore> for the
         // Load() IO-error surfacing introduced in PR #157 review rel-001.
@@ -86,6 +94,13 @@ public sealed class GaPlugin : IChatPlugin
         // ── Hooks (execute in registration order at each lifecycle point) ─────
         services.AddSingleton<IChatHook, PromptSanitizationHook>();
         services.AddSingleton<IChatHook, MemoryHook>();
+        // MemoryWriteHook (2026-05-11) — picks up MemoryWriteRequest emitted
+        // by RememberThisSkill on AgentResponse.Data and persists with the
+        // caller's SessionId. Registered AFTER MemoryHook so MemoryHook's
+        // transcript-write fires first (transcript = ground truth of what
+        // was said), then MemoryWriteHook persists the structured durable
+        // claim. Both are idempotent; order is for log ordering, not safety.
+        services.AddSingleton<IChatHook, MemoryWriteHook>();
         services.AddSingleton<IChatHook, ObservabilityHook>();
     }
 

--- a/Common/GA.Business.ML/Agents/Hooks/MemoryWriteHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryWriteHook.cs
@@ -1,0 +1,117 @@
+namespace GA.Business.ML.Agents.Hooks;
+
+using Memory;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Picks up a <see cref="MemoryWriteRequest"/> emitted on
+/// <see cref="AgentResponse.Data"/> by <c>RememberThisSkill</c> (or any
+/// future skill that wants to persist durable knowledge) and writes it
+/// to <see cref="MemoryStore"/> under the caller's
+/// <see cref="ChatHookContext.SessionId"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a hook rather than skill-side writes:</b>
+/// <see cref="IOrchestratorSkill.ExecuteAsync"/> is session-agnostic — the
+/// skill cannot see <see cref="ChatHookContext.SessionId"/>. Routing every
+/// durable-write through this hook keeps session-scoping enforced
+/// centrally: the storage write happens in exactly one place, with one
+/// known invariant (SessionId from the live chat context).
+/// </para>
+/// <para>
+/// <b>Refuses on null SessionId.</b> Same posture as
+/// <see cref="MemoryHook.OnResponseSent"/>'s SC-001 guard: writing to the
+/// global partition without the operator-flagged
+/// <c>Memory:AllowLlmGlobalWrite</c> path would defeat the session-scoping
+/// defense. When SessionId is null, log a warning and let the user's
+/// "I've saved..." confirmation hang — operationally that's a clearer
+/// signal than silently writing to global and breaking the security
+/// posture downstream.
+/// </para>
+/// <para>
+/// <b>Refuses on disallowed types.</b> Only <c>fact</c> / <c>preference</c> /
+/// <c>focus</c> writes are accepted. <c>response</c> is the transient
+/// transcript-store type post-PR #174 — a remember-skill emitting that
+/// type would mean a bug, and we refuse rather than re-introduce the
+/// architectural conflation that PR #173/#174 closed.
+/// </para>
+/// </remarks>
+public sealed class MemoryWriteHook(
+    MemoryStore memoryStore,
+    ILogger<MemoryWriteHook> logger) : IChatHook
+{
+    /// <summary>
+    /// Durable-memory types this hook will persist. <c>response</c> is
+    /// deliberately excluded — that's transcript-log content, which lives
+    /// in <see cref="ChatTranscriptStore"/> per PR #173/#174.
+    /// </summary>
+    public static readonly IReadOnlySet<string> AllowedTypes =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "fact",
+            "preference",
+            "focus",
+        };
+
+    public Task<HookResult> OnRequestReceived(ChatHookContext ctx, CancellationToken ct = default) =>
+        Task.FromResult(HookResult.Continue);
+
+    public Task<HookResult> OnResponseSent(ChatHookContext ctx, CancellationToken ct = default)
+    {
+        if (ctx.Response?.Data is not MemoryWriteRequest req)
+            return Task.FromResult(HookResult.Continue);
+
+        if (ctx.SessionId is null)
+        {
+            logger.LogWarning(
+                "MemoryWriteHook: refused to persist '{Type}/{Key}' — SessionId is null. " +
+                "Writing here would land an entry in the global partition without an " +
+                "operator-flagged path (SC-001 defense). The user's confirmation message " +
+                "has already been sent — there's now a soft inconsistency. Check the " +
+                "orchestrator's SessionId plumbing (PR #157 Phase B regression?).",
+                req.Type, req.Key);
+            return Task.FromResult(HookResult.Continue);
+        }
+
+        if (!AllowedTypes.Contains(req.Type))
+        {
+            logger.LogWarning(
+                "MemoryWriteHook: refused to persist '{Type}/{Key}' — type is not in the " +
+                "durable-memory whitelist ({Allowed}). 'response' belongs in the transcript " +
+                "store (PR #173/#174); arbitrary types would re-introduce the conflation.",
+                req.Type, req.Key, string.Join(", ", AllowedTypes));
+            return Task.FromResult(HookResult.Continue);
+        }
+
+        try
+        {
+            memoryStore.Write(
+                sessionId: ctx.SessionId,
+                key:       req.Key,
+                type:      req.Type,
+                content:   req.Content,
+                tags:      req.Tags.ToArray());
+
+            logger.LogInformation(
+                "MemoryWriteHook: persisted {Type} entry '{Key}' for session {SessionId} " +
+                "(content length {Len}).",
+                req.Type, req.Key, ctx.SessionId, req.Content.Length);
+        }
+        catch (Exception ex)
+        {
+            // Mirror MemoryHook.OnResponseSent's posture: log loudly,
+            // don't rethrow — the user has already seen the confirmation
+            // and there's nothing we can do mid-pipeline. The soft
+            // inconsistency is preferable to a thrown exception that
+            // surfaces as a 500 to the chat client.
+            logger.LogError(ex,
+                "MemoryWriteHook: failed to persist {Type} entry '{Key}' for session " +
+                "{SessionId}. The user has already received the 'I've saved' confirmation; " +
+                "they will likely re-ask later and hit the same failure.",
+                req.Type, req.Key, ctx.SessionId);
+        }
+
+        return Task.FromResult(HookResult.Continue);
+    }
+}

--- a/Common/GA.Business.ML/Agents/Memory/MemoryWriteRequest.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryWriteRequest.cs
@@ -1,0 +1,44 @@
+namespace GA.Business.ML.Agents.Memory;
+
+/// <summary>
+/// A pending durable-memory write that a skill emits via
+/// <see cref="AgentResponse.Data"/>. The owning <c>MemoryWriteHook</c>
+/// (on <c>OnResponseSent</c>) picks it up and persists it with the
+/// caller's <see cref="Hooks.ChatHookContext.SessionId"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This indirection exists because <see cref="IOrchestratorSkill.ExecuteAsync"/>
+/// is intentionally session-agnostic (skills are pure-functional units
+/// that don't know which user is calling). The skill parses intent and
+/// emits a request; the hook owns the actual <see cref="MemoryStore"/>
+/// write with the correct session scope. This keeps the SC-001 defense
+/// intact — no skill can write into a session it doesn't own, and no
+/// skill can write globally without an operator-flagged path.
+/// </para>
+/// <para>
+/// <b>Why a record on AgentResponse.Data rather than a side-channel:</b>
+/// <list type="bullet">
+///   <item>The hook fires after the response is produced; passing the
+///         request through Data keeps the flow strictly synchronous.</item>
+///   <item>The hook can pattern-match <c>ctx.Response.Data is MemoryWriteRequest req</c>
+///         without inspecting any other context — no shared state.</item>
+///   <item>If the skill is invoked from a test that doesn't wire the
+///         hook, the request is harmlessly ignored.</item>
+/// </list>
+/// </para>
+/// </remarks>
+/// <param name="Key">Stable key used for <see cref="MemoryStore"/> dedup
+/// within a session. Skills generate this from the content (typically
+/// a slug + short hash) so the same write request is idempotent.</param>
+/// <param name="Type">Memory entry type — <c>fact</c>, <c>preference</c>,
+/// <c>focus</c>, or another future durable type. Never <c>response</c>
+/// (that's the transient transcript-store type post-PR #174).</param>
+/// <param name="Content">The user-supplied content to persist verbatim
+/// (after sanitization upstream via <c>PromptSanitizationHook</c>).</param>
+/// <param name="Tags">Optional structured tags for filtering and search.</param>
+public sealed record MemoryWriteRequest(
+    string Key,
+    string Type,
+    string Content,
+    IReadOnlyList<string> Tags);

--- a/Common/GA.Business.ML/Agents/Skills/RememberThisParser.cs
+++ b/Common/GA.Business.ML/Agents/Skills/RememberThisParser.cs
@@ -1,0 +1,115 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Memory;
+
+/// <summary>
+/// Pure parser that turns a "remember that X" / "save this: X" / "note: X"
+/// user utterance into a <see cref="MemoryWriteRequest"/>. Kept separate
+/// from the skill so the parsing rules are independently unit-testable
+/// and so reasonable tests don't need to spin up an orchestrator.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Type inference (in priority order):</b>
+/// </para>
+/// <list type="bullet">
+///   <item><c>preference</c> — phrasing signals taste: "I prefer", "my favorite",
+///         "I like", "I always", "I usually"</item>
+///   <item><c>focus</c> — phrasing signals current attention: "I'm working on",
+///         "right now I'm", "this week", "currently"</item>
+///   <item><c>fact</c> — everything else (default)</item>
+/// </list>
+/// <para>
+/// <b>Key generation:</b> a stable slug from the first 4 content words
+/// plus the first 8 hex chars of a SHA256 over the full content. Same
+/// content → same key, so subsequent "remember the same thing" calls
+/// idempotently overwrite the prior entry rather than creating a
+/// fact_xyz1, fact_xyz2, fact_xyz3 spray.
+/// </para>
+/// <para>
+/// <b>What this parser is NOT:</b> an LLM-driven semantic extractor.
+/// It's a deliberately tiny regex layer that handles the explicit
+/// "remember X" / "save X" / "note X" surface. Auto-extraction of
+/// implicit preferences from arbitrary chat — option C from the
+/// PR #172 audit — is a separate, riskier feature deferred for now.
+/// </para>
+/// </remarks>
+public static class RememberThisParser
+{
+    /// <summary>
+    /// Lead phrases stripped from the input to isolate the content. The
+    /// regex is anchored on word boundaries and case-insensitive; only
+    /// matches at the start of the trimmed message.
+    /// </summary>
+    private static readonly Regex LeadPhrase = new(
+        @"^\s*(?:please\s+)?(?:can\s+you\s+)?(?:remember(?:\s+that)?|save(?:\s+this)?|note(?:\s+this)?|store(?:\s+that)?|don'?t\s+forget(?:\s+that)?)[:,]?\s*",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex PreferenceCue = new(
+        @"\b(?:i\s+prefer|my\s+favorite|i\s+like|i\s+always|i\s+usually|i\s+love)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex FocusCue = new(
+        @"\b(?:i'?m\s+working\s+on|i'?m\s+focused\s+on|right\s+now\s+i'?m|this\s+week|currently|focused\s+on|practicing)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Attempts to parse <paramref name="message"/> as a remember-request.
+    /// Returns null when no lead-phrase is detected — the message isn't
+    /// addressed to this skill.
+    /// </summary>
+    public static MemoryWriteRequest? TryParse(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return null;
+
+        var match = LeadPhrase.Match(message);
+        if (!match.Success) return null;
+
+        var content = message[match.Length..].Trim().TrimEnd('.', '!', '?');
+        if (content.Length == 0) return null;
+
+        var type = InferType(content);
+        var key  = GenerateKey(type, content);
+
+        return new MemoryWriteRequest(
+            Key:     key,
+            Type:    type,
+            Content: content,
+            Tags:    ["user-stated", $"type:{type}"]);
+    }
+
+    /// <summary>
+    /// True when the lead-phrase regex would match — exposed so the skill's
+    /// <c>CanHandle</c> can short-circuit cheaply without re-running parse.
+    /// </summary>
+    public static bool LooksLikeRememberRequest(string message) =>
+        !string.IsNullOrWhiteSpace(message) && LeadPhrase.IsMatch(message);
+
+    private static string InferType(string content)
+    {
+        // Preference takes priority over focus when both fire (e.g.,
+        // "I prefer working on jazz" — taste statement primary).
+        if (PreferenceCue.IsMatch(content)) return "preference";
+        if (FocusCue.IsMatch(content))      return "focus";
+        return "fact";
+    }
+
+    private static string GenerateKey(string type, string content)
+    {
+        var slugWords = content
+            .Split(new[] { ' ', '\t', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Take(4)
+            .Select(static w => new string([.. w.ToLowerInvariant().Where(char.IsLetterOrDigit)]))
+            .Where(w => w.Length > 0)
+            .ToList();
+        var slug = slugWords.Count > 0 ? string.Join("-", slugWords) : "entry";
+
+        var hashHex = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(content)))[..8].ToLowerInvariant();
+
+        return $"{type}_{slug}_{hashHex}";
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/RememberThisSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/RememberThisSkill.cs
@@ -1,0 +1,110 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using Memory;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Explicit "remember this" skill — the first durable-memory writer in the
+/// chatbot. Parses "remember that I prefer drop-2 voicings" / "save this:
+/// jazz comping focus" / "note: my favorite key is Bb" into a
+/// <see cref="MemoryWriteRequest"/> and emits it on
+/// <see cref="AgentResponse.Data"/>. The owning <c>MemoryWriteHook</c>
+/// then persists it under the caller's
+/// <see cref="Hooks.ChatHookContext.SessionId"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists:</b> after PR #173/#174 split transcript content from
+/// durable memory, <see cref="MemoryStore"/> is empty of <c>fact</c> /
+/// <c>preference</c> / <c>focus</c> entries — there's nothing for
+/// <c>Memory:EnrichOnRetrieve=true</c> to retrieve. This skill is the
+/// first writer; without it, the memory retrieval surface stays unfilled
+/// regardless of how good the retrieval mechanics get.
+/// </para>
+/// <para>
+/// <b>Explicit-only by design:</b> this skill fires ONLY when the user
+/// directly says "remember"/"save"/"note"/"store"/"don't forget" — never
+/// auto-extracts implicit preferences from arbitrary chat. Auto-extraction
+/// is option C from the PR #172 audit and was deferred for safety: the
+/// chatbot inferring "the user prefers X" and silently writing it is a
+/// trust-leak vector that bypasses both SC-001's MCP-write gate and the
+/// session-scoping defense.
+/// </para>
+/// <para>
+/// <b>Session attribution:</b> the skill does not (and cannot) know the
+/// caller's SessionId — <see cref="IOrchestratorSkill.ExecuteAsync"/> is
+/// session-agnostic by interface design. The skill emits the request,
+/// the hook owns the write with the correct session. If <c>MemoryWriteHook</c>
+/// is not registered in DI, the request is harmlessly ignored and the
+/// user sees only the confirmation message.
+/// </para>
+/// </remarks>
+public sealed class RememberThisSkill(ILogger<RememberThisSkill> logger) : IOrchestratorSkill
+{
+    public string Name        => "RememberThis";
+    public string Description =>
+        "Persists a user-stated fact, preference, or focus to durable memory " +
+        "for retrieval in future conversations. Fires on explicit phrasings " +
+        "like 'remember that...', 'save this:', 'note:', 'don't forget...'. " +
+        "Never auto-extracts — the user must explicitly ask.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "remember that I prefer drop-2 voicings for jazz comping",
+        "save this: my favorite key is Bb",
+        "note: I'm working on fingerstyle technique this month",
+        "don't forget that I'm an intermediate guitarist",
+        "remember I always tune to drop D for these songs",
+        "store this fact: my main guitar is a Telecaster",
+        "please remember my focus this week is jazz comping",
+    ];
+
+    public bool CanHandle(string message) =>
+        RememberThisParser.LooksLikeRememberRequest(message);
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var request = RememberThisParser.TryParse(message);
+        if (request is null)
+        {
+            // Defensive — the router shouldn't reach here without a
+            // remember-phrasing, but if it did, refuse rather than write
+            // an empty entry. Returns a low-confidence response so any
+            // downstream confidence-gated logic ignores it.
+            logger.LogDebug("RememberThisSkill: no remember-phrasing detected in: {Msg}", message);
+            return Task.FromResult(AgentResponse.CannotHelp(
+                agentId: "remember-this",
+                reason:  "I didn't find anything to remember in that message — try " +
+                         "phrasing it as 'remember that ...' or 'save this: ...'."));
+        }
+
+        logger.LogInformation(
+            "RememberThisSkill: parsed remember-request type={Type} key={Key} contentLen={Len}",
+            request.Type, request.Key, request.Content.Length);
+
+        // The confirmation message uses present-perfect ("I've noted...")
+        // to signal commitment to the user. The actual write hasn't
+        // happened yet — MemoryWriteHook does it after this method
+        // returns and OnResponseSent fires — but by then the response
+        // text is fixed, so we have to write the message optimistically.
+        // If the hook can't persist (e.g., no session), it logs a warning
+        // and the user has a soft inconsistency. Acceptable for v0.1
+        // since the alternative (delaying the response until after the
+        // write completes) requires a deeper orchestrator refactor.
+        var confirmation = request.Type switch
+        {
+            "preference" => $"Got it — I'll remember your preference: \"{request.Content}\".",
+            "focus"      => $"Noted — current focus: \"{request.Content}\".",
+            _            => $"Saved — I'll remember: \"{request.Content}\".",
+        };
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId    = "remember-this",
+            Result     = confirmation,
+            Confidence = 1.0f,
+            Evidence   = [$"Parsed as type={request.Type}", $"Key: {request.Key}"],
+            Data       = request,
+        });
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/RememberThisTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/RememberThisTests.cs
@@ -1,0 +1,265 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Hooks;
+using GA.Business.ML.Agents.Memory;
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// Pins the RememberThisSkill + MemoryWriteHook split. Three layers:
+/// </summary>
+/// <list type="number">
+/// <item>RememberThisParser — pure parsing of user phrasing → MemoryWriteRequest.</item>
+/// <item>RememberThisSkill — wraps the parser; emits the request on AgentResponse.Data.</item>
+/// <item>MemoryWriteHook — picks up the request, persists with ctx.SessionId.</item>
+/// </list>
+/// <remarks>
+/// The split is load-bearing for SC-001: skills are session-agnostic so
+/// they can't write the wrong session by mistake; the hook owns the
+/// SessionId boundary and refuses to write when it's null.
+/// </remarks>
+[TestFixture]
+public class RememberThisTests
+{
+    // ─── Parser ─────────────────────────────────────────────────────────
+
+    [TestCase("remember that I prefer drop-2 voicings", "preference")]
+    [TestCase("save this: my favorite key is Bb",       "preference")]
+    [TestCase("note: I'm working on fingerstyle",       "focus")]
+    [TestCase("don't forget that I'm an intermediate guitarist", "fact")]
+    [TestCase("remember I always tune to drop D",       "preference")]
+    [TestCase("please remember my focus this week is jazz comping", "focus")]
+    [TestCase("store this fact: my main guitar is a Telecaster",    "fact")]
+    public void Parser_InfersType_FromPhrasing(string input, string expectedType)
+    {
+        var req = RememberThisParser.TryParse(input);
+        Assert.That(req, Is.Not.Null, $"Expected a MemoryWriteRequest for: \"{input}\"");
+        Assert.That(req!.Type, Is.EqualTo(expectedType));
+    }
+
+    [TestCase("What is Cmaj7?")]
+    [TestCase("hello")]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("I prefer drop-2 voicings")]   // no lead phrase — bare statement
+    public void Parser_RejectsNonRememberMessages(string input)
+    {
+        var req = RememberThisParser.TryParse(input);
+        Assert.That(req, Is.Null, $"Parser should NOT match: \"{input}\"");
+    }
+
+    [Test]
+    public void Parser_StripsLeadPhraseAndPunctuation()
+    {
+        var req = RememberThisParser.TryParse("remember that I prefer drop-2 voicings.");
+        Assert.That(req!.Content, Is.EqualTo("I prefer drop-2 voicings"),
+            "Lead phrase and trailing punctuation should both be stripped.");
+    }
+
+    [Test]
+    public void Parser_GeneratesDeterministicKey_SameContent_SameKey()
+    {
+        var a = RememberThisParser.TryParse("remember I prefer drop-2 voicings");
+        var b = RememberThisParser.TryParse("remember I prefer drop-2 voicings");
+        Assert.That(a!.Key, Is.EqualTo(b!.Key),
+            "Same content → same key, so re-running 'remember the same thing' is idempotent.");
+    }
+
+    [Test]
+    public void Parser_KeyPrefixedWithInferredType()
+    {
+        var req = RememberThisParser.TryParse("remember that I prefer drop-2 voicings");
+        Assert.That(req!.Key, Does.StartWith("preference_"));
+    }
+
+    [Test]
+    public void Parser_RejectsEmptyContent_AfterStrippingLead()
+    {
+        // The lead phrase parser would consume "remember:" leaving nothing.
+        var req = RememberThisParser.TryParse("remember:");
+        Assert.That(req, Is.Null);
+    }
+
+    [Test]
+    public void Parser_TagsIncludeTypeAndUserStated()
+    {
+        var req = RememberThisParser.TryParse("remember that I prefer drop-2 voicings");
+        Assert.That(req!.Tags, Does.Contain("user-stated"));
+        Assert.That(req.Tags, Does.Contain("type:preference"));
+    }
+
+    [Test]
+    public void Parser_LooksLikeRememberRequest_QuickCheck()
+    {
+        Assert.That(RememberThisParser.LooksLikeRememberRequest("remember that X"), Is.True);
+        Assert.That(RememberThisParser.LooksLikeRememberRequest("save this: X"),    Is.True);
+        Assert.That(RememberThisParser.LooksLikeRememberRequest("What is Cmaj7?"),  Is.False);
+        Assert.That(RememberThisParser.LooksLikeRememberRequest(""),                Is.False);
+        Assert.That(RememberThisParser.LooksLikeRememberRequest(null!),             Is.False);
+    }
+
+    // ─── Skill ──────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Skill_HappyPath_ReturnsConfirmationWithDataPayload()
+    {
+        var skill = new RememberThisSkill(NullLogger<RememberThisSkill>.Instance);
+
+        var response = await skill.ExecuteAsync("remember that I prefer drop-2 voicings");
+
+        Assert.That(response.Confidence, Is.EqualTo(1.0f));
+        Assert.That(response.AgentId, Is.EqualTo("remember-this"));
+        Assert.That(response.Result, Does.Contain("remember"));
+        Assert.That(response.Result, Does.Contain("drop-2 voicings"));
+        Assert.That(response.Data, Is.InstanceOf<MemoryWriteRequest>());
+        var req = (MemoryWriteRequest)response.Data!;
+        Assert.That(req.Type, Is.EqualTo("preference"));
+        Assert.That(req.Content, Is.EqualTo("I prefer drop-2 voicings"));
+    }
+
+    [Test]
+    public async Task Skill_NonRememberMessage_ReturnsCannotHelp_WithNoData()
+    {
+        var skill = new RememberThisSkill(NullLogger<RememberThisSkill>.Instance);
+
+        var response = await skill.ExecuteAsync("What is Cmaj7?");
+
+        Assert.That(response.Confidence, Is.EqualTo(0.0f),
+            "CannotHelp confidence is 0 so downstream gates ignore it.");
+        Assert.That(response.Data, Is.Null,
+            "No MemoryWriteRequest emitted — nothing for the hook to write.");
+    }
+
+    [Test]
+    public void Skill_CanHandle_AgreesWithParser()
+    {
+        var skill = new RememberThisSkill(NullLogger<RememberThisSkill>.Instance);
+        Assert.That(skill.CanHandle("remember that X"), Is.True);
+        Assert.That(skill.CanHandle("save this: X"),    Is.True);
+        Assert.That(skill.CanHandle("What is Cmaj7?"),  Is.False);
+    }
+
+    // ─── Hook ───────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Hook_NoData_IsNoOp()
+    {
+        using var harness = new HookHarness();
+
+        await harness.Hook.OnResponseSent(MakeCtx(harness, data: null));
+
+        Assert.That(harness.Store.TotalEntriesAllSessions(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Hook_HappyPath_PersistsToCallerSession()
+    {
+        using var harness = new HookHarness();
+        var req = new MemoryWriteRequest("preference_foo_deadbeef", "preference",
+            "I prefer drop-2 voicings", Tags: ["user-stated", "type:preference"]);
+
+        await harness.Hook.OnResponseSent(MakeCtx(harness, data: req, sessionId: "sess-A"));
+
+        Assert.That(harness.Store.TotalEntriesAllSessions(), Is.EqualTo(1));
+        var stored = harness.Store.Read(sessionId: "sess-A", key: "preference_foo_deadbeef");
+        Assert.That(stored, Is.Not.Null);
+        Assert.That(stored!.Type, Is.EqualTo("preference"));
+        Assert.That(stored.Content, Is.EqualTo("I prefer drop-2 voicings"));
+        Assert.That(stored.SessionId, Is.EqualTo("sess-A"),
+            "Entry MUST be scoped to the caller's session — global writes would defeat SC-001.");
+    }
+
+    [Test]
+    public async Task Hook_NullSessionId_RefusesToWrite()
+    {
+        using var harness = new HookHarness();
+        var req = new MemoryWriteRequest("fact_x_abcd1234", "fact", "the user is a guitarist", Tags: []);
+
+        await harness.Hook.OnResponseSent(MakeCtx(harness, data: req, sessionId: null));
+
+        Assert.That(harness.Store.TotalEntriesAllSessions(), Is.EqualTo(0),
+            "Null SessionId → refuse to write. Mirrors MemoryHook's SC-001 posture; " +
+            "writing globally would defeat the session-scoping defense.");
+    }
+
+    [TestCase("response")]
+    [TestCase("conversation")]
+    [TestCase("anything_else")]
+    public async Task Hook_DisallowedType_RefusesToWrite(string disallowedType)
+    {
+        using var harness = new HookHarness();
+        var req = new MemoryWriteRequest("k", disallowedType, "content", Tags: []);
+
+        await harness.Hook.OnResponseSent(MakeCtx(harness, data: req, sessionId: "sess-A"));
+
+        Assert.That(harness.Store.TotalEntriesAllSessions(), Is.EqualTo(0),
+            $"Type '{disallowedType}' is not in the durable-memory whitelist; refusing prevents " +
+            "re-introducing the transcript/memory conflation that PR #173/#174 closed.");
+    }
+
+    [Test]
+    public async Task Hook_StoreThrows_LoggedNotRethrown()
+    {
+        // Use a path the OS rejects to force an IO failure on Write.
+        // Mid-pipeline exceptions become 500s to the chat client; the
+        // hook must swallow and log.
+        var badPath = "Z:\\does-not-exist\\subdir\\memory.json";
+        var store   = new MemoryStore(badPath);
+        var hook    = new MemoryWriteHook(store, NullLogger<MemoryWriteHook>.Instance);
+        var req = new MemoryWriteRequest("k", "fact", "content", Tags: []);
+
+        Assert.DoesNotThrowAsync(async () =>
+            await hook.OnResponseSent(new ChatHookContext
+            {
+                OriginalMessage = "x",
+                CurrentMessage  = "x",
+                CorrelationId   = Guid.NewGuid(),
+                SessionId       = "sess-A",
+                Response = new AgentResponse
+                {
+                    AgentId    = "remember-this",
+                    Result     = "ok",
+                    Confidence = 1.0f,
+                    Data       = req,
+                },
+            }));
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    private sealed class HookHarness : IDisposable
+    {
+        public string Dir { get; }
+        public MemoryStore Store { get; }
+        public MemoryWriteHook Hook { get; }
+
+        public HookHarness()
+        {
+            Dir   = Path.Combine(Path.GetTempPath(), $"ga-remember-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Dir);
+            Store = new MemoryStore(Path.Combine(Dir, "memory.json"));
+            Hook  = new MemoryWriteHook(Store, NullLogger<MemoryWriteHook>.Instance);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static ChatHookContext MakeCtx(HookHarness h, object? data, string? sessionId = "sess-A") => new()
+    {
+        OriginalMessage = "remember stuff",
+        CurrentMessage  = "remember stuff",
+        CorrelationId   = Guid.NewGuid(),
+        SessionId       = sessionId,
+        Response = new AgentResponse
+        {
+            AgentId    = "remember-this",
+            Result     = "I've saved that.",
+            Confidence = 1.0f,
+            Data       = data,
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Closes the loop on `EnrichOnRetrieve`. Until this PR, `MemoryStore` had no `fact`/`preference`/`focus` writer at all — transcript turns post-PR #174 go to `ChatTranscriptStore`, and there was nothing populating durable knowledge for retrieval to surface.

## Architecture (load-bearing for SC-001)

```
RememberThisSkill                MemoryWriteHook
     │                                 │
     │ parse "remember that..."        │
     │ → MemoryWriteRequest            │
     │ on AgentResponse.Data           │
     │                                 │
     └─────────── OnResponseSent ─────►│
                                       │ persist with
                                       │ ctx.SessionId
                                       │ (refuses if null)
                                       ▼
                                  MemoryStore
```

Why the split: `IOrchestratorSkill.ExecuteAsync` is session-agnostic by interface design — a skill cannot see `ChatHookContext.SessionId`. Routing every durable-write through this hook keeps session-scoping enforced centrally. The skill emits the request; the hook owns the write.

## Files

| File | Purpose |
|---|---|
| `Common/GA.Business.ML/Agents/Memory/MemoryWriteRequest.cs` | record passed via `AgentResponse.Data` |
| `Common/GA.Business.ML/Agents/Skills/RememberThisParser.cs` | pure parser, regex-driven type inference (preference / focus / fact), deterministic SHA256-derived key |
| `Common/GA.Business.ML/Agents/Skills/RememberThisSkill.cs` | wraps parser, emits request, returns user confirmation |
| `Common/GA.Business.ML/Agents/Hooks/MemoryWriteHook.cs` | picks up the request, refuses on null SessionId (SC-001 mirror), refuses on disallowed types |
| `Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs` | registers both — hook order: `MemoryHook` first (transcript), then `MemoryWriteHook` (durable claim) |

## Explicit-only by design

Skill fires only on `remember` / `save` / `note` / `store` / `don't forget` phrasings. No auto-extraction — that's Option C from PR #172 and was deferred for safety: silent inference of "the user prefers X" bypasses both SC-001's MCP-write gate and the session-scoping defense.

## Test plan

- [x] 28 unit tests in `RememberThisTests.cs`:
  - Parser type inference (7 cases — preference/focus/fact across phrasings)
  - Parser rejection of non-remember messages (5)
  - Parser determinism + idempotency
  - Parser tags + key prefix
  - Skill happy path + non-match
  - Hook no-data noop
  - Hook session-scoped persistence
  - Hook null-SessionId refusal (SC-001 mirror)
  - Hook disallowed-type refusal (3 types)
  - Hook exception swallowing under IO failure
- [x] Build green
- [x] Existing test suites unaffected

## What this unlocks

Once merged + an operator flips `Memory:EnrichOnRetrieve=true`, the chatbot can finally use its memory infrastructure end-to-end:

1. User: "remember that I prefer drop-2 voicings"
2. `RememberThisSkill` → confirmation + `MemoryWriteRequest`
3. `MemoryWriteHook` → persists `preference_i-prefer-drop-2-voicings_<hash>` under user's SessionId
4. Next session same user: `MemoryHook.OnRequestReceived` retrieves entries for that session, injects as `[Relevant context from memory]` prefix
5. Chatbot answers with awareness of the preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)