### PR TITLE
feat(memory): hybrid BM25 + cosine search (v0.4)

### DIFF
--- a/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
@@ -35,7 +35,54 @@ public sealed record MemoryEntry(
     // compat: pre-v0.4 entries on disk have no embedding field and
     // deserialize with Embedding=null; SearchHybridAsync skips the
     // cosine contribution for those entries and falls back to pure BM25.
-    float[]? Embedding = null);
+    float[]? Embedding = null)
+{
+    /// <summary>
+    /// Override structural equality to use semantic comparison rather
+    /// than the record-synthesized reference equality for array-typed
+    /// fields (<see cref="Tags"/> and <see cref="Embedding"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why this matters (PR #195 review finding corr-004):</b> the
+    /// compiler-synthesized <c>Equals</c> for a record compares each
+    /// field via <c>EqualityComparer&lt;T&gt;.Default</c>. For
+    /// <c>string[]</c> and <c>float[]</c> that's REFERENCE equality —
+    /// two entries with semantically identical Tags/Embedding arrays
+    /// but different array references would compare unequal. That
+    /// breaks <c>HashSet&lt;MemoryEntry&gt;</c>, <c>Distinct()</c>,
+    /// and <see cref="object.Equals(object?)"/>-based change detection.
+    /// Specifically: a re-loaded-from-disk entry's Tags array is a
+    /// fresh allocation that doesn't share a reference with any
+    /// in-memory copy, so the two compare unequal under the synthesized
+    /// equality even though they represent the same record.
+    /// </para>
+    /// <para>
+    /// <b>Embedding excluded from equality entirely:</b> embeddings are
+    /// a cached derived value (BM25 + cosine retrieval lookup). Two
+    /// entries with identical Content but different Embedding values
+    /// (e.g. one freshly computed, one not yet computed) should be
+    /// considered the same entry. Including the embedding in equality
+    /// would mean a backfilled entry is "different" from its
+    /// pre-backfill self.
+    /// </para>
+    /// </remarks>
+    public bool Equals(MemoryEntry? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Key == other.Key
+            && Type == other.Type
+            && Content == other.Content
+            && Tags.SequenceEqual(other.Tags)
+            && Timestamp == other.Timestamp
+            && SessionId == other.SessionId;
+        // Embedding intentionally NOT compared — it's a derived cache.
+    }
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Key, Type, Content, Timestamp, SessionId);
+}
 
 /// <summary>
 /// In-process agent memory backed by a JSON file at <c>~/.ga/memory.json</c>.
@@ -366,6 +413,8 @@ public sealed class MemoryStore
         var queryTokens = TokenizeAndFilter(query);
         if (queryTokens.Count == 0) return [];
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         var corpus = _entries.Values
             .Where(e => InScope(e, sessionId))
             .Where(e => type is null || e.Type.Equals(type, StringComparison.OrdinalIgnoreCase))
@@ -389,27 +438,88 @@ public sealed class MemoryStore
             .Select(d => (d.Entry, Bm25: ComputeBm25(d, queryTokens, idf, avgDocLength)))
             .ToList();
         var maxBm25 = bm25Scores.Max(s => s.Bm25);
