### PR TITLE
fix(voicing-search): paren tokenization + drop2 alias (ICV deferred)

### DIFF
--- a/Common/GA.Business.Config/Configuration/SymbolicTagRegistry.cs
+++ b/Common/GA.Business.Config/Configuration/SymbolicTagRegistry.cs
@@ -172,6 +172,23 @@ public class SymbolicTagRegistry
 
         var normalized = tag.ToLowerInvariant().Trim().Replace(" ", "-").Replace("_", "-");
         _tagToBitMap[normalized] = bitIndex;
+
+        // 2026-05-12 telemetry sweep: queries like "drop2" miss "drop-2-voicings"
+        // because GetBitIndex's substring fallback never inserts hyphens at the
+        // letter↔digit boundary. Register a dehyphenated alias so user-typed
+        // "drop2" substring-matches "drop2voicings". Gated on the tag containing
+        // a digit — this restricts aliasing to the letter/digit-boundary case and
+        // avoids false positives where the dehyphenated form of an English-phrase
+        // tag (e.g. "tension-and-release" → "tensionandrelease") would otherwise
+        // make short query tokens like "and" silently fire.
+        if (normalized.Any(char.IsDigit))
+        {
+            var dehyphenated = normalized.Replace("-", "");
+            if (dehyphenated.Length > 0 && dehyphenated != normalized)
+            {
+                _tagToBitMap.TryAdd(dehyphenated, bitIndex);
+            }
+        }
     }
 
     public int? GetBitIndex(string tag)

--- a/Common/GA.Business.Config/Configuration/SymbolicTagRegistry.cs
+++ b/Common/GA.Business.Config/Configuration/SymbolicTagRegistry.cs
@@ -177,10 +177,12 @@ public class SymbolicTagRegistry
         // because GetBitIndex's substring fallback never inserts hyphens at the
         // letter↔digit boundary. Register a dehyphenated alias so user-typed
         // "drop2" substring-matches "drop2voicings". Gated on the tag containing
