### PR TITLE
feat(memory): explicit owner-only DACL on Windows

### DIFF
--- a/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
@@ -1,5 +1,7 @@
 namespace GA.Business.ML.Agents.Memory;
 
+using System.Security.AccessControl;
+using System.Security.Principal;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
@@ -11,33 +13,47 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Why this exists (PR #174 follow-up):</b> both <see cref="MemoryStore"/>
-/// and <see cref="ChatTranscriptStore"/> persist per-session user data
-/// (preferences, focus statements, full chat transcript text). Default
-/// <see cref="File.WriteAllText(string, string)"/> on Unix uses the
-/// process umask — typically <c>0644</c> — so other users on a shared
-/// host can read the file. On Windows the user-profile directory
-/// (<c>%USERPROFILE%\.ga</c>) is already restricted by inherited ACLs in
-/// practice, but the file itself was not explicitly locked down.
+/// <b>Why this exists (PR #174 follow-up, expanded 2026-05-11):</b> both
+/// <see cref="MemoryStore"/> and <see cref="ChatTranscriptStore"/> persist
+/// per-session user data (preferences, focus statements, full chat
+/// transcript text). Default <see cref="File.WriteAllText(string, string)"/>
+/// on Unix uses the process umask — typically <c>0644</c> — so other users
+/// on a shared host can read the file. On Windows the user-profile
+/// directory (<c>%USERPROFILE%\.ga</c>) is restricted by inherited ACLs in
+/// practice, but a fresh file at a non-profile path (e.g. a custom
+/// <c>StorageDirectory</c> configured against a shared scratch dir) would
+/// inherit the parent's ACL — which on shared CI agents and bastions can
+/// include Authenticated Users read.
 /// </para>
 /// <para>
-/// <b>What this guarantees:</b> on Unix the persisted file has
-/// <c>UnixFileMode.UserRead | UnixFileMode.UserWrite</c> (mode <c>0600</c>)
-/// from the moment it appears at its final path — the mode is set on the
-/// <c>.tmp</c> file BEFORE the rename, so there's no window where the
-/// file exists at the canonical path with a broader mode. On Windows the
-/// helper is a no-op for ACL — the user-profile ACL inheritance is the
-/// load-bearing defense and adding an explicit DACL adds a
-/// platform-dependent <c>System.IO.FileSystem.AccessControl</c> dependency
-/// that isn't worth the extra surface today.
+/// <b>What this guarantees:</b>
+/// <list type="bullet">
+///   <item>On Unix the persisted file has
+///     <c>UnixFileMode.UserRead | UnixFileMode.UserWrite</c> (mode <c>0600</c>)
+///     from the moment it appears at its final path — the mode is set on
+///     the <c>.tmp</c> file BEFORE the rename, so there's no window where
+///     the file exists at the canonical path with a broader mode.</item>
+///   <item>On Windows the persisted file has an explicit DACL with
+///     inheritance disabled. Allowed principals: the current user
+///     (full control), <c>NT AUTHORITY\SYSTEM</c> (full control), and
+///     <c>BUILTIN\Administrators</c> (full control). Every other principal
+///     — including <c>Authenticated Users</c> and <c>Everyone</c> — is
+///     implicitly denied. Applied to the <c>.tmp</c> before the move so
+///     the canonical path is never observable with the inherited ACL.</item>
+/// </list>
 /// </para>
 /// <para>
-/// <b>Failure mode:</b> <see cref="File.SetUnixFileMode"/> can throw on
+/// <b>Failure mode:</b> on Unix
+/// <see cref="File.SetUnixFileMode(string, UnixFileMode)"/> can throw on
 /// filesystems that don't support POSIX permissions (rare on the user
-/// profile dir; happens on some FAT-mounted shares). The helper catches
-/// and logs at Warning level — the write still completes, but the file
-/// lands with default mode. Treat as a defense-in-depth gap visible in
-/// logs, not a hard failure.
+/// profile dir; happens on some FAT-mounted shares). On Windows
+/// <see cref="FileSystemAclExtensions.SetAccessControl(FileInfo, FileSecurity)"/>
+/// can throw on non-NTFS filesystems (e.g. FAT, exFAT, some network
+/// mounts) and inside containers with a stripped <c>WindowsIdentity</c>.
+/// In both cases the helper catches and logs at Warning level — the
+/// write still completes, but the file lands with the platform default
+/// ACL/mode. Treat as a defense-in-depth gap visible in logs, not a hard
+/// failure.
 /// </para>
 /// </remarks>
 public static class MemoryFileWriter
@@ -51,16 +67,17 @@ public static class MemoryFileWriter
 
     /// <summary>
     /// Writes <paramref name="content"/> to <paramref name="path"/>
-    /// atomically with owner-only permissions on Unix. Creates the parent
-    /// directory if it doesn't exist.
+    /// atomically with owner-only permissions on Unix and an explicit
+    /// owner-only DACL on Windows. Creates the parent directory if it
+    /// doesn't exist.
     /// </summary>
     /// <param name="path">Destination path. The temp file used in transit
     /// is <c>path + ".tmp"</c>.</param>
     /// <param name="content">UTF-8 text content.</param>
-    /// <param name="logger">Optional logger for the
-    /// <see cref="File.SetUnixFileMode"/> failure case. When null, the
-    /// failure is swallowed silently — acceptable because the file still
-    /// lands at <paramref name="path"/>; only the ACL hardening is missed.</param>
+    /// <param name="logger">Optional logger for ACL-application failure.
+    /// When null, the failure is swallowed silently — acceptable because
+    /// the file still lands at <paramref name="path"/>; only the ACL
+    /// hardening is missed.</param>
     public static void WriteAtomic(string path, string content, ILogger? logger = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
@@ -73,28 +90,91 @@ public static class MemoryFileWriter
         var tmp = path + ".tmp";
         File.WriteAllText(tmp, content);
 
-        // Apply owner-only mode to the tmp file BEFORE the rename so the
-        // destination atomically inherits the restricted mode. Without
-        // this ordering, a parallel reader could race in the window
-        // between rename and SetUnixFileMode and see the file at its
-        // permissive default mode.
-        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() ||
-            OperatingSystem.IsFreeBSD())
-        {
-            try
-            {
-                File.SetUnixFileMode(tmp, OwnerOnlyMode);
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(ex,
-                    "MemoryFileWriter: failed to set 0600 on {Path} — file system " +
-                    "may not support POSIX permissions (FAT, some network mounts). " +
-                    "Write proceeds with default mode; defense-in-depth gap visible " +
-                    "in this log.", tmp);
-            }
-        }
+        // Apply owner-only ACL/mode to the tmp file BEFORE the rename so
+        // the destination atomically inherits the restricted permissions.
+        // Without this ordering, a parallel reader could race in the
+        // window between rename and the permission tightening and see the
+        // file at its permissive default. Each helper short-circuits on
+        // the wrong OS so the analyzer (CA1416) can see the gate.
+        TrySetUnixOwnerOnlyMode(tmp, logger);
+        TrySetWindowsOwnerOnlyAcl(tmp, logger);
 
         File.Move(tmp, path, overwrite: true);
+    }
+
+    private static void TrySetUnixOwnerOnlyMode(string path, ILogger? logger)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS() && !OperatingSystem.IsFreeBSD())
+            return;
+
+        try
+        {
+            File.SetUnixFileMode(path, OwnerOnlyMode);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "MemoryFileWriter: failed to set 0600 on {Path} — file system " +
+                "may not support POSIX permissions (FAT, some network mounts). " +
+                "Write proceeds with default mode; defense-in-depth gap visible " +
+                "in this log.", path);
+        }
+    }
+
+    private static void TrySetWindowsOwnerOnlyAcl(string path, ILogger? logger)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        try
+        {
+            var fileInfo = new FileInfo(path);
+            var security = new FileSecurity();
+
+            // Strip inherited ACEs — we want a known-explicit DACL, not the
+            // parent directory's grab-bag. preserveInheritance:false means
+            // we don't copy the inherited rules in as explicit before
+            // stripping — they're gone.
+            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+            using var identity = WindowsIdentity.GetCurrent();
+            var userSid = identity.User
+                ?? throw new InvalidOperationException(
+                    "WindowsIdentity.GetCurrent() returned no User SID — " +
+                    "running in a stripped/container identity?");
+
+            // Current user: full control.
+            security.AddAccessRule(new FileSystemAccessRule(
+                userSid,
+                FileSystemRights.FullControl,
+                AccessControlType.Allow));
+
+            // NT AUTHORITY\SYSTEM: full control. Without this, scheduled
+            // tasks running as SYSTEM (e.g. backup, antivirus, the GA
+            // service worker) can't read the memory store.
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+                FileSystemRights.FullControl,
+                AccessControlType.Allow));
+
+            // BUILTIN\Administrators: full control. Admin tooling and
+            // ga-cli operations running elevated need this; without it,
+            // an admin debugging a customer's machine can't touch the
+            // file without taking ownership first.
+            security.AddAccessRule(new FileSystemAccessRule(
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                FileSystemRights.FullControl,
+                AccessControlType.Allow));
+
+            fileInfo.SetAccessControl(security);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "MemoryFileWriter: failed to apply owner-only DACL on Windows " +
+                "path {Path}. File falls back to the inherited ACL of its parent " +
+                "directory — defense-in-depth gap visible in this log. Most " +
+                "common cause: non-NTFS filesystem (FAT, exFAT) or a stripped " +
+                "WindowsIdentity inside a container.", path);
+        }
     }
 }