-        if (maxBm25 <= 0) maxBm25 = 1;  // defensive — every entry has BM25 = 0; cosine carries the ranking
+
+        // PR #195 review corr-002: when maxBm25 == 0 (every entry's BM25
+        // is zero — no token overlap at all), the normalized BM25 term
+        // collapses to 0 and the hybrid score collapses to
+        // HybridCosineWeight * cosine, capping at 0.5. That makes
+        // no-BM25-signal queries return scores incomparable with
+        // BM25-signal queries from other calls. Switch to cosine-only
+        // weighting in that branch so cosine carries the full score.
+        var noBm25Signal = maxBm25 <= 0;
+        if (noBm25Signal) maxBm25 = 1;  // guard divide-by-zero; bm25/maxBm25 stays 0
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Cosine layer — embed the query once, embed any uncached entries.
-        var queryEmbedding = await EmbedAsync(query, cancellationToken);
-
-        // Lazy backfill: gather entries needing embedding, batch into a
-        // single embedder call (the IEmbeddingGenerator surface is
-        // designed for batches; per-entry calls would multiply latency).
-        var needEmbedding = corpus
-            .Where(d => d.Entry.Embedding is null || d.Entry.Embedding.Length == 0)
-            .ToList();
-        if (needEmbedding.Count > 0)
+        float[] queryEmbedding;
+        bool embedAvailable = true;
+        try
         {
-            var texts = needEmbedding.Select(d => EmbeddingText(d.Entry)).ToList();
-            var newEmbeddings = await _embedder.GenerateAsync(texts, cancellationToken: cancellationToken);
-            for (var i = 0; i < needEmbedding.Count; i++)
+            queryEmbedding = await EmbedAsync(query, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // PR #195 review corr-005: embed failure should not throw past
+            // the caller. Fall back to BM25-only ranking. Log so the
+            // operator sees the degraded ranking quality in production.
+            _logger?.LogWarning(ex,
+                "MemoryStore.SearchHybridAsync: query embed failed; falling back " +
+                "to BM25-only ranking. Embedder may be unreachable.");
+            embedAvailable = false;
+            queryEmbedding = [];
+        }
+
+        if (embedAvailable)
+        {
+            // Lazy backfill: gather entries needing embedding, batch into a
+            // single embedder call (the IEmbeddingGenerator surface is
+            // designed for batches; per-entry calls would multiply latency).
+            var needEmbedding = corpus
+                .Where(d => d.Entry.Embedding is null || d.Entry.Embedding.Length == 0)
+                .ToList();
+            if (needEmbedding.Count > 0)
             {
-                var entry = needEmbedding[i].Entry;
-                var vec   = newEmbeddings[i].Vector.ToArray();
-                var updated = entry with { Embedding = vec };
-                _entries[CompositeKey(updated.SessionId, updated.Key)] = updated;
+                try
+                {
+                    var texts = needEmbedding.Select(d => EmbeddingText(d.Entry)).ToList();
+                    var newEmbeddings = await _embedder.GenerateAsync(texts, cancellationToken: cancellationToken);
+                    for (var i = 0; i < needEmbedding.Count; i++)
+                    {
+                        var captured = needEmbedding[i].Entry;
+                        var vec      = newEmbeddings[i].Vector.ToArray();
+                        var key      = CompositeKey(captured.SessionId, captured.Key);
+
+                        // PR #195 review corr-001: AddOrUpdate with a
+                        // capture-vs-current guard. If a concurrent Write
+                        // replaced the entry between the corpus snapshot
+                        // and this assignment, we must NOT overwrite the
+                        // newer entry with our stale (captured) copy
+                        // wearing a fresh embedding. The embedding was
+                        // computed from captured.Content; attaching it to
+                        // a newer entry with different content would also
+                        // be wrong. So: only attach if the current entry
+                        // is byte-identical (modulo embedding) to the
+                        // captured one.
+                        _entries.AddOrUpdate(
+                            key,
+                            addValueFactory: _ => captured with { Embedding = vec },
+                            updateValueFactory: (_, current) =>
+                                current.Timestamp == captured.Timestamp
+                                    && current.Content == captured.Content
+                                    && current.Type == captured.Type
+                                    ? current with { Embedding = vec }
+                                    : current);  // newer entry; drop the stale embedding
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger?.LogWarning(ex,
+                        "MemoryStore.SearchHybridAsync: corpus embed batch failed; " +
+                        "continuing with whatever embeddings are already cached.");
+                    // Fall through — entries that already have embeddings still
+                    // contribute cosine; entries without get cosine = 0.
+                }
             }
         }
 
@@ -421,11 +531,12 @@ public sealed class MemoryStore
             var current = _entries.TryGetValue(CompositeKey(entry.SessionId, entry.Key), out var fresh)
                 ? fresh
                 : entry;
-            var cosine = current.Embedding is { Length: > 0 }
+            var cosine = embedAvailable && current.Embedding is { Length: > 0 }
                 ? CosineSimilarity(queryEmbedding, current.Embedding)
                 : 0.0;
-            var hybrid = HybridBm25Weight * (bm25 / maxBm25)
-                       + HybridCosineWeight * cosine;
+            var hybrid = noBm25Signal
+                ? cosine  // cosine-only weighting when BM25 has no signal
+                : HybridBm25Weight * (bm25 / maxBm25) + HybridCosineWeight * cosine;
             ranked.Add((current, hybrid));
         }
 
@@ -464,14 +575,34 @@ public sealed class MemoryStore
     }
 
     /// <summary>
-    /// Builds the text to embed for an entry — content + key + tags
-    /// concatenated. Mirrors the BM25 token-haystack so cosine and
-    /// BM25 score the same surface.
+    /// Builds the text to embed for an entry — content + tags only.
+    /// Key is deliberately excluded.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why Key is excluded (PR #195 review corr-003):</b> keys in
+    /// this codebase include hash-suffixed identifiers like
+    /// <c>response_a3f9b2</c> / <c>preference_drop2-voicings-jazz_8e1f4ab2</c>
+    /// (see <c>LegacyResponseMigration.DeriveId</c>,
+    /// <c>RememberThisParser.GenerateKey</c>). Modern sentence-transformer
+    /// embedders (nomic-embed-text et al.) tokenize prose; injecting a
+    /// hash-suffix adds non-semantic tokens that distort the vector and
+    /// degrade cosine quality across entries sharing key-prefix patterns
+    /// (every <c>response_*</c> entry would cluster purely because of
+    /// the shared prefix). The BM25 side is a token bag with length
+    /// normalization and TF saturation, so adding Key there does no
+    /// harm — but the embedder doesn't get those defenses.
+    /// </para>
+    /// <para>
+    /// Tags ARE included because they're user-meaningful prose
+    /// (<c>"jazz"</c>, <c>"audience:intermediate"</c>, <c>"user-stated"</c>)
+    /// that genuinely contribute to the semantic surface.
+    /// </para>
+    /// </remarks>
     private static string EmbeddingText(MemoryEntry entry)
     {
-        if (entry.Tags.Length == 0) return $"{entry.Content} {entry.Key}";
-        return $"{entry.Content} {entry.Key} {string.Join(' ', entry.Tags)}";
+        if (entry.Tags.Length == 0) return entry.Content;
+        return $"{entry.Content} {string.Join(' ', entry.Tags)}";
     }
 
     private static double CosineSimilarity(float[] a, float[] b)

