### PR TITLE
feat(memory): wire MemoryHook to SearchHybridAsync (activate hybrid retrieval)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -77,8 +77,19 @@ public sealed class GaPlugin : IChatPlugin
         // Without the logger the legacy parameterless ctor swallows
         // permission-denied / disk-full silently — which historically looked
         // identical to "memory forgot everything between restarts."
+        //
+        // Embedder (PR after #195): if the host registered an
+        // IEmbeddingGenerator<string, Embedding<float>> (e.g. via
+        // AddTextEmbeddings / OllamaEmbeddingGenerator), pass it through so
+        // SearchHybridAsync's cosine layer actually runs. When the host
+        // didn't register one, MemoryStore silently degrades to BM25-only
+        // and emits a one-shot warning the first time SearchHybridAsync
+        // is called — that's the operator's signal that the embedder
+        // binding is missing.
         services.TryAddSingleton<MemoryStore>(sp =>
-            new MemoryStore(sp.GetService<ILogger<MemoryStore>>() ?? NullLogger<MemoryStore>.Instance));
+            new MemoryStore(
+                sp.GetService<ILogger<MemoryStore>>() ?? NullLogger<MemoryStore>.Instance,
+                sp.GetService<Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>>()));
 
         // ── Transcript log (PR #173 Phase 1 + PR #174 Phase 2) ───────────────
         // Sibling to MemoryStore: holds per-turn chat content, not durable

--- a/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
+++ b/Common/GA.Business.ML/Agents/Hooks/MemoryHook.cs
@@ -74,9 +74,9 @@ public sealed class MemoryHook(
     /// Searches memory for context relevant to the incoming message and prepends it.
     /// Off by default; enable with <c>Memory:EnrichOnRetrieve=true</c>.
     /// </summary>
-    public Task<HookResult> OnRequestReceived(ChatHookContext ctx, CancellationToken ct = default)
+    public async Task<HookResult> OnRequestReceived(ChatHookContext ctx, CancellationToken ct = default)
     {
-        if (!_enrichOnRetrieve) return Task.FromResult(HookResult.Continue);
+        if (!_enrichOnRetrieve) return HookResult.Continue;
 
         // Safety belt: when SessionId isn't plumbed, refuse to retrieve. The
         // alternative (treat null as a global session) replays the leak that
@@ -103,10 +103,16 @@ public sealed class MemoryHook(
                     "into ChatHookContext.SessionId. See PR #157 Phase B. This message logs once " +
                     "per process; subsequent skips are silent.");
             }
-            return Task.FromResult(HookResult.Continue);
+            return HookResult.Continue;
         }
 
-        var matches = memoryStore.Search(ctx.SessionId, ctx.CurrentMessage);
+        // PR after #195: SearchHybridAsync runs BM25 + cosine when an
+        // IEmbeddingGenerator is registered in DI; degrades cleanly to
+        // BM25-only when not. The async cost is paid only when retrieval
+        // is gated on (Memory:EnrichOnRetrieve=true), so this isn't on
+        // the hot path for the default-off configuration.
+        var matches = await memoryStore.SearchHybridAsync(
+            ctx.SessionId, ctx.CurrentMessage, cancellationToken: ct);
 
         // SC-001 defense in depth: filter out entries that originated from
         // MemoryMcpTools.MemoryWrite (LLM-callable). Even if the
@@ -132,7 +138,7 @@ public sealed class MemoryHook(
                 "setting Memory:AllowLlmGlobalWrite=false.",
                 filteredOutCount, Memory.MemoryMcpTools.McpOriginTag);
         }
-        if (filtered.Count == 0) return Task.FromResult(HookResult.Continue);
+        if (filtered.Count == 0) return HookResult.Continue;
 
         var contextBlock = string.Join("\n", filtered.Take(3)
             .Select(m => $"[memory:{m.Key}] {m.Content}"));
@@ -141,7 +147,7 @@ public sealed class MemoryHook(
         logger.LogDebug(
             "MemoryHook: injecting {Count} memory entries for session {SessionId}",
             filtered.Count, ctx.SessionId);
-        return Task.FromResult(HookResult.Mutate(enriched));
+        return HookResult.Mutate(enriched);
     }
 
     /// <summary>