--- a/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
@@ -2,58 +2,56 @@ namespace GA.Business.ML.Agents.Memory;
 
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Text;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
 /// Shared atomic-write helper for the JSON-backed memory and transcript
-/// stores. Ensures every persisted file lands with owner-only permissions
-/// where the platform supports them, then atomic-renames into place so a
-/// crash mid-write can't leave a half-flushed file that subsequent
+/// stores. Creates every persisted file with owner-only permissions
+/// applied at creation time, then atomic-renames into place so a crash
+/// mid-write can't leave a half-flushed file that subsequent
 /// <c>Load()</c> calls would silently swallow.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Why this exists (PR #174 follow-up, expanded 2026-05-11):</b> both
-/// <see cref="MemoryStore"/> and <see cref="ChatTranscriptStore"/> persist
-/// per-session user data (preferences, focus statements, full chat
-/// transcript text). Default <see cref="File.WriteAllText(string, string)"/>
-/// on Unix uses the process umask — typically <c>0644</c> — so other users
-/// on a shared host can read the file. On Windows the user-profile
-/// directory (<c>%USERPROFILE%\.ga</c>) is restricted by inherited ACLs in
-/// practice, but a fresh file at a non-profile path (e.g. a custom
-/// <c>StorageDirectory</c> configured against a shared scratch dir) would
-/// inherit the parent's ACL — which on shared CI agents and bastions can
-/// include Authenticated Users read.
+/// <b>Why "applied at creation time" matters (security review of PR #187,
+/// 2026-05-11):</b> the earlier draft of this helper called
+/// <see cref="File.WriteAllText(string, string)"/> first and tightened
+/// permissions afterwards. That left a TOCTOU window — typically a few
+/// milliseconds — where the <c>.tmp</c> existed at the parent
+/// directory's inherited ACL with the full plaintext content already on
+/// disk. A co-tenant racing an open-for-read against the predictable
+/// <c>.tmp</c> path could obtain a handle that survives a subsequent
+/// <c>SetAccessControl</c>: Windows DACL changes do not revoke already
+/// open handles. The current implementation closes that window by
+/// creating the file already-protected — on Windows via
+/// <see cref="FileSystemAclExtensions.Create(FileSecurity, string, FileMode, FileSystemRights, FileShare, int, FileOptions)"/>
+/// and on Unix via <see cref="FileStreamOptions.UnixCreateMode"/>.
 /// </para>
 /// <para>
 /// <b>What this guarantees:</b>
 /// <list type="bullet">
 ///   <item>On Unix the persisted file has
 ///     <c>UnixFileMode.UserRead | UnixFileMode.UserWrite</c> (mode <c>0600</c>)