--- a/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
+++ b/Common/GA.Business.ML/Agents/Memory/MemoryStore.cs
@@ -28,7 +28,14 @@ public sealed record MemoryEntry(
     string Content,
     string[] Tags,
     DateTimeOffset Timestamp,
-    string? SessionId = null);
+    string? SessionId = null,
+    // PR after #194: per-entry embedding vector for hybrid BM25 + cosine
+    // retrieval. Lazily populated on first SearchHybridAsync() call if
+    // the store was constructed with an IEmbeddingGenerator. Backward
+    // compat: pre-v0.4 entries on disk have no embedding field and
+    // deserialize with Embedding=null; SearchHybridAsync skips the
+    // cosine contribution for those entries and falls back to pure BM25.
+    float[]? Embedding = null);
 
 /// <summary>
 /// In-process agent memory backed by a JSON file at <c>~/.ga/memory.json</c>.
@@ -66,6 +73,14 @@ public sealed class MemoryStore
 
     private readonly string _storePath;
     private readonly ILogger<MemoryStore>? _logger;
+
+    /// <summary>
+    /// Optional embedder for hybrid BM25 + cosine retrieval. When null,
+    /// <see cref="SearchHybridAsync"/> degrades to pure BM25 and emits
+    /// a one-shot warning so operators notice the misconfiguration
+    /// rather than silently losing the embedding-ranking lift.
+    /// </summary>
+    private readonly Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>? _embedder;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -127,11 +142,32 @@ public sealed class MemoryStore
     /// overloads above.
     /// </summary>
     public MemoryStore(string storePath, ILogger<MemoryStore>? logger)
+        : this(storePath, logger, embedder: null) { }
+
+    /// <summary>
+    /// Hybrid-retrieval constructor — adds an optional embedder for
+    /// <see cref="SearchHybridAsync"/>. When the embedder is null the
+    /// store falls back to pure BM25; when provided it lazy-populates
+    /// per-entry embeddings on first hybrid-search of each entry.
+    /// </summary>
+    public MemoryStore(
+        string storePath,
+        ILogger<MemoryStore>? logger,
+        Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>? embedder)
     {
         _storePath = storePath ?? throw new ArgumentNullException(nameof(storePath));
         _logger    = logger;
+        _embedder  = embedder;
         _entries   = Load(_storePath, logger);
     }
+
+    /// <summary>
+    /// DI-friendly hybrid constructor — default path, logger, embedder.
+    /// </summary>
+    public MemoryStore(
+        ILogger<MemoryStore> logger,
+        Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>? embedder)
+        : this(DefaultStorePath, logger, embedder) { }
 
     // Bounded so anonymous chatbot traffic at the public demo URL can't grow
     // ~/.ga/memory.json unbounded — see PR #151 review (reliability rel-007).
@@ -279,6 +315,179 @@ public sealed class MemoryStore
             .ThenByDescending(scored => scored.Entry.Timestamp)
             .Select(scored => scored.Entry)
             .ToList();
