### PR TITLE
feat(orchestrator): RememberThis priority fix + shared test harness

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
@@ -549,6 +549,24 @@ public class ProductionOrchestrator(
         out GuitarAlchemistAgentBase agent,
         out AgentRoutingMetadata routing)
     {
+        // Remember-this requests take precedence over the voicing fast-path.
+        // Otherwise a prompt like "remember that I prefer drop-2 voicings for
+        // jazz comping" matches IsExplicitVoicingRequest (because "drop-2
+        // voicings" is in the keyword list) and short-circuits to VoicingAgent,
+        // returning voicings instead of writing to MemoryStore. Surfaced by
+        // the live-orchestrator e2e test (PR after #190 harness).
+        //
+        // The remember-phrasing is high-precision — RememberThisParser
+        // requires an explicit "remember"/"save"/"note"/"don't forget" lead
+        // phrase. Any prompt that passes that gate is unambiguously a
+        // memory-write request whose voicing-keyword content is incidental.
+        if (GA.Business.ML.Agents.Skills.RememberThisParser.LooksLikeRememberRequest(message))
+        {
+            agent = null!;
+            routing = null!;
+            return false;
+        }
+
         if (IsExplicitVoicingRequest(message)
             && router.Agents.FirstOrDefault(a => a.AgentId == AgentIds.Voicing) is { } voicingAgent)
         {

--- a/Common/GA.Business.ML/Agents/Skills/RememberThisParser.cs
+++ b/Common/GA.Business.ML/Agents/Skills/RememberThisParser.cs
@@ -44,8 +44,27 @@ public static class RememberThisParser
     /// regex is anchored on word boundaries and case-insensitive; only
     /// matches at the start of the trimmed message.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Tightening (PR #192 review):</b> the verbs <c>save</c>,
+    /// <c>note</c>, <c>store</c> have semantic overlap with non-memory
+    /// operations (save file, note pitch, store data). Bare forms like
+    /// "save these drop-2 voicings" — where the user wants to save
+    /// voicings to a library, not to durable memory — used to match
+    /// because <c>\s+this</c> was optional. Now those three verbs
+    /// require either <c>\s+this</c> / <c>\s+that</c> (explicit
+    /// memorable referent) or an immediate <c>:</c> / <c>,</c> separator
+    /// (canonical "note: X" / "save: X" format). <c>remember</c> and
+    /// <c>don't forget</c> stay flexible because they're high-precision
+    /// memory verbs with little non-memory overlap.
+    /// </para>
+    /// </remarks>
     private static readonly Regex LeadPhrase = new(
-        @"^\s*(?:please\s+)?(?:can\s+you\s+)?(?:remember(?:\s+that)?|save(?:\s+this)?|note(?:\s+this)?|store(?:\s+that)?|don'?t\s+forget(?:\s+that)?)[:,]?\s*",
+        @"^\s*(?:please\s+)?(?:can\s+you\s+)?(?:" +
+            @"remember(?:\s+that)?" +
+            @"|(?:save|note|store)(?:\s+(?:this|that)\b|(?=\s*[:,]))" +
+            @"|don'?t\s+forget(?:\s+that)?" +
+        @")[:,]?\s*",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private static readonly Regex PreferenceCue = new(

--- a/Tests/Apps/GaChatbot.Tests/Integration/LiveOrchestratorMemoryRetentionTests.cs
+++ b/Tests/Apps/GaChatbot.Tests/Integration/LiveOrchestratorMemoryRetentionTests.cs
@@ -1,18 +1,9 @@
 namespace GaChatbot.Tests.Integration;
 
-using GA.Business.Core.Orchestration.Abstractions;
-using GA.Business.Core.Orchestration.Extensions;
 using GA.Business.Core.Orchestration.Models;
 using GA.Business.Core.Orchestration.Services;
 using GA.Business.ML.Agents.Memory;
-using GA.Business.ML.Extensions;
-using GA.Business.ML.Search;
-using GA.Infrastructure.Documentation;
-using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
 /// <summary>
@@ -31,7 +22,7 @@ using NUnit.Framework;
 /// <c>ChatHookContext</c>. ALL of them passed for the entirety of the
 /// 2026-05-11 chatbot-improvement session, and the chatbot's
 /// remember-flow was silently broken in production the whole time —
-/// <see cref="OrchestratorSkillIntent.ExecuteAsync"/> was dropping
+/// <c>OrchestratorSkillIntent.ExecuteAsync</c> was dropping
 /// <c>AgentResponse.Data</c> during the adapter map, so
 /// <c>MemoryWriteHook</c>'s
 /// <c>ctx.Response?.Data is MemoryWriteRequest</c> guard never matched.
@@ -58,23 +49,13 @@ using NUnit.Framework;
 /// </remarks>
 [TestFixture]
 [Explicit(
-    "Requires (a) live Ollama embedding endpoint at localhost:11434 AND " +
-    "(b) the shared OrchestratorTestHarness — pending follow-up PR. The " +
-    "current SetUp wires the minimum surface (IChatClient, " +
-    "IEmbeddingGenerator, IGroundedNarrator, SchemaDiscoveryService, " +
-    "EnhancedVoicingSearchService + IVoicingSearchStrategy + " +
-    "VoicingIndexingService) but the production DI graph requires more " +
-    "services (IMusicalQueryExtractor, CompositeMusicalQueryExtractor, " +
-    "and their transitive deps) that no test framework wires by default. " +
-    "Run produces a DI-resolution exception listing the next missing " +
-    "type — that's the checklist for the harness PR. Until that lands, " +
-    "OrchestratorSkillIntentDataPropagationTests at " +
-    "Tests/Common/GA.Business.Core.Tests/Orchestration/ pins the " +
-    "PR #185 regression at unit level.")]
+    "Requires a live Ollama embedding endpoint at localhost:11434 for the " +
+    "SemanticIntentRouter to actually pick an intent. CI agents don't have " +
+    "Ollama wired, so the fixture is excluded from default runs. Trigger " +
+    "manually with `dotnet test --filter " +
+    "\"FullyQualifiedName~LiveOrchestratorMemoryRetentionTests\"`.")]
 public class LiveOrchestratorMemoryRetentionTests
 {
-    private const string EmbedEndpoint = "http://localhost:11434";
-
     private string _tempDir = string.Empty;
     private string _tempMemoryPath = string.Empty;
     private ServiceProvider _provider = null!;
@@ -88,74 +69,21 @@ public class LiveOrchestratorMemoryRetentionTests
         Directory.CreateDirectory(_tempDir);
         _tempMemoryPath = Path.Combine(_tempDir, "memory.json");
 
-        var configValues = new Dictionary<string, string?>
-        {
-            // Don't exercise retrieval — this test only proves writes.
-            ["Memory:EnrichOnRetrieve"]    = "false",
-            ["Memory:AllowLlmGlobalWrite"] = "false",
-            ["Ollama:Endpoint"]            = EmbedEndpoint,
-        };
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(configValues)
-            .Build();
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IConfiguration>(config);
-        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
-        services.AddGuitarAlchemistAI();
-        services.AddChatbotOrchestration();
-
-        // ── Host-provided wiring not done by AddChatbotOrchestration ──────
-        // The orchestration extension intentionally leaves a few interfaces
-        // unregistered so each host (GaApi, GaChatbot, GaChatbotCli) can
-        // wire its own implementation. The test mirrors GaChatbotCli's
-        // setup since that's the closest to a minimal-dep harness.
-
-        // DomainMetadataPrompter dependency.
-        services.TryAddSingleton<SchemaDiscoveryService>();
-
-        // SemanticRouter agent fallback — uses IChatClient. Tests don't
-        // hit that path (RememberThis lands via the embedding intent
-        // router) but DI requires the binding to construct SemanticRouter.
-        services.TryAddSingleton<IChatClient>(_ =>
-            new OllamaChatClient(new Uri(EmbedEndpoint), "llama3.2"));
-
-        // Embedder for SemanticIntentRouter — this is the load-bearing
-        // path: the router embeds the prompt and every intent's
-        // description+examples to pick the best match. Without this the
-        // test can't route to RememberThisSkill.
-        services.TryAddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(_ =>
-            new OllamaEmbeddingGenerator(new Uri(EmbedEndpoint), "nomic-embed-text"));
-
-        // Voicing-search stack — VoicingAgent (transitively required by
-        // SemanticRouter, which constructs eagerly with ALL agents) needs
-        // these even though this test never exercises voicing. CPU strategy
-        // is parameterless and doesn't need a GPU or OPTK index file.
-        services.TryAddSingleton<VoicingIndexingService>();
-        services.TryAddSingleton<IVoicingSearchStrategy>(new CpuVoicingSearchStrategy());
-        services.TryAddSingleton<EnhancedVoicingSearchService>();
-
-        // Test-scoped MemoryStore at a temp path so the test doesn't pollute
-        // the developer's real ~/.ga/memory.json. The plugin host registers
-        // a default; we replace it.
-        services.RemoveAll<MemoryStore>();
-        services.AddSingleton(_ => new MemoryStore(_tempMemoryPath));
-
-        // Stub IGroundedNarrator — orchestration intentionally doesn't
-        // register one, hosts must provide it. RememberThisSkill is
-        // deterministic; the narrator is on the fallback path which this
-        // test doesn't take.
-        services.AddSingleton<IGroundedNarrator>(new StubGroundedNarrator());
-
-        _provider = services.BuildServiceProvider();
+        _provider = OrchestratorTestHarness.Build(
+            memoryPathProvider: () => _tempMemoryPath);
         _memoryStore = _provider.GetRequiredService<MemoryStore>();
         _orchestrator = _provider.GetRequiredService<ProductionOrchestrator>();
     }
 
     [TearDown]
-    public void TearDown()
+    public async Task TearDown()
     {
-        _provider?.Dispose();
+        // ServiceProvider must be disposed asynchronously when any
+        // service implements IAsyncDisposable only (e.g.
+        // InProcessMcpToolsProvider registered by AddChatPluginHost).
+        // Calling Dispose() on the sync surface throws.
+        if (_provider is not null)
+            await _provider.DisposeAsync();
         if (Directory.Exists(_tempDir))
         {
             try { Directory.Delete(_tempDir, recursive: true); }
@@ -270,11 +198,5 @@ public class LiveOrchestratorMemoryRetentionTests
             "MemoryWriteHook.AllowedTypes still excludes everything except " +
             "{fact, preference, focus} AND that no other skill is " +
             "accidentally emitting a MemoryWriteRequest on AgentResponse.Data.");
-    }
-
-    private sealed class StubGroundedNarrator : IGroundedNarrator
-    {
-        public Task<string> NarrateAsync(string query, IReadOnlyList<CandidateVoicing> candidates) =>
-            Task.FromResult($"[stub narrator] {candidates.Count} candidates for: {query}");
     }
 }

--- a/Tests/Apps/GaChatbot.Tests/Integration/OrchestratorTestHarness.cs
+++ b/Tests/Apps/GaChatbot.Tests/Integration/OrchestratorTestHarness.cs
@@ -1,0 +1,182 @@
+namespace GaChatbot.Tests.Integration;
+
+using GA.Business.Core.Orchestration.Abstractions;
+using GA.Business.Core.Orchestration.Extensions;
+using GA.Business.Core.Orchestration.Models;
+using GA.Business.Core.Orchestration.Services;
+using GA.Business.ML.Agents;
+using GA.Business.ML.Extensions;
+using GA.Business.ML.Search;
+using GA.Infrastructure.Documentation;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Shared test harness that wires the production-shaped DI graph for
+/// <c>ProductionOrchestrator</c> so integration tests can run the full
+/// orchestrator dispatch without each test re-discovering the ~15
+/// host-side services that <c>AddChatbotOrchestration</c> intentionally
+/// leaves to the host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Mirrors:</b> <c>GaChatbot.Api.Extensions.ServiceCollectionExtensions.AddMinimalChatbotApi</c>
+/// in the <c>usesOrchestration</c> branch — the canonical reference for
+/// what a chatbot host needs to register. When that production wiring
+/// changes, the harness must follow.
+/// </para>
+/// <para>
+/// <b>Created to unblock:</b> <see cref="LiveOrchestratorMemoryRetentionTests"/>
+/// (3 tests that pin the RememberThisSkill → MemoryWriteHook → MemoryStore
+/// retention loop end-to-end). Without this harness those tests were
+/// <see cref="NUnit.Framework.ExplicitAttribute">[Explicit]</see>-skipped
+/// and the e2e contract that would have caught the PR #185 production bug
+/// was uncovered.
+/// </para>
+/// <para>
+/// <b>External dependencies:</b> still requires a live Ollama embedding
+/// endpoint at <c>localhost:11434</c> for the
+/// <see cref="SemanticIntentRouter"/> dispatch to actually pick an intent.
+/// Tests using the harness should keep <c>[Explicit]</c> for that reason.
+/// </para>
+/// </remarks>
+public static class OrchestratorTestHarness
+{
+    /// <summary>
+    /// Default Ollama endpoint. Override per-test via the
+    /// <paramref name="builder"/> action if needed.
+    /// </summary>
+    public const string DefaultOllamaEndpoint = "http://localhost:11434";
+
+    /// <summary>
+    /// Wires the full production-shaped DI graph plus a test-isolated
+    /// <see cref="GA.Business.ML.Agents.Memory.MemoryStore"/> at the path
+    /// returned by <paramref name="memoryPathProvider"/>.
+    /// </summary>
+    /// <param name="memoryPathProvider">Returns the path that the
+    /// in-process MemoryStore should persist to. Tests typically pass a
+    /// per-test temp path so concurrent tests don't share storage.</param>
+    /// <param name="ollamaEndpoint">Optional Ollama base URL. Defaults to
+    /// <see cref="DefaultOllamaEndpoint"/>.</param>
+    /// <param name="builder">Optional hook for tests to register
+    /// additional services or override harness defaults BEFORE
+    /// BuildServiceProvider.</param>
+    /// <returns>A fully-wired <see cref="ServiceProvider"/>. Callers own
+    /// disposal.</returns>
+    public static ServiceProvider Build(
+        Func<string>                memoryPathProvider,
+        string?                     ollamaEndpoint = null,
+        Action<IServiceCollection>? builder        = null)
+    {
+        ArgumentNullException.ThrowIfNull(memoryPathProvider);
+        var endpoint = ollamaEndpoint ?? DefaultOllamaEndpoint;
+
+        var configValues = new Dictionary<string, string?>
+        {
+            ["Memory:EnrichOnRetrieve"]    = "false",
+            ["Memory:AllowLlmGlobalWrite"] = "false",
+            ["Ollama:Endpoint"]            = endpoint,
+            ["Ollama:BaseUrl"]             = endpoint,
+        };
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+
+        // ── Order matters: AddGuitarAlchemistAI registers TryAdd defaults,
+        //    AddChatbotOrchestration registers TryAdd defaults including the
+        //    plugin host. Host-specific services that the orchestration
+        //    extension intentionally leaves for the host (per its inline
+        //    comments at GA.Business.Core.Orchestration/Extensions/
+        //    ChatbotOrchestrationExtensions.cs:72-76) are registered AFTER
+        //    so they win against any defaults.
+
+        services.AddMemoryCache();
+
+        // Repositories that the orchestrator's tab/progression analysis
+        // services transitively depend on. In-memory variants are fine
+        // for tests — production uses real corpus stores.
+        services.AddSingleton<GA.Business.ML.Agents.IRoutingFeedback,
+            GA.Business.ML.Agents.InMemoryRoutingFeedback>();
+        services.AddSingleton<GA.Domain.Repositories.ITabCorpusRepository,
+            GA.Infrastructure.Persistence.Repositories.InMemoryTabCorpusRepository>();
+        services.AddSingleton<GA.Domain.Repositories.IProgressionCorpusRepository,
+            GA.Infrastructure.Persistence.Repositories.InMemoryProgressionCorpusRepository>();
+
+        // DomainMetadataPrompter dependency. Not in AddGuitarAlchemistAI
+        // by design — each host registers it explicitly.
+        services.AddSingleton<SchemaDiscoveryService>();
+
+        // Voicing-search stack. VoicingAgent (transitively required by
+        // SemanticRouter, which constructs eagerly with ALL agents) needs
+        // these even for tests that never exercise voicing.
+        services.AddSingleton<VoicingIndexingService>();
+        services.AddSingleton<IVoicingSearchStrategy, CpuVoicingSearchStrategy>();
+        services.AddSingleton<EnhancedVoicingSearchService>();
+
+        // Musical-query extractors. CompositeMusicalQueryExtractor sits
+        // on top of Typed + Llm; both must be registered for the
+        // composite to resolve.
+        services.AddSingleton<MusicalQueryEncoder>();
+        services.AddSingleton<TypedMusicalQueryExtractor>();
+        services.AddSingleton<LlmMusicalQueryExtractor>();
+        services.AddSingleton<IMusicalQueryExtractor, CompositeMusicalQueryExtractor>();
+
+        // Core ML services (agents, embedding generator, semantic router).
+        services.AddGuitarAlchemistAI();
+
+        // Orchestration stack — IIntent registry, hook chain, dispatch.
+        services.AddChatbotOrchestration();
+
+        // ── Host-provided abstractions ────────────────────────────────────
+        // SemanticRouter fallback path requires an IChatClient; tests
+        // typically don't exercise it but the binding must resolve.
+        services.TryAddSingleton<IChatClient>(_ =>
+            new OllamaChatClient(new Uri(endpoint), "llama3.2"));
+
+        // SemanticIntentRouter embedder — the LOAD-BEARING path. The
+        // router embeds the prompt and every intent's
+        // description+examples to pick the best match. Without this
+        // tests can't actually route.
+        services.TryAddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(_ =>
+            new OllamaEmbeddingGenerator(new Uri(endpoint), "nomic-embed-text"));
+
+        // Stub narrator. RememberThisSkill / deterministic skills don't
+        // hit the narrator path; tests that do should supply a real
+        // narrator via the builder action.
+        services.TryAddSingleton<IGroundedNarrator>(new StubGroundedNarrator());
+
+        // ── Test-isolated MemoryStore ────────────────────────────────────
+        // Plugin host registered a default MemoryStore at ~/.ga/memory.json
+        // via AddChatbotOrchestration; replace with a per-test temp path
+        // so tests don't pollute the developer's real store.
+        services.RemoveAll<GA.Business.ML.Agents.Memory.MemoryStore>();
+        services.AddSingleton(sp =>
+            new GA.Business.ML.Agents.Memory.MemoryStore(
+                memoryPathProvider(),
+                sp.GetService<ILogger<GA.Business.ML.Agents.Memory.MemoryStore>>()));
+
+        // Per-test customization happens AFTER all harness defaults so
+        // tests can override anything they need.
+        builder?.Invoke(services);
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Stub <see cref="IGroundedNarrator"/> — returns a deterministic
+    /// placeholder string. Tests that exercise the narrator path must
+    /// supply their own via the harness builder action.
+    /// </summary>
+    private sealed class StubGroundedNarrator : IGroundedNarrator
+    {
+        public Task<string> NarrateAsync(string query, IReadOnlyList<CandidateVoicing> candidates) =>
+            Task.FromResult($"[stub narrator] {candidates.Count} candidates for: {query}");
+    }
+}

--- a/Tests/Common/GA.Business.Core.Tests/Orchestration/RememberOverVoicingPriorityTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Orchestration/RememberOverVoicingPriorityTests.cs
@@ -1,0 +1,74 @@
+namespace GA.Business.Core.Tests.Orchestration;
+
+using GA.Business.ML.Agents.Skills;
+
+/// <summary>
+/// Pins the priority-order invariant in
+/// <c>ProductionOrchestrator.TrySelectDeterministicAgent</c>:
+/// remember-this requests MUST take precedence over the voicing fast-path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The bug this prevents (surfaced 2026-05-12 by the live-orchestrator
+/// e2e):</b> the orchestrator runs <c>IsExplicitVoicingRequest</c> before
+/// the semantic intent router. That deterministic fast-path matches on
+/// <c>ExplicitVoicingKeywords</c>, which includes "drop-2 voicings",
+/// "chord shape", "fingering", etc. A user typing "remember that I prefer
+/// drop-2 voicings for jazz comping" matched the voicing keyword first,
+/// short-circuited to <c>VoicingAgent</c>, and got back a list of
+/// voicings — the memory write never happened.
+/// </para>
+/// <para>
+/// <b>Why this is a unit test:</b> the e2e
+/// (<c>LiveOrchestratorMemoryRetentionTests</c>) catches the bug only
+/// when an Ollama embedder is available, which means CI doesn't catch
+/// it. This test pins the <c>RememberThisParser.LooksLikeRememberRequest</c>
+/// contract that the orchestrator now gates on — if the parser stops
+/// matching the canonical remember-phrasings (or accidentally matches
+/// pure voicing requests), CI fails before the bug ships.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class RememberOverVoicingPriorityTests
+{
+    // Canonical remember phrasings that contain voicing keywords. Each MUST
+    // be detected as a remember-request — if any of these returns false,
+    // the orchestrator's TrySelectDeterministicAgent will short-circuit to
+    // the voicing fast-path and the memory write silently disappears.
+    [TestCase("remember that I prefer drop-2 voicings for jazz comping")]
+    [TestCase("save this: my favorite chord shapes are drop-3")]
+    [TestCase("note: I always use rootless voicings for ballads")]
+    [TestCase("don't forget I'm working on barre chord fingerings this month")]
+    [TestCase("please remember that drop 2 voicings of Cmaj7 are my go-to")]
+    public void RememberRequestsWithVoicingKeywords_MustBeDetectedAsRemember(string message)
+    {
+        Assert.That(RememberThisParser.LooksLikeRememberRequest(message), Is.True,
+            $"Message must parse as a remember-request: \"{message}\". " +
+            "If this fails, ProductionOrchestrator.TrySelectDeterministicAgent " +
+            "will fall through to IsExplicitVoicingRequest, match a voicing " +
+            "keyword, and dispatch the message to VoicingAgent — the user " +
+            "gets voicings back instead of a memory write. RememberThisParser " +
+            "must keep matching the canonical remember/save/note/don't-forget " +
+            "lead phrases regardless of trailing content.");
+    }
+
+    // Pure voicing requests (no remember-phrasing) MUST NOT be detected as
+    // remember-requests — otherwise legitimate voicing queries would lose
+    // the voicing fast-path and degrade to semantic routing.
+    [TestCase("show me drop-2 voicings of Cmaj7")]
+    [TestCase("what are the best fingerings for Am7")]
+    [TestCase("rootless voicings for ii-V-I in C")]
+    [TestCase("chord shapes for the blues")]
+    [TestCase("drop 3 voicings on the top four strings")]
+    public void VoicingRequests_WithoutRememberPhrasing_MustNotBeDetectedAsRemember(string message)
+    {
+        Assert.That(RememberThisParser.LooksLikeRememberRequest(message), Is.False,
+            $"Message must NOT parse as a remember-request: \"{message}\". " +
+            "If this fires true on a pure voicing query, the orchestrator's " +
+            "voicing fast-path will be bypassed and the message will fall " +
+            "into the semantic router, where (per the 2026-05-07 codex " +
+            "diagnosis) voicing queries can misroute to the modes intent at " +
+            "~0.71 cosine. The remember-parser's role is to gate on EXPLICIT " +
+            "remember phrasing only.");
+    }
+}

--- a/Tests/Common/GA.Business.Core.Tests/Orchestration/RememberOverVoicingPriorityTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Orchestration/RememberOverVoicingPriorityTests.cs
@@ -71,4 +71,110 @@ public class RememberOverVoicingPriorityTests
             "~0.71 cosine. The remember-parser's role is to gate on EXPLICIT " +
             "remember phrasing only.");
     }