-        // a digit — this restricts aliasing to the letter/digit-boundary case and
-        // avoids false positives where the dehyphenated form of an English-phrase
-        // tag (e.g. "tension-and-release" → "tensionandrelease") would otherwise
-        // make short query tokens like "and" silently fire.
+        // a digit, which keeps English-phrase tags out of the aliased pool —
+        // "tension-and-release" dehyphenates to "tensionandrelease" and would
+        // make short query tokens like "and" silently fire. The gate does NOT
+        // prevent intentional aliasing across digit-containing structural tags
+        // (e.g. a hypothetical "6-9-voicings" alias "69voicings" lets "69" hit
+        // the bit), which is the desired behavior for the drop2 case.
         if (normalized.Any(char.IsDigit))
         {
             var dehyphenated = normalized.Replace("-", "");

--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -1,5 +1,6 @@
 namespace GA.Business.ML.Search;
 
+using System.Text;
 using Embeddings;
 using Embeddings.Services;
 using Rag.Models;
@@ -48,7 +49,20 @@ public sealed class MusicalQueryEncoder(
         var root2 = q.RootPitchClass ?? (q.ChordSymbol is { } cs2 && ChordPitchClasses.TryParse(cs2, out var r2, out _) ? r2 : null);
         if (pcs is { Length: > 0 })
         {
-            var structure = theory.ComputeEmbedding(pitchClasses: pcs, rootPitchClass: root2);
+            // 2026-05-12: pass the query's ICV (computed from its own PCs) so STRUCTURE
+            // dims 13-18 (ICV) plus the ICV-derived consonance (20) and brightness (21)
+            // carry signal. Without this, the query slice was zero across those 8 dims
+            // while the corpus slice was non-zero — per-partition L2 normalization then
+            // shrank the chroma contribution on Dm7 queries below that of subset Dm/F
+            // voicings, because the corpus Dm7 vector's L2 norm is larger (more nonzero
+            // dims) so each shared bit weighs less. Net effect: "Dm7" returned top-5 Dm
+            // triads with identical 0.5066 score. Computing ICV query-side restores
+            // proper discrimination between a chord and its proper subsets.
+            var icvString = ComputeIcvString(pcs);
+            var structure = theory.ComputeEmbedding(
+                pitchClasses: pcs,
+                rootPitchClass: root2,
+                intervalClassVector: icvString);
             Array.Copy(structure, 0, raw, EmbeddingSchema.StructureOffset, structure.Length);
         }
 
@@ -99,6 +113,29 @@ public sealed class MusicalQueryEncoder(
         // is therefore zero, which is the correct behavior.
 
         return ExtractCompactAndNormalize(raw);
+    }
+
+    /// <summary>
+    ///     Computes the 6-digit interval-class vector string for a pitch-class set, in the
+    ///     same digit-per-position format <see cref="TheoryVectorService.ComputeEmbedding"/>
+    ///     parses. Counts cap at 9 since the parser is char-by-char; this only bites for
+    ///     extremely dense (10+ PC) sets, which the index doesn't carry.
+    /// </summary>
+    internal static string ComputeIcvString(int[] pcs)
+    {
+        var counts = new int[6];
+        for (var i = 0; i < pcs.Length; i++)
+        {
+            for (var j = i + 1; j < pcs.Length; j++)
+            {
+                var diff = Math.Abs(pcs[i] - pcs[j]);
+                var ic = Math.Min(diff, 12 - diff);
+                if (ic is >= 1 and <= 6) counts[ic - 1]++;
+            }
+        }
+        var sb = new StringBuilder(6);
+        for (var i = 0; i < 6; i++) sb.Append((char)('0' + Math.Min(counts[i], 9)));
+        return sb.ToString();
     }
 
     /// <summary>

--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -1,6 +1,5 @@
 namespace GA.Business.ML.Search;
 
-using System.Text;
 using Embeddings;
 using Embeddings.Services;
 using Rag.Models;
@@ -49,20 +48,7 @@ public sealed class MusicalQueryEncoder(
         var root2 = q.RootPitchClass ?? (q.ChordSymbol is { } cs2 && ChordPitchClasses.TryParse(cs2, out var r2, out _) ? r2 : null);
         if (pcs is { Length: > 0 })
         {
-            // 2026-05-12: pass the query's ICV (computed from its own PCs) so STRUCTURE
-            // dims 13-18 (ICV) plus the ICV-derived consonance (20) and brightness (21)
-            // carry signal. Without this, the query slice was zero across those 8 dims
-            // while the corpus slice was non-zero — per-partition L2 normalization then
-            // shrank the chroma contribution on Dm7 queries below that of subset Dm/F
-            // voicings, because the corpus Dm7 vector's L2 norm is larger (more nonzero
-            // dims) so each shared bit weighs less. Net effect: "Dm7" returned top-5 Dm
-            // triads with identical 0.5066 score. Computing ICV query-side restores
-            // proper discrimination between a chord and its proper subsets.
-            var icvString = ComputeIcvString(pcs);
-            var structure = theory.ComputeEmbedding(
-                pitchClasses: pcs,
-                rootPitchClass: root2,
-                intervalClassVector: icvString);
+            var structure = theory.ComputeEmbedding(pitchClasses: pcs, rootPitchClass: root2);
             Array.Copy(structure, 0, raw, EmbeddingSchema.StructureOffset, structure.Length);
         }
 
@@ -113,29 +99,6 @@ public sealed class MusicalQueryEncoder(
         // is therefore zero, which is the correct behavior.
 
         return ExtractCompactAndNormalize(raw);
-    }
-
-    /// <summary>
-    ///     Computes the 6-digit interval-class vector string for a pitch-class set, in the
-    ///     same digit-per-position format <see cref="TheoryVectorService.ComputeEmbedding"/>
-    ///     parses. Counts cap at 9 since the parser is char-by-char; this only bites for
-    ///     extremely dense (10+ PC) sets, which the index doesn't carry.
-    /// </summary>
-    internal static string ComputeIcvString(int[] pcs)
-    {
-        var counts = new int[6];
-        for (var i = 0; i < pcs.Length; i++)
-        {
-            for (var j = i + 1; j < pcs.Length; j++)
-            {
-                var diff = Math.Abs(pcs[i] - pcs[j]);
-                var ic = Math.Min(diff, 12 - diff);
-                if (ic is >= 1 and <= 6) counts[ic - 1]++;
-            }
-        }
-        var sb = new StringBuilder(6);
-        for (var i = 0; i < 6; i++) sb.Append((char)('0' + Math.Min(counts[i], 9)));
-        return sb.ToString();
     }
 
     /// <summary>

--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -240,6 +240,25 @@ public static class ChordPitchClasses
 
         if (!Qualities.TryGetValue(qualityStr, out var offsets))
         {
+            // Paren-stripped retry: the user-facing notation `E7(#9)`, `C7(b9)`,
+            // `C(add9)`, `Cm(maj9)` carries parens around the alteration suffix. The
+            // dictionary keys store the canonical paren-less forms ("7#9", "7b9",
+            // "add9"). Without this retry, removing parens from the tokenizer
+            // (companion fix in TypedMusicalQueryExtractor) would regress those
+            // forms — they'd reach TryParse as a single token, fail the lookup,
+            // and be dropped entirely. The only key that genuinely needs parens
+            // is "m(maj7)" which already matches on the first attempt.
+            if (qualityStr.Contains('(') || qualityStr.Contains(')'))
+            {
+                var stripped = qualityStr.Replace("(", "").Replace(")", "");
+                if (Qualities.TryGetValue(stripped, out offsets))
+                {
+                    root = r;
+                    pitchClasses = offsets.Select(o => (r + o) % 12).Distinct().OrderBy(x => x).ToArray();
+                    return true;
+                }
+            }
+
             // Reject unknown qualities — otherwise every english word starting with a letter
             // A-G (e.g. "and", "fade", "be") parses as a chord and every query carries false
             // musical structure into retrieval.

--- a/Common/GA.Business.ML/Search/TypedMusicalQueryExtractor.cs
+++ b/Common/GA.Business.ML/Search/TypedMusicalQueryExtractor.cs
@@ -57,8 +57,15 @@ public sealed class TypedMusicalQueryExtractor : IMusicalQueryExtractor
         "play", "playing", "position",
     };
 
+    // 2026-05-12: '(' and ')' removed from delimiters so chord-symbol shorthand
+    // like "Em(maj7)" reaches ChordPitchClasses.TryParse as a single token. The
+    // dictionary key "m(maj7)" already resolves to [0,3,7,11]; with the previous
+    // tokenizer the symbol was split into ["Em", "maj7"] and the maj7 was lost as
+    // a tag. Space-separated forms like "Cmaj7 (jazz)" still resolve correctly —
+    // the second token "(jazz)" hits SymbolicTagRegistry's substring fallback on
+    // "jazz".
     private static readonly char[] TokenDelimiters =
-        [' ', '\t', '\n', '\r', ',', ';', '.', '!', '?', '(', ')', '[', ']'];
+        [' ', '\t', '\n', '\r', ',', ';', '.', '!', '?', '[', ']'];
 
     public Task<StructuredQuery> ExtractAsync(string query, CancellationToken cancellationToken = default)
     {

--- a/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
@@ -66,6 +66,26 @@ public class MusicalQueryEncoderTests
         Assert.That(ok, Is.False);
     }
 
+    [TestCase("E7(#9)",  4, new[] { 4, 8, 11, 2, 7 })]    // Hendrix chord: E G# B D + #9=F##(=G)
+    [TestCase("C7(b9)",  0, new[] { 0, 4, 7, 10, 1 })]    // C7b9: C E G Bb + b9=Db
+    [TestCase("G7(b5)",  7, new[] { 7, 11, 1, 5 })]       // G7b5: G B Db F
+    [TestCase("G7(#5)",  7, new[] { 7, 11, 3, 5 })]       // G7#5: G B D# F
+    [TestCase("C(add9)", 0, new[] { 0, 4, 7, 2 })]        // Cadd9: C E G + 9=D
+    public void TryParse_ParenWrappedAlterations_FallBackToDeparenthesizedQuality(
+        string symbol, int expectedRoot, int[] expectedPcs)
+    {
+        // 2026-05-12 review: removing '(' and ')' from TypedMusicalQueryExtractor's
+        // tokenizer (companion fix) makes these queries arrive as single tokens
+        // like "E7(#9)" instead of split into ["E7", "#9"]. Without the
+        // paren-strip retry in TryParse, the quality string "7(#9)" wouldn't
+        // match the dictionary key "7#9" and the chord would be dropped entirely
+        // — a worse outcome than the pre-fix partial parse.
+        var ok = ChordPitchClasses.TryParse(symbol, out var root, out var pcs);
+        Assert.That(ok, Is.True, $"paren-stripped retry should accept {symbol}");
+        Assert.That(root, Is.EqualTo(expectedRoot));
+        Assert.That(pcs, Is.EquivalentTo(expectedPcs));
+    }
+
     [Test]
     public void TryParse_SlashBass_IgnoresSlashPortion()
     {

--- a/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
@@ -161,45 +161,6 @@ public class MusicalQueryEncoderTests
             "different chords must produce measurably different OPTK vectors.");
     }
 
-    [Test]
-    public void Encode_4PcChord_OutscoresIts3PcSubset()
-    {
-        // 2026-05-12 telemetry regression: "Dm7" returned only Dm triads (PCs 2,5,9)
-        // at identical 0.5066 — the query's STRUCTURE vector had zero ICV while the
-        // corpus carried non-zero ICV, so per-partition L2 normalization scaled
-        // the chroma contribution differently for super-set vs subset matches.
-        // After computing the ICV on the encoder side, the query vector for Dm7 must
-        // self-match (cosine ≈ partition-weight-sum) strictly better than it
-        // matches the encoded subset Dm.
-        var dm7Pcs = new[] { 0, 2, 5, 9 };
-        var dmPcs  = new[] { 2, 5, 9 };
-
-        var dm7 = _encoder.Encode(new StructuredQuery("Dm7", 2, dm7Pcs, null, null));
-        var dm  = _encoder.Encode(new StructuredQuery("Dm",  2, dmPcs,  null, null));
-
-        var selfDot = 0.0;
-        var subsetDot = 0.0;
-        for (var i = 0; i < dm7.Length; i++)
-        {
-            selfDot += dm7[i] * dm7[i];
-            subsetDot += dm7[i] * dm[i];
-        }
-
-        Assert.That(selfDot, Is.GreaterThan(subsetDot + 0.01),
-            $"Dm7 self-cosine ({selfDot:F4}) must exceed Dm7→Dm subset cosine " +
-            $"({subsetDot:F4}) — proves the ICV/cardinality discriminator is active.");
-    }
-
-    [TestCase(new[] { 0, 4, 7 },                  "001110")]  // C major triad: ic3,4,5
-    [TestCase(new[] { 0, 4, 7, 11 },              "101220")]  // Cmaj7: 1×ic1, 1×ic3, 2×ic4, 2×ic5
-    [TestCase(new[] { 0, 2, 5, 9 },               "012120")]  // Dm7 PCs: ic2 + 2×ic3 + ic4 + 2×ic5
-    [TestCase(new[] { 0, 3, 6, 9 },               "004002")]  // dim7 — symmetric, 4×ic3 + 2×ic6
-    public void ComputeIcvString_KnownPcSets_MatchAnalyticIcv(int[] pcs, string expected)
-    {
-        var actual = MusicalQueryEncoder.ComputeIcvString(pcs);
-        Assert.That(actual, Is.EqualTo(expected));
-    }
-
     // ─── Leak-fix proof: per-partition normalization ──────────────────────────
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
@@ -161,6 +161,45 @@ public class MusicalQueryEncoderTests
             "different chords must produce measurably different OPTK vectors.");
     }
 
