### PR TITLE
refactor(memory): rename IChatTranscriptStore → IOperatorTranscriptReader

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -84,11 +84,14 @@ public sealed class GaPlugin : IChatPlugin
         // Sibling to MemoryStore: holds per-turn chat content, not durable
         // memory. MemoryHook.OnResponseSent (post-#174) writes user +
         // assistant turns here so MemoryStore stays clean for durable
-        // knowledge. Also exposes IChatTranscriptStore so the memory
-        // curator's existing transcript slot has a real backing.
+        // knowledge. Also exposes IOperatorTranscriptReader (renamed from
+        // IChatTranscriptStore on 2026-05-12) so the memory curator and
+        // similar offline tooling have a cross-session view — that
+        // interface name explicitly carries the operator-only contract,
+        // discouraging any chat-runtime caller from accidentally wiring it.
         services.TryAddSingleton<ChatTranscriptStore>(sp =>
             new ChatTranscriptStore(sp.GetService<ILogger<ChatTranscriptStore>>() ?? NullLogger<ChatTranscriptStore>.Instance));
-        services.TryAddSingleton<IChatTranscriptStore>(sp =>
+        services.TryAddSingleton<IOperatorTranscriptReader>(sp =>
             sp.GetRequiredService<ChatTranscriptStore>());
 
         // ── Hooks (execute in registration order at each lifecycle point) ─────

--- a/Common/GA.Business.ML/Agents/Memory/ChatTranscriptStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/ChatTranscriptStore.cs
@@ -9,8 +9,10 @@ using Microsoft.Extensions.Logging;
 /// File-backed store for chat transcript turns. Sibling to
 /// <see cref="MemoryStore"/> — same atomic-write + session-scoping pattern,
 /// but for *transient* per-turn chat content rather than *durable* memory.
-/// Implements <see cref="IChatTranscriptStore"/> so the memory curator can
-/// consume real transcripts in Phase 2 of the curator architecture.
+/// Implements <see cref="IOperatorTranscriptReader"/> so the memory
+/// curator can consume real transcripts in Phase 2 of the curator
+/// architecture. The interface name carries an explicit "operator-only,
+/// cross-session" contract — see its remarks for the boundary rule.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -37,7 +39,7 @@ using Microsoft.Extensions.Logging;
 /// one row.
 /// </para>
 /// </remarks>
-public sealed class ChatTranscriptStore : IChatTranscriptStore
+public sealed class ChatTranscriptStore : IOperatorTranscriptReader
 {
     /// <summary>Default on-disk location: <c>~/.ga/transcripts.json</c>.</summary>
     public static readonly string DefaultStorePath =
@@ -306,8 +308,9 @@ public sealed class ChatTranscriptStore : IChatTranscriptStore
 
 /// <summary>
 /// One persisted transcript turn. Internal storage shape — the curator-
-/// facing <see cref="TranscriptTurn"/> record (defined in
-/// <c>IChatTranscriptStore.cs</c>) is what callers see.
+/// facing <see cref="TranscriptTurn"/> record (defined alongside
+/// <see cref="FixtureChatTranscriptStore"/> in the Curator namespace)
+/// is what callers see.
 /// </summary>
 /// <param name="Id">Unique per-turn key, generated at write time. Used to
 /// dedupe across concurrent Saves.</param>

--- a/Common/GA.Business.ML/Agents/Memory/Curator/IChatTranscriptStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/IChatTranscriptStore.cs
@@ -1,27 +1,21 @@
 namespace GA.Business.ML.Agents.Memory.Curator;
 
 /// <summary>
-/// Header-only interface (v0.1) — the production transcript-capture story is
-/// not yet wired. Memory curator depends on this contract so v0.2 can drop in
-/// a real implementation without changing curator code.
+/// In-memory fixture for v0.1 curator runs. Tests and the CLI pre-load
+/// this with the transcripts they want the curator to consider.
 /// </summary>
 /// <remarks>
-/// For v0.1 spike runs, tests and the CLI pass a hand-written fixture
-/// implementation (e.g. <see cref="FixtureChatTranscriptStore"/>). For v0.2,
-/// the production implementation will read from whatever transcript log the
-/// chatbot persists per <see cref="Hooks.ChatHookContext"/> session.
+/// Implements <see cref="IOperatorTranscriptReader"/> — the cross-session
+/// reader interface. Use only from operator / CLI contexts.
 /// </remarks>
-public interface IChatTranscriptStore
+public sealed class FixtureChatTranscriptStore(IReadOnlyList<ChatTranscript> transcripts)
+    : IOperatorTranscriptReader
 {
-    /// <summary>
-    /// Returns up to <paramref name="maxSessions"/> recent chat session
-    /// transcripts. Order is newest-first. Empty list is a legitimate
-    /// answer (no transcripts available — the curator will operate over
-    /// the memory store alone).
-    /// </summary>
-    Task<IReadOnlyList<ChatTranscript>> GetRecentAsync(
+    public Task<IReadOnlyList<ChatTranscript>> GetRecentAsync(
         int maxSessions,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<ChatTranscript>>(
+            transcripts.Take(maxSessions).ToList());
 }
 
 /// <summary>
@@ -35,16 +29,3 @@ public sealed record ChatTranscript(
 
 /// <summary>One conversational turn — user or assistant — within a transcript.</summary>
 public sealed record TranscriptTurn(string Role, string Content, DateTimeOffset Timestamp);
-
-/// <summary>
-/// In-memory fixture for v0.1. Tests and the CLI pre-load this with the
-/// transcripts they want the curator to consider.
-/// </summary>
-public sealed class FixtureChatTranscriptStore(IReadOnlyList<ChatTranscript> transcripts) : IChatTranscriptStore
-{
-    public Task<IReadOnlyList<ChatTranscript>> GetRecentAsync(
-        int maxSessions,
-        CancellationToken cancellationToken = default) =>
-        Task.FromResult<IReadOnlyList<ChatTranscript>>(
-            transcripts.Take(maxSessions).ToList());
-}

--- a/Common/GA.Business.ML/Agents/Memory/IOperatorTranscriptReader.cs
+++ b/Common/GA.Business.ML/Agents/Memory/IOperatorTranscriptReader.cs
@@ -1,0 +1,55 @@
+namespace GA.Business.ML.Agents.Memory;
+
+using Curator;
+
+/// <summary>
+/// Operator-only reader over the transcript store. Exposes
+/// <see cref="GetRecentAsync"/>, which returns the most recently active
+/// sessions <b>across ALL sessions in the store</b>. This cross-session
+/// view is by design for the memory curator and similar offline tooling;
+/// it MUST NOT be consumed from a chat-runtime path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this interface exists (2026-05-12, PR #174 follow-up):</b> the
+/// cross-session semantics of <see cref="GetRecentAsync"/> are a
+/// content-leak vector if a chat-runtime caller wires it up — reading
+/// "recent transcripts" inside an in-flight chat request would leak other
+/// users' conversations into the calling user's prompt. The same defect
+/// class that PR #157 closed for <see cref="MemoryStore"/>.
+/// </para>
+/// <para>
+/// The type name carries the contract. Anyone reaching for
+/// <c>IOperatorTranscriptReader</c> in a chat-runtime code path now has
+/// to acknowledge they're outside per-session scope — and at that point
+/// the right answer is to file an issue for a per-session reader, not to
+/// bypass the boundary.
+/// </para>
+/// <para>
+/// <b>Legitimate consumers:</b> <c>GaMemoryCli</c>'s curator command, the
+/// memory curator background job, future ops tooling that needs to see
+/// recent activity across users for quality / abuse / sentiment analysis.
+/// </para>
+/// <para>
+/// <b>Illegitimate consumers:</b> anything that runs inside
+/// <c>ProductionOrchestrator.ProcessAsync</c> or its hook chain.
+/// </para>
+/// <para>
+/// <b>History:</b> renamed from <c>IChatTranscriptStore</c> on 2026-05-12.
+/// The prior name suggested "a store for transcripts" — neutral enough
+/// that a future contributor could have plausibly added it to a hook's
+/// constructor. The new name is intentionally ugly to discourage that.
+/// </para>
+/// </remarks>
+public interface IOperatorTranscriptReader
+{
+    /// <summary>
+    /// Returns up to <paramref name="maxSessions"/> recent chat session
+    /// transcripts. Order is newest-first across <b>all</b> sessions in
+    /// the store. Empty list is a legitimate answer (no transcripts
+    /// available — the curator will operate over the memory store alone).
+    /// </summary>
+    Task<IReadOnlyList<ChatTranscript>> GetRecentAsync(
+        int maxSessions,
+        CancellationToken cancellationToken = default);
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/IOperatorTranscriptReaderBoundaryTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/IOperatorTranscriptReaderBoundaryTests.cs
@@ -1,0 +1,73 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Reflection;
+using GA.Business.ML.Agents.Hooks;
+using GA.Business.ML.Agents.Memory;
+
+/// <summary>
+/// Static-analysis pin enforcing the architectural boundary around
+/// <see cref="IOperatorTranscriptReader"/> — the interface that exposes
+/// cross-session transcript reads. Chat-runtime hooks must NOT inject
+/// it; if they did, an in-flight chat request could read other users'
+/// transcripts and leak them into the calling user's prompt context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The boundary lives in the type name and DI registration, not in any
+/// runtime check. This test makes the boundary enforceable: any reflection
+/// that surfaces a chat-runtime <see cref="IChatHook"/> implementation
+/// taking <see cref="IOperatorTranscriptReader"/> in its constructor will
+/// fail here. The author of such a change is expected to either
+/// (a) revert and use a per-session reader, or (b) delete this test with
+/// an explicit justification commit message.
+/// </para>
+/// <para>
+/// Reflection-load is intentional — we don't want to maintain a
+/// hand-curated allowlist of hook types; new hooks are protected by this
+/// pin from the moment they're registered as <see cref="IChatHook"/>.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class IOperatorTranscriptReaderBoundaryTests
+{
+    [Test]
+    public void NoChatHookConstructor_DependsOn_IOperatorTranscriptReader()
+    {
+        var hookInterface = typeof(IChatHook);
+        var bannedDep = typeof(IOperatorTranscriptReader);
+
+        // Scan the GA.Business.ML assembly for every concrete IChatHook
+        // implementation. Allows future hooks added by the same plugin to
+        // be covered automatically.
+        var hookImpls = hookInterface.Assembly
+            .GetTypes()
+            .Where(t => !t.IsAbstract && !t.IsInterface && hookInterface.IsAssignableFrom(t))
+            .ToList();
+
+        Assert.That(hookImpls, Is.Not.Empty,
+            "Expected at least one IChatHook implementation in the assembly. " +
+            "If this fails, the assembly load is broken (no hooks discovered).");
+
+        var violations = new List<string>();
+        foreach (var hookType in hookImpls)
+        {
+            foreach (var ctor in hookType.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                foreach (var p in ctor.GetParameters())
+                {
+                    if (p.ParameterType == bannedDep)
+                    {
+                        violations.Add(
+                            $"{hookType.FullName}::ctor parameter '{p.Name}' has type " +
+                            $"{bannedDep.Name} — IChatHook implementations must NOT depend on " +
+                            "the operator-only transcript reader. Use a per-session reader, " +
+                            "or file an issue if one doesn't exist yet.");
+                    }
+                }
+            }
+        }
+
+        Assert.That(violations, Is.Empty,
+            "Cross-session boundary violation:\n  " + string.Join("\n  ", violations));
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last PR #174 review follow-up. The interface exposes `GetRecentAsync`, which returns sessions across **all** stored sessions — a content-leak vector if a chat-runtime caller wires it up. The prior name `IChatTranscriptStore` was neutral enough that a future contributor could have plausibly added it to a hook's constructor; the new name is intentionally explicit.

## Changes

| File | Change |
|---|---|
| `Common/GA.Business.ML/Agents/Memory/IOperatorTranscriptReader.cs` | **New.** Interface with XML docs explicitly listing legitimate consumers (curator, ops tooling) vs illegitimate (anything in `ProductionOrchestrator`'s hook chain) |
| `Common/GA.Business.ML/Agents/Memory/Curator/IChatTranscriptStore.cs` | File path retained for stability. Now contains only `ChatTranscript` / `TranscriptTurn` records + `FixtureChatTranscriptStore` (which implements the new interface) |
| `Common/GA.Business.ML/Agents/Memory/ChatTranscriptStore.cs` | `: IChatTranscriptStore` → `: IOperatorTranscriptReader` |
| `Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs` | DI registration switched to `IOperatorTranscriptReader` |

## Static-analysis pin

Reflection-loaded boundary test:

```
Tests/Common/GA.Business.ML.Tests/Unit/IOperatorTranscriptReaderBoundaryTests.cs
```

Scans every concrete `IChatHook` implementation in `GA.Business.ML`; asserts **none** have `IOperatorTranscriptReader` in their constructor parameters. Any future chat-runtime hook that accidentally injects the operator reader fails here.

The author of such a change has to either fix the design or delete the test with explicit justification — making the boundary review-visible.

## Test plan

- [x] 156/156 across the full memory test surface (unchanged behavior)
- [x] 1 new boundary test — green (no current hook violates the boundary)
- [x] Build green
- [x] No production behavior change — pure rename + boundary lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)