-///     from the moment it appears at its final path — the mode is set on
-///     the <c>.tmp</c> file BEFORE the rename, so there's no window where
-///     the file exists at the canonical path with a broader mode.</item>
-///   <item>On Windows the persisted file has an explicit DACL with
-///     inheritance disabled. Allowed principals: the current user
-///     (full control), <c>NT AUTHORITY\SYSTEM</c> (full control), and
-///     <c>BUILTIN\Administrators</c> (full control). Every other principal
-///     — including <c>Authenticated Users</c> and <c>Everyone</c> — is
-///     implicitly denied. Applied to the <c>.tmp</c> before the move so
-///     the canonical path is never observable with the inherited ACL.</item>
+///     from the moment the inode is created — there is no observable
+///     state where it exists with default umask permissions.</item>
+///   <item>On Windows the persisted file has an explicit DACL applied
+///     at <c>CREATE_NEW</c> time with inheritance disabled. Allowed
+///     principals: the current user (full control),
+///     <c>NT AUTHORITY\SYSTEM</c> (full control), and
+///     <c>BUILTIN\Administrators</c> (full control). Every other
+///     principal — including <c>Authenticated Users</c> and
+///     <c>Everyone</c> — is implicitly denied. There is no observable
+///     state where the file exists at the parent's inherited ACL.</item>
 /// </list>
 /// </para>
 /// <para>
-/// <b>Failure mode:</b> on Unix
-/// <see cref="File.SetUnixFileMode(string, UnixFileMode)"/> can throw on
-/// filesystems that don't support POSIX permissions (rare on the user
-/// profile dir; happens on some FAT-mounted shares). On Windows
-/// <see cref="FileSystemAclExtensions.SetAccessControl(FileInfo, FileSecurity)"/>
-/// can throw on non-NTFS filesystems (e.g. FAT, exFAT, some network
-/// mounts) and inside containers with a stripped <c>WindowsIdentity</c>.
-/// In both cases the helper catches and logs at Warning level — the
-/// write still completes, but the file lands with the platform default
-/// ACL/mode. Treat as a defense-in-depth gap visible in logs, not a hard
-/// failure.
+/// <b>Failure mode:</b> if the create-with-permissions primitive fails
+/// (non-NTFS filesystem on Windows; some network mounts on Unix that
+/// don't honor the create-mode parameter), the helper falls back to the
+/// older "write then tighten" pattern AND logs a warning. The brief
+/// race window is then visible in logs, not silent. The write itself
+/// still completes — defense-in-depth gap, not a hard failure.
 /// </para>
 /// </remarks>
 public static class MemoryFileWriter
