### PR TITLE
feat(memory): file ACL hardening — UnixFileMode 0600 on memory + transcript stores

### DIFF
--- a/Common/GA.Business.ML/Agents/Memory/ChatTranscriptStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/ChatTranscriptStore.cs
@@ -236,21 +236,15 @@ public sealed class ChatTranscriptStore : IChatTranscriptStore
 
     private void Save()
     {
-        var dir = Path.GetDirectoryName(_storePath);
-        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-
         // Snapshot under the lock so concurrent AppendTurns can't tear the
-        // serialise; atomic-rename so a crash mid-write can't leave a
-        // half-flushed file that Load() silently swallows on next boot.
-        // Same pattern as MemoryStore.Save (PR #151 rel-006 fix).
+        // serialise. MemoryFileWriter then handles the atomic-rename + the
+        // owner-only mode (PR #174 review follow-up: 0600 on Unix, default
+        // ACL inheritance on Windows). Same Save() pattern as MemoryStore.
         _saveLock.Wait();
         try
         {
-            var json    = JsonSerializer.Serialize(_turns.Values.ToList(), JsonOpts);
-            var tmpPath = _storePath + ".tmp";
-            File.WriteAllText(tmpPath, json);
-            File.Move(tmpPath, _storePath, overwrite: true);
+            var json = JsonSerializer.Serialize(_turns.Values.ToList(), JsonOpts);
+            MemoryFileWriter.WriteAtomic(_storePath, json, _logger);
         }
         finally
         {

--- a/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
@@ -1,0 +1,100 @@
+namespace GA.Business.ML.Agents.Memory;
+
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Shared atomic-write helper for the JSON-backed memory and transcript
+/// stores. Ensures every persisted file lands with owner-only permissions
+/// where the platform supports them, then atomic-renames into place so a
+/// crash mid-write can't leave a half-flushed file that subsequent
+/// <c>Load()</c> calls would silently swallow.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists (PR #174 follow-up):</b> both <see cref="MemoryStore"/>
+/// and <see cref="ChatTranscriptStore"/> persist per-session user data
+/// (preferences, focus statements, full chat transcript text). Default
+/// <see cref="File.WriteAllText(string, string)"/> on Unix uses the
+/// process umask — typically <c>0644</c> — so other users on a shared
+/// host can read the file. On Windows the user-profile directory
+/// (<c>%USERPROFILE%\.ga</c>) is already restricted by inherited ACLs in
+/// practice, but the file itself was not explicitly locked down.
+/// </para>
+/// <para>
+/// <b>What this guarantees:</b> on Unix the persisted file has
+/// <c>UnixFileMode.UserRead | UnixFileMode.UserWrite</c> (mode <c>0600</c>)
+/// from the moment it appears at its final path — the mode is set on the
+/// <c>.tmp</c> file BEFORE the rename, so there's no window where the
+/// file exists at the canonical path with a broader mode. On Windows the
+/// helper is a no-op for ACL — the user-profile ACL inheritance is the
+/// load-bearing defense and adding an explicit DACL adds a
+/// platform-dependent <c>System.IO.FileSystem.AccessControl</c> dependency
+/// that isn't worth the extra surface today.
+/// </para>
+/// <para>
+/// <b>Failure mode:</b> <see cref="File.SetUnixFileMode"/> can throw on
+/// filesystems that don't support POSIX permissions (rare on the user
+/// profile dir; happens on some FAT-mounted shares). The helper catches
+/// and logs at Warning level — the write still completes, but the file
+/// lands with default mode. Treat as a defense-in-depth gap visible in
+/// logs, not a hard failure.
+/// </para>
+/// </remarks>
+public static class MemoryFileWriter
+{
+    /// <summary>
+    /// Owner-only POSIX mode: read + write for the owner, nothing for
+    /// group or other. Equivalent to <c>chmod 0600</c>.
+    /// </summary>
+    private const UnixFileMode OwnerOnlyMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    /// <summary>
+    /// Writes <paramref name="content"/> to <paramref name="path"/>
+    /// atomically with owner-only permissions on Unix. Creates the parent
+    /// directory if it doesn't exist.
+    /// </summary>
+    /// <param name="path">Destination path. The temp file used in transit
+    /// is <c>path + ".tmp"</c>.</param>
+    /// <param name="content">UTF-8 text content.</param>
+    /// <param name="logger">Optional logger for the
+    /// <see cref="File.SetUnixFileMode"/> failure case. When null, the
+    /// failure is swallowed silently — acceptable because the file still
+    /// lands at <paramref name="path"/>; only the ACL hardening is missed.</param>
+    public static void WriteAtomic(string path, string content, ILogger? logger = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(content);
+
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var tmp = path + ".tmp";
+        File.WriteAllText(tmp, content);
+
+        // Apply owner-only mode to the tmp file BEFORE the rename so the
+        // destination atomically inherits the restricted mode. Without
+        // this ordering, a parallel reader could race in the window
+        // between rename and SetUnixFileMode and see the file at its
+        // permissive default mode.
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() ||
+            OperatingSystem.IsFreeBSD())
+        {
+            try
+            {
+                File.SetUnixFileMode(tmp, OwnerOnlyMode);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex,
+                    "MemoryFileWriter: failed to set 0600 on {Path} — file system " +
+                    "may not support POSIX permissions (FAT, some network mounts). " +
+                    "Write proceeds with default mode; defense-in-depth gap visible " +
+                    "in this log.", tmp);
+            }
+        }
+
+        File.Move(tmp, path, overwrite: true);
+    }
+}