+    [Test]
+    public void Encode_4PcChord_OutscoresIts3PcSubset()
+    {
+        // 2026-05-12 telemetry regression: "Dm7" returned only Dm triads (PCs 2,5,9)
+        // at identical 0.5066 — the query's STRUCTURE vector had zero ICV while the
+        // corpus carried non-zero ICV, so per-partition L2 normalization scaled
+        // the chroma contribution differently for super-set vs subset matches.
+        // After computing the ICV on the encoder side, the query vector for Dm7 must
+        // self-match (cosine ≈ partition-weight-sum) strictly better than it
+        // matches the encoded subset Dm.
+        var dm7Pcs = new[] { 0, 2, 5, 9 };
+        var dmPcs  = new[] { 2, 5, 9 };
+
+        var dm7 = _encoder.Encode(new StructuredQuery("Dm7", 2, dm7Pcs, null, null));
+        var dm  = _encoder.Encode(new StructuredQuery("Dm",  2, dmPcs,  null, null));
+
+        var selfDot = 0.0;
+        var subsetDot = 0.0;
+        for (var i = 0; i < dm7.Length; i++)
+        {
+            selfDot += dm7[i] * dm7[i];
+            subsetDot += dm7[i] * dm[i];
+        }
+
+        Assert.That(selfDot, Is.GreaterThan(subsetDot + 0.01),
+            $"Dm7 self-cosine ({selfDot:F4}) must exceed Dm7→Dm subset cosine " +
+            $"({subsetDot:F4}) — proves the ICV/cardinality discriminator is active.");
+    }
+
+    [TestCase(new[] { 0, 4, 7 },                  "001110")]  // C major triad: ic3,4,5
+    [TestCase(new[] { 0, 4, 7, 11 },              "101220")]  // Cmaj7: 1×ic1, 1×ic3, 2×ic4, 2×ic5
+    [TestCase(new[] { 0, 2, 5, 9 },               "012120")]  // Dm7 PCs: ic2 + 2×ic3 + ic4 + 2×ic5
+    [TestCase(new[] { 0, 3, 6, 9 },               "004002")]  // dim7 — symmetric, 4×ic3 + 2×ic6
+    public void ComputeIcvString_KnownPcSets_MatchAnalyticIcv(int[] pcs, string expected)
+    {
+        var actual = MusicalQueryEncoder.ComputeIcvString(pcs);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
     // ─── Leak-fix proof: per-partition normalization ──────────────────────────
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Search/TypedMusicalQueryExtractorTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/TypedMusicalQueryExtractorTests.cs
@@ -189,6 +189,42 @@ public class TypedMusicalQueryExtractorTests
         Assert.That(q.Tags, Is.Null);
     }
 
