### PR TITLE
chore(tests): move ModalCharacteristicIntervalServiceTests to ML.Tests

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Musical/ModalCharacteristicIntervalServiceTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Musical/ModalCharacteristicIntervalServiceTests.cs
@@ -1,81 +1,77 @@
-namespace GaChatbot.Tests;
+namespace GA.Business.ML.Tests;
 
 using GA.Business.ML.Musical.Enrichment;
-using NUnit.Framework;
 
 /// <summary>
-/// Tests for ModalCharacteristicIntervalService programmatic interval computation.
+/// Tests for <see cref="ModalCharacteristicIntervalService"/> programmatic
+/// interval computation. Moved from <c>GaChatbot.Tests</c> on 2026-05-12 —
+/// the service lives in <c>GA.Business.ML</c> so its tests belong with
+/// the rest of the ML test suite, not in the chatbot host project.
 /// </summary>
+/// <remarks>
+/// Uses the root <c>GA.Business.ML.Tests</c> namespace (matching the
+/// sibling <c>DatasetExportTests</c> in the same folder) rather than a
+/// nested <c>.Musical</c> namespace — the nested form would shadow the
+/// production <c>GA.Business.ML.Musical</c> namespace for any test file
+/// that does <c>using GA.Business.ML.Musical;</c>.
+/// </remarks>
 [TestFixture]
 public class ModalCharacteristicIntervalServiceTests
 {
     [Test]
     public void Instance_LoadsModes_FromDomainModel()
     {
-        // Act
         var service = ModalCharacteristicIntervalService.Instance;
         var modeNames = service.GetAllModeNames().ToList();
 
-        // Assert
         Assert.That(modeNames, Is.Not.Empty);
-        Assert.That(modeNames.Count, Is.GreaterThanOrEqualTo(7)); // At least 7 major scale modes
-        Console.WriteLine($"Loaded {modeNames.Count} modes from domain model.");
+        Assert.That(modeNames.Count, Is.GreaterThanOrEqualTo(7),
+            "At least 7 major scale modes expected.");
     }
 
     [Test]
     public void GetCharacteristicSemitones_Lydian_ContainsSharp4()
     {
-        // Lydian's characteristic interval is #4 (6 semitones)
         var service = ModalCharacteristicIntervalService.Instance;
-        
-        // Act
+
         var semitones = service.GetCharacteristicSemitones("Lydian");
 
-        // Assert
         Assert.That(semitones, Is.Not.Null);
-        Assert.That(semitones, Does.Contain(6), "Lydian should contain #4 (6 semitones)");
-        Console.WriteLine($"Lydian characteristic intervals (semitones): {string.Join(", ", semitones!)}");
+        Assert.That(semitones, Does.Contain(6),
+            "Lydian should contain #4 (6 semitones).");
     }
 
     [Test]
     public void GetCharacteristicSemitones_Dorian_ContainsMajor6()
     {
-        // Dorian's characteristic interval is Major 6 (9 semitones) with minor 3rd
         var service = ModalCharacteristicIntervalService.Instance;
-        
-        // Act
+
         var semitones = service.GetCharacteristicSemitones("Dorian");
 
-        // Assert
         Assert.That(semitones, Is.Not.Null);
-        Assert.That(semitones, Does.Contain(9), "Dorian should contain Major 6 (9 semitones)");
-        Console.WriteLine($"Dorian characteristic intervals (semitones): {string.Join(", ", semitones!)}");
+        Assert.That(semitones, Does.Contain(9),
+            "Dorian should contain Major 6 (9 semitones).");
     }
 
     [Test]
     public void GetCharacteristicSemitones_Phrygian_ContainsFlat2()
     {
-        // Phrygian's characteristic interval is b2 (1 semitone)
         var service = ModalCharacteristicIntervalService.Instance;
-        
-        // Act
+
         var semitones = service.GetCharacteristicSemitones("Phrygian");
 
-        // Assert
         Assert.That(semitones, Is.Not.Null);
-        Assert.That(semitones, Does.Contain(1), "Phrygian should contain b2 (1 semitone)");
-        Console.WriteLine($"Phrygian characteristic intervals (semitones): {string.Join(", ", semitones!)}");
+        Assert.That(semitones, Does.Contain(1),
+            "Phrygian should contain b2 (1 semitone).");
     }
 
     [Test]
     public void GetCharacteristicSemitones_UnknownMode_ReturnsNull()
     {
         var service = ModalCharacteristicIntervalService.Instance;
-        
-        // Act
+
         var semitones = service.GetCharacteristicSemitones("NonExistentMode");
 
-        // Assert
         Assert.That(semitones, Is.Null);
     }
 
@@ -85,7 +81,6 @@ public class ModalCharacteristicIntervalServiceTests
         var service = ModalCharacteristicIntervalService.Instance;
         var modeNames = service.GetAllModeNames().ToList();
 
-        // Assert - Major scale modes
         Assert.That(modeNames, Does.Contain("Ionian"));
         Assert.That(modeNames, Does.Contain("Dorian"));
         Assert.That(modeNames, Does.Contain("Phrygian"));


### PR DESCRIPTION
## Summary

Ties off PR #190 review's M1 finding: GaChatbot.Tests had drifted — its surviving tests targeted GA.Business.ML types, so the project name misrepresented its contents.

Moves \`ModalCharacteristicIntervalServiceTests\` (6 tests, pure \`GA.Business.ML.Musical.Enrichment\` surface) into \`GA.Business.ML.Tests\`. \`ToneEvaluatorTests\` stays because it tests \`GaChatbot.Components\` — genuinely chatbot-host code.

## Post-move GaChatbot.Tests holds

| File | Reason for staying |
|---|---|
| ToneEvaluatorTests | Tests GaChatbot.Components |
| Integration/OrchestratorTestHarness | Shared DI helper for live e2e |
| Integration/LiveOrchestratorMemoryRetentionTests | [Explicit] e2e, needs GaChatbot project ref |

## Namespace gotcha I hit

First attempt used \`namespace GA.Business.ML.Tests.Musical\` — that shadowed the production \`GA.Business.ML.Musical\` namespace for any test doing \`using GA.Business.ML.Musical;\`, breaking 11 other test files. Fixed by using the root \`GA.Business.ML.Tests\` namespace, matching the sibling \`DatasetExportTests\` in the same folder.

## Test plan

- [x] 6/6 ModalCharacteristic tests pass in new home
- [x] 9/9 GaChatbot.Tests pass (3 [Explicit] still correctly skipped)
- [x] 1271/1271 GA.Business.ML.Tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)