--- a/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
@@ -65,6 +65,7 @@ public sealed class MemoryStore
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".ga", "memory.json");
 
     private readonly string _storePath;
+    private readonly ILogger<MemoryStore>? _logger;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -128,6 +129,7 @@ public sealed class MemoryStore
     public MemoryStore(string storePath, ILogger<MemoryStore>? logger)
     {
         _storePath = storePath ?? throw new ArgumentNullException(nameof(storePath));
+        _logger    = logger;
         _entries   = Load(_storePath, logger);
     }
 
@@ -367,20 +369,15 @@ public sealed class MemoryStore
 
     private void Save()
     {
-        var dir = Path.GetDirectoryName(_storePath)!;
-        if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-
         // Snapshot under the lock so concurrent Writes that mutate _entries
-        // mid-serialise don't produce truncated JSON, AND atomic-rename so a
-        // crash mid-write can't leave a half-flushed file that Load()
-        // silently swallows on next boot.
+        // mid-serialise don't produce truncated JSON. MemoryFileWriter then
+        // handles the atomic-rename + owner-only mode (PR #174 review
+        // follow-up: 0600 on Unix, default ACL inheritance on Windows).
         _saveLock.Wait();
         try
         {
-            var json    = JsonSerializer.Serialize(_entries.Values.ToList(), JsonOpts);
-            var tmpPath = _storePath + ".tmp";
-            File.WriteAllText(tmpPath, json);
-            File.Move(tmpPath, _storePath, overwrite: true);
+            var json = JsonSerializer.Serialize(_entries.Values.ToList(), JsonOpts);
+            MemoryFileWriter.WriteAtomic(_storePath, json, _logger);
         }
         finally
         {

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryFileWriterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryFileWriterTests.cs
@@ -1,0 +1,106 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Memory;
+
+/// <summary>
+/// Pins the atomic-write + owner-only-mode contract shipped by
+/// <see cref="MemoryFileWriter"/>. Atomic-rename behavior tested on every
+/// platform; the mode-setting branch is asserted only on Unix-likes
+/// (Windows uses inherited user-profile ACL, no explicit DACL set).
+/// </summary>
+[TestFixture]
+public class MemoryFileWriterTests
+{
+    private string _tempDir = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ga-fwriter-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Test]
+    public void WriteAtomic_WritesContent_AtDestinationPath()
+    {
+        var path = Path.Combine(_tempDir, "memory.json");
+        MemoryFileWriter.WriteAtomic(path, """{"a":1}""");
+
+        Assert.That(File.Exists(path), Is.True);
+        Assert.That(File.ReadAllText(path), Is.EqualTo("""{"a":1}"""));
+    }
+
+    [Test]
+    public void WriteAtomic_CreatesParentDirectory_IfMissing()
+    {
+        // Nested path with non-existent intermediate directory. The helper
+        // must create the parent so first-boot doesn't fail.
+        var path = Path.Combine(_tempDir, "nested", "deep", "memory.json");
+        MemoryFileWriter.WriteAtomic(path, "x");
+
+        Assert.That(File.Exists(path), Is.True);
+        Assert.That(File.ReadAllText(path), Is.EqualTo("x"));
+    }
+
+    [Test]
+    public void WriteAtomic_OverwritesExistingFile()
+    {
+        var path = Path.Combine(_tempDir, "memory.json");
+        File.WriteAllText(path, "original");
+
+        MemoryFileWriter.WriteAtomic(path, "updated");
+
+        Assert.That(File.ReadAllText(path), Is.EqualTo("updated"),
+            "Atomic-rename with overwrite:true must replace existing content " +
+            "— that's the whole point of the rename pattern.");
+    }
+
+    [Test]
+    public void WriteAtomic_DoesNotLeaveTmpFile_OnSuccess()
+    {
+        var path = Path.Combine(_tempDir, "memory.json");
+        MemoryFileWriter.WriteAtomic(path, "x");
+
+        var tmp = path + ".tmp";
+        Assert.That(File.Exists(tmp), Is.False,
+            "Successful WriteAtomic must rename tmp → path; no leftover .tmp.");
+    }
+
+    [Test]
+    public void WriteAtomic_NullOrEmptyPath_Throws()
+    {
+        Assert.That(() => MemoryFileWriter.WriteAtomic("",   "x"), Throws.InstanceOf<ArgumentException>());
+        Assert.That(() => MemoryFileWriter.WriteAtomic(null!, "x"), Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void WriteAtomic_NullContent_Throws()
+    {
+        var path = Path.Combine(_tempDir, "memory.json");
+        Assert.That(() => MemoryFileWriter.WriteAtomic(path, null!),
+            Throws.InstanceOf<ArgumentNullException>());
+    }
+
+    [Test]
+    [Platform("Linux,Unix,MacOSX")]
+    public void WriteAtomic_OnUnix_SetsOwnerOnlyMode()
+    {
+        // On Linux / macOS / FreeBSD the file must land at mode 0600
+        // (owner read + write). On Windows this test is skipped — the
+        // mode-setting branch is gated by OperatingSystem.IsLinux() and
+        // friends; Windows relies on user-profile ACL inheritance.
+        var path = Path.Combine(_tempDir, "memory.json");
+        MemoryFileWriter.WriteAtomic(path, "x");
+
+        var mode = File.GetUnixFileMode(path);
+        Assert.That(mode, Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite),
+            $"Expected 0600 (UserRead | UserWrite); got {mode}. Group / other " +
+            "permissions are a defense-in-depth gap on shared hosts.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the PR #174 review follow-up. Both `~/.ga/memory.json` and `~/.ga/transcripts.json` hold per-session user data (preferences, focus statements, full chat transcript text). Default `File.WriteAllText` on Unix uses the process umask — typically `0644` — so other users on a shared host could read the files.

## Approach

Centralized atomic-write helper `MemoryFileWriter.WriteAtomic(path, content, logger)`:

1. Write content to `path + ".tmp"`
2. On Linux / macOS / FreeBSD: set `UnixFileMode = UserRead | UserWrite` (0600) on the tmp file **BEFORE rename** — destination atomically inherits the restricted mode, no window with a permissive mode at the canonical path
3. Atomic `File.Move(tmp, path, overwrite: true)`

Both `MemoryStore.Save()` and `ChatTranscriptStore.Save()` now route through this helper, replacing inline `File.WriteAllText` + `File.Move` pairs. `MemoryStore` gained a `_logger` field to surface the `SetUnixFileMode` failure case (mirror of `ChatTranscriptStore` which already had one).

## Windows posture

No-op for explicit DACL. Adding one would require a `System.IO.FileSystem.AccessControl` dependency; the user-profile dir `%USERPROFILE%\.ga` is already restricted by inherited ACLs in practice. Filing as a known defense-in-depth gap.

## Failure mode is soft

`File.SetUnixFileMode` can throw on filesystems that don't support POSIX permissions (rare on user profile; happens on some FAT-mounted shares). The helper catches and logs at Warning level — the write still completes, just without the hardening. Visible in logs as a defense-in-depth gap, not a hard failure.

## Test plan

- [x] 7 cases in `MemoryFileWriterTests.cs` — content at path, parent dir created, overwrite existing, no leftover `.tmp`, null/empty arg throws
- [x] Unix-mode assertion is `[Platform("Linux,Unix,MacOSX")]` — skipped on Windows, runs on CI Linux where it asserts `mode == 0600`
- [x] **156/156** across the full memory test surface (MemoryStore + ChatTranscript + MemoryHook + MemoryWriteHook + MemoryMcp + EnrichOnRetrieve + RememberThis + LegacyResponse + MemoryFileWriter)
- [x] Build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)