@@ -67,17 +65,18 @@ public static class MemoryFileWriter
 
     /// <summary>
     /// Writes <paramref name="content"/> to <paramref name="path"/>
-    /// atomically with owner-only permissions on Unix and an explicit
-    /// owner-only DACL on Windows. Creates the parent directory if it
+    /// atomically with owner-only permissions applied at creation time
+    /// on every supported platform. Creates the parent directory if it
     /// doesn't exist.
     /// </summary>
     /// <param name="path">Destination path. The temp file used in transit
     /// is <c>path + ".tmp"</c>.</param>
     /// <param name="content">UTF-8 text content.</param>
-    /// <param name="logger">Optional logger for ACL-application failure.
-    /// When null, the failure is swallowed silently — acceptable because
-    /// the file still lands at <paramref name="path"/>; only the ACL
-    /// hardening is missed.</param>
+    /// <param name="logger">Optional logger for the create-with-perms
+    /// fallback path. When null, fallback warnings are swallowed
+    /// silently — acceptable because the file still lands at
+    /// <paramref name="path"/>; only the TOCTOU-closure guarantee is
+    /// lost.</param>
     public static void WriteAtomic(string path, string content, ILogger? logger = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
@@ -88,93 +87,261 @@ public static class MemoryFileWriter
             Directory.CreateDirectory(dir);
 
         var tmp = path + ".tmp";
-        File.WriteAllText(tmp, content);
 
-        // Apply owner-only ACL/mode to the tmp file BEFORE the rename so
-        // the destination atomically inherits the restricted permissions.
-        // Without this ordering, a parallel reader could race in the
-        // window between rename and the permission tightening and see the
-        // file at its permissive default. Each helper short-circuits on
-        // the wrong OS so the analyzer (CA1416) can see the gate.
-        TrySetUnixOwnerOnlyMode(tmp, logger);
-        TrySetWindowsOwnerOnlyAcl(tmp, logger);
+        // Stale .tmp from a prior crash would conflict with CreateNew.
+        // Remove it best-effort; if removal fails, the create will throw
+        // below and the outer try/finally cleans up after.
+        if (File.Exists(tmp))
+        {
+            try { File.Delete(tmp); } catch (IOException) { /* fall through */ }
+            catch (UnauthorizedAccessException) { /* fall through */ }
+        }
 
-        File.Move(tmp, path, overwrite: true);
+        try
+        {
+            WriteWithOwnerOnlyPermissions(tmp, content, logger);
+            MoveAtomic(tmp, path, logger);
+        }
+        catch
+        {
+            // Best-effort cleanup of the orphaned tmp on any failure path
+            // (including OOM, thread abort). We do NOT swallow — we
+            // re-throw so the caller sees the original failure. Without
+            // this, a crash between WriteWithOwnerOnlyPermissions and
+            // MoveAtomic would leave a .tmp on disk; the next call would
+            // notice it via the File.Exists(tmp) guard above, but a
+            // process kill between Delete and CreateNew could observe a
+            // gap. Try/finally + delete-on-entry closes both.
+            try { if (File.Exists(tmp)) File.Delete(tmp); }
+            catch (IOException) { /* best effort */ }
+            catch (UnauthorizedAccessException) { /* best effort */ }
+            throw;
+        }
     }
 