+    [TestCase("Em(maj7)",   "Em(maj7)",  4, new[] { 4, 7, 11, 3 })]    // E, G, B, D# — minor-major 7
+    [TestCase("Cm(maj7)",   "Cm(maj7)",  0, new[] { 0, 3, 7, 11 })]
+    [TestCase("F#m(maj7)",  "F#m(maj7)", 6, new[] { 6, 9, 1, 5 })]     // F#, A, C#, F — m(maj7)
+    public async Task Extract_ParenWrappedQuality_StaysOneTokenAndParses(
+        string query, string expectedSymbol, int expectedRoot, int[] expectedPcs)
+    {
+        // 2026-05-12 telemetry regression: queries like "Em(maj7)" previously split
+        // on parens and parsed as chord=Em (minor triad) + tag=["maj7"], silently
+        // dropping the maj7 extension. ChordPitchClasses key "m(maj7)" exists;
+        // removing '(' and ')' from the tokenizer lets the symbol reach TryParse
+        // intact. (Other paren-wrapped qualities like "m(maj9)" aren't in the
+        // dictionary yet — those would need a separate Qualities entry.)
+        var q = await _typed.ExtractAsync(query);
+        Assert.That(q.ChordSymbol, Is.EqualTo(expectedSymbol));
+        Assert.That(q.RootPitchClass, Is.EqualTo(expectedRoot));
+        Assert.That(q.PitchClasses, Is.EquivalentTo(expectedPcs));
+        Assert.That(q.Tags, Is.Null.Or.Empty,
+            "Paren-wrapped quality suffix must not leak into Tags.");
+    }
+
+    [TestCase("Cmaj7 drop2",  "drop")]    // dehyphenated alias makes "drop2" hit "drop-2-voicings"
+    [TestCase("Dm7 drop3",    "drop")]
+    public async Task Extract_DigitSuffixedTag_ResolvesViaDehyphenatedAlias(
+        string query, string expectedTagFragment)
+    {
+        // 2026-05-12 telemetry regression: "drop2" missed "drop-2-voicings" because
+        // GetBitIndex's substring fallback never inserts hyphens at letter/digit
+        // boundaries. RegisterTag now also stores a dehyphenated alias so the
+        // user-typed "drop2" substring-matches "drop2voicings".
+        var q = await _typed.ExtractAsync(query);
+        Assert.That(q.Tags, Is.Not.Null.And.Not.Empty,
+            $"'{query}' should pick up the drop-{expectedTagFragment} tag via dehyphenated alias.");
+        Assert.That(q.Tags!.Any(t => t.Contains(expectedTagFragment, StringComparison.OrdinalIgnoreCase)),
+            Is.True);
+    }
+
     // ─── composite ─────────────────────────────────────────────────────────
 
     [Test]