+    }
+
+    /// <summary>
+    /// Hybrid BM25 + cosine-similarity search. Each entry's final score is
+    /// <c>HybridBm25Weight * normalizedBm25 + HybridCosineWeight * cosine</c>
+    /// where normalizedBm25 is the entry's BM25 score divided by the
+    /// best BM25 score in the in-scope corpus (so the two terms are
+    /// comparable). Entries with no precomputed embedding are
+    /// lazy-embedded during this call and the result is cached back to
+    /// disk via <see cref="Save"/> on the next write.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why hybrid:</b> BM25 alone misses paraphrases that share
+    /// concept-space but no surface tokens ("drop-2 voicings I like"
+    /// vs "two-note-skip jazz chord shapes"). Pure cosine alone over-
+    /// matches semantically-related-but-not-asked entries (a query for
+    /// "jazz" pulls every entry that ever mentioned music). The hybrid
+    /// gets both signals.
+    /// </para>
+    /// <para>
+    /// <b>When no embedder is configured</b> the method emits a one-
+    /// shot warning and delegates to <see cref="Search"/> for pure
+    /// BM25. The caller's contract is unchanged — they still get an
+    /// ordered list — only the ranking quality differs.
+    /// </para>
+    /// <para>
+    /// <b>Lazy backfill:</b> any in-scope entry without an embedding is
+    /// embedded once during this call. The updated <see cref="MemoryEntry"/>
+    /// replaces the existing one in <see cref="_entries"/>; the next
+    /// <see cref="Write"/> serializes the embeddings to disk. This
+    /// avoids paying the embedding cost on Write while still
+    /// accumulating the cache over time.
+    /// </para>
+    /// </remarks>
+    public async Task<IReadOnlyList<MemoryEntry>> SearchHybridAsync(
+        string? sessionId,
+        string query,
+        string? type = null,
+        string[]? tags = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_embedder is null)
+        {
+            WarnNoEmbedderOnce();
+            return Search(sessionId, query, type, tags);
+        }
+
+        var queryTokens = TokenizeAndFilter(query);
+        if (queryTokens.Count == 0) return [];
+
+        var corpus = _entries.Values
+            .Where(e => InScope(e, sessionId))
+            .Where(e => type is null || e.Type.Equals(type, StringComparison.OrdinalIgnoreCase))
+            .Where(e => tags is null || tags.Any(t => e.Tags.Contains(t, StringComparer.OrdinalIgnoreCase)))
+            .Select(TokenizeEntry)
+            .ToList();
+        if (corpus.Count == 0) return [];
+
+        // BM25 layer — same math as Search() so the score is comparable.
+        var avgDocLength = corpus.Average(d => d.TokenCount);
+        if (avgDocLength <= 0) avgDocLength = 1;
+
+        var idf = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var q in queryTokens)
+        {
+            var df = corpus.Count(d => d.TermFreq.ContainsKey(q));
+            idf[q] = Math.Log(1.0 + (corpus.Count - df + 0.5) / (df + 0.5));
+        }
+
+        var bm25Scores = corpus
+            .Select(d => (d.Entry, Bm25: ComputeBm25(d, queryTokens, idf, avgDocLength)))
+            .ToList();
+        var maxBm25 = bm25Scores.Max(s => s.Bm25);
+        if (maxBm25 <= 0) maxBm25 = 1;  // defensive — every entry has BM25 = 0; cosine carries the ranking
+
+        // Cosine layer — embed the query once, embed any uncached entries.
+        var queryEmbedding = await EmbedAsync(query, cancellationToken);
+
+        // Lazy backfill: gather entries needing embedding, batch into a
+        // single embedder call (the IEmbeddingGenerator surface is
+        // designed for batches; per-entry calls would multiply latency).
+        var needEmbedding = corpus
+            .Where(d => d.Entry.Embedding is null || d.Entry.Embedding.Length == 0)
+            .ToList();
+        if (needEmbedding.Count > 0)
+        {
+            var texts = needEmbedding.Select(d => EmbeddingText(d.Entry)).ToList();
+            var newEmbeddings = await _embedder.GenerateAsync(texts, cancellationToken: cancellationToken);
+            for (var i = 0; i < needEmbedding.Count; i++)
+            {
+                var entry = needEmbedding[i].Entry;
+                var vec   = newEmbeddings[i].Vector.ToArray();
+                var updated = entry with { Embedding = vec };
+                _entries[CompositeKey(updated.SessionId, updated.Key)] = updated;
+            }
+        }
+
+        // Re-read entries from _entries to pick up the lazy-backfilled
+        // embeddings (corpus has the stale snapshot).
+        var ranked = new List<(MemoryEntry Entry, double Hybrid)>(bm25Scores.Count);
+        foreach (var (entry, bm25) in bm25Scores)
+        {
+            var current = _entries.TryGetValue(CompositeKey(entry.SessionId, entry.Key), out var fresh)
+                ? fresh
+                : entry;
+            var cosine = current.Embedding is { Length: > 0 }
+                ? CosineSimilarity(queryEmbedding, current.Embedding)
+                : 0.0;
+            var hybrid = HybridBm25Weight * (bm25 / maxBm25)
+                       + HybridCosineWeight * cosine;
+            ranked.Add((current, hybrid));
+        }
+
+        return ranked
+            .Where(r => r.Hybrid > 0)
+            .OrderByDescending(r => r.Hybrid)
+            .ThenByDescending(r => r.Entry.Timestamp)
+            .Select(r => r.Entry)
+            .ToList();
+    }
+
+    /// <summary>BM25 weight in the hybrid score. <c>0.5</c> balances
+    /// exact-token recall against semantic-similarity recall.</summary>
+    public const double HybridBm25Weight = 0.5;
+
+    /// <summary>Cosine weight in the hybrid score. <c>0.5</c> balances
+    /// semantic-similarity against exact-token recall.</summary>
+    public const double HybridCosineWeight = 0.5;
+
+    private int _warnNoEmbedderFired;
+
+    private void WarnNoEmbedderOnce()
+    {
+        if (Interlocked.Exchange(ref _warnNoEmbedderFired, 1) != 0) return;
+        _logger?.LogWarning(
+            "MemoryStore.SearchHybridAsync called without an IEmbeddingGenerator " +
+            "configured — falling back to pure BM25. Hybrid ranking lift is " +
+            "lost. To enable, register an IEmbeddingGenerator<string, " +
+            "Embedding<float>> in DI before constructing MemoryStore.");
+    }
+
+    private async Task<float[]> EmbedAsync(string text, CancellationToken ct)
+    {
+        var batch = await _embedder!.GenerateAsync([text], cancellationToken: ct);
+        return batch[0].Vector.ToArray();
+    }
+
+    /// <summary>
+    /// Builds the text to embed for an entry — content + key + tags
+    /// concatenated. Mirrors the BM25 token-haystack so cosine and
+    /// BM25 score the same surface.
+    /// </summary>
+    private static string EmbeddingText(MemoryEntry entry)
+    {
+        if (entry.Tags.Length == 0) return $"{entry.Content} {entry.Key}";
+        return $"{entry.Content} {entry.Key} {string.Join(' ', entry.Tags)}";
+    }
+
+    private static double CosineSimilarity(float[] a, float[] b)
+    {
+        if (a.Length == 0 || b.Length == 0) return 0;
+        if (a.Length != b.Length) return 0;
+
+        double dot = 0, magA = 0, magB = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot  += a[i] * b[i];
+            magA += a[i] * a[i];
+            magB += b[i] * b[i];
+        }
+        var denom = Math.Sqrt(magA) * Math.Sqrt(magB);
+        return denom > 0 ? dot / denom : 0;
     }
 
     /// <summary>BM25 default <c>k1</c> (term-frequency saturation).</summary>

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryStoreSearchHybridTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryStoreSearchHybridTests.cs
@@ -190,6 +190,173 @@ public class MemoryStoreSearchHybridTests
             "Missing Embedding field deserializes to null (record default).");
     }
 