-    private static void TrySetUnixOwnerOnlyMode(string path, ILogger? logger)
+    private static void MoveAtomic(string tmp, string path, ILogger? logger)
+    {
+        try
+        {
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // File.Move(overwrite:true) needs DELETE on the destination,
+            // which means the destination's DACL must grant the current
+            // user delete-or-modify. If the previous WriteAtomic was run
+            // as a different identity (service-account → per-user install,
+            // or a roaming profile opened on a new machine), the current
+            // identity is not in the destination's ACE list and the move
+            // fails. File.Replace goes through a Win32 ReplaceFile path
+            // that preserves the destination's DACL via the security
+            // descriptor of the source, which IS owned by the current
+            // user — so it succeeds where Move fails.
+            if (!OperatingSystem.IsWindows()) throw;
+
+            logger?.LogWarning(ex,
+                "MemoryFileWriter: File.Move(overwrite) into {Path} failed with " +
+                "UnauthorizedAccessException — destination DACL may exclude the " +
+                "current user (cross-identity install upgrade?). Falling back to " +
+                "File.Replace.", path);
+            File.Replace(tmp, path, destinationBackupFileName: null);
+        }
+    }
+
+    private static void WriteWithOwnerOnlyPermissions(string tmp, string content, ILogger? logger)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            WriteWithWindowsOwnerOnlyDacl(tmp, content, logger);
+        }
+        else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS() || OperatingSystem.IsFreeBSD())
+        {
+            WriteWithUnixOwnerOnlyMode(tmp, content, logger);
+        }
+        else
+        {
+            // Unknown OS — write plainly, no hardening available.
+            File.WriteAllText(tmp, content);
+        }
+    }
+
+    private static void WriteWithUnixOwnerOnlyMode(string path, string content, ILogger? logger)
     {
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS() && !OperatingSystem.IsFreeBSD())
             return;
 
         try
         {
-            File.SetUnixFileMode(path, OwnerOnlyMode);
+            // UnixCreateMode applies at open(2)/creat(2) time via the mode
+            // argument — the inode is born with 0600. No window where the
+            // file exists at the umask-default mode.
+            var options = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                UnixCreateMode = OwnerOnlyMode,
+            };
+            using var fs = new FileStream(path, options);
+            using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            writer.Write(content);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (
+            ex is NotSupportedException or
+                  PlatformNotSupportedException or
+                  IOException)
         {
+            // Some filesystems (FAT, certain network mounts) don't honor
+            // UnixCreateMode at create-time. Fall back to write-then-chmod
+            // — brief window where the file exists with default mode.
             logger?.LogWarning(ex,
-                "MemoryFileWriter: failed to set 0600 on {Path} — file system " +
-                "may not support POSIX permissions (FAT, some network mounts). " +
-                "Write proceeds with default mode; defense-in-depth gap visible " +
-                "in this log.", path);
+                "MemoryFileWriter: UnixCreateMode unsupported on {Path}; falling back " +
+                "to write-then-chmod pattern. Brief window where file exists with " +
+                "default mode — defense-in-depth gap visible in this log.", path);
+            File.WriteAllText(path, content);
+            try { File.SetUnixFileMode(path, OwnerOnlyMode); }
+            catch (Exception modeEx)
+            {
+                logger?.LogWarning(modeEx,
+                    "MemoryFileWriter: fallback chmod 0600 also failed on {Path}. " +
+                    "File lands with default mode.", path);
+            }
         }
     }
 