+
+    // PR #192 correctness review false-positive guards. The verbs
+    // save/note/store have non-memory senses (save to library, note as a
+    // verb on a pitch, store data) that were leaking through because the
+    // parser allowed bare forms. Tightening required \s+this/\s+that or
+    // an immediate colon/comma. These tests pin the tightening.
+    [TestCase("save these drop-2 voicings of Cmaj7")]
+    [TestCase("save the chord shape for Am7")]
+    [TestCase("note these chord shapes for ii-V-I")]
+    [TestCase("note the fingering for Drop 3 Cmaj7")]
+    [TestCase("store the drop-2 voicing in my library")]
+    public void SaveOrNoteOrStore_WithoutMemorableReferent_MustNotMatch(string message)
+    {
+        Assert.That(RememberThisParser.LooksLikeRememberRequest(message), Is.False,
+            $"\"{message}\" — save/note/store followed by 'these'/'the'/etc. " +
+            "is a domain operation (save to library, note as pitch, store as " +
+            "data), NOT a memory write. The parser must NOT match unless the " +
+            "verb is followed by an explicit memorable referent (\\s+this | " +
+            "\\s+that | : | ,).");
+    }
+
+    // Positive cases that documented save/note/store usages MUST still match
+    // after the tightening — these are direct copies of the example prompts
+    // in RememberThisSkill.ExamplePrompts so a parser regression here would
+    // break the canonical chatbot UX.
+    [TestCase("save this: my favorite key is Bb")]
+    [TestCase("note: I'm working on fingerstyle technique this month")]
+    [TestCase("store this fact: my main guitar is a Telecaster")]
+    [TestCase("save that I prefer drop-2 voicings")]
+    [TestCase("note this drop-2 fingering is my favorite")]
+    public void SaveOrNoteOrStore_WithMemorableReferent_StillMatch(string message)
+    {
+        Assert.That(RememberThisParser.LooksLikeRememberRequest(message), Is.True,
+            $"\"{message}\" — save/note/store with explicit memorable " +
+            "referent (this/that/colon/comma) MUST still parse as a " +
+            "remember-request. These are the documented example prompts in " +
+            "RememberThisSkill.ExamplePrompts; regressing them breaks the " +
+            "canonical chatbot UX.");
+    }
+
+    // Pin the orchestrator's call ordering: TrySelectDeterministicAgent
+    // must call LooksLikeRememberRequest BEFORE IsExplicitVoicingRequest.
+    // We can't reach the private method directly, but we can pin the
+    // STRUCTURAL invariant by reading the source — if a future refactor
+    // reorders or removes the gate, the assertion below fails with a
+    // human-readable explanation that points the reader at the right
+    // location.
+    [Test]
+    public void ProductionOrchestrator_HasRememberGate_BeforeVoicingFastPath()
+    {
+        var path = LocateProductionOrchestratorSource();
+        var source = File.ReadAllText(path);
+
+        // Match the CALL sites specifically (not the documentation
+        // comments or the method definition). The remember check is a
+        // call to `LooksLikeRememberRequest(message)`; the voicing
+        // fast-path is a call to `IsExplicitVoicingRequest(message)`.
+        // Searching for the method-call shape (`(message)` suffix)
+        // skips matches inside XML-doc comments that may mention the
+        // method names but don't represent the ordering.
+        var rememberGateIndex = source.IndexOf(
+            "LooksLikeRememberRequest(message)",
+            StringComparison.Ordinal);
+        var voicingGateIndex = source.IndexOf(
+            "IsExplicitVoicingRequest(message)",
+            StringComparison.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rememberGateIndex, Is.GreaterThan(0),
+                "ProductionOrchestrator.cs must call " +
+                "RememberThisParser.LooksLikeRememberRequest somewhere — " +
+                "the gate that lets remember-with-voicing-keyword prompts " +
+                "skip the voicing fast-path. If this assertion fails, the " +
+                "gate was removed and the PR #192 production bug has " +
+                "regressed: 'remember that I prefer drop-2 voicings' will " +
+                "route to VoicingAgent instead of writing to MemoryStore.");
+
+            Assert.That(rememberGateIndex, Is.LessThan(voicingGateIndex),
+                "RememberThisParser.LooksLikeRememberRequest must appear " +
+                "BEFORE IsExplicitVoicingRequest in TrySelectDeterministicAgent. " +
+                "If the gate is moved below, the voicing fast-path fires " +
+                "first and the remember-flow silently breaks for any " +
+                "prompt containing a voicing keyword. See PR #192.");
+        });
+    }
+
+    private static string LocateProductionOrchestratorSource()
+    {
+        // Walk up from the test bin dir to the repo root (the GA.Business.ML.Tests
+        // harness does the same dance — kept inline here to avoid coupling
+        // this test project to that one).
+        var d = new DirectoryInfo(AppContext.BaseDirectory);
+        while (d is not null)
+        {
+            var candidate = Path.Combine(
+                d.FullName,
+                "Common", "GA.Business.Core.Orchestration", "Services",
+                "ProductionOrchestrator.cs");
+            if (File.Exists(candidate)) return candidate;
+            d = d.Parent;
+        }
+        throw new FileNotFoundException(
+            "Could not locate ProductionOrchestrator.cs by walking up from " +
+            AppContext.BaseDirectory);
+    }
 }