--- a/Tests/Common/GA.Business.ML.Tests/Integration/EnrichOnRetrieveLoopTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Integration/EnrichOnRetrieveLoopTests.cs
@@ -283,4 +283,76 @@ public class EnrichOnRetrieveLoopTests
             "Layered remember-calls must accumulate; the voicings preference is one entry " +
             "and must surface for a query that overlaps its content.");
     }
+
+    // ─── Hybrid retrieval — PR after #195 wire-up regression pin ──────
+
+    [Test]
+    public async Task RetrieveHook_UsesHybridSearch_WhenEmbedderIsRegistered()
+    {
+        // The MemoryHook switched from sync .Search to async
+        // .SearchHybridAsync in the PR-after-#195 wire-up. This test
+        // pins that wiring by routing the call through a recording
+        // embedder — if MemoryHook were still calling .Search, the
+        // embedder's CallCount would be 0 after a retrieve.
+        var recordingEmbedder = new RecordingEmbedder();
+        var storeWithEmbedder = new MemoryStore(
+            Path.Combine(_tempDir, "hybrid-pin.json"),
+            logger: null,
+            embedder: recordingEmbedder);
+        // Seed a preference for the same session.
+        storeWithEmbedder.Write("sess-pin", "k1", "preference",
+            content: "I prefer drop-2 voicings for jazz", tags: []);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Memory:EnrichOnRetrieve"] = "true",
+            })
+            .Build();
+        var retrieveHook = new MemoryHook(
+            storeWithEmbedder, _transcripts, config,
+            NullLogger<MemoryHook>.Instance);
+
+        // Trigger retrieval.
+        await retrieveHook.OnRequestReceived(new ChatHookContext
+        {
+            OriginalMessage = "what voicings should I use for jazz",
+            CurrentMessage  = "what voicings should I use for jazz",
+            CorrelationId   = Guid.NewGuid(),
+            SessionId       = "sess-pin",
+        });
+
+        Assert.That(recordingEmbedder.CallCount, Is.GreaterThan(0),
+            "MemoryHook must invoke SearchHybridAsync — which goes through " +
+            "the IEmbeddingGenerator — when an embedder is registered. " +
+            "If this fails, MemoryHook regressed to sync .Search and the " +
+            "hybrid ranking path is dead code in production again.");
+    }
+
+    /// <summary>
+    /// Minimal stub that just counts how many times it's called and
+    /// returns a zero-vector embedding. Used to verify the production
+    /// call path actually reaches the embedder.
+    /// </summary>
+    private sealed class RecordingEmbedder
+        : Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>
+    {
+        public int CallCount { get; private set; }
+
+        public Task<Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            Microsoft.Extensions.AI.EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            var embeddings = values
+                .Select(_ => new Microsoft.Extensions.AI.Embedding<float>(new float[4]))
+                .ToArray();
+            return Task.FromResult(
+                new Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>>(embeddings));
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
 }


### PR DESCRIPTION
## Summary

PR #195 added \`SearchHybridAsync\` but **no production caller invoked it**. \`MemoryHook.OnRequestReceived\` was still calling sync \`Search\` — so the hybrid retrieval shipped as dead code: the path existed, tests passed, but cosine never ran on a production retrieval.

This PR closes the wire-up:
1. \`GaPlugin\` resolves \`IEmbeddingGenerator\` from DI when constructing \`MemoryStore\` (optional, falls back gracefully).
2. \`MemoryHook.OnRequestReceived\` switches to \`await SearchHybridAsync\`.
3. New regression test pins the wiring via a \`RecordingEmbedder\` — if MemoryHook ever regresses to sync \`Search\`, the embedder's \`CallCount\` stays at 0 and the test fails.

## Result

Hosts that wire an \`IEmbeddingGenerator\` (e.g. GaChatbot.Api via \`AddTextEmbeddings\`) now get hybrid BM25 + cosine retrieval automatically. Hosts that don't see the one-shot warning from \`MemoryStore.SearchHybridAsync\` and continue with BM25-only.

## Test plan

- [x] \`91/91\` Memory tests pass
- [x] \`803/803\` GA.Business.Core tests pass
- [x] New \`RetrieveHook_UsesHybridSearch_WhenEmbedderIsRegistered\` test pins the wiring
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)