-    private static void TrySetWindowsOwnerOnlyAcl(string path, ILogger? logger)
+    private static void WriteWithWindowsOwnerOnlyDacl(string path, string content, ILogger? logger)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        FileSecurity? security;
+        try
+        {
+            security = BuildOwnerOnlyFileSecurity();
+        }
+        catch (Exception ex) when (
+            ex is InvalidOperationException or
+                  IdentityNotMappedException or
+                  PlatformNotSupportedException)
+        {
+            // BuildOwnerOnlyFileSecurity can throw if WindowsIdentity.GetCurrent()
+            // returns a SID with User == null (stripped container identity).
+            // Fall back to a plain write — the file lands at parent ACL.
+            logger?.LogWarning(ex,
+                "MemoryFileWriter: failed to build owner-only DACL for {Path} " +
+                "(stripped WindowsIdentity?). Falling back to plain write — " +
+                "file lands at parent directory's inherited ACL. " +
+                "Defense-in-depth gap visible in this log.", path);
+            File.WriteAllText(path, content);
+            return;
+        }
+
+        try
+        {
+            // FileSystemAclExtensions.Create applies the DACL atomically at
+            // CREATE_NEW time — the file is born with the locked-down ACL.
+            // No observable state where the parent's inherited ACL applies.
+            using var fs = new FileInfo(path).Create(
+                FileMode.CreateNew,
+                FileSystemRights.WriteData | FileSystemRights.Synchronize,
+                FileShare.None,
+                bufferSize: 4096,
+                FileOptions.None,
+                security);
+            using var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            writer.Write(content);
+        }
+        catch (Exception ex) when (
+            ex is UnauthorizedAccessException or
+                  IOException or
+                  PlatformNotSupportedException or
+                  NotSupportedException or
+                  PrivilegeNotHeldException or
+                  ArgumentException)
+        {
+            // Non-NTFS filesystem (FAT, exFAT, some network mounts) doesn't
+            // support DACLs. Fall back to plain write + post-write
+            // SetAccessControl — closes most of the gap, but leaves the
+            // TOCTOU window the security review flagged. Logged so it's
+            // visible in production. The catch list is deliberately narrow:
+            // OOM, ThreadInterrupted, AccessViolation, StackOverflow MUST
+            // propagate — they indicate the runtime is in a bad state and
+            // continuing the write would compound the problem.
+            logger?.LogWarning(ex,
+                "MemoryFileWriter: failed to create {Path} with pre-applied DACL " +
+                "(likely non-NTFS filesystem). Falling back to write-then-DACL " +
+                "pattern — brief race window where parent ACL applies before the " +
+                "DACL is tightened. Defense-in-depth gap visible in this log.", path);
+            File.WriteAllText(path, content);
+            TrySetWindowsOwnerOnlyAclOnExisting(path, security, logger);
+        }
+    }
+
+    private static void TrySetWindowsOwnerOnlyAclOnExisting(string path, FileSecurity security, ILogger? logger)
     {
         if (!OperatingSystem.IsWindows()) return;
 
         try
         {
-            var fileInfo = new FileInfo(path);
-            var security = new FileSecurity();
-
-            // Strip inherited ACEs — we want a known-explicit DACL, not the
-            // parent directory's grab-bag. preserveInheritance:false means
-            // we don't copy the inherited rules in as explicit before
-            // stripping — they're gone.
-            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
-
-            using var identity = WindowsIdentity.GetCurrent();
-            var userSid = identity.User
-                ?? throw new InvalidOperationException(
-                    "WindowsIdentity.GetCurrent() returned no User SID — " +
-                    "running in a stripped/container identity?");
-
-            // Current user: full control.
-            security.AddAccessRule(new FileSystemAccessRule(
-                userSid,
-                FileSystemRights.FullControl,
-                AccessControlType.Allow));
-
-            // NT AUTHORITY\SYSTEM: full control. Without this, scheduled
-            // tasks running as SYSTEM (e.g. backup, antivirus, the GA
-            // service worker) can't read the memory store.
-            security.AddAccessRule(new FileSystemAccessRule(
-                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
-                FileSystemRights.FullControl,
-                AccessControlType.Allow));
-
-            // BUILTIN\Administrators: full control. Admin tooling and
-            // ga-cli operations running elevated need this; without it,
-            // an admin debugging a customer's machine can't touch the
-            // file without taking ownership first.
-            security.AddAccessRule(new FileSystemAccessRule(
-                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
-                FileSystemRights.FullControl,
-                AccessControlType.Allow));
-
-            fileInfo.SetAccessControl(security);
+            new FileInfo(path).SetAccessControl(security);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (
+            ex is UnauthorizedAccessException or
+                  IOException or
+                  PlatformNotSupportedException or
+                  PrivilegeNotHeldException or
+                  ArgumentException)
         {
             logger?.LogWarning(ex,
-                "MemoryFileWriter: failed to apply owner-only DACL on Windows " +
-                "path {Path}. File falls back to the inherited ACL of its parent " +
-                "directory — defense-in-depth gap visible in this log. Most " +
-                "common cause: non-NTFS filesystem (FAT, exFAT) or a stripped " +
-                "WindowsIdentity inside a container.", path);
+                "MemoryFileWriter: post-write SetAccessControl also failed on {Path}. " +
+                "File falls back to the inherited ACL of its parent directory.", path);
         }
+    }
+
+    private static FileSecurity BuildOwnerOnlyFileSecurity()
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("Windows-only.");
+
+        var security = new FileSecurity();
+
+        // Strip inherited ACEs — we want a known-explicit DACL, not the
+        // parent directory's grab-bag. preserveInheritance:false means
+        // we don't copy the inherited rules in as explicit before
+        // stripping — they're gone.
+        security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+        using var identity = WindowsIdentity.GetCurrent();
+        var userSid = identity.User
+            ?? throw new InvalidOperationException(
+                "WindowsIdentity.GetCurrent() returned no User SID — " +
+                "running in a stripped/container identity?");
+
+        // Current user: full control.
+        security.AddAccessRule(new FileSystemAccessRule(
+            userSid,
+            FileSystemRights.FullControl,
+            AccessControlType.Allow));
+
+        // NT AUTHORITY\SYSTEM: full control. Without this, scheduled
+        // tasks running as SYSTEM (e.g. backup, antivirus, the GA
+        // service worker) can't read the memory store. Excluding SYSTEM
+        // would also be security theater — SeTakeOwnershipPrivilege
+        // lets SYSTEM read anything regardless.
+        security.AddAccessRule(new FileSystemAccessRule(
+            new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+            FileSystemRights.FullControl,
+            AccessControlType.Allow));
+
+        // BUILTIN\Administrators: full control. Admin tooling and ga-cli
+        // operations running elevated need this; without it, an admin
+        // debugging a customer's machine would need to take ownership
+        // first (generating 4670 events for no security gain — admins
+        // can always take ownership).
+        security.AddAccessRule(new FileSystemAccessRule(
+            new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+            FileSystemRights.FullControl,
+            AccessControlType.Allow));
+
+        return security;
     }
 }

--- a/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryFileWriter.cs
@@ -139,6 +139,15 @@ public static class MemoryFileWriter
             // user — so it succeeds where Move fails.
             if (!OperatingSystem.IsWindows()) throw;
 
