### PR TITLE
refactor(icv): dual-format ParseIcv + ComputeIcvString helper (Step 1)

### DIFF
--- a/Common/GA.Business.ML/Embeddings/Services/TheoryVectorService.cs
+++ b/Common/GA.Business.ML/Embeddings/Services/TheoryVectorService.cs
@@ -86,13 +86,47 @@ public class TheoryVectorService
     }
 
     /// <summary>
-    ///     Parses an ICV string (e.g. "001110") into six interval-class counts.
+    ///     Parses an ICV string into six interval-class counts. Accepts two formats:
+    ///     <list type="bullet">
+    ///       <item><description>Digit-per-position: <c>"001110"</c> — one decimal digit
+    ///         per IC bin, in order [IC1, IC2, IC3, IC4, IC5, IC6]. Used by query-side
+    ///         <c>MusicalQueryEncoder.ComputeIcvString</c> and the schema fixture tests.</description></item>
+    ///       <item><description>Bracket-space: <c>"&lt;2 5 4 3 6 1&gt;"</c> — angle-bracketed,
+    ///         space-separated decimal integers. Emitted by
+    ///         <see cref="GA.Domain.Core.Theory.Atonal.IntervalClassVectorId.ToString"/> and what
+    ///         the corpus-side <c>VoicingDocumentFactory</c> stores in
+    ///         <c>ChordVoicingRagDocument.IntervalClassVector</c>.</description></item>
+    ///     </list>
+    ///     Per-bin values are capped at 9 so the digit-per-position form remains lossless
+    ///     for the realistic IC-count range (voicings ≤ 7 PCs cap at 6 pairs per IC).
     ///     Returns zeros on null/empty/malformed input.
+    ///     <para>
+    ///     <b>Why dual format:</b> the corpus has been writing bracket-space verbatim into
+    ///     the embedding pipeline (PR #186 telemetry surfaced this) while the query side
+    ///     wrote nothing. Pre-fix, the corpus's STRUCTURE dims 13-18 carried positionally
+    ///     shifted garbage (e.g. <c>"&lt;2 5 4"</c> parsed as <c>[0,2,0,5,0,4]</c>) and the
+    ///     query side wrote zeros, so the ICV cosine was zero everywhere — neutral but
+    ///     non-discriminating. Accepting both formats here lets the writer keep its
+    ///     canonical display string while the query side (with a known PC array)
+    ///     contributes a real signal. The corpus must be rebuilt for the corrected counts
+    ///     to take effect on indexed vectors (see <c>docs/plans/2026-05-12-icv-format-reconciliation-plan.md</c>).
+    ///     </para>
     /// </summary>
-    private static int[] ParseIcv(string? icv)
+    internal static int[] ParseIcv(string? icv)
     {
         var counts = new int[6];
         if (string.IsNullOrEmpty(icv)) return counts;
+
+        if (icv.IndexOf('<') >= 0 || icv.IndexOf(' ') >= 0)
+        {
+            var parts = icv.Trim('<', '>').Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < Math.Min(6, parts.Length); i++)
+            {
+                if (int.TryParse(parts[i], out var v)) counts[i] = Math.Clamp(v, 0, 9);
+            }
+            return counts;
+        }
+
         for (var i = 0; i < Math.Min(6, icv.Length); i++)
         {
             if (char.IsDigit(icv[i])) counts[i] = icv[i] - '0';

--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -48,6 +48,13 @@ public sealed class MusicalQueryEncoder(
         var root2 = q.RootPitchClass ?? (q.ChordSymbol is { } cs2 && ChordPitchClasses.TryParse(cs2, out var r2, out _) ? r2 : null);
         if (pcs is { Length: > 0 })
         {
+            // ICV not yet wired into the query path. The helper ComputeIcvString +
+            // dual-format ParseIcv (this PR) are forward-ready; turning the wiring on
+            // requires the corpus rebuild step described in
+            // docs/plans/2026-05-12-icv-format-reconciliation-plan.md §2 — without it,
+            // a real query-side ICV signal cosines against the still-misparsed corpus
+            // ICV slice and skews top-K away from exact PC-set matches (see acceptance
+            // criterion: OptickIntegrationTests.cs:118 — "score should rise, not fall").
             var structure = theory.ComputeEmbedding(pitchClasses: pcs, rootPitchClass: root2);
             Array.Copy(structure, 0, raw, EmbeddingSchema.StructureOffset, structure.Length);
         }
@@ -99,6 +106,34 @@ public sealed class MusicalQueryEncoder(
         // is therefore zero, which is the correct behavior.
 
         return ExtractCompactAndNormalize(raw);
+    }
+
+    /// <summary>
+    ///     Computes the interval-class vector of a pitch-class set as a digit-per-position
+    ///     string (e.g. <c>"012120"</c>) where position <c>i</c> is the count of interval
+    ///     class <c>i+1</c> (IC1..IC6). For each unordered PC pair, the interval class is
+    ///     <c>min(d, 12 - d)</c> where <c>d = |pc_a - pc_b| mod 12</c>. Counts are clamped
+    ///     to a single digit (max 9) so the lossless digit-per-position form is preserved;
+    ///     in practice voicings of ≤ 7 PCs cap at 6 pairs per IC. Mirrors the math behind
+    ///     <c>IntervalClassVectorId.GetVector</c> while emitting the format
+    ///     <c>TheoryVectorService.ParseIcv</c> reads alongside the corpus's bracket-space
+    ///     form. Exposed <c>internal</c> for symmetry tests.
+    /// </summary>
+    internal static string ComputeIcvString(int[] pitchClasses)
+    {
+        var counts = new int[6];
+        var distinct = pitchClasses.Distinct().ToArray();
+        for (var i = 0; i < distinct.Length; i++)
+        {
+            for (var j = i + 1; j < distinct.Length; j++)
+            {
+                var diff = Math.Abs(distinct[i] - distinct[j]) % 12;
+                var ic = Math.Min(diff, 12 - diff);
+                if (ic is >= 1 and <= 6) counts[ic - 1]++;
+            }
+        }
+        // Single-digit-per-position: clamp at 9 (caller-aligned with ParseIcv).
+        return string.Concat(counts.Select(c => (char)('0' + Math.Min(c, 9))));
     }
 
     /// <summary>

--- a/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
@@ -231,6 +231,79 @@ public class MusicalQueryEncoderTests
             "MORPHOLOGY slice should retain the input variation.");
     }
 