+    // ─── Concurrent Write race (corr-001 from PR #195 review) ─────────
+
+    [Test]
+    public async Task ConcurrentWrite_DuringLazyBackfill_DoesNotClobberNewerEntry()
+    {
+        // Reproduces the race the reviewer flagged: a SearchHybridAsync
+        // captures entry v1, Write replaces it with v2 mid-flight, the
+        // search's lazy-backfill must NOT overwrite v2 with `v1 with
+        // { Embedding = ... }`. The slow embedder forces the
+        // interleaving deterministically.
+        var slowEmbedder = new SlowStubEmbedder(delayMs: 200);
+        var store = new MemoryStore(
+            Path.Combine(_tempDir, "race.json"),
+            logger: null,
+            embedder: slowEmbedder);
+
+        store.Write("sess-A", "k1", "preference",
+            content: "v1 content", tags: []);
+
+        // Start the search; it'll await on the slow embedder.
+        var searchTask = store.SearchHybridAsync("sess-A", "anything");
+
+        // Wait long enough that the search has snapshotted the corpus
+        // and is awaiting the embedder. Then Write v2.
+        await Task.Delay(50);
+        store.Write("sess-A", "k1", "preference",
+            content: "v2 content overwritten", tags: ["v2-tag"]);
+
+        // Now let the search complete.
+        await searchTask;
+
+        // The post-state entry must be v2, NOT a v1-with-embedding zombie.
+        var entry = store.Read("sess-A", "k1")!;
+        Assert.That(entry.Content, Is.EqualTo("v2 content overwritten"),
+            "Race regression: lazy-backfill must not clobber a concurrent Write. " +
+            "Captured v1, Write replaced with v2, embed-call resolved AFTER — the " +
+            "AddOrUpdate guard must detect that current.Timestamp != captured.Timestamp " +
+            "and skip the embedding assignment. Otherwise v1's content/tags zombie back.");
+        Assert.That(entry.Tags, Is.EquivalentTo(new[] { "v2-tag" }),
+            "Tags must be v2's, not v1's.");
+    }
+
+    // ─── corr-002: no-BM25-signal cosine-only path ────────────────────
+
+    [Test]
+    public async Task NoBm25Signal_CosineOnlyWeighting_StillReturnsResults()
+    {
+        // Construct a corpus where NONE of the entries share a token
+        // with the query — BM25 = 0 for all. The cosine layer should
+        // carry the ranking on its own. Without the corr-002 fix the
+        // hybrid score would cap at 0.5 * cosine; with the fix the
+        // score is cosine directly.
+        //
+        // Use a DENSE stub embedder that produces guaranteed-positive
+        // cosine for any two inputs — otherwise the hash-bucket stub
+        // produces orthogonal vectors for disjoint strings and the
+        // filter (Hybrid > 0) excludes the entries before we can verify
+        // the weighting branch.
+        var store = new MemoryStore(
+            Path.Combine(_tempDir, "nobm25.json"),
+            logger: null,
+            embedder: new DenseStubEmbedder());
+        store.Write("sess-A", "k1", "fact",
+            content: "fingerstyle technique practice", tags: []);
+        store.Write("sess-A", "k2", "fact",
+            content: "jazz harmony fundamentals", tags: []);
+
+        // Query has NO token overlap with either entry (after stopwords).
+        var results = await store.SearchHybridAsync("sess-A", "drop voicings");
+
+        Assert.That(results, Is.Not.Empty,
+            "Hybrid search must return entries when BM25 finds nothing but " +
+            "cosine has signal. With corr-002 fix, scores are cosine-only " +
+            "in this branch — entries with cosine > 0 still surface.");
+    }
+
+    // ─── corr-003: Key string excluded from embedding text ────────────
+
+    [Test]
+    public async Task EmbeddingText_ExcludesKey_HashSuffixedKeysDoNotPolluteVector()
+    {
+        // Two entries with identical content but different (hash-shaped)
+        // keys MUST produce identical embeddings — otherwise the hash
+        // suffix is leaking into the semantic vector and entries with
+        // different keys but same content would cluster by key, not
+        // by meaning.
+        var embedder = new RecordingEmbedder();
+        var store = new MemoryStore(
+            Path.Combine(_tempDir, "key-pollution.json"),
+            logger: null,
+            embedder: embedder);
+
+        store.Write("sess-A", "preference_voicings_a1b2c3d4", "preference",
+            content: "drop-2 voicings for jazz comping", tags: []);
+        store.Write("sess-A", "response_e5f6a7b8", "preference",
+            content: "drop-2 voicings for jazz comping", tags: []);
+
+        await store.SearchHybridAsync("sess-A", "jazz");
+
+        Assert.That(embedder.AllRecordedTexts, Is.Not.Empty,
+            "Embedder must have been called at least once.");
+        foreach (var text in embedder.AllRecordedTexts)
+        {
+            Assert.That(text, Does.Not.Contain("preference_voicings_a1b2c3d4"),
+                "EmbeddingText must NOT include the entry's key. Hash-suffixed " +
+                "keys would inject non-semantic tokens that distort the vector.");
+            Assert.That(text, Does.Not.Contain("response_e5f6a7b8"),
+                "EmbeddingText must NOT include the entry's key.");
+        }
+    }
+
+    // ─── corr-004: record equality with array fields ──────────────────
+
+    [Test]
+    public void MemoryEntry_Equality_UsesSemanticArrayComparison()
+    {
+        var ts = new DateTimeOffset(2026, 5, 12, 0, 0, 0, TimeSpan.Zero);
+        var a = new MemoryEntry("k", "fact", "content",
+            ["jazz", "user-stated"], ts, "sess-A");
+        var b = new MemoryEntry("k", "fact", "content",
+            ["jazz", "user-stated"], ts, "sess-A");
+
+        Assert.That(a, Is.EqualTo(b),
+            "MemoryEntry with semantically identical Tags must compare equal " +
+            "regardless of array reference identity. The record-synthesized " +
+            "equality would use reference equality here, breaking " +
+            "HashSet/Distinct/AreEqual.");
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()),
+            "Equal entries must hash equal.");
+    }
+
+    [Test]
+    public void MemoryEntry_Equality_IgnoresEmbedding()
+    {
+        var ts = new DateTimeOffset(2026, 5, 12, 0, 0, 0, TimeSpan.Zero);
+        var withoutEmb = new MemoryEntry("k", "fact", "c", [], ts, "sess-A",
+            Embedding: null);
+        var withEmb = new MemoryEntry("k", "fact", "c", [], ts, "sess-A",
+            Embedding: [0.1f, 0.2f, 0.3f]);
+
+        Assert.That(withoutEmb, Is.EqualTo(withEmb),
+            "Entries identical apart from Embedding must compare equal — " +
+            "Embedding is a derived cache, not semantic identity.");
+    }
+
+    // ─── corr-005: embedder failure falls back to BM25 ────────────────
+
+    [Test]
+    public async Task EmbedderFailure_FallsBackToBm25_WithoutThrowing()
+    {
+        var failingEmbedder = new ThrowingEmbedder();
+        var store = new MemoryStore(
+            Path.Combine(_tempDir, "embed-fail.json"),
+            logger: null,
+            embedder: failingEmbedder);
+
+        store.Write("sess-A", "k1", "preference",
+            content: "drop-2 voicings for jazz", tags: []);
+
+        var results = await store.SearchHybridAsync("sess-A", "voicings");
+
+        Assert.That(results, Has.Count.EqualTo(1),
+            "When the embedder throws, SearchHybridAsync must catch and fall " +
+            "back to BM25-only ranking — callers expect Search-like graceful " +
+            "degradation, not propagated exceptions.");
+    }
+
     // ─── Stub embedder — deterministic, no Ollama dependency ──────────
 
     private sealed class StubEmbedder : IEmbeddingGenerator<string, Embedding<float>>