+            // File.Replace REQUIRES the destination to exist (Win32 ReplaceFile
+            // throws FileNotFoundException otherwise). UAE without a pre-existing
+            // destination indicates a different problem — e.g. parent-dir
+            // permission denial — and falling through to File.Replace would
+            // mask the real cause with a confusing FileNotFoundException.
+            // Re-throw the original UAE so the operator sees the actual
+            // permission failure. Found by PR #187 correctness review.
+            if (!File.Exists(path)) throw;
+
             logger?.LogWarning(ex,
                 "MemoryFileWriter: File.Move(overwrite) into {Path} failed with " +
                 "UnauthorizedAccessException — destination DACL may exclude the " +

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryFileWriterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryFileWriterTests.cs
@@ -1,12 +1,17 @@
 namespace GA.Business.ML.Tests.Unit;
 
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using GA.Business.ML.Agents.Memory;
 
 /// <summary>
-/// Pins the atomic-write + owner-only-mode contract shipped by
+/// Pins the atomic-write + owner-only-permission contract shipped by
 /// <see cref="MemoryFileWriter"/>. Atomic-rename behavior tested on every
-/// platform; the mode-setting branch is asserted only on Unix-likes
-/// (Windows uses inherited user-profile ACL, no explicit DACL set).
+/// platform; the mode-setting branch is asserted on Unix-likes; the
+/// explicit-DACL branch is asserted on Windows. Each platform-gated test
+/// is decorated with <c>[Platform(...)]</c> so the other platform's CI
+/// silently skips rather than failing.
 /// </summary>
 [TestFixture]
 public class MemoryFileWriterTests
@@ -94,7 +99,7 @@ public class MemoryFileWriterTests
         // On Linux / macOS / FreeBSD the file must land at mode 0600
         // (owner read + write). On Windows this test is skipped — the
         // mode-setting branch is gated by OperatingSystem.IsLinux() and
-        // friends; Windows relies on user-profile ACL inheritance.
+        // friends; Windows is covered by the DACL test below.
         var path = Path.Combine(_tempDir, "memory.json");
         MemoryFileWriter.WriteAtomic(path, "x");
 
@@ -102,5 +107,80 @@ public class MemoryFileWriterTests
         Assert.That(mode, Is.EqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite),
             $"Expected 0600 (UserRead | UserWrite); got {mode}. Group / other " +
             "permissions are a defense-in-depth gap on shared hosts.");
+    }
+
+    [Test]
+    [Platform("Win")]
+    [SupportedOSPlatform("windows")]
+    public void WriteAtomic_OnWindows_AppliesExplicitOwnerOnlyDacl()
+    {
+        // On Windows the file must land with:
+        //   • inheritance disabled (AreAccessRulesProtected == true)
+        //   • the current user with FullControl
+        //   • NT AUTHORITY\SYSTEM with FullControl
+        //   • BUILTIN\Administrators with FullControl
+        //   • no Authenticated Users / Everyone Allow ACEs (those are
+        //     what the inherited ACL on shared CI agents typically
+        //     leaks through)
+        var path = Path.Combine(_tempDir, "memory.json");
+        MemoryFileWriter.WriteAtomic(path, "x");
+
+        var info     = new FileInfo(path);
+        var security = info.GetAccessControl();
+
+        Assert.That(security.AreAccessRulesProtected, Is.True,
+            "DACL must be marked Protected (inheritance disabled). " +
+            "Without this, the parent dir's ACL leaks back in.");
+
+        var rules = security
+            .GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
+            .Cast<FileSystemAccessRule>()
+            .ToList();
+
+        // Sanity: every Allow rule we set is FullControl. We don't assert
+        // negative ACEs because the absence of an Allow already implies
+        // the principal has no access — that's the Windows ACL model.
+        using var identity = WindowsIdentity.GetCurrent();
+        var userSid  = identity.User!;
+        var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+        var adminSid  = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+
+        Assert.That(rules.Any(r =>
+                r.IdentityReference.Equals(userSid) &&
+                r.FileSystemRights == FileSystemRights.FullControl &&
+                r.AccessControlType == AccessControlType.Allow),
+            "Current user must have an explicit Allow FullControl ACE.");
+
+        Assert.That(rules.Any(r =>
+                r.IdentityReference.Equals(systemSid) &&
+                r.FileSystemRights == FileSystemRights.FullControl &&
+                r.AccessControlType == AccessControlType.Allow),
+            "NT AUTHORITY\\SYSTEM must have an explicit Allow FullControl ACE " +
+            "(backup/AV/service workers running as SYSTEM need read access).");
+
+        Assert.That(rules.Any(r =>
+                r.IdentityReference.Equals(adminSid) &&
+                r.FileSystemRights == FileSystemRights.FullControl &&
+                r.AccessControlType == AccessControlType.Allow),
+            "BUILTIN\\Administrators must have an explicit Allow FullControl ACE " +
+            "(admin tooling must not require take-ownership).");
+
+        // Explicitly assert that Authenticated Users and Everyone are NOT
+        // listed. These are the two principals shared CI agents most
+        // commonly inherit from the parent dir.
+        var authenticatedUsersSid = new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null);
+        var everyoneSid           = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+
+        Assert.That(rules.Any(r =>
+                r.IdentityReference.Equals(authenticatedUsersSid) &&
+                r.AccessControlType == AccessControlType.Allow),
+            Is.False,
+            "Authenticated Users must NOT have an Allow ACE — that's the " +
+            "leak vector this DACL is closing.");
+        Assert.That(rules.Any(r =>
+                r.IdentityReference.Equals(everyoneSid) &&
+                r.AccessControlType == AccessControlType.Allow),
+            Is.False,
+            "Everyone must NOT have an Allow ACE.");
     }
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryFileWriterTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryFileWriterTests.cs
@@ -182,5 +182,42 @@ public class MemoryFileWriterTests
                 r.AccessControlType == AccessControlType.Allow),
             Is.False,
             "Everyone must NOT have an Allow ACE.");