+    // ─── ICV reconciliation (writer/reader symmetry, 2026-05-12 plan) ──────
+
+    [TestCase(new[] { 0, 4, 7 },               "001110", TestName = "MajorTriad_ICV_001110")]
+    [TestCase(new[] { 0, 3, 7 },               "001110", TestName = "MinorTriad_ICV_001110")]
+    [TestCase(new[] { 0, 4, 7, 11 },           "101220", TestName = "Maj7_ICV_101220")]   // Cmaj7
+    [TestCase(new[] { 0, 2, 5, 9 },            "012120", TestName = "Min7_ICV_012120")]   // Dm7 = D F A C → IC5 hits twice ((0,5) + (2,9))
+    [TestCase(new[] { 0, 3, 6, 9 },            "004002", TestName = "Dim7_ICV_004002")]   // fully diminished
+    [TestCase(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }, "999996", TestName = "Chromatic12_ICV_capped_at_9_except_IC6")]   // raw [12,12,12,12,12,6] clamped at 9 → "999996"
+    public void ComputeIcvString_KnownPcSets_ProducesExpectedIcv(int[] pcs, string expectedIcv)
+    {
+        var icv = MusicalQueryEncoder.ComputeIcvString(pcs);
+
+        Assert.That(icv, Has.Length.EqualTo(6),
+            "ICV string must be exactly 6 digits — one per IC bin.");
+        Assert.That(icv, Is.EqualTo(expectedIcv),
+            $"PC-set {{{string.Join(",", pcs)}}} → expected ICV {expectedIcv}, got {icv}.");
+    }
+
+    [Test]
+    public void ComputeIcvString_EmptyAndSinglePc_ReturnsAllZeros()
+    {
+        Assert.That(MusicalQueryEncoder.ComputeIcvString([]),  Is.EqualTo("000000"));
+        Assert.That(MusicalQueryEncoder.ComputeIcvString([5]), Is.EqualTo("000000"));
+    }
+
+    [Test]
+    public void ComputeIcvString_DuplicatePcs_AreDeduplicatedBeforeCounting()
+    {
+        // Duplicates would otherwise double-count intervals — Cmaj written twice as
+        // [0, 0, 4, 4, 7, 7] must still produce the major-triad ICV "001110".
+        var icv = MusicalQueryEncoder.ComputeIcvString([0, 0, 4, 4, 7, 7]);
+        Assert.That(icv, Is.EqualTo("001110"));
+    }
+
+    [TestCase("001110",      new[] { 0, 0, 1, 1, 1, 0 }, TestName = "ParseIcv_DigitPerPosition_MajorTriad")]
+    [TestCase("101220",      new[] { 1, 0, 1, 2, 2, 0 }, TestName = "ParseIcv_DigitPerPosition_Maj7")]
+    [TestCase("<0 0 1 1 1 0>", new[] { 0, 0, 1, 1, 1, 0 }, TestName = "ParseIcv_BracketSpace_MajorTriad")]
+    [TestCase("<2 5 4 3 6 1>", new[] { 2, 5, 4, 3, 6, 1 }, TestName = "ParseIcv_BracketSpace_MajorScale")]
+    [TestCase("<10 5 4 3 6 1>", new[] { 9, 5, 4, 3, 6, 1 }, TestName = "ParseIcv_BracketSpace_ClampsTo9")]
+    public void ParseIcv_AcceptsBothFormats(string input, int[] expected)
+    {
+        var actual = TheoryVectorService.ParseIcv(input);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ParseIcv_NullOrEmpty_ReturnsAllZeros()
+    {
+        Assert.That(TheoryVectorService.ParseIcv(null),       Is.EqualTo(new[] { 0, 0, 0, 0, 0, 0 }));
+        Assert.That(TheoryVectorService.ParseIcv(string.Empty), Is.EqualTo(new[] { 0, 0, 0, 0, 0, 0 }));
+    }
+
+    [TestCase(new[] { 0, 4, 7 },     "<0 0 1 1 1 0>", TestName = "RoundTrip_MajorTriad")]
+    [TestCase(new[] { 0, 4, 7, 11 }, "<1 0 1 2 2 0>", TestName = "RoundTrip_Maj7")]
+    [TestCase(new[] { 0, 2, 5, 9 },  "<0 1 2 1 2 0>", TestName = "RoundTrip_Min7")]
+    public void RoundTrip_QueryAndCorpusFormat_ProduceSameCounts(int[] pcs, string corpusBracketForm)
+    {
+        // Symmetry guarantee: query-side ComputeIcvString → ParseIcv must produce
+        // the same int[6] as corpus-side IntervalClassVectorId.ToString() → ParseIcv.
+        // This is the contract the encoder docstring claims and what the corpus rebuild
+        // unlocks. Pre-fix the corpus side parsed the bracket form character-by-character
+        // and silently produced positionally-shifted garbage; pre-fix the query side
+        // wrote zeros. Post-fix both paths land on the same int[6].
+        var queryString  = MusicalQueryEncoder.ComputeIcvString(pcs);
+        var queryCounts  = TheoryVectorService.ParseIcv(queryString);
+        var corpusCounts = TheoryVectorService.ParseIcv(corpusBracketForm);
+
+        Assert.That(queryCounts, Is.EqualTo(corpusCounts),
+            $"Query ICV string {queryString} and corpus bracket form {corpusBracketForm} " +
+            "must parse to identical IC counts. If this drifts, the writer/reader symmetry " +
+            "regresses and 4+PC chord queries will misrank against indexed subsets.");
+    }
+
     // ─── helpers ───────────────────────────────────────────────────────────
 
     private static void AssertPartitionNonZero(double[] v, int start, int dim, string name)


### PR DESCRIPTION
## Summary
- **Phase 1 of `docs/plans/2026-05-12-icv-format-reconciliation-plan.md`** — surfaces the OPTIC-K v1.8 writer/reader symmetry break PR #186 telemetry surfaced (corpus writes `<2 5 4 3 6 1>` bracket form; `ParseIcv` was reading it character-by-character → positionally-shifted garbage in STRUCTURE dims 13-18/20/21).
- Ships **parser tolerance** + a **query-side `ComputeIcvString` helper**. Both forward-ready, both unwired into `Encode()` deliberately — the on-disk corpus was indexed against the misparsed reader, so flipping the query side now (without a corpus rebuild) skews top-K *away* from exact PC-set matches. Verified locally: `OptickIntegrationTests.EndToEnd_SearchForCmaj7` fell out of top-5 with the query-side wiring on. The plan's acceptance criterion ("score should rise, not fall") only holds post-rebuild.
- Step 2 (corpus rebuild, one-way door, ~140s with services stopped) and Step 3 (telemetry re-baseline) will land in a follow-up PR that bundles the wire-up + rebuild atomically.

## What changes
- `TheoryVectorService.ParseIcv` — visibility `internal`, accepts both `"NNNNNN"` and `"<a b c d e f>"` forms, per-bin clamp at 9, zeros on null/empty.
- `MusicalQueryEncoder.ComputeIcvString` — pure helper: `pcs → min(d, 12-d)` for each pair, deduplicates, emits 6-digit string.
- `MusicalQueryEncoder.Encode` — **unchanged behavior**; comment explains why the helper is held until rebuild.

## Tests added
- `ComputeIcvString_KnownPcSets` (6 cases): major triad `001110`, maj7 `101220`, min7 `012120`, dim7 `004002`, chromatic12 `999996` (post-clamp).
- `ComputeIcvString_EmptyAndSinglePc` → zeros; `ComputeIcvString_DuplicatePcs_AreDeduplicatedBeforeCounting`.
- `ParseIcv_AcceptsBothFormats` (5 cases) including bracket-form `<10 5 4 3 6 1>` clamped to `[9 5 4 3 6 1]`.
- `RoundTrip_QueryAndCorpusFormat_ProduceSameCounts` — pins the symmetry guarantee: `ComputeIcvString(pcs)` and the corresponding corpus bracket string parse to the same `int[6]`.

## Test plan
- [x] `dotnet test Tests/Common/GA.Business.ML.Tests/...` → **Failed: 0, Passed: 1298, Skipped: 9** (no regressions in `OptickIntegrationTests` because `Encode()` is unchanged)
- [ ] CI green on this PR
- [ ] Follow-up PR wires `Encode()` + does corpus rebuild (one-way door, needs explicit go-ahead per plan §"One-way door log")

🤖 Generated with [Claude Code](https://claude.com/claude-code)