@@ -230,6 +397,118 @@ public class MemoryStoreSearchHybridTests
                 for (var i = 0; i < vec.Length; i++) vec[i] /= mag;
             return vec;
         }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Stub that delays each batch by <paramref name="delayMs"/> ms so
+    /// tests can interleave a concurrent Write between the corpus
+    /// snapshot and the embedder's resolution. Used by the
+    /// ConcurrentWrite race test.
+    /// </summary>
+    private sealed class SlowStubEmbedder(int delayMs) : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(delayMs, cancellationToken);
+            var embeddings = values
+                .Select(text => new Embedding<float>(new float[8]))
+                .ToArray();
+            return new GeneratedEmbeddings<Embedding<float>>(embeddings);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Records every text the embedder is asked to embed. Used by the
+    /// Key-exclusion test to verify EmbeddingText doesn't leak hash-shaped
+    /// keys into the embedding input.
+    /// </summary>
+    private sealed class RecordingEmbedder : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        private readonly List<string> _all = new();
+        public IReadOnlyList<string> AllRecordedTexts => _all;
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var texts = values.ToList();
+            _all.AddRange(texts);
+            var embeddings = texts
+                .Select(_ => new Embedding<float>(new float[8]))
+                .ToArray();
+            return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(embeddings));
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Dense stub — every dimension has a positive baseline so cosine
+    /// is always &gt; 0 even for disjoint inputs. Used by the no-BM25-
+    /// signal test, which needs the cosine-only branch to actually
+    /// return entries.
+    /// </summary>
+    private sealed class DenseStubEmbedder : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var embeddings = values
+                .Select(MakeDenseVector)
+                .Select(v => new Embedding<float>(v))
+                .ToArray();
+            return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(embeddings));
+        }
+
+        private static float[] MakeDenseVector(string text)
+        {
+            // 8-dim vector. Baseline of 0.5 in every dimension so any two
+            // vectors have cosine ≥ 0.5 even when text content is fully
+            // disjoint. Per-word contributions still differentiate
+            // semantically similar strings.
+            var vec = new float[8];
+            for (var i = 0; i < vec.Length; i++) vec[i] = 0.5f;
+            foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var hash = word.ToLowerInvariant().GetHashCode();
+                var slot = ((hash % 8) + 8) % 8;
+                vec[slot] += 0.3f;
+            }
+            // Normalize.
+            var mag = MathF.Sqrt(vec.Sum(v => v * v));
+            for (var i = 0; i < vec.Length; i++) vec[i] /= mag;
+            return vec;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Stub that throws on every call. Exercises the graceful-fallback
+    /// path in SearchHybridAsync (corr-005). Without the try/catch the
+    /// exception propagates out and breaks the caller's contract.
+    /// </summary>
+    private sealed class ThrowingEmbedder : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("simulated embedder failure");
 
         public object? GetService(Type serviceType, object? serviceKey = null) => null;
         public void Dispose() { }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MemoryStoreSearchHybridTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MemoryStoreSearchHybridTests.cs
@@ -1,0 +1,237 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Memory;
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Pins the v0.4 hybrid BM25 + cosine ranking behavior of
+/// <see cref="MemoryStore.SearchHybridAsync"/>. Three layers of coverage:
+/// matching contract, lazy-backfill behavior, and graceful fallback when
+/// no embedder is configured.
+/// </summary>
+/// <remarks>
+/// These tests use a deterministic stub embedder (vectors derived from
+/// hashed token sets) so the rank-ordering invariants are reproducible
+/// without an Ollama dependency. Tests that need a real embedder belong
+/// in the live e2e suite, not here.
+/// </remarks>
+[TestFixture]
+public class MemoryStoreSearchHybridTests
+{
+    private string _tempDir = string.Empty;
+    private MemoryStore _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ga-mem-hybrid-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _store = new MemoryStore(
+            Path.Combine(_tempDir, "memory.json"),
+            logger: null,
+            embedder: new StubEmbedder());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ─── Matching contract — same shape as BM25 ────────────────────────
+
+    [Test]
+    public async Task HybridSearch_ReturnsEntries_WithAnyOverlapping_TokensOrConcept()
+    {
+        _store.Write("sess-A", "pref", "preference",
+            content: "I prefer drop-2 voicings for jazz comping",
+            tags: ["user-stated"]);
+
+        var results = await _store.SearchHybridAsync("sess-A", "voicings jazz");
+
+        Assert.That(results, Has.Count.EqualTo(1),
+            "Hybrid must match anything that BM25 would match — strictly " +
+            "additive on the matching contract.");
+    }
+
+    [Test]
+    public async Task HybridSearch_RespectsSessionScope()
+    {
+        _store.Write("sess-A", "k1", "preference", content: "voicings jazz", tags: []);
+        _store.Write("sess-B", "k2", "preference", content: "voicings jazz", tags: []);
+
+        var resultsA = await _store.SearchHybridAsync("sess-A", "voicings");
+
+        Assert.That(resultsA.Select(e => e.Key), Is.EquivalentTo(new[] { "k1" }),
+            "Hybrid must enforce the same session scope as Search — the " +
+            "SC-001 defense lives on this invariant.");
+    }
+
+    // ─── Lazy backfill — entries gain embeddings on first search ──────
+
+    [Test]
+    public async Task HybridSearch_PopulatesEmbedding_OnFirstQuery()
+    {
+        _store.Write("sess-A", "k1", "preference",
+            content: "drop-2 voicings", tags: []);
+
+        // Before search: no embedding on the entry.
+        var before = _store.Read("sess-A", "k1")!;
+        Assert.That(before.Embedding, Is.Null,
+            "Write must NOT trigger embedding — that's the lazy-backfill " +
+            "design (Write stays fast, embedding cost amortized on Search).");
+
+        await _store.SearchHybridAsync("sess-A", "jazz");
+
+        // After search: embedding is cached.
+        var after = _store.Read("sess-A", "k1")!;
+        Assert.That(after.Embedding, Is.Not.Null,
+            "SearchHybridAsync must lazy-backfill embeddings for in-scope " +
+            "entries that don't have them yet.");
+        Assert.That(after.Embedding!.Length, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public async Task HybridSearch_DoesNotReEmbed_OnSubsequentSearches()
+    {
+        var embedder = new StubEmbedder();
+        var store = new MemoryStore(
+            Path.Combine(_tempDir, "memory2.json"),
+            logger: null,
+            embedder: embedder);
+
+        store.Write("sess-A", "k1", "preference", content: "drop-2 voicings", tags: []);
+
+        await store.SearchHybridAsync("sess-A", "jazz");
+        var callsAfterFirst = embedder.CallCount;
+
+        await store.SearchHybridAsync("sess-A", "blues");
+        var callsAfterSecond = embedder.CallCount;
+
+        // Second search embeds the QUERY ("blues") but NOT the entry —
+        // the entry's cached embedding is reused. So delta is exactly 1.
+        Assert.That(callsAfterSecond - callsAfterFirst, Is.EqualTo(1),
+            "Second search must reuse cached entry embeddings; only the " +
+            "new query gets embedded. If the entry is re-embedded, the " +
+            "lazy-cache is broken and SearchHybridAsync pays the full " +
+            "embedding cost on every call.");
+    }
+
+    // ─── Fallback — no embedder configured ────────────────────────────
+
+    [Test]
+    public async Task HybridSearch_WithoutEmbedder_FallsBackToBm25()
+    {
+        var storeWithoutEmbedder = new MemoryStore(
+            Path.Combine(_tempDir, "memory3.json"));
+        storeWithoutEmbedder.Write("sess-A", "k1", "preference",
+            content: "drop-2 voicings", tags: []);
+
+        var results = await storeWithoutEmbedder.SearchHybridAsync("sess-A", "voicings");
+
+        Assert.That(results, Has.Count.EqualTo(1),
+            "Without an embedder, SearchHybridAsync must fall back to pure " +
+            "BM25 — same matching contract, just no cosine layer. Callers " +
+            "must NOT see a behavior change beyond ranking quality.");
+
+        // Verify no embedding got persisted.
+        var entry = storeWithoutEmbedder.Read("sess-A", "k1")!;
+        Assert.That(entry.Embedding, Is.Null,
+            "When no embedder is available, entries must NOT acquire " +
+            "empty embeddings — the field stays null so a future " +
+            "constructor with an embedder can backfill cleanly.");
+    }
+
+    // ─── Hybrid weighting — both layers contribute ────────────────────
+
+    [Test]
+    public async Task HybridWeights_AreStable()
+    {
+        // Pin the weights to 0.5 each so a future tuning regression
+        // recompiles consumers and runs through a retrieval-quality
+        // baseline before landing. Same posture as Bm25K1/Bm25B.
+        Assert.That(MemoryStore.HybridBm25Weight, Is.EqualTo(0.5));
+        Assert.That(MemoryStore.HybridCosineWeight, Is.EqualTo(0.5));
+        Assert.That(MemoryStore.HybridBm25Weight + MemoryStore.HybridCosineWeight,
+            Is.EqualTo(1.0),
+            "Weights must sum to 1 so the hybrid score is in [0, 1].");
+    }
+
+    // ─── Backward compat — pre-v0.4 entries deserialize cleanly ──────
+
+    [Test]
+    public void LegacyEntry_WithoutEmbeddingField_DeserializesAsNull()
+    {
+        // Simulate a memory.json file written by a pre-v0.4 process:
+        // no Embedding field on the entry. Forward-compat path: must
+        // deserialize cleanly with Embedding=null.
+        var legacyJson = """
+        [
+          {
+            "Key": "legacy",
+            "Type": "preference",
+            "Content": "drop-2 voicings",
+            "Tags": ["user-stated"],
+            "Timestamp": "2026-05-01T00:00:00Z",
+            "SessionId": "sess-A"
+          }
+        ]
+        """;
+        var path = Path.Combine(_tempDir, "legacy.json");
+        File.WriteAllText(path, legacyJson);
+
+        var store = new MemoryStore(path);
+        var entry = store.Read("sess-A", "legacy");
+
+        Assert.That(entry, Is.Not.Null,
+            "Pre-v0.4 memory.json files must still load — the Embedding " +
+            "field is additive with a null default.");
+        Assert.That(entry!.Embedding, Is.Null,
+            "Missing Embedding field deserializes to null (record default).");
+    }
+
+    // ─── Stub embedder — deterministic, no Ollama dependency ──────────
+
+    private sealed class StubEmbedder : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public int CallCount { get; private set; }
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            var embeddings = values
+                .Select(text => new Embedding<float>(MakeVector(text)))
+                .ToArray();
+            return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(embeddings));
+        }
+
+        /// <summary>
+        /// Deterministic 16-dim vector derived from the input text's
+        /// token hash. Two semantically-similar strings (e.g. share a
+        /// common token) produce embeddings with non-zero cosine; two
+        /// disjoint strings produce orthogonal vectors. Enough to
+        /// exercise the rank-ordering paths without an LLM.
+        /// </summary>
+        private static float[] MakeVector(string text)
+        {
+            var vec = new float[16];
+            foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var hash = word.ToLowerInvariant().GetHashCode();
+                var slot = ((hash % 16) + 16) % 16;
+                vec[slot] += 1.0f;
+            }
+            // Normalize so cosine is in [-1, 1].
+            var mag = MathF.Sqrt(vec.Sum(v => v * v));
+            if (mag > 0)
+                for (var i = 0; i < vec.Length; i++) vec[i] /= mag;
+            return vec;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary

Adds embedding-based retrieval alongside v0.3 BM25. New \`SearchHybridAsync\` embeds the query + each entry, computes cosine similarity, and combines with normalized BM25 (0.5 weight each). Closes the recall gap on paraphrases that share concept-space but no surface tokens.

## Design choices

- **Optional embedder** — constructor takes a nullable \`IEmbeddingGenerator\`. When null, falls back to BM25 + warning.
- **Lazy backfill** — Write doesn't embed (stays fast, sync). Entries embed on their first hybrid-search appearance; cached back to \`_entries\` and persisted on next Write.
- **Batch embedding** — uncached entries in one search → single \`GenerateAsync\` call.
- **Backward compat** — \`MemoryEntry.Embedding\` is nullable with default null. Pre-v0.4 memory.json files deserialize cleanly.

## Test plan

- [x] 7 new \`MemoryStoreSearchHybridTests\`:
  - Matching contract (additive)
  - Session scope (SC-001 defense)
  - Lazy backfill works
  - Cache reuse on second search
  - No-embedder fallback
  - Weight constants pinned
  - Legacy JSON without Embedding field
- [x] Deterministic stub \`IEmbeddingGenerator\` — no Ollama dependency in unit tests
- [x] \`85/85\` Memory tests pass (was 78)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)