+
+        // Strict-equality contract: exactly three explicit Allow rules.
+        // Catches drift where a future change adds a domain-group Allow
+        // (e.g. "CI-Agents") without auditing the security implication.
+        Assert.That(rules.Count, Is.EqualTo(3),
+            "DACL must contain exactly 3 explicit Allow rules: current user, " +
+            "SYSTEM, Administrators. Any other rule is unaudited drift.");
+    }
+
+    [Test]
+    [Platform("Win")]
+    [SupportedOSPlatform("windows")]
+    public void WriteAtomic_OnWindows_OverwritePreservesExplicitDacl()
+    {
+        // Reliability concern flagged by the review: File.Move(overwrite:true)
+        // must not silently leak the destination's prior ACL back in. The
+        // second write at the same path must land with the same explicit
+        // DACL (inheritance still disabled, same three SIDs) as the first.
+        var path = Path.Combine(_tempDir, "memory.json");
+        MemoryFileWriter.WriteAtomic(path, "first");
+        MemoryFileWriter.WriteAtomic(path, "second");
+
+        Assert.That(File.ReadAllText(path), Is.EqualTo("second"));
+
+        var security = new FileInfo(path).GetAccessControl();
+        Assert.That(security.AreAccessRulesProtected, Is.True,
+            "After overwrite, the DACL must still be Protected. Without this, " +
+            "a regression in the create-with-DACL primitive would silently fall " +
+            "back to the inherited ACL on the second write.");
+
+        var explicitRules = security
+            .GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
+            .Cast<FileSystemAccessRule>()
+            .ToList();
+        Assert.That(explicitRules.Count, Is.EqualTo(3),
+            "Second write must land with the same 3-ACE DACL, not the prior " +
+            "destination's ACL leaked through File.Move/Replace.");
     }
 }


### PR DESCRIPTION
## Summary

- Closes the Windows defense-in-depth gap on `MemoryFileWriter` — file now lands with an explicit DACL (inheritance disabled, current user + SYSTEM + Administrators only) instead of relying on inherited ACL from the parent dir.
- Symmetric to the existing Unix 0600 branch: restricted permissions applied to the `.tmp` *before* the atomic move, so the canonical path is never observable with the broader inherited ACL.
- Failure modes (non-NTFS FS, stripped container identity) log at Warning; write still completes.

## Why now

The previous comment in the helper acknowledged this as a known gap (`adding an explicit DACL adds a platform-dependent dependency that isn't worth the extra surface today`). It became worth doing because the relevant types (`System.Security.AccessControl.FileSecurity`, `FileSystemAclExtensions.SetAccessControl`) are in .NET 10 BCL with zero new package references, and the default `StorageDirectory` is configurable — pointing it at a shared scratch dir on a CI agent silently broadens read access through inherited ACEs (Authenticated Users on most agents).

## Test plan

- [x] `dotnet build Common/GA.Business.ML/GA.Business.ML.csproj` — 0 errors, no new warnings (CA1416 from the analyzer's call-site view of the Unix helper handled by moving the OS guard inside the helper).
- [x] `dotnet test --filter "FullyQualifiedName~MemoryFileWriterTests"` — 7 passed, 1 skipped (Unix-only test correctly skipped on Windows).
- [x] `dotnet test --filter "FullyQualifiedName~Memory"` — 70 passed.
- [x] New test `WriteAtomic_OnWindows_AppliesExplicitOwnerOnlyDacl` asserts the exact ACE set with negative assertions on Authenticated Users / Everyone (the two leakage principals on shared hosts).
- [ ] CI green on Windows + Linux.

Fixes the standing "Windows explicit DACL" follow-up item from the 2026-05-11 chatbot-improvement sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)