--- a/docs/plans/2026-05-12-icv-format-reconciliation-plan.md
+++ b/docs/plans/2026-05-12-icv-format-reconciliation-plan.md
@@ -1,0 +1,120 @@
+# ICV Format Reconciliation — OPTIC-K Writer/Reader Symmetry
+
+**Status:** Pending
+**Date:** 2026-05-12
+**Owner:** spareilleux
+**Reversibility:** **One-way door** for the corpus rebuild step; two-way for the parser/writer code itself.
+**Revisit trigger:** Re-baseline `state/telemetry/voicing-search/` after corpus rebuild; if 4-PC-chord queries (e.g. `Dm7`) still return their 3-PC subsets at top-K, escalate.
+
+## Problem statement
+
+The 2026-05-12 telemetry sweep (PR #186 review) surfaced that the OPTIC-K v1.8 corpus has been writing its STRUCTURE partition's interval-class-vector (ICV) slice with a **misparsed string** for the entire life of the index. The defect is silent: cosine similarity still ranks something, just not what the schema docstring claims.
+
+| Side | What it writes / reads | Result for major scale `<2 5 4 3 6 1>` |
+|---|---|---|
+| Writer (`MusicalEmbeddingGenerator.cs:98` ← `VoicingDocumentFactory.cs:75` ← `VoicingHarmonicAnalyzer.cs:37`) | `pcSet.IntervalClassVector.ToString()` → `"<2 5 4 3 6 1>"` (angle-bracketed, space-separated, see `IntervalClassVectorId.cs:24`) | string passed verbatim to `TheoryVectorService` |
+| `ParseIcv` (`TheoryVectorService.cs:92-101`) | `for i in 0..5: if char.IsDigit(s[i]) counts[i] = s[i] - '0'` | `s = "<2 5 4"` → `counts = [0, 2, 0, 5, 0, 4]` — values misaligned by position, last three IC counts discarded entirely |
+
+The encoder's docstring (`MusicalQueryEncoder.cs:30-31`) claims "Query and corpus therefore live in the identical semantic space — no alignment training required." That claim has been false since the v1.0 of the index.
+
+Consequences:
+- STRUCTURE dims 13-18 (ICV bins) carry positionally-shifted garbage on the corpus side.
+- Dims 20 (`IcvConsonance`) and 21 (`IcvBrightness`) are computed from the misparsed counts, so they're also wrong.
+- Pre-PR-#186 the query side wrote zeros to these dims, so the cosine on that 8-dim slice was effectively zero — neutral.
+- The initial fix in PR #186 tried to populate the query side with the correct format. That widened the gap rather than closing it, and was reverted in commit `27a0b8ec`.
+
+## What's blocked
+
+- **`Dm7` returns Dm/F triads at identical 0.5066** (the original telemetry finding). The query side has no ICV signal, so the partition is decided entirely by chroma + cardinality + tonal — and chroma overlap of `{0,2,5,9}` vs `{2,5,9}` is 3-of-4, ranked identically.
+- **All 4+ PC chord queries collapse to nearest 3-PC subset** when the corpus has subset voicings indexed alongside the full chord.
+- **Higher-cardinality chord retrieval is generally degraded** (Cmaj9#11 → Esus2, F#m11 → Gbm(add9), G13b9 → E7(shell)).
+
+## Decision
+
+Two independent reconciliation paths. Each is internally consistent; mixing them is the bug.
+
+### Path A — Fix the reader (lower risk, requires corpus rebuild)
+
+Make `ParseIcv` tolerant of both formats:
+- The intended digit-per-position form `"NNNNNN"` (what the parser was designed for and what `EmbeddingSchemaValidationTests` fixtures use).
+- The actual writer form `"<a b c d e f>"` — split on whitespace, drop `<`/`>`, parse decimal integers, cap at 9.
+
+```csharp
+private static int[] ParseIcv(string? icv)
+{
+    var counts = new int[6];
+    if (string.IsNullOrEmpty(icv)) return counts;
+    if (icv.IndexOf('<') >= 0 || icv.IndexOf(' ') >= 0)
+    {
+        // Bracket-space form: "<2 5 4 3 6 1>"
+        var parts = icv.Trim('<', '>').Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < Math.Min(6, parts.Length); i++)
+            if (int.TryParse(parts[i], out var v)) counts[i] = Math.Min(v, 9);
+        return counts;
+    }
+    // Digit-per-position form: "012120"
+    for (var i = 0; i < Math.Min(6, icv.Length); i++)
+        if (char.IsDigit(icv[i])) counts[i] = icv[i] - '0';
+    return counts;
+}
+```
+
+Then re-add the query-side `ComputeIcvString` (the helper that was in PR #186 commit `d2e7590e`), which emits `"NNNNNN"` form so the query and corpus pass through the same reader logic and produce aligned counts.
+
+**Required follow-on:** rebuild the corpus. Existing on-disk vectors are frozen with the misparsed values; only re-running `OptickIndexWriter` against the corrected reader fixes them. Per `state/voicings/README.md` and the `optic-k-rebuild` skill, this is the standard ~140s procedure (stop GaApi+GaMcpServer, run `FretboardVoicingsCLI`, restart).
+
+### Path B — Fix the writer (higher risk, also requires rebuild)
+
+Change `IntervalClassVectorId.ToString()` to emit `"NNNNNN"`. This is the wider blast radius — `ToString()` is used by `DisplayName` properties, debug output, logs, JSON-serialized exports across the whole domain. Every consumer that has a regex or string match on the `<2 5 4 3 6 1>` form would break.
+
+Not recommended unless we find concrete benefit beyond fixing the embedding pipeline.
+
+## Recommended path
+
+**Path A**, in three sub-steps:
+
+1. **Code change** (this PR's follow-up):
+   - Patch `ParseIcv` to accept both formats.
+   - Re-add `MusicalQueryEncoder.ComputeIcvString` and the `intervalClassVector:` pass-through call (port from reverted commit `27a0b8ec`).
+   - Add a **corpus-vs-query integration test** that:
+     - Encodes a known voicing (e.g. C major triad on guitar) via `MusicalEmbeddingGenerator` (corpus path).
+     - Encodes the same query via `MusicalQueryEncoder` (query path).
+     - Asserts `compactQuery[13..18]` (ICV slice) matches `compactCorpus[13..18]` to within float tolerance after per-partition normalization.
+   - This test would have failed pre-PR — it's the symmetry guarantee the encoder docstring claims.
+
+2. **Corpus rebuild**:
+   - Stop GaApi + GaMcpServer (mmap lock).
+   - Run `OptickIndexWriter` against the corrected `ParseIcv`. ~140s for 313k voicings per `optic-k-rebuild` skill.
+   - Restart services.
+
+3. **Verification**:
+   - Re-run the 25-query telemetry sweep from PR #186's review.
+   - Confirm `Dm7` returns 4-PC `Dm7` voicings before any 3-PC `Dm/F` subset.
+   - Confirm `Cmaj9#11`, `F#m11`, `G13b9` retrievals show their actual PC sets at top-K, not subset-of-PCs fallbacks.
+   - Compare `state/telemetry/voicing-search/2026-05-12.jsonl` distribution before/after — expect score distribution to broaden (more discrimination, less ties).
+
+## Out of scope (for now)
+
+- `IntervalClassVector` consumers outside the embedding pipeline. The `<2 5 4 3 6 1>` form remains the canonical display string.
+- Adding a `ParseIcv`-equivalent helper to `EmbeddingSchema` as the canonical format spec. Worth doing once the asymmetry is closed; tracked in this plan's follow-up rather than this PR.
+- The other findings from PR #186 review (paren-wrapped alterations, drop2 alias) — those landed in PR #186 and are independent.
+
+## One-way door log
+
+- **Corpus rebuild is a one-way door.** Once the new `OptickIndexWriter` runs, the old misparsed-ICV vectors are overwritten. Downstream consumers (chord-recommendation, GA-Nightly-Quality baselines under `ga/state/quality/`, any pinned expected-results in `Tests/.../OptickIntegrationTests.cs`) need a re-baseline pass.
+- **Schema hash unchanged.** The partition layout / weight matrix is untouched; `SchemaHashV4` stays. Existing tests that snapshot the schema hash will continue to pass.
+
+## Cross-repo coordination
+
+ix's `crates/ix-optick` and `crates/ix-optick-invariants` read the OPTIC-K index. The Rust readers only do dot-products on stored vectors; they don't re-parse ICV strings. So no ix code change is required for Path A. The invariant-coverage tests in `ix-optick-invariants` may shift scores after the rebuild — re-baseline if any invariant regresses.
+
+`tars` and `Demerzel` don't touch the OPTIC-K corpus directly.
+
+## Acceptance criteria
+
+- [ ] `ParseIcv` accepts both `"NNNNNN"` and `"<a b c d e f>"` forms — test in `TheoryVectorServiceTests`.
+- [ ] Corpus-vs-query integration test exists and passes.
+- [ ] Corpus rebuilt against the new writer/reader.
+- [ ] 25-query telemetry sweep confirms `Dm7 > Dm/F` and 4 other 4+ PC chord queries return their actual PC sets at top-K.
+- [ ] Re-baseline check: `OptickIntegrationTests.cs:118` (`results[0].Score > 0.4` for Cmaj7) still holds — score should rise, not fall.
+- [ ] No invariant regression in `ix-optick-invariants` (current passes #25, #32 at 100%).


### PR DESCRIPTION
## Summary

Drove 25 realistic queries against the OPTIC-K v1.8 index via MCP. Surfaced **three bugs**; **two are landed in this PR** and **one is deferred** pending a paired writer/reader fix.

## Landed

### 1. `Em(maj7)` parser fall-through
**Before:** `Em(maj7)` parsed as `chord=Em, tags=["maj7"]` — the maj7 was lost. Same on every `Xm(maj7)`.
**Root cause:** `TypedMusicalQueryExtractor.TokenDelimiters` included `(` and `)`, splitting the symbol before it reached `ChordPitchClasses.TryParse` (which has `"m(maj7)" → [0,3,7,11]`).
**Fix:** Drop `(` and `)` from delimiters, plus a paren-strip retry in `TryParse` (`a0ecc08f`) so other alteration forms like `E7(#9)`, `C7(b9)`, `C7(b5)`, `C(add9)` don't regress — those split into `[Xn, alteration]` before, and would fail outright as single tokens without the retry. Tag-only forms like `Cmaj7 (jazz)` still resolve via the registry's substring fallback.

### 2. `drop2` doesn't match `drop-2-voicings`
**Before:** Vocabulary doc promises hyphen-normalization, but `GetBitIndex` only normalizes spaces/underscores to dashes — never inserts dashes at letter↔digit boundaries.
**Fix:** When registering a tag that contains a digit, also store the dehyphenated form. The digit gate keeps English-phrase tags (`tension-and-release` → `tensionandrelease`) out of the aliased pool so the substring fallback doesn't over-fire on `"and"`.

## Deferred — split into a follow-up PR

### 3. ICV signal missing in query encoder (P0, complicated)
**The bug:** `Dm7` (PCs 0,2,5,9) returned 5 `Dm/F` triads all at identical `0.5066`.
**Why the original fix was reverted (`27a0b8ec`):** The corpus has been writing the ICV via `IntervalClassVectorId.ToString()` which emits `"<2 5 4 3 6 1>"` (angle-bracketed, space-separated). `TheoryVectorService.ParseIcv` reads only `char.IsDigit` from positions 0–5, so the corpus has been storing **misparsed-but-nonzero** values like `[0, 2, 0, 5, 0, 4]` for the entire life of the OPTIC-K index. Initial fix made the query write the *correct* digit-per-position format → asymmetry widened. The regression test only passed because it encoded both sides through the same fixed encoder; production retrieval has no such symmetry.

**Real fix needs (separate PR):**
- Reconcile writer/reader format: either fix `ParseIcv` to accept the `<a b c d e f>` form, or change `IntervalClassVectorId.ToString()` to emit `"NNNNNN"`.
- Add a corpus-vs-query integration test that confirms STRUCTURE[13..21] agrees on both sides for known PC sets.
- Schedule a corpus rebuild (existing on-disk vectors stay misparsed until rebuilt).

## Test coverage

New regression tests:
- `Extract_ParenWrappedQuality_StaysOneTokenAndParses` × 3 (`Em(maj7)`, `Cm(maj7)`, `F#m(maj7)`)
- `Extract_DigitSuffixedTag_ResolvesViaDehyphenatedAlias` × 2 (`drop2`, `drop3`)
- `TryParse_ParenWrappedAlterations_FallBackToDeparenthesizedQuality` × 5 (`E7(#9)`, `C7(b9)`, `G7(b5)`, `G7(#5)`, `C(add9)`)

**111 tests pass** across `MusicalQueryEncoderTests`, `TypedMusicalQueryExtractorTests`, `SymbolicTag*`, `VoicingTagEnricher*`, `Embedding*` suites.

## Schema invariance

`SchemaHashV4` unchanged — `CompactLayoutV4` is derived from partition names/dims/offsets, none of which the PR touches. The existing on-disk `state/voicings/optick.index` will not be rejected.

## Commits

| | |
|---|---|
| `d2e7590e` | Initial three-bug fix |
| `27a0b8ec` | Revert ICV (writer/reader format mismatch — deferred to follow-up) |
| `a0ecc08f` | Paren-strip fallback in TryParse + tighten alias comment |

## Test plan

- [x] \`dotnet test\` extractor + encoder + adjacent suites — 111/111
- [ ] Restart GaApi + GaMcpServer locally and re-run the 25-query telemetry sweep — confirm `Em(maj7)` parses correctly, `Cmaj7 drop2` tag fires, no regression on `E7(#9)` etc.