### PR TITLE
fix(ci): override AI:ChatProvider=ollama in TestWebApplicationFactory

### DIFF
--- a/Tests/Apps/GaApi.Tests/TestInfrastructure/TestWebApplicationFactory.cs
+++ b/Tests/Apps/GaApi.Tests/TestInfrastructure/TestWebApplicationFactory.cs
@@ -13,6 +13,19 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseContentRoot(TestPaths.RepositoryPath("Apps", "ga-server", "GaApi"));
+
+        // Force the Ollama IChatClient path during tests. appsettings.Development.json
+        // pins AI:ChatProvider=claude, which makes AddLlmServices eagerly construct
+        // an AnthropicProvider IChatClient at boot (intentional per PR #151 — fail
+        // fast on misconfig). CI has no ANTHROPIC_API_KEY, so every WebApplicationFactory
+        // test in this assembly blew up at host build with InvalidOperationException
+        // out of AnthropicProvider.CreateChatClient. None of the GaApi.Tests fixtures
+        // actually exercise the chat endpoint — they cover GraphQL, REST, and DI
+        // shape. The Ollama branch registers a lazy adapter that never probes the
+        // network unless something resolves IChatService, so this is safe even
+        // without an Ollama instance running.
+        builder.UseSetting("AI:ChatProvider", "ollama");
+
         base.ConfigureWebHost(builder);
     }
 


### PR DESCRIPTION
## Summary
- `.NET` workflow has been red on main for ~12 hours after `appsettings.Development.json` pinned `AI:ChatProvider=claude`. `WebApplicationFactory` defaults `ASPNETCORE_ENVIRONMENT=Development`, so `AddLlmServices` eagerly built an `AnthropicProvider` `IChatClient` at host startup (intentional per PR #151 — fail-fast on misconfig). CI has no `ANTHROPIC_API_KEY`, so 9 GraphQL endpoint tests blew up at host build with empty TRX errors (`MSB4181: VSTestTask returned false but did not log an error`).
- One-line fix on the shared `TestWebApplicationFactory`: `UseSetting("AI:ChatProvider", "ollama")` ahead of `base.ConfigureWebHost`. The Ollama branch in `AddLlmServices` registers a lazy `IChatService`/`IChatClient` that never probes the network unless resolved, so this is safe in CI without an Ollama daemon. PR #151's fail-fast behavior is preserved for the real `ga-server` boot — only the in-memory `TestServer` is narrowed.

## Impact
- Unblocks honest CI signal. The last 12 PRs (#186-#197) required `--admin` override; this fixes the underlying cause.
- Failing tests fixed (all in `Tests/Apps/GaApi.Tests`): `ChordNamingGraphQLTests.*`, `DomainSchemaGraphQLTests.GetDomainSchema_Returns_Relationships`, `MusicTheoryGraphQLTests.GetKey_Returns_Data`, `MusicTheoryGraphQLTests.GetNote_Returns_Data`. None exercise the chat path.

## Test plan
- [x] Local build: `dotnet build Tests/Apps/GaApi.Tests/GaApi.Tests.csproj` → 0 errors
- [x] Reproduction of CI failure mode: `env -u ANTHROPIC_API_KEY dotnet test ...` against the 9 failing tests → **Failed: 0, Passed: 9**
- [ ] CI green on this PR (the proof point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)