### PR DESCRIPTION
## Summary

**Real production bug surfaced by the live-orchestrator e2e:** a user typing \`remember that I prefer drop-2 voicings for jazz comping\` got voicings back instead of a memory write. The orchestrator's deterministic voicing fast-path matched \"drop-2 voicings\" and short-circuited before \`RememberThisSkill\` could fire. The remember-flow was silently broken for an entire class of preferences (voicing preferences — the most common kind in jazz teaching). No test caught it because there was no live-orchestrator e2e until this PR.

## What this PR ships

1. **Orchestrator fix** — \`TrySelectDeterministicAgent\` now checks \`RememberThisParser.LooksLikeRememberRequest\` first. If the prompt is a remember-request, return false immediately and let the semantic router dispatch to RememberThisSkill.

2. **OrchestratorTestHarness** — shared DI wiring that mirrors \`GaChatbot.Api.Extensions.AddMinimalChatbotApi\`. Unblocks the 3 \`LiveOrchestratorMemoryRetentionTests\` scaffolded in PR #190.

3. **RememberOverVoicingPriorityTests** — 10 CI-runnable unit tests that pin the priority-order invariant. Covers 5 canonical remember-with-voicing-keyword prompts (must detect as remember) and 5 pure voicing prompts (must NOT detect as remember).

## Test plan

- [x] \`dotnet test GA.Business.ML.Tests\` — 1251/1251 pass
- [x] \`dotnet test GA.Business.Core.Tests\` — 782/782 pass + 10 new priority pin
- [x] \`dotnet test GaChatbot.Tests\` — 9/9 pass (default run) + 3/3 [Explicit] e2e pass against live Ollama
- [x] Live e2e \`RememberPreference_PersistsToMemoryStore_UnderSessionScope\` exercises the full pipeline: \`AnswerAsync → SemanticIntentRouter → OrchestratorSkillIntent → MemoryWriteHook → MemoryStore.Search\`
- [ ] CI green

## Why the high-precision gate works

\`RememberThisParser.LooksLikeRememberRequest\` requires an explicit lead phrase (\`remember\`/\`save\`/\`note\`/\`don't forget\`/\`store\`). Pure voicing queries (\`show me drop-2 voicings of Cmaj7\`) don't pass that gate, so they keep their voicing fast-path. The 10 unit tests pin both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)