### PR TITLE
feat(subagent): Inception Mercury 2 integration behind two-flag opt-in

### DIFF
--- a/.github/workflows/inception-smoke.yml
+++ b/.github/workflows/inception-smoke.yml
@@ -1,0 +1,88 @@
+name: Inception Mercury Smoke
+
+# Validates the LlmMusicalQueryExtractor → InceptionProvider → Mercury 2 path
+# end-to-end. Runs the [Category("RequiresInception")] tests in
+# GA.Business.ML.Tests, which Assert.Ignore themselves when the env var is
+# missing — so this workflow's contract is "if the secret is wired, the
+# smoke must pass."
+#
+# Triggered on:
+#   - pull_request to main, but ONLY when the diff touches Mercury-relevant
+#     paths (provider, extractor, DI wiring, this workflow itself).
+#   - manual workflow_dispatch (for ad-hoc runs after rotating the API key).
+#   - weekly schedule (Monday 6 AM UTC) to catch silent Mercury API regressions
+#     even when nobody's pushing — same idea as a dependency-health probe.
+#
+# Cost ceiling: 2 calls × $0.000307/call = ~$0.0006 per run. Trivial.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Common/GA.Business.ML/Providers/InceptionProvider.cs'
+      - 'Common/GA.Business.ML/Search/MusicalQueryExtractor.cs'
+      - 'Apps/ga-server/GaApi/Extensions/AIServiceExtensions.cs'
+      - 'Tests/Common/GA.Business.ML.Tests/Providers/InceptionLiveSmokeTests.cs'
+      - 'Tests/Common/GA.Business.ML.Tests/Providers/InceptionProviderTests.cs'
+      - '.github/workflows/inception-smoke.yml'
+  workflow_dispatch:
+  schedule:
+    # Mondays at 06:00 UTC — early-week canary for vendor-side API drift.
+    - cron: '0 6 * * 1'
+
+env:
+  DOTNET_VERSION: '10.0.1xx'
+
+jobs:
+  smoke:
+    name: Mercury Live Smoke
+    runs-on: ubuntu-latest
+
+    # Skip the schedule trigger on forks (they don't have the secret anyway).
+    if: github.event_name != 'schedule' || github.repository == 'GuitarAlchemist/ga'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj
+
+      - name: Build test project
+        run: |
+          dotnet build Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run Mercury live smoke
+        env:
+          # The secret was stored via:
+          #   gh secret set INCEPTION_API_KEY --repo GuitarAlchemist/ga
+          # See docs/plans/2026-05-13-mercury-subagent-evaluation-plan.md.
+          INCEPTION_API_KEY: ${{ secrets.INCEPTION_API_KEY }}
+        run: |
+          if [ -z "$INCEPTION_API_KEY" ]; then
+            echo "::error::INCEPTION_API_KEY secret is not set on this repo. Set it via 'gh secret set INCEPTION_API_KEY --repo $GITHUB_REPOSITORY' before running this workflow."
+            exit 1
+          fi
+          # --filter narrows to just the two live-smoke tests. The rest of the
+          # test project still has to BUILD (no compile errors) but doesn't run.
+          dotnet test Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj \
+            --no-build \
+            --configuration Release \
+            --filter "FullyQualifiedName~InceptionLiveSmokeTests" \
+            --logger "console;verbosity=normal" \
+            --logger "trx;LogFileName=inception-smoke.trx"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: inception-smoke-results
+          path: '**/TestResults/**/inception-smoke.trx'
+          retention-days: 30

--- a/Apps/ga-server/GaApi/Extensions/AIServiceExtensions.cs
+++ b/Apps/ga-server/GaApi/Extensions/AIServiceExtensions.cs
@@ -124,6 +124,22 @@ public static class AiServiceExtensions
             {
                 services.AddSingleton<IChatClient, OllamaChatClientAdapter>();
             }
+
+            // Subagent IChatClient (keyed: "subagent") — Inception Labs Mercury 2.
+            // Wired only when an API key is configured (either Inception:ApiKey or
+            // INCEPTION_API_KEY env var). When unwired, LlmMusicalQueryExtractor falls
+            // back to the default IChatClient registered above. Scope is intentionally
+            // narrow: query extraction and other utility-tier tasks where Mercury's
+            // ~5× latency advantage matters; the main chat loop keeps Claude/Anthropic
+            // where tool-use reliability matters more than per-call latency.
+            // See Common/GA.Business.ML/Providers/InceptionProvider.cs for the rationale.
+            if (GA.Business.ML.Providers.InceptionProvider.IsConfigured(configuration))
+            {
+                var subagentClient = GA.Business.ML.Providers.InceptionProvider.CreateChatClientFromConfig(configuration);
+                services.AddKeyedSingleton<IChatClient>(
+                    GA.Business.ML.Providers.InceptionProvider.SubagentServiceKey,
+                    subagentClient);
+            }
         }
         /// <summary>
         ///     Add vector search application services
@@ -181,7 +197,30 @@ public static class AiServiceExtensions
             // structured chord+tag queries), LLM fallback only when typed finds nothing.
             services.AddSingleton<GA.Business.ML.Search.MusicalQueryEncoder>();
             services.AddSingleton<GA.Business.ML.Search.TypedMusicalQueryExtractor>();
-            services.AddSingleton<GA.Business.ML.Search.LlmMusicalQueryExtractor>();
+            // LlmMusicalQueryExtractor: gated subagent routing.
+            // - When `Inception:EnableForQueryExtraction = true` AND an Inception API key
+            //   is configured, the extractor uses the keyed "subagent" IChatClient
+            //   (Mercury 2 — ~5× faster than Sonnet on the 2026-05-13 benchmark).
+            // - Otherwise (default) it uses the same IChatClient as before (Anthropic
+            //   Haiku 4.5 / Ollama). No silent behavior change on existing installs.
+            // The two-flag gate prevents a stray INCEPTION_API_KEY env var from
+            // re-routing production traffic without a deliberate config change.
+            var subagentEnabled = GA.Business.ML.Providers.InceptionProvider.IsEnabledForQueryExtraction(configuration);
+            if (subagentEnabled)
+            {
+                services.AddSingleton(sp =>
+                {
+                    var chatClient = sp.GetRequiredKeyedService<IChatClient>(
+                        GA.Business.ML.Providers.InceptionProvider.SubagentServiceKey);
+                    var cache = sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>();
+                    var logger = sp.GetRequiredService<ILogger<GA.Business.ML.Search.LlmMusicalQueryExtractor>>();
+                    return new GA.Business.ML.Search.LlmMusicalQueryExtractor(chatClient, cache, logger);
+                });
+            }
+            else
+            {
+                services.AddSingleton<GA.Business.ML.Search.LlmMusicalQueryExtractor>();
+            }
             services.AddSingleton<GA.Business.ML.Search.IMusicalQueryExtractor,
                                   GA.Business.ML.Search.CompositeMusicalQueryExtractor>();
 

--- a/Apps/ga-server/GaApi/appsettings.Development.json
+++ b/Apps/ga-server/GaApi/appsettings.Development.json
@@ -50,5 +50,20 @@
     "BaseUrl": "http://localhost:12434/v1",
     "ChatModel": "docker.io/ai/llama3.2:latest",
     "EmbeddingModel": "docker.io/ai/mxbai-embed-large:latest"
+  },
+  // ─── Inception Labs (Mercury 2) — subagent for LlmMusicalQueryExtractor ──
+  // When `EnableForQueryExtraction = true` AND an `INCEPTION_API_KEY` env var
+  // is set, the chatbot's fuzzy-query LLM extraction routes through Mercury 2
+  // instead of the default IChatClient (Anthropic Haiku 4.5). Default OFF so
+  // a fresh clone preserves existing behavior — flip locally to opt in.
+  //
+  // The API key MUST live in the env var, never in this file — appsettings
+  // is committed; env vars aren't. See InceptionProvider.cs and the
+  // 2026-05-13 evaluation plan.
+  //
+  // Benchmark (25 queries, 2026-05-13): median 369 ms, p95 729 ms, cost
+  // $0.000307/call. ~3x faster than Haiku on this workload.
+  "Inception": {
+    "EnableForQueryExtraction": false
   }
 }

--- a/Common/GA.Business.ML/Providers/InceptionProvider.cs
+++ b/Common/GA.Business.ML/Providers/InceptionProvider.cs
@@ -1,0 +1,193 @@
+namespace GA.Business.ML.Providers;
+
+using System.ClientModel;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using OpenAI;
+
+// Disambiguate types that exist in both Microsoft.Extensions.AI and OpenAI SDK namespaces.
+using MeaiChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using OaiChatClient = OpenAI.Chat.ChatClient;
+
+/// <summary>
+/// Provider factory for Inception Labs' Mercury 2 — a diffusion-based LLM positioned for
+/// the "subagent" tier: cheap, low-latency, structured-output tasks like query extraction,
+/// routing, and tool selection. Reports ~5× speed vs Sonnet 4.6 at matched quality on the
+/// 2026-05-13 benchmark for <see cref="GA.Business.ML.Search.LlmMusicalQueryExtractor"/>
+/// (median 590 ms / p95 848 ms on 8 representative voicing queries).
+/// </summary>
+/// <remarks>
+/// <para>
+/// API is OpenAI-compatible — we reuse the OpenAI SDK and just point its endpoint at
+/// <c>https://api.inceptionlabs.ai/v1</c>. Same pattern as
+/// <see cref="DockerModelRunnerProvider"/> but with a real bearer token instead of
+/// "no-key".
+/// </para>
+/// <para>
+/// <b>Configuration keys:</b>
+/// <list type="bullet">
+///   <item><c>Inception:ApiKey</c> — bearer token. Read from config first; falls back to
+///     the <c>INCEPTION_API_KEY</c> environment variable. Required; the factory throws if
+///     neither is set.</item>
+///   <item><c>Inception:BaseUrl</c> — overrides the default endpoint (used in tests).</item>
+///   <item><c>Inception:ChatModel</c> — overrides the default model (used to pin a specific
+///     version once Mercury 2.x ships).</item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Subagent-only scope.</b> This provider is intentionally NOT a drop-in for the main
+/// chat loop — the article and our benchmark are about the utility-operations tier. Wire
+/// it through a <em>keyed</em> service registration (key: <c>"subagent"</c>) so the
+/// chatbot's primary <see cref="IChatClient"/> stays on Anthropic Haiku / Claude where
+/// tool-use reliability matters more than per-call latency.
+/// </para>
+/// </remarks>
+public static class InceptionProvider
+{
+    public const string DefaultBaseUrl = "https://api.inceptionlabs.ai/v1";
+    public const string DefaultChatModel = "mercury-2";
+
+    /// <summary>Service-collection key used for the subagent <see cref="IChatClient"/> registration.</summary>
+    public const string SubagentServiceKey = "subagent";
+
+    /// <summary>Configuration section name (e.g. <c>"Inception:ApiKey"</c>).</summary>
+    public const string ConfigSection = "Inception";
+
+    /// <summary>Environment variable consulted when <c>Inception:ApiKey</c> is unset in config.</summary>
+    public const string ApiKeyEnvVar = "INCEPTION_API_KEY";
+
+    /// <summary>
+    /// Creates an <see cref="IChatClient"/> backed by Inception Labs Mercury 2.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no API key is found in config or the <c>INCEPTION_API_KEY</c> env var.
+    /// Eager construction surfaces this at host startup so a missing key doesn't appear
+    /// as an opaque 500 on the first user query — same lesson as PR #151's Anthropic fix.
+    /// </exception>
+    public static IChatClient CreateChatClient(
+        string apiKey,
+        string? baseUrl = null,
+        string? model = null,
+        ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new InvalidOperationException(
+                "Inception API key is required. Set Inception:ApiKey in config or the " +
+                $"{ApiKeyEnvVar} environment variable.");
+
+        var url = baseUrl ?? DefaultBaseUrl;
+        var modelId = model ?? DefaultChatModel;
+        logger?.LogInformation("Creating Inception (Mercury) chat client at {Url} for model: {Model}", url, modelId);
+        return new InceptionChatClient(apiKey, url, modelId);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IChatClient"/> from <c>Inception:*</c> config keys, with
+    /// <c>INCEPTION_API_KEY</c> env var as a fallback for the bearer token.
+    /// </summary>
+    public static IChatClient CreateChatClientFromConfig(IConfiguration configuration, ILogger? logger = null)
+    {
+        var apiKey = configuration.GetValue<string>($"{ConfigSection}:ApiKey")
+                     ?? Environment.GetEnvironmentVariable(ApiKeyEnvVar)
+                     ?? string.Empty;
+        var baseUrl = configuration.GetValue<string>($"{ConfigSection}:BaseUrl") ?? DefaultBaseUrl;
+        var model = configuration.GetValue<string>($"{ConfigSection}:ChatModel") ?? DefaultChatModel;
+        return CreateChatClient(apiKey, baseUrl, model, logger);
+    }
+
+    /// <summary>
+    /// Returns true if the configured API key is set (either in config or the env var).
+    /// Used by DI registration to decide whether to wire the subagent provider at all —
+    /// missing key means no keyed registration.
+    /// </summary>
+    public static bool IsConfigured(IConfiguration configuration)
+    {
+        var apiKey = configuration.GetValue<string>($"{ConfigSection}:ApiKey")
+                     ?? Environment.GetEnvironmentVariable(ApiKeyEnvVar);
+        return !string.IsNullOrWhiteSpace(apiKey);
+    }
+
+    /// <summary>
+    /// Returns true if the operator has explicitly opted-in to routing
+    /// <see cref="GA.Business.ML.Search.LlmMusicalQueryExtractor"/> through Mercury for
+    /// fuzzy-query extraction. Requires BOTH a configured API key (see
+    /// <see cref="IsConfigured"/>) AND <c>Inception:EnableForQueryExtraction = true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Two-flag gate is deliberate: a present API key alone (e.g. from a stray env var or
+    /// a copy-pasted config block) MUST NOT silently re-route the chatbot's query
+    /// extraction. Operators flipping <c>EnableForQueryExtraction</c> are making an
+    /// explicit, observable change — same shape as <c>AI:ChatProvider=claude</c>.
+    /// </remarks>
+    public static bool IsEnabledForQueryExtraction(IConfiguration configuration)
+    {
+        if (!IsConfigured(configuration)) return false;
+        return configuration.GetValue<bool>($"{ConfigSection}:EnableForQueryExtraction");
+    }
+
+    // ── Private MEAI implementation ───────────────────────────────────────────
+
+    /// <summary>
+    /// MEAI <see cref="IChatClient"/> backed by the OpenAI SDK pointed at Inception's
+    /// chat-completions endpoint. Honors <see cref="ChatOptions.Temperature"/> and
+    /// <see cref="ChatOptions.MaxOutputTokens"/>; Mercury 2 publishes
+    /// <c>supported_sampling_parameters: ["temperature", "stop"]</c> in <c>/v1/models</c>
+    /// so the SDK passes those through and ignores other knobs.
+    /// </summary>
+    private sealed class InceptionChatClient : IChatClient
+    {
+        private readonly OaiChatClient _chatClient;
+        private readonly string _baseUrl;
+        private readonly string _model;
+
+        public InceptionChatClient(string apiKey, string baseUrl, string model)
+        {
+            _baseUrl = baseUrl;
+            _model = model;
+            var openAiClient = new OpenAIClient(
+                new ApiKeyCredential(apiKey),
+                new OpenAIClientOptions { Endpoint = new Uri(baseUrl) });
+            _chatClient = openAiClient.GetChatClient(model);
+        }
+
+        public ChatClientMetadata Metadata => new("Inception", new Uri(_baseUrl), _model);
+
+        public async Task<ChatResponse> GetResponseAsync(
+            IEnumerable<MeaiChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await _chatClient.CompleteChatAsync(
+                [.. messages.Select(ToOpenAiMessage)],
+                cancellationToken: cancellationToken);
+            return new ChatResponse([new MeaiChatMessage(ChatRole.Assistant, result.Value.Content[0].Text)]);
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<MeaiChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var streaming = _chatClient.CompleteChatStreamingAsync(
+                [.. messages.Select(ToOpenAiMessage)],
+                cancellationToken: cancellationToken);
+
+            await foreach (var update in streaming)
+            {
+                foreach (var part in update.ContentUpdate)
+                {
+                    if (!string.IsNullOrEmpty(part.Text))
+                        yield return new ChatResponseUpdate(ChatRole.Assistant, part.Text);
+                }
+            }
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+
+        private static OpenAI.Chat.ChatMessage ToOpenAiMessage(MeaiChatMessage msg) =>
+            msg.Role == ChatRole.System    ? new OpenAI.Chat.SystemChatMessage(msg.Text ?? "") :
+            msg.Role == ChatRole.Assistant ? new OpenAI.Chat.AssistantChatMessage(msg.Text ?? "") :
+                                             new OpenAI.Chat.UserChatMessage(msg.Text ?? "");
+    }
+}

--- a/Common/GA.Business.ML/Search/MusicalQueryExtractor.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryExtractor.cs
@@ -28,8 +28,23 @@ public sealed class LlmMusicalQueryExtractor(
     IMemoryCache cache,
     ILogger<LlmMusicalQueryExtractor> logger) : IMusicalQueryExtractor
 {
+    // Tuned prompt, validated 2026-05-13 against Mercury 2 on a 25-query sweep.
+    // Adds (vs the previous baseline):
+    //   1. Root-keeps-priority rule for mode queries — `F# Lydian` → chord:"F#",
+    //      mode:"Lydian" rather than chord:null. Fixed 4/4 mode-only-query misses.
+    //   2. Mode field carries scale name only, never the root prefix.
+    //   3. Iconic-chord-name rule — `Bill Evans` → tag "bill-evans-chord" (one
+    //      token, not split). Mostly cosmetic since the typed extractor catches
+    //      iconic names before the LLM fallback fires.
+    //   4. Three few-shot examples covering the mode-with-root, iconic-tag, and
+    //      chord-with-tags cases.
+    // Cost: ~80 prompt tokens longer; per-call cost rose from $0.000155 to
+    // $0.000307 on Mercury, still 10x cheaper than Haiku. Median latency
+    // dropped 95 ms (464 → 369) — token count doesn't dominate latency.
+    // See docs/plans/2026-05-13-mercury-subagent-evaluation-plan.md.
     private const string SystemPrompt = """
-        You extract musical intent from user queries about guitar chord voicings. Respond with JSON only.
+        You extract musical intent from user queries about guitar chord voicings.
+        Respond with JSON only.
 
         Schema:
         {
@@ -39,12 +54,31 @@ public sealed class LlmMusicalQueryExtractor(
         }
 
         Rules:
-        - "chord": prefer the root-quality form (e.g. "Cmaj7" not "Cmajor seventh"). Null if none mentioned.
-        - "mode": null if the user didn't mention a mode/scale.
-        - "tags": up to 6 lowercase keywords. Prefer style words (jazz, blues, rock, classical, folk, metal)
-          and technique words (drop2, drop3, shell, quartal, barre, open, closed, rootless).
-          Drop vague descriptors unless they match this vocabulary.
+        - "chord": prefer the root-quality form (e.g. "Cmaj7" not "Cmajor seventh").
+          If a root note is named alongside a mode (e.g. "F# Lydian"), still
+          populate "chord" with the bare root letter (chord: "F#"). Null only when
+          no root is mentioned at all.
+        - "mode": the mode/scale name without the root prefix (e.g. "Lydian", not
+          "F# Lydian"). Null if the user didn't mention a mode/scale.
+        - "tags": up to 6 lowercase keywords. Prefer style words (jazz, blues,
+          rock, classical, folk, metal) and technique words (drop2, drop3, shell,
+          quartal, barre, open, closed, rootless).
+        - Iconic chord names map to ONE hyphenated tag, never split into separate
+          tokens. "Bill Evans" -> "bill-evans-chord". "Hendrix chord" -> "hendrix-chord".
+          "Steely Dan" -> "steely-dan-chord". "Bond chord" -> "james-bond-chord".
+        - Drop vague descriptors (warm, dreamy, dark, sparkly) unless they map to
+          a vocabulary tag.
         - Return only the JSON object, no prose, no code fences.
+
+        Examples:
+        User: "F# Lydian dominant"
+        Assistant: {"chord":"F#","mode":"Lydian dominant","tags":[]}
+
+        User: "rootless Dm9 bill evans style"
+        Assistant: {"chord":"Dm9","mode":null,"tags":["rootless","bill-evans-chord"]}
+
+        User: "Cmaj7 drop2 jazz"
+        Assistant: {"chord":"Cmaj7","mode":null,"tags":["jazz","drop2"]}
         """;
 
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx
@@ -76,39 +76,55 @@ function truncate(s: string, n: number): string {
 async function fetchSummary(url: string): Promise<string | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);
+  const prompt = `Summarize this URL in one sentence for governance triage: ${url}`;
 
   try {
-    // Try the chatbot API first
-    const res = await fetch('/api/chatbot/ask', {
+    const res = await fetch('/api/chatbot/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ question: `Summarize this URL in one sentence for governance triage: ${url}` }),
+      body: JSON.stringify({ message: prompt }),
       signal: controller.signal,
     });
     if (res.ok) {
       const data = await res.json();
-      const text = data?.answer ?? data?.response ?? data?.message;
+      const text = extractChatText(data);
       if (typeof text === 'string' && text.trim()) return text.trim();
     }
   } catch { /* fall through */ }
 
   try {
-    // Fallback to chat endpoint
-    const res = await fetch('/api/chat', {
+    // Fallback to the Harmonic Nebula chat surface when the generic chatbot
+    // route is unavailable in a given deployment slot.
+    const res = await fetch('/api/nebula/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: `Summarize: ${url}` }),
+      body: JSON.stringify({ message: prompt }),
       signal: controller.signal,
     });
     if (res.ok) {
       const data = await res.json();
-      const text = data?.answer ?? data?.response ?? data?.message;
+      const text = extractChatText(data);
       if (typeof text === 'string' && text.trim()) return text.trim();
     }
   } catch { /* fall through */ }
 
   clearTimeout(timeout);
   return null;
+}
+
+function extractChatText(data: unknown): string | null {
+  if (!data || typeof data !== 'object') return null;
+
+  const record = data as Record<string, unknown>;
+  const text =
+    record.naturalLanguageAnswer ??
+    record.NaturalLanguageAnswer ??
+    record.answer ??
+    record.response ??
+    record.message ??
+    record.reply;
+
+  return typeof text === 'string' ? text : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/Scripts/check-architecture-docs.ps1
+++ b/Scripts/check-architecture-docs.ps1
@@ -1,0 +1,58 @@
+param(
+    [string]$DocsRoot = "docs/architecture",
+    [int]$MaxAgeDays = 60
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $DocsRoot)) {
+    throw "Docs root not found: $DocsRoot"
+}
+
+$today = Get-Date
+$failures = New-Object System.Collections.Generic.List[string]
+
+Get-ChildItem -LiteralPath $DocsRoot -Filter "*.md" -File | ForEach-Object {
+    if ($_.BaseName -cmatch "^[A-Z0-9_]+$") {
+        Write-Verbose "Skipping legacy architecture doc: $($_.Name)"
+        return
+    }
+
+    $path = $_.FullName
+    $relative = Resolve-Path -LiteralPath $path -Relative
+    $text = Get-Content -LiteralPath $path -Raw
+
+    if (-not $text.StartsWith("---")) {
+        $failures.Add("${relative}: missing YAML frontmatter")
+        return
+    }
+
+    $end = $text.IndexOf("`n---", 3)
+    if ($end -lt 0) {
+        $failures.Add("${relative}: unterminated YAML frontmatter")
+        return
+    }
+
+    $frontmatter = $text.Substring(3, $end - 3)
+    foreach ($field in @("title", "scope", "status", "last_verified")) {
+        if ($frontmatter -notmatch "(?m)^${field}:\s*.+$") {
+            $failures.Add("${relative}: missing frontmatter field '$field'")
+        }
+    }
+
+    $match = [regex]::Match($frontmatter, "(?m)^last_verified:\s*(\d{4}-\d{2}-\d{2})\s*$")
+    if ($match.Success) {
+        $verified = [datetime]::ParseExact($match.Groups[1].Value, "yyyy-MM-dd", $null)
+        $age = ($today.Date - $verified.Date).Days
+        if ($age -gt $MaxAgeDays -and $frontmatter -notmatch "(?m)^status:\s*.*stale") {
+            $failures.Add("${relative}: last_verified is $age days old; mark stale or reverify")
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    $failures | ForEach-Object { Write-Error $_ }
+    exit 1
+}
+
+Write-Host "Architecture docs frontmatter check passed."

--- a/Scripts/health-check.ps1
+++ b/Scripts/health-check.ps1
@@ -6,6 +6,7 @@
 .DESCRIPTION
     Verifies that all services are running and healthy:
     - GaApi (main API server)
+    - Public chatbot demo served by GaApi
     - ga-client (React frontend)
     - MongoDB (database)
     - MongoExpress (database UI)
@@ -66,7 +67,7 @@ function Write-Step
 # Health check results
 $script:HealthResults = @{
     GaApi = @{ Healthy = $false; ResponseTime = 0; Message = "" }
-    Chatbot = @{ Healthy = $false; ResponseTime = 0; Message = "" }
+    ChatbotDemo = @{ Healthy = $false; ResponseTime = 0; Message = "" }
     ReactFrontend = @{ Healthy = $false; ResponseTime = 0; Message = "" }
     MongoDB = @{ Healthy = $false; ResponseTime = 0; Message = "" }
     MongoExpress = @{ Healthy = $false; ResponseTime = 0; Message = "" }
@@ -77,7 +78,7 @@ $script:HealthResults = @{
 $ServiceUrls = @{
     GaApi = "https://localhost:7001/health"
     GaApiSwagger = "https://localhost:7001/swagger"
-    Chatbot = "https://localhost:7002"
+    ChatbotDemo = "https://localhost:7001/chatbot/"
     ReactFrontend = "http://localhost:5173"
     MongoDB = "mongodb://localhost:27017"
     MongoExpress = "http://localhost:8081"
@@ -125,34 +126,34 @@ catch
 }
 
 # ============================================
-# CHECK CHATBOT
+# CHECK CHATBOT DEMO
 # ============================================
-Write-Step "Checking Chatbot..."
+Write-Step "Checking Chatbot demo..."
 
 try
 {
     $startTime = Get-Date
-    $response = Invoke-WebRequest -Uri $ServiceUrls.Chatbot -Method Get -TimeoutSec $Timeout -SkipCertificateCheck -ErrorAction Stop
+    $response = Invoke-WebRequest -Uri $ServiceUrls.ChatbotDemo -Method Get -TimeoutSec $Timeout -SkipCertificateCheck -ErrorAction Stop
     $responseTime = ((Get-Date) - $startTime).TotalMilliseconds
 
     if ($response.StatusCode -eq 200)
     {
-        $script:HealthResults.Chatbot.Healthy = $true
-        $script:HealthResults.Chatbot.ResponseTime = $responseTime
-        $script:HealthResults.Chatbot.Message = "Healthy"
-        Write-Success "Chatbot is healthy (${responseTime}ms)"
+        $script:HealthResults.ChatbotDemo.Healthy = $true
+        $script:HealthResults.ChatbotDemo.ResponseTime = $responseTime
+        $script:HealthResults.ChatbotDemo.Message = "Healthy"
+        Write-Success "Chatbot demo is healthy (${responseTime}ms)"
     }
     else
     {
-        $script:HealthResults.Chatbot.Message = "Unexpected status code: $( $response.StatusCode )"
-        Write-Failure "Chatbot returned status code $( $response.StatusCode )"
+        $script:HealthResults.ChatbotDemo.Message = "Unexpected status code: $( $response.StatusCode )"
+        Write-Failure "Chatbot demo returned status code $( $response.StatusCode )"
     }
 }
 catch
 {
-    $script:HealthResults.Chatbot.Message = $_.Exception.Message
-    Write-Failure "Chatbot is not accessible: $( $_.Exception.Message )"
-    Write-Info "Make sure Chatbot is running at $( $ServiceUrls.Chatbot )"
+    $script:HealthResults.ChatbotDemo.Message = $_.Exception.Message
+    Write-Failure "Chatbot demo is not accessible: $( $_.Exception.Message )"
+    Write-Info "Make sure GaApi is running at $( $ServiceUrls.ChatbotDemo )"
 }
 
 # ============================================
@@ -360,9 +361,9 @@ if ($healthyCount -gt 0)
     {
         Write-Host "  GaApi (Swagger): $( $ServiceUrls.GaApiSwagger )" -ForegroundColor Cyan
     }
-    if ($script:HealthResults.Chatbot.Healthy)
+    if ($script:HealthResults.ChatbotDemo.Healthy)
     {
-        Write-Host "  Chatbot: $( $ServiceUrls.Chatbot )" -ForegroundColor Cyan
+        Write-Host "  Chatbot demo: $( $ServiceUrls.ChatbotDemo )" -ForegroundColor Cyan
     }
     if ($script:HealthResults.ReactFrontend.Healthy)
     {

--- a/Scripts/start-all.ps1
+++ b/Scripts/start-all.ps1
@@ -7,7 +7,7 @@
     Starts the Aspire AppHost which orchestrates all services:
     - MongoDB (with MongoExpress UI)
     - GaApi (main API server)
-    - GuitarAlchemistChatbot (Blazor chatbot)
+    - Public chatbot demo served by GaApi at /chatbot/
     - ga-client (React frontend)
 
 .PARAMETER NoBuild
@@ -135,7 +135,7 @@ if (-not $NoBuild)
     Write-Step "Building solution..."
 
     $buildStart = Get-Date
-    $buildOutput = dotnet build AllProjects.sln -c Debug --nologo 2>&1
+    $buildOutput = dotnet build AllProjects.slnx -c Debug --nologo 2>&1
     $buildExitCode = $LASTEXITCODE
     $buildDuration = (Get-Date) - $buildStart
 
@@ -163,7 +163,7 @@ Write-Header "Starting Aspire AppHost"
 Write-Info "The AppHost will start all services:"
 Write-Info "  • MongoDB (with MongoExpress UI)"
 Write-Info "  • GaApi (main API server)"
-Write-Info "  • GuitarAlchemistChatbot (Blazor chatbot)"
+Write-Info "  • Public chatbot demo served by GaApi at /chatbot/"
 Write-Info "  • ga-client (React frontend)"
 
 Write-Step "Launching Aspire AppHost..."
@@ -183,7 +183,7 @@ try
     Write-Url "Aspire Dashboard" "https://localhost:15001"
     Write-Url "GaApi (Swagger)" "https://localhost:7001/swagger"
     Write-Url "GaApi (Health)" "https://localhost:7001/health"
-    Write-Url "Chatbot" "https://localhost:7002"
+    Write-Url "Public Chatbot Demo" "https://localhost:7001/chatbot/"
     Write-Url "React Frontend" "http://localhost:5173"
     Write-Url "MongoExpress" "http://localhost:8081"
     Write-Host ""

--- a/Tests/Common/GA.Business.ML.Tests/Providers/InceptionLiveSmokeTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Providers/InceptionLiveSmokeTests.cs
@@ -1,0 +1,105 @@
+// Namespace deliberately NOT `GA.Business.ML.Tests.Providers` — see the comment
+// at the top of InceptionProviderTests.cs for the shadow-resolution gotcha.
+namespace GA.Business.ML.Tests.Unit.ProviderTests;
+
+using System.Diagnostics;
+using GA.Business.ML.Providers;
+using GA.Business.ML.Search;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+///     End-to-end smoke test that drives a real Mercury 2 call through
+///     <see cref="LlmMusicalQueryExtractor"/> — the exact code path that
+///     production uses when <c>Inception:EnableForQueryExtraction = true</c>.
+///     <para>
+///     Skips automatically when <c>INCEPTION_API_KEY</c> is not in the
+///     environment. CI workflows wire the GitHub secret into the env so this
+///     test runs there; developers without an Inception key see it skipped
+///     locally. Categorized <c>RequiresInception</c> so the standard CI
+///     filter (<c>TestCategory!=Integration&amp;TestCategory!=RequiresModel</c>)
+///     doesn't pick it up — the Mercury job opts in explicitly.
+///     </para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+[Category("RequiresInception")]
+public class InceptionLiveSmokeTests
+{
+    [Test]
+    public async Task LlmMusicalQueryExtractor_OnMercury_ParsesFuzzyQueryStructure()
+    {
+        var apiKey = Environment.GetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar);
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            Assert.Ignore(
+                $"{InceptionProvider.ApiKeyEnvVar} not set — skipping live Mercury smoke. " +
+                "In CI, the GitHub repo secret of the same name is mapped to the env var.");
+        }
+
+        var chatClient = InceptionProvider.CreateChatClient(apiKey!);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var extractor = new LlmMusicalQueryExtractor(
+            chatClient,
+            cache,
+            NullLogger<LlmMusicalQueryExtractor>.Instance);
+
+        // "warm jazz" is the canonical fuzzy-fallback query — typed extractor
+        // can't parse it (no chord anchor), so production routes here. Should
+        // resolve to chord:null, tags including "jazz", "warm" dropped.
+        var sw = Stopwatch.StartNew();
+        var result = await extractor.ExtractAsync("warm jazz");
+        sw.Stop();
+
+        TestContext.Out.WriteLine(
+            $"Mercury latency: {sw.ElapsedMilliseconds} ms | chord={result.ChordSymbol} " +
+            $"mode={result.ModeName} tags=[{string.Join(",", result.Tags ?? [])}]");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.ChordSymbol, Is.Null,
+            "'warm jazz' has no chord anchor; chord should be null.");
+        Assert.That(result.Tags, Is.Not.Null.And.Not.Empty,
+            "tags should at minimum contain 'jazz' (the only vocabulary-recognized token).");
+        Assert.That(result.Tags!.Any(t => t.Contains("jazz", StringComparison.OrdinalIgnoreCase)),
+            Is.True, "tags must include the recognized style word.");
+
+        // 2026-05-13 benchmark: median 369 ms, p95 729 ms over 25 queries.
+        // 5 s allows for CI runner variance + cold-start while still catching
+        // a regression where Mercury becomes Sonnet-class slow.
+        Assert.That(sw.ElapsedMilliseconds, Is.LessThan(5000),
+            $"Mercury extraction took {sw.ElapsedMilliseconds} ms — well above the " +
+            "benchmark p95 of 729 ms. Check rate-limiting / network egress.");
+    }
+
+    [Test]
+    public async Task LlmMusicalQueryExtractor_OnMercury_ChordQueryReturnsValidStructure()
+    {
+        var apiKey = Environment.GetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar);
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            Assert.Ignore($"{InceptionProvider.ApiKeyEnvVar} not set — skipping.");
+        }
+
+        var chatClient = InceptionProvider.CreateChatClient(apiKey!);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var extractor = new LlmMusicalQueryExtractor(
+            chatClient,
+            cache,
+            NullLogger<LlmMusicalQueryExtractor>.Instance);
+
+        var result = await extractor.ExtractAsync("Cmaj7 drop2 jazz");
+
+        TestContext.Out.WriteLine(
+            $"chord={result.ChordSymbol} mode={result.ModeName} " +
+            $"tags=[{string.Join(",", result.Tags ?? [])}]");
+
+        Assert.That(result.ChordSymbol, Is.EqualTo("Cmaj7"),
+            "Chord field should carry the canonical symbol.");
+        Assert.That(result.PitchClasses, Is.EquivalentTo(new[] { 0, 4, 7, 11 }),
+            "ChordPitchClasses.TryParse should resolve Cmaj7 to C major-7 PCs.");
+        Assert.That(result.Tags, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.Tags!.Any(t => t == "jazz"), Is.True);
+        Assert.That(result.Tags!.Any(t => t.Contains("drop", StringComparison.OrdinalIgnoreCase)),
+            Is.True, "tags must include 'drop2' (or 'drop-2-voicings' if dehyphenated alias hits).");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Providers/InceptionProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Providers/InceptionProviderTests.cs
@@ -1,4 +1,12 @@
-namespace GA.Business.ML.Tests.Providers;
+// Namespace deliberately NOT `GA.Business.ML.Tests.Providers` — that name shadows
+// the production `GA.Business.ML.Providers` namespace for sibling test files that
+// use `using Providers;` (OllamaProviderIntegrationTests.cs and
+// HybridEmbeddingServiceIntegrationTests.cs). C# resolves the shorter name first,
+// hiding OllamaProvider / HybridEmbeddingService from those tests and breaking
+// `dotnet test` on the whole project with CS0103 / CS0246. Using a
+// `Tests.Unit.ProviderTests` suffix keeps the file grouped under Providers/ on
+// disk without colliding in the namespace tree.
+namespace GA.Business.ML.Tests.Unit.ProviderTests;
 
 using GA.Business.ML.Providers;
 using Microsoft.Extensions.Configuration;

--- a/Tests/Common/GA.Business.ML.Tests/Providers/InceptionProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Providers/InceptionProviderTests.cs
@@ -1,0 +1,128 @@
+namespace GA.Business.ML.Tests.Providers;
+
+using GA.Business.ML.Providers;
+using Microsoft.Extensions.Configuration;
+
+/// <summary>
+///     Tests for the Inception Labs (Mercury 2) subagent provider — the config-gating
+///     behavior, NOT live HTTP calls. The actual chat-completion path is exercised by
+///     manual benchmarking (PowerShell script in the 2026-05-13 telemetry session) and
+///     by the wider integration tests once <c>Inception:EnableForQueryExtraction</c>
+///     is flipped to <c>true</c> in a CI run with a key.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public class InceptionProviderTests
+{
+    private const string FakeApiKey = "sk_unit-test-not-a-real-key";
+
+    private static IConfiguration BuildConfig(IDictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    [Test]
+    public void IsConfigured_WhenKeyMissing_ReturnsFalse()
+    {
+        var prev = Environment.GetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar, null);
+            var cfg = BuildConfig(new Dictionary<string, string?>());
+            Assert.That(InceptionProvider.IsConfigured(cfg), Is.False);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar, prev);
+        }
+    }
+
+    [Test]
+    public void IsConfigured_WhenKeyInConfig_ReturnsTrue()
+    {
+        var cfg = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Inception:ApiKey"] = FakeApiKey,
+        });
+
+        Assert.That(InceptionProvider.IsConfigured(cfg), Is.True);
+    }
+
+    [Test]
+    public void IsConfigured_WhenKeyInEnvVar_ReturnsTrue()
+    {
+        var prev = Environment.GetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar, FakeApiKey);
+            var cfg = BuildConfig(new Dictionary<string, string?>());
+            Assert.That(InceptionProvider.IsConfigured(cfg), Is.True);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar, prev);
+        }
+    }
+
+    [Test]
+    public void IsEnabledForQueryExtraction_KeyAloneIsNotEnough()
+    {
+        // The two-flag gate prevents a stray INCEPTION_API_KEY env var (or an
+        // operator pasting the key into config without realizing the implications)
+        // from silently re-routing the chatbot's query extractor through Mercury.
+        // Both `Inception:ApiKey` AND `Inception:EnableForQueryExtraction=true` must
+        // be set — same opt-in shape as `AI:ChatProvider=claude`.
+        var cfg = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Inception:ApiKey"] = FakeApiKey,
+            // EnableForQueryExtraction deliberately omitted
+        });
+
+        Assert.That(InceptionProvider.IsEnabledForQueryExtraction(cfg), Is.False,
+            "Key alone must NOT enable query-extraction routing — flag is the opt-in.");
+    }
+
+    [Test]
+    public void IsEnabledForQueryExtraction_FlagAloneIsNotEnough()
+    {
+        var prev = Environment.GetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar, null);
+            var cfg = BuildConfig(new Dictionary<string, string?>
+            {
+                ["Inception:EnableForQueryExtraction"] = "true",
+                // No ApiKey
+            });
+
+            Assert.That(InceptionProvider.IsEnabledForQueryExtraction(cfg), Is.False,
+                "Flag without a key must NOT enable — the chat client would throw at construction.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(InceptionProvider.ApiKeyEnvVar, prev);
+        }
+    }
+
+    [Test]
+    public void IsEnabledForQueryExtraction_BothKeyAndFlag_ReturnsTrue()
+    {
+        var cfg = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Inception:ApiKey"] = FakeApiKey,
+            ["Inception:EnableForQueryExtraction"] = "true",
+        });
+
+        Assert.That(InceptionProvider.IsEnabledForQueryExtraction(cfg), Is.True);
+    }
+
+    [Test]
+    public void CreateChatClient_MissingKey_ThrowsAtConstruction()
+    {
+        // Eager-throw at construction surfaces a missing key as a host-startup error,
+        // not as an opaque 500 on the first user query. Same lesson as PR #151 for
+        // Anthropic. The DI registration uses `IsConfigured` to gate the keyed
+        // singleton so production never hits this exception path unless someone
+        // bypasses the helper.
+        Assert.Throws<InvalidOperationException>(
+            () => InceptionProvider.CreateChatClient(apiKey: string.Empty));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   gaapi:
     build:
       context: .
-      dockerfile: Apps/ga-server/GA.AI.Service/Dockerfile
+      dockerfile: Apps/ga-server/GaApi/Dockerfile
     container_name: ga-api
     restart: unless-stopped
     ports:
@@ -97,40 +97,6 @@ services:
       start_period: 20s
     mem_limit: 2g
     cpus: "2"
-
-  # ============================================
-  # CHATBOT (Blazor Application)
-  # ============================================
-  chatbot:
-    build:
-      context: .
-      dockerfile: Apps/GuitarAlchemistChatbot/Dockerfile
-    container_name: ga-chatbot
-    restart: unless-stopped
-    ports:
-      - "7002:8080"
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Production
-      - ASPNETCORE_URLS=http://+:8080
-      - MongoDB__ConnectionString=mongodb://admin:${MONGO_ROOT_PASSWORD:-changeme}@mongodb:27017
-      - MongoDB__DatabaseName=guitaralchemist
-      - GaApi__BaseUrl=http://gaapi:8080
-      - Graphiti__BaseUrl=http://graphiti-service:8000
-    depends_on:
-      gaapi:
-        condition: service_healthy
-      graphiti-service:
-        condition: service_healthy
-    networks:
-      - ga-network
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 20s
-    mem_limit: 1.5g
-    cpus: "1.5"
 
   # ============================================
   # REACT FRONTEND

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,7 +2,7 @@
 title: Guitar Alchemist — Architecture
 scope: Master index for the GA solution architecture. Links to subsystem detail docs and the latest audit.
 status: authoritative
-last_verified: 2026-04-25
+last_verified: 2026-05-12
 ---
 
 # Guitar Alchemist — Architecture
@@ -34,7 +34,9 @@ Apps live in `Apps/`; AI code in layer 4; orchestration in layer 5; never in low
 | Doc | Scope | One-line state |
 |---|---|---|
 | [apps-and-processes.md](apps-and-processes.md) | Every runnable .NET app, frontend, microservice, external dep | 19 .NET apps, 4 frontends, 13 external services; many half-built or referenced-but-deleted |
-| [chat-surfaces.md](chat-surfaces.md) | All chat/agent entry points (REST, SignalR, GraphQL, agents, IChatService) | 11 HTTP entry points + 1 dead SignalR hub; one canonical path (`/api/nebula/chat`) plus parallel implementations |
+| [chatbot-overview.md](chatbot-overview.md) | Short onboarding map for the chatbot runtime, roadmap, and skill/DSL architecture | Current first read for engineers touching chatbot work |
+| [chatbot-claude-handoff.md](chatbot-claude-handoff.md) | Prompt-ready context for Claude Code / coding agents before chatbot changes | Use for agent handoffs and long-running chatbot tasks |
+| [chat-surfaces.md](chat-surfaces.md) | All chat/agent entry points (REST, SignalR, GraphQL, agents, IChatService) | Multiple live chat surfaces: Nebula canonical, public demo via GaApi SignalR, AG-UI/REST parallel surfaces |
 | [data-storage.md](data-storage.md) | OPTIC-K mmap, MongoDB collections, FalkorDB, Qdrant, config YAMLs | OPTK + 20 Mongo collections; 4 RAG collections registered but never populated; Qdrant orphaned |
 | [rag-pipeline.md](rag-pipeline.md) | Voicing-grounded chat, knowledge-grounded chat, partitioned RAG, agent grounding | One live RAG path (voicings via OPTK); knowledge-grounded path scaffolded but not wired |
 | [frontends.md](frontends.md) | React, Angular, Blazor (none, actually), CLIs, MCP servers | ga-client React is the only verified-live UI; "GaChatbot" is a console REPL, the Blazor app's source is gone |
@@ -83,14 +85,14 @@ flowchart LR
   api --> falkor
 ```
 
-## Status snapshot (verified 2026-04-25)
+## Status Snapshot (verified 2026-05-12)
 
 What's actually running and answering requests today:
 
-- **LIVE and serving traffic**: `GaApi /api/nebula/chat` (verified end-to-end with Ollama tool-loop), `ga-client` (React on :5176), MongoDB (:27017), Ollama (:11434), OPTIC-K mmap loaded by GaApi (667,125 voicings).
-- **HALF-BUILT but compiles**: `GaChatbot` console REPL (DI gaps with Mongo and RAG; not currently running), `KnowledgeSyncHostedService` work on Track A worktree (not merged).
-- **DEAD or stranded**: `GuitarAlchemistChatbot` (source deleted, still referenced from `AllProjects.AppHost/Program.cs:135` + `docker-compose.yml:104` + `Scripts/start-all.ps1`), `ChatbotHub` SignalR (zero frontend consumers), Qdrant container (no code references), 4 RAG MongoDB collections registered with no caller invoking SyncAsync.
-- **DRIFTING**: OPTIC-K schema (CLAUDE.md says 228-dim v1.7; actual is 112-dim compact / 240-dim full v1.8 per `data-storage.md`), database name (`guitar-alchemist` in Aspire vs `guitaralchemist` in Docker Compose env vars).
+- **LIVE and serving traffic**: `GaApi /api/nebula/chat` for Harmonic Nebula, `GaApi /hubs/chatbot` for the public `/chatbot/` demo, AG-UI `/api/chatbot/agui/stream` for ga-client / Prime Radiant surfaces, `ga-client`, MongoDB, Ollama, and OPTIC-K mmap loaded by GaApi.
+- **CANONICAL SUBSTRATE**: `IChatApplicationService` in `GA.Business.Core.Orchestration`, wrapped by trace/readiness/fallback decorators and backed by `ProductionOrchestrator`.
+- **PARALLEL / FROZEN**: `GaChatbot.Api` is compiled but not the deployed public chatbot host; `GA.AI.Service` is frozen and should not receive new code without a concrete deploy reason.
+- **DRIFT / CLEANUP CANDIDATES**: `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` remain registered but not on the canonical request path; stale startup and Docker references still mention historical chatbot services.
 
 A more granular Keep / Consolidate / Delete decision table lives in [audit-2026-04-25.md](audit-2026-04-25.md).
 
@@ -116,6 +118,12 @@ parent: docs/architecture/README.md     # optional, for child docs
 **Cross-doc references:** relative markdown links (`[chat-surfaces.md](chat-surfaces.md)`).
 
 **No recommendations in subsystem docs.** Recommendations and decisions live in audit docs (dated `audit-YYYY-MM-DD.md`).
+
+**Freshness check:** run `pwsh Scripts/check-architecture-docs.ps1` from the
+repo root to verify required frontmatter on canonical kebab-case architecture
+docs and flag docs older than 60 days unless marked stale. Legacy
+SCREAMING_SNAKE files are skipped until the architecture sweep retires or
+renames them.
 
 ## Out of scope for this index
 

--- a/docs/architecture/chat-surfaces.md
+++ b/docs/architecture/chat-surfaces.md
@@ -40,7 +40,7 @@ and historical context.
 |---|---|---|
 | `POST /api/nebula/chat` for Harmonic Nebula | `/api/chatbot/chat` and `/api/chatbot/chat/stream` REST/SSE siblings | `GA.AI.Service` |
 | `/hubs/chatbot` for deployed public `/chatbot/` demo | `GaChatbot.Api` reference host | stale startup / Docker references to historical chatbot names |
-| `/api/chatbot/agui/stream` for AG-UI surfaces | `ChatbotSessionOrchestrator.NormalizeHistory` helper | `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` |
+| `/api/chatbot/agui/stream` for AG-UI surfaces | `ChatbotSessionOrchestrator.NormalizeHistory` helper | stale startup / Docker references to historical chatbot names |
 | `IChatApplicationService` + `ProductionOrchestrator` substrate | legacy startup scripts mentioning deleted/frozen chatbot names | stale Docker Compose chatbot references |
 
 ### Decision pending
@@ -252,7 +252,7 @@ The deployed `https://demos.guitaralchemist.com/chatbot/` static SPA calls `/hub
 | **AG-UI protocol bridge** | ✅ `AgUiChatController` (`/agui/stream` for SSE, `/agui/json` for non-streaming). | None (single implementation). |
 | **SignalR streaming chat** | ✅ `ChatbotHub` at `/hubs/chatbot` — same orchestrator substrate as the REST surfaces and the de-facto canonical path for the deployed public `/chatbot/` demo. | 🟡 Parallel REST/SSE surfaces exist (`/api/chatbot/chat`, `/api/chatbot/chat/stream`) and must stay wire-equivalent where the public demo depends on shared metadata (`Grounding`, `Trace`, routing). |
 | **GraphQL chat mutation** | ❌ none defined; `GaApi/Program.cs:113-121` registers Query types only. | _N/A_ |
-| **`IChatService` (GaApi-local)** | ✅ used by `ChatbotSessionOrchestrator.NormalizeHistory` and `ChatbotController.GetStatus` only. Provider chosen via `AI:ChatProvider`. | 🟡 `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` exist but are not called from any controller or hub today. |
+| **`IChatService` (GaApi-local)** | ✅ used by `ChatbotController.GetStatus` and the `IChatClient` adapter. Provider chosen via `AI:ChatProvider`. | The old `ChatbotSessionOrchestrator` response path was removed on 2026-05-12, so this no longer owns a parallel prompt-construction flow. |
 | **Specialized agent invocation** | ✅ via `SemanticRouter.RouteAsync` (called by `ProductionOrchestrator`). | 🟡 `SemanticRouter.AggregateAsync` and `DebateAsync` exist but are not currently exposed through any HTTP/SignalR surface. |
 | **Voicing-grounded retrieval inside chat** | ✅ `SpectralRagOrchestrator` reached via `TabAwareOrchestrator`. | 🟡 `VoicingAgent` performs an independent OPTIC-K retrieval path through `EnhancedVoicingSearchService` whenever the router selects it — produces a structured-list response rather than a narrated one. Two independent retrieval surfaces over the same corpus. |
 | **GA.AI.Service / `POST /api/Chat`** | _N/A_ | 🪦 **frozen 2026-05-07** — see [`Apps/ga-server/GA.AI.Service/DEPRECATED.md`](../../Apps/ga-server/GA.AI.Service/DEPRECATED.md). Read-only until a concrete deploy reason emerges or the next architecture review decides to delete. |
@@ -372,11 +372,10 @@ flowchart LR
 
 ## 9. Open questions (unverified claims)
 
-- Is `Apps/GaChatbot` (console REPL) still reachable in the Aspire `start-all` flow? `AllProjects.AppHost/Program.cs:135` adds a different project (`GuitarAlchemistChatbot.csproj`); the `Apps/GaChatbot` project appears to be a separate console host that is never started by Aspire.
+- Is `Apps/GaChatbot` (console REPL) still reachable in any maintained startup flow? Aspire starts GaApi and ga-client, not the console REPL.
 - Does `AgUiChatController` have any active frontend consumer beyond `<GAChatPanel>` and the ga-client `chatAtoms`? Confirm whether the legacy SSE endpoints (`/chat/stream`, `/chat`) can be retired.
 - Are there any `ChatbotHub` consumers besides the deployed public `/chatbot/` static SPA (`Apps/ga-server/GaApi/wwwroot/chatbot/index.html`)? Confirm before relocating or retiring the hub.
 - Is `GA.AI.Service` (whose `ChatController` shadows `ProductionOrchestrator` directly) ever launched in CI/dev? AppHost registration is commented out (`AllProjects.AppHost/Program.cs:87`); confirm no other entry point spins it up.
-- `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` are registered but not invoked from any controller. Should they be removed, or are they intended for an upcoming SignalR/REST surface?
 - `SemanticRouter.AggregateAsync` and `DebateAsync` (multi-agent fan-out / Critic adjudication) are implemented but no HTTP endpoint exposes them. Plan to surface, or dead code?
 - The Nebula tool `get_corpus_stats` falls back to a hard-coded `{guitar=667125, bass=12614, ukulele=8612}` distribution when `InstrumentCounts` is missing from context (`NebulaSidekickService.cs:545`). Does the React frontend ever populate `instrumentCounts`, or is the fallback the only value the LLM ever sees?
 - `ProductionOrchestrator.AnswerStreamingAsync` only true-streams when the selected agent is a `GuitarAlchemistAgentBase`; tab/path branches and skill fast-paths emit word-level simulated tokens. Is this intentional given the AG-UI contract that frontends interpret as token streaming?

--- a/docs/architecture/chat-surfaces.md
+++ b/docs/architecture/chat-surfaces.md
@@ -2,7 +2,7 @@
 title: Chat & Agent Surfaces
 scope: All HTTP/SignalR/GraphQL chat endpoints and the orchestrator/agent stack behind them
 status: authoritative
-last_verified: 2026-05-07
+last_verified: 2026-05-12
 parent: docs/architecture/README.md
 ---
 
@@ -31,12 +31,38 @@ The product-surface confusion flagged by the 2026-05-07 multi-LLM review is real
 | AG-UI streaming for Prime Radiant / ga-client | `POST /api/chatbot/agui/stream` on **GaApi** | duplicated route in `GaChatbot.Api` is not yet on a deployed origin |
 | In-process chat (CLI / console) | `IHarmonicChatOrchestrator` (`= ProductionOrchestrator`) via DI | nothing |
 
+### Current-state shortcut
+
+Read this section as current state; later sections preserve detailed inventory
+and historical context.
+
+| Keep current | Parallel / sync carefully | Frozen / cleanup candidate |
+|---|---|---|
+| `POST /api/nebula/chat` for Harmonic Nebula | `/api/chatbot/chat` and `/api/chatbot/chat/stream` REST/SSE siblings | `GA.AI.Service` |
+| `/hubs/chatbot` for deployed public `/chatbot/` demo | `GaChatbot.Api` reference host | stale startup / Docker references to historical chatbot names |
+| `/api/chatbot/agui/stream` for AG-UI surfaces | `ChatbotSessionOrchestrator.NormalizeHistory` helper | `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` |
+| `IChatApplicationService` + `ProductionOrchestrator` substrate | legacy startup scripts mentioning deleted/frozen chatbot names | stale Docker Compose chatbot references |
+
 ### Decision pending
 
 Before declaring `GaChatbot.Api` the canonical deployable, one of three paths needs to be chosen — each has different blast radius (Section 5b enumerates).
 
 - Verified canonical Nebula path (used by `NebulaChat.tsx`): `NebulaChatController` → `NebulaSidekickService` → Anthropic Claude Haiku 4.5 (or Ollama).
 - Verified canonical demo path (used by `wwwroot/chatbot/index.html`): SPA → SignalR `/hubs/chatbot` → GaApi `ChatbotHub` → `ProductionOrchestrator`.
+
+### Verification notes — 2026-05-12
+
+- `Apps/ga-server/GaApi/wwwroot/chatbot/index.html` loads SignalR and calls
+  `withUrl("/hubs/chatbot")`.
+- `Apps/ga-server/GaApi/Program.cs` maps
+  `app.MapHub<ChatbotHub>("/hubs/chatbot")`.
+- `ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx`
+  no longer calls `/api/chatbot/ask`; it now uses existing chatbot surfaces for
+  summary fallback.
+- `AllProjects.AppHost/Program.cs` starts `GaApi`, does not register
+  `GaChatbot.Api`, and keeps `GA.AI.Service` commented out as `ai-service`.
+- `Scripts/start-chatbot-api.ps1` can start `GaChatbot.Api` manually; that is
+  not the same as making it the public deployed chatbot host.
 
 ---
 
@@ -52,7 +78,6 @@ Before declaring `GaChatbot.Api` the canonical deployable, one of three paths ne
 | `/api/chatbot/chat` | POST | `ChatbotController.Chat` (`Apps/ga-server/GaApi/Controllers/ChatbotController.cs:119`) | GaApi | `ChatRequest` (same as above) | `ChatJsonResponse { NaturalLanguageAnswer; AgentId; Confidence; RoutingMethod; ElapsedMs; TraceId? }` (`ChatRequest.cs:15`) | 🟡 parallel-to-canonical | Non-streaming JSON for MCP tool callers. |
 | `/api/chatbot/status` | GET | `ChatbotController.GetStatus` (`Apps/ga-server/GaApi/Controllers/ChatbotController.cs:159`) | GaApi | _(none)_ | `ChatbotStatus { IsAvailable; Message; Timestamp }` (`Apps/ga-server/GaApi/Controllers/ChatbotStatus.cs:3`) | 🟡 health helper | Probes `IChatService.IsAvailableAsync` (Ollama by default). |
 | `/api/chatbot/examples` | GET | `ChatbotController.GetExamples` (`Apps/ga-server/GaApi/Controllers/ChatbotController.cs:177`) | GaApi | _(none)_ | `string[]` of canned prompts | 🟡 helper | Hard-coded list, no orchestrator hop. |
-| `/api/chatbot/ask` | POST | _(no controller)_ | GaApi (?) | unknown — frontend sends `{question?, query?}` (`ReactComponents/.../PrimeRadiant/TriageDropZone.tsx:82`) | _N/A_ | 🪦 deprecated-candidate / dangling | No matching server-side action found via grep across `Apps/ga-server/`. Frontend caller likely fails with 404 today. |
 | `/api/Chat` | POST | `GA.AI.Service.Controllers.ChatController.Chat` (`Apps/ga-server/GA.AI.Service/Controllers/ChatController.cs:14`) | **GA.AI.Service** (separate microservice) | `GA.Business.Core.Orchestration.Models.ChatRequest { Message; SessionId?; KeyContext?; History? }` (`Common/GA.Business.Core.Orchestration/Models/ChatModels.cs:11`) | `ChatResponse { NaturalLanguageAnswer; Candidates; Progression?; Routing?; QueryFilters?; DebugParams? }` (`ChatModels.cs:86`) | 🪦 deprecated-candidate | Service is **not started** by Aspire AppHost — `AddProject("ai-service", …)` is commented out at `AllProjects.AppHost/Program.cs:87`. Reachable only if launched manually. |
 | GraphQL `/graphql` chat mutations | _N/A_ | _N/A_ | GaApi | _(none)_ | _(none)_ | ❌ none exist | The HotChocolate schema is built from `Query` + four `TypeExtension`s only (`Apps/ga-server/GaApi/Program.cs:113-121`). Grep for `[Mutation]`, `MutationType`, `Subscription` in `Apps/ga-server/GaApi/GraphQL/**` returns no matches. |
 
@@ -93,7 +118,7 @@ Tool catalogue exposed to the model: `search_voicings`, `describe_selected_voici
 
 | Hub | Path | App | Methods | Status |
 |---|---|---|---|---|
-| `ChatbotHub` (`Apps/ga-server/GaApi/Hubs/ChatbotHub.cs:15`) | `/hubs/chatbot` (mapped at `Apps/ga-server/GaApi/Program.cs:404`) | GaApi | `SendMessage(string, bool useSemanticSearch = true)`, `ClearHistory()`, `GetHistory() : List<ChatMessage>`, `SearchKnowledge(string, int = 10) : List<SemanticSearchResult>`, `OnConnectedAsync`, `OnDisconnectedAsync`. Server pushes: `Connected`, `Error`, `MessageRoutingMetadata { agentId, confidence, routingMethod }`, `ReceiveMessageChunk(string)`, `MessageComplete(string)`. | 🟡 parallel-to-canonical (no frontend grep hit) |
+| `ChatbotHub` (`Apps/ga-server/GaApi/Hubs/ChatbotHub.cs:15`) | `/hubs/chatbot` (mapped at `Apps/ga-server/GaApi/Program.cs:404`) | GaApi | `SendMessage(string, bool useSemanticSearch = true)`, `ClearHistory()`, `GetHistory() : List<ChatMessage>`, `SearchKnowledge(string, int = 10) : List<SemanticSearchResult>`, `OnConnectedAsync`, `OnDisconnectedAsync`. Server pushes: `Connected`, `Error`, `MessageRoutingMetadata { agentId, confidence, routingMethod }`, `ReceiveMessageChunk(string)`, `MessageComplete(string)`. | ✅ de-facto canonical for the deployed public `/chatbot/` demo |
 
 Per-connection conversation history kept in a static `ConcurrentDictionary<string, List<ChatMessage>>` capped at 50 messages; pipeline budget is `25s` (`ChatbotHub.cs:24`). Uses `[Authorize]` and `ILlmConcurrencyGate`. Backed by `ProductionOrchestrator` + `ChatbotSessionOrchestrator` for history normalisation.
 
@@ -159,7 +184,7 @@ Important: `IChatService` is **not** the same channel as the `IChatClient` (Micr
 | `Apps/ga-client/src/services/chatApi.ts` (`ChatApiService.streamChat`, `sendMessage`, `checkStatus`, `getExamples`) | `POST /api/chatbot/chat/stream`, `POST /api/chatbot/chat`, `GET /api/chatbot/status`, `GET /api/chatbot/examples` | Pre-AG-UI SSE protocol still imported by some ga-client surfaces. Singleton exported as `chatApi`. |
 | `Apps/ga-client/src/services/chatService.ts:94` (`sendChatMessageStream`) | `POST /api/chatbot/chat/stream` | Same protocol, alternate functional API. |
 | `<ChatWidget>` (`ReactComponents/ga-react-components/src/components/PrimeRadiant/ChatWidget.tsx:917`) | `POST /api/chatbot/chat` | Non-streaming. Used inside the Prime Radiant operator console. |
-| `<TriageDropZone>` (`ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx:82`) | `POST /api/chatbot/ask` | **No matching server endpoint exists.** Likely 404 today — see Open Questions. |
+| `<TriageDropZone>` (`ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx:82`) | `POST /api/chatbot/chat`, fallback `POST /api/nebula/chat` | Uses existing chatbot endpoints for best-effort URL summaries. |
 | `<ForceRadiant>` (`…/PrimeRadiant/ForceRadiant.tsx:3502`), `HealthBindingEngine.ts:198` | `GET/HEAD /api/chatbot/status` | Health probe only. |
 | Apps/GaChatbot Console (`Apps/GaChatbot/Program.cs:25`) | _(no HTTP)_ | In-process: instantiates `ProductionOrchestrator` directly via DI and calls `AnswerAsync`. Console REPL. |
 | Apps/GaChatbotCli (`Apps/GaChatbotCli/Program.cs:55,91`) | _(no HTTP)_ | In-process: resolves `IHarmonicChatOrchestrator` (= `ProductionOrchestrator`) via DI. Single-shot or `--interactive` REPL. JSON output mode for tooling. |
@@ -225,13 +250,12 @@ The deployed `https://demos.guitaralchemist.com/chatbot/` static SPA calls `/hub
 | **HTTP endpoint serving the legacy ga-client / Prime Radiant chat UIs** | ✅ AG-UI: `POST /api/chatbot/agui/stream` → `AgUiChatController.AgUiStream` → `IHarmonicChatOrchestrator.AnswerStreamingAsync` (= `ProductionOrchestrator`). | 🟡 `POST /api/chatbot/chat/stream` (`ChatbotController`) — same orchestrator backend, different SSE shape; still consumed by `chatApi.ts` + `chatService.ts`. 🟡 `POST /api/chatbot/agui/json` — non-streaming sibling, same orchestrator, used by MCP / agent callers. 🟡 `POST /api/chatbot/chat` — non-streaming sibling, same orchestrator, used by `<ChatWidget>`. |
 | **In-process chat for console / CLI** | ✅ `IHarmonicChatOrchestrator` (= `ProductionOrchestrator`) resolved via DI in `GaChatbotCli` and `GaChatbot`. | None notable — both apps share the same `AddChatbotOrchestration` registrations. |
 | **AG-UI protocol bridge** | ✅ `AgUiChatController` (`/agui/stream` for SSE, `/agui/json` for non-streaming). | None (single implementation). |
-| **SignalR streaming chat** | 🟡 `ChatbotHub` at `/hubs/chatbot` — same `ProductionOrchestrator` backend, but no JS/TS frontend hits the hub today (`signalR`/`hubConnection` greps return zero matches under `Apps/`). | 🪦 deprecated-candidate unless a consumer is reintroduced. |
+| **SignalR streaming chat** | ✅ `ChatbotHub` at `/hubs/chatbot` — same orchestrator substrate as the REST surfaces and the de-facto canonical path for the deployed public `/chatbot/` demo. | 🟡 Parallel REST/SSE surfaces exist (`/api/chatbot/chat`, `/api/chatbot/chat/stream`) and must stay wire-equivalent where the public demo depends on shared metadata (`Grounding`, `Trace`, routing). |
 | **GraphQL chat mutation** | ❌ none defined; `GaApi/Program.cs:113-121` registers Query types only. | _N/A_ |
 | **`IChatService` (GaApi-local)** | ✅ used by `ChatbotSessionOrchestrator.NormalizeHistory` and `ChatbotController.GetStatus` only. Provider chosen via `AI:ChatProvider`. | 🟡 `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` exist but are not called from any controller or hub today. |
 | **Specialized agent invocation** | ✅ via `SemanticRouter.RouteAsync` (called by `ProductionOrchestrator`). | 🟡 `SemanticRouter.AggregateAsync` and `DebateAsync` exist but are not currently exposed through any HTTP/SignalR surface. |
 | **Voicing-grounded retrieval inside chat** | ✅ `SpectralRagOrchestrator` reached via `TabAwareOrchestrator`. | 🟡 `VoicingAgent` performs an independent OPTIC-K retrieval path through `EnhancedVoicingSearchService` whenever the router selects it — produces a structured-list response rather than a narrated one. Two independent retrieval surfaces over the same corpus. |
 | **GA.AI.Service / `POST /api/Chat`** | _N/A_ | 🪦 **frozen 2026-05-07** — see [`Apps/ga-server/GA.AI.Service/DEPRECATED.md`](../../Apps/ga-server/GA.AI.Service/DEPRECATED.md). Read-only until a concrete deploy reason emerges or the next architecture review decides to delete. |
-| **`POST /api/chatbot/ask`** | _N/A_ | 🪦 dangling frontend call (TriageDropZone) with no server implementation. |
 
 ---
 
@@ -257,7 +281,6 @@ flowchart LR
         AGJ["POST /api/chatbot/agui/json 🟡"]
         CCS["POST /api/chatbot/chat/stream 🟡"]
         CC["POST /api/chatbot/chat 🟡"]
-        ASK["POST /api/chatbot/ask 🪦"]
         STAT["GET /api/chatbot/status 🟡"]
         HUB["SignalR /hubs/chatbot 🟡"]
     end
@@ -308,7 +331,8 @@ flowchart LR
     CHATAPI --> CC
     CHATAPI --> STAT
     CW --> CC
-    TDZ -.dangling.-> ASK
+    TDZ --> CC
+    TDZ -.fallback.-> NEB
 
     CCS --> PROD
     CC --> PROD
@@ -350,8 +374,7 @@ flowchart LR
 
 - Is `Apps/GaChatbot` (console REPL) still reachable in the Aspire `start-all` flow? `AllProjects.AppHost/Program.cs:135` adds a different project (`GuitarAlchemistChatbot.csproj`); the `Apps/GaChatbot` project appears to be a separate console host that is never started by Aspire.
 - Does `AgUiChatController` have any active frontend consumer beyond `<GAChatPanel>` and the ga-client `chatAtoms`? Confirm whether the legacy SSE endpoints (`/chat/stream`, `/chat`) can be retired.
-- Does any client connect to `ChatbotHub` (`/hubs/chatbot`)? Grep for `signalR`/`hubConnection` under `Apps/` returns zero matches; the hub may be dead today.
-- `POST /api/chatbot/ask` is called by `TriageDropZone` but no controller action implements it — does this fail silently or is it served by a route fallback elsewhere?
+- Are there any `ChatbotHub` consumers besides the deployed public `/chatbot/` static SPA (`Apps/ga-server/GaApi/wwwroot/chatbot/index.html`)? Confirm before relocating or retiring the hub.
 - Is `GA.AI.Service` (whose `ChatController` shadows `ProductionOrchestrator` directly) ever launched in CI/dev? AppHost registration is commented out (`AllProjects.AppHost/Program.cs:87`); confirm no other entry point spins it up.
 - `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` are registered but not invoked from any controller. Should they be removed, or are they intended for an upcoming SignalR/REST surface?
 - `SemanticRouter.AggregateAsync` and `DebateAsync` (multi-agent fan-out / Critic adjudication) are implemented but no HTTP endpoint exposes them. Plan to surface, or dead code?

--- a/docs/architecture/chatbot-claude-handoff.md
+++ b/docs/architecture/chatbot-claude-handoff.md
@@ -1,0 +1,77 @@
+---
+title: GA Chatbot Claude Code Handoff
+scope: Prompt-ready context for Claude Code or another coding agent before chatbot work.
+status: authoritative
+last_verified: 2026-05-12
+parent: docs/architecture/README.md
+---
+
+# GA Chatbot Claude Code Handoff
+
+Use this before assigning chatbot work to Claude Code.
+
+## Read Order
+
+1. `CLAUDE.md`
+2. `docs/architecture/chatbot-overview.md`
+3. `docs/architecture/chat-surfaces.md`
+4. `docs/plans/2026-05-07-chatbot-roadmap.md`
+5. `docs/plans/2026-05-06-skills-orchestration-architecture.md`
+6. `docs/chatbot/Chatbot_Technical_Roadmap.md` only for long-term product context
+
+Treat `chat-surfaces.md` as authoritative for runtime wiring. Treat the
+2026-05-07 roadmap as authoritative for shipped orchestration decisions.
+
+## Current Shape
+
+- Harmonic Nebula uses `POST /api/nebula/chat`.
+- The public `/chatbot/` demo uses GaApi SignalR `/hubs/chatbot`.
+- AG-UI surfaces use `/api/chatbot/agui/stream`.
+- REST/SSE siblings exist at `/api/chatbot/chat` and `/api/chatbot/chat/stream`.
+- `IChatApplicationService` is the host-neutral orchestration boundary.
+- `ProductionOrchestrator` owns the main skill/router/RAG path.
+- `GaChatbot.Api` compiles but is not the public deployed host.
+- `GA.AI.Service` is frozen.
+
+## Do Not Do Silently
+
+- Do not promote `GaChatbot.Api` without updating AppHost, ingress, docs, and
+  the public `/chatbot/` SPA route.
+- Do not add chatbot behavior to `GA.AI.Service`.
+- Do not change public chat wire fields (`Grounding`, `Trace`, routing
+  metadata, failure reasons) without updating `chat-surfaces.md`.
+- Do not let deterministic skills silently degrade when `ga_dsl_eval` or a
+  keyhole MCP tool was expected.
+- Do not treat simulated word-split streaming as true model streaming without
+  documenting the limitation.
+
+## Common Traps
+
+- `IChatService` and `IChatClient` are different abstractions.
+- `NebulaSidekickService` talks to providers directly and is not the same path
+  as `ProductionOrchestrator`.
+- `ChatbotHub` is not dead: the public `/chatbot/` SPA calls `/hubs/chatbot`.
+- `POST /api/chatbot/ask` was removed from `TriageDropZone`; do not reintroduce
+  it without adding a tested server route.
+- `ChatbotSessionOrchestrator.GetResponseAsync` and `StreamResponseAsync` are
+  cleanup candidates, not the canonical request path.
+
+## Verification Commands
+
+```powershell
+rg -n "/hubs/chatbot|HubConnectionBuilder|signalR" Apps/ga-server/GaApi/wwwroot/chatbot
+rg -n "MapHub<ChatbotHub>|/hubs/chatbot" Apps/ga-server/GaApi/Program.cs
+rg -n "api/chatbot/ask|chatbot/ask" Apps ReactComponents
+rg -n "GaChatbot.Api|GA.AI.Service|ai-service" AllProjects.AppHost Apps Scripts docker-compose.yml
+```
+
+## Test Commands
+
+```powershell
+dotnet build AllProjects.slnx -c Debug
+dotnet test AllProjects.slnx
+pwsh Scripts/test-chatbot-quality.ps1
+```
+
+For narrower changes, prefer targeted tests first, then run the full build/test
+pair before claiming success.

--- a/docs/architecture/chatbot-overview.md
+++ b/docs/architecture/chatbot-overview.md
@@ -1,0 +1,115 @@
+---
+title: GA Chatbot Overview
+scope: Short onboarding map for the current chatbot runtime, roadmap, and skill/DSL architecture.
+status: authoritative
+last_verified: 2026-05-12
+parent: docs/architecture/README.md
+---
+
+# GA Chatbot Overview
+
+This is the short read before changing chatbot code. It points to the detailed
+docs and summarizes the current runtime shape.
+
+## Source of Truth
+
+- Endpoint and runtime inventory:
+  [chat-surfaces.md](chat-surfaces.md)
+- Current execution roadmap:
+  [../plans/2026-05-07-chatbot-roadmap.md](../plans/2026-05-07-chatbot-roadmap.md)
+- Skills / `ga_dsl_eval` / F# closure-registry design:
+  [../plans/2026-05-06-skills-orchestration-architecture.md](../plans/2026-05-06-skills-orchestration-architecture.md)
+- Long-term OPTIC-K / wavelet / spectral-RAG vision:
+  [../chatbot/Chatbot_Technical_Roadmap.md](../chatbot/Chatbot_Technical_Roadmap.md)
+
+When these disagree, trust `chat-surfaces.md` for runtime wiring and the
+2026-05-07 roadmap for shipped orchestration decisions.
+
+## Runtime Shape
+
+GA currently has multiple live chat surfaces:
+
+| Surface | Current role |
+|---|---|
+| `POST /api/nebula/chat` | Harmonic Nebula UI canonical path. Uses `NebulaChatController` and `NebulaSidekickService`. |
+| SignalR `/hubs/chatbot` | De-facto public `/chatbot/` demo path served by GaApi. |
+| `POST /api/chatbot/agui/stream` | AG-UI streaming path for ga-client / Prime Radiant surfaces. |
+| `POST /api/chatbot/chat` and `/chat/stream` | REST/SSE sibling surfaces over the same orchestrator substrate. |
+| `Apps/GaChatbot.Api` | Compiles, but is not the deployed public chatbot host. Keep frozen until there is a concrete deploy reason. |
+| `GA.AI.Service` | Frozen. Do not add new code unless the architecture decision changes. |
+
+```mermaid
+flowchart LR
+  nebula[Harmonic Nebula UI] --> nebulaApi[POST /api/nebula/chat]
+  publicDemo[Public /chatbot/ SPA] --> hub[SignalR /hubs/chatbot]
+  agui[ga-client / Prime Radiant] --> aguiApi[POST /api/chatbot/agui/stream]
+  rest[REST/SSE callers] --> restApi[POST /api/chatbot/chat]
+
+  nebulaApi --> nebulaSvc[NebulaSidekickService]
+  hub --> appSvc[IChatApplicationService]
+  aguiApi --> appSvc
+  restApi --> appSvc
+
+  appSvc --> decorators[Trace / Fallback / Readiness decorators]
+  decorators --> harmonic[HarmonicChatApplicationService]
+  harmonic --> orchestrator[ProductionOrchestrator]
+  orchestrator --> skills[Deterministic skills + ga_dsl_eval]
+  orchestrator --> router[SemanticRouter]
+  orchestrator --> rag[TabAwareOrchestrator + SpectralRagOrchestrator]
+```
+
+## Core Orchestration
+
+The shared runtime substrate is:
+
+```text
+GaApi controller / hub
+  -> IChatApplicationService
+  -> Traceable / Fallback / Readiness decorators
+  -> HarmonicChatApplicationService
+  -> IHarmonicChatOrchestrator
+  -> ProductionOrchestrator
+```
+
+`ProductionOrchestrator` owns the main agentic path: hooks, deterministic
+skills, semantic routing, tab handling, `TabAwareOrchestrator`, and
+`SpectralRagOrchestrator`.
+
+## Skills And DSL
+
+The chatbot uses repo-versioned `skills/` plus C# wrappers. The highest-value
+bridge is `ga_dsl_eval`, which exposes curated F# `GaClosureRegistry` domain
+operations to skill-driven answers without creating one MCP tool per musical
+operation.
+
+Current guidance:
+
+- Keep deterministic music-theory operations grounded through DSL closures or
+  keyhole MCP tools.
+- Do not let the chatbot silently degrade when a deterministic skill fails to
+  call the expected tool.
+- Surface `Grounding`, `Trace`, routing metadata, and failure reasons on public
+  chat wires where clients depend on them.
+
+## Known Sync Points
+
+- Keep `ChatbotHub` and REST/SSE chatbot surfaces wire-equivalent where public
+  metadata matters.
+- Do not promote `GaChatbot.Api` until the deploy target and ingress path are
+  explicit.
+- Treat `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync`
+  as cleanup candidates unless a new consumer appears.
+
+## Verification Notes
+
+Verified by grep on 2026-05-12:
+
+- `Apps/ga-server/GaApi/wwwroot/chatbot/index.html` loads SignalR and calls
+  `withUrl("/hubs/chatbot")`.
+- `Apps/ga-server/GaApi/Program.cs` maps
+  `app.MapHub<ChatbotHub>("/hubs/chatbot")`.
+- `ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx`
+  previously called `/api/chatbot/ask`; it now calls existing chatbot surfaces
+  instead.
+- `AllProjects.AppHost/Program.cs` starts `GaApi` but does not register
+  `GaChatbot.Api`; `GA.AI.Service` remains commented out as `ai-service`.

--- a/docs/chatbot/README.md
+++ b/docs/chatbot/README.md
@@ -1,7 +1,7 @@
 ---
 title: Chatbot — entry point
 status: index
-last_updated: 2026-05-02
+last_updated: 2026-05-12
 ---
 
 # Chatbot — entry point
@@ -13,16 +13,28 @@ index is the consolidation.
 
 ## What is the chatbot?
 
-The user-facing chatbot is the **Harmonic Nebula React UI** backed by the
-**`POST /api/nebula/chat`** endpoint (`NebulaChatController` →
-`NebulaSidekickService` → Anthropic Claude Haiku 4.5 or local Ollama). Every
-other chat surface in the solution is parallel-to-canonical or deprecated.
+The chatbot is not a single endpoint anymore. Current GA has several live chat
+surfaces:
+
+- **Harmonic Nebula UI** — `POST /api/nebula/chat` →
+  `NebulaChatController` → `NebulaSidekickService`.
+- **Public `/chatbot/` demo** — static SPA served by GaApi, connected to
+  SignalR `/hubs/chatbot`.
+- **AG-UI / Prime Radiant / ga-client chat** — `POST
+  /api/chatbot/agui/stream` and related REST/SSE siblings.
+
+All of these converge on the same orchestration substrate where practical, but
+their wire contracts are not identical. For current endpoint status, trust
+`docs/architecture/chat-surfaces.md`.
 
 For the full live architecture — every endpoint, every orchestrator, every
 agent, with status flags — see:
 
-- **`docs/architecture/chat-surfaces.md`** ← authoritative, last verified
-  2026-04-25. Cross-referenced from `docs/architecture/README.md`.
+- **`docs/architecture/chatbot-overview.md`** ← short onboarding map for
+  runtime architecture, roadmap, and skill/DSL docs.
+- **`docs/architecture/chat-surfaces.md`** ← authoritative endpoint /
+  orchestrator inventory, last verified 2026-05-12. Cross-referenced from
+  `docs/architecture/README.md`.
 
 If `chat-surfaces.md` says one thing and any doc here says another, trust
 `chat-surfaces.md`.
@@ -59,9 +71,10 @@ These two were previously buried under
 
 | Surface | Status | Notes |
 |---|---|---|
-| `Apps/ga-server/GaApi/Controllers/NebulaChatController.cs` (+ `NebulaSidekickService`) | ✅ canonical | The user-facing path. |
-| `Apps/ga-server/GaApi/Controllers/AgUiChatController.cs` | 🟡 parallel-to-canonical | AG-UI bridge for ga-react-components. |
-| `Apps/ga-server/GaApi/Controllers/ChatbotController.cs` + `Hubs/ChatbotHub.cs` | 🟡 parallel-to-canonical | Pre-Nebula SSE + SignalR, still used by Prime Radiant ChatWidget. |
+| `Apps/ga-server/GaApi/Controllers/NebulaChatController.cs` (+ `NebulaSidekickService`) | ✅ canonical | Harmonic Nebula user-facing path. |
+| `Apps/ga-server/GaApi/Hubs/ChatbotHub.cs` | ✅ de-facto canonical | Public `/chatbot/` demo SignalR path. |
+| `Apps/ga-server/GaApi/Controllers/AgUiChatController.cs` | ✅ canonical for AG-UI | AG-UI bridge for ga-react-components / ga-client surfaces. |
+| `Apps/ga-server/GaApi/Controllers/ChatbotController.cs` | 🟡 parallel-to-canonical | REST/SSE sibling surface over the orchestrator; keep in sync with `ChatbotHub`. |
 | `Apps/GaChatbot/` (console) | ✅ secondary | Local-dev REPL; not started by Aspire. |
 | `Apps/GaChatbotCli/` | ✅ secondary | Production CLI; supports `--json` and `--interactive`. |
 | `GaMcpServer/Tools/ChatTool.cs` | ✅ live | MCP tool (`AskChatbot`) calling `/api/chatbot/agui/json`. |

--- a/docs/plans/2026-05-06-skills-orchestration-architecture.md
+++ b/docs/plans/2026-05-06-skills-orchestration-architecture.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-05-06
-status: plan (not yet operationalized)
+status: partially executed; see 2026-05-07-chatbot-roadmap.md for current runtime state
 reversibility: phased; Phase 1 is two-way, Phase 2 introduces a one-way door (closure-registry exposure as MCP)
 owners: needs assignment
 audience: GA chatbot maintainers / Claude Code authors
@@ -10,6 +10,17 @@ predecessor: 2026-05-03-chatbot-agent-framework-migration-recommendation.md
 # GA Skills Orchestration Architecture
 
 How the GA chatbot's **C# orchestrator** should consume **both Claude-Code-flavoured `.agent/skills/`** and **chatbot-flavoured `skills/` markdown** to produce grounded answers via the **F# DSL closure registry** and **OPTIC-K hybrid search** — without writing 10 keyhole MCP tools per BACKLOG #139.
+
+## Status Update — 2026-05-12
+
+This document remains the design rationale for the skills / `ga_dsl_eval` /
+F# closure-registry architecture, but parts of it are no longer future tense.
+The implementation work recorded in
+[`2026-05-07-chatbot-roadmap.md`](2026-05-07-chatbot-roadmap.md) shipped the
+closure-registry bootstrap, `ga_dsl_eval` invocation tracking, grounding
+sentinels, deterministic-skill failure taxonomy, and the canonical
+`IChatApplicationService` decorator stack. Treat this plan as background and
+use the roadmap as the current operational state.
 
 ## TL;DR
 
@@ -272,7 +283,9 @@ Each gap becomes a 1-2 day iteration: identify the closure, graduate the SKILL.m
 
 ---
 
-**Status**: this plan is intentionally not yet operationalized — Phase 0 (contract design) needs explicit sign-off before Phase 1 starts. Open questions for the maintainer:
+**Status**: partially executed. The original Phase 0/1 framing is superseded by
+the shipped work tracked in `docs/plans/2026-05-07-chatbot-roadmap.md`. Open
+questions that still matter for future skill graduations:
 1. Closure-arg format: flat key-value, JSON string, or per-closure typed contracts?
 2. Visible-to-chatbot closure set: Domain only, or Domain + curated Pipeline?
 3. Phase 3 success threshold: is 80% invocation success the right bar, or should it be higher?

--- a/docs/plans/2026-05-07-chatbot-roadmap.md
+++ b/docs/plans/2026-05-07-chatbot-roadmap.md
@@ -125,7 +125,7 @@ Already tracked. Re-enables retrieval safely.
 
 Codex's "don't leave a third option dangling" called for either delete or wire-for-a-real-consumer. The full project is bigger than just `ChatController` (8+ controllers covering AI, search, benchmarks, notebooks, tab analysis), so wholesale delete carries reference-value cost. Decision: **firm freeze** with a `DEPRECATED.md` that lists every controller, points at the canonical replacement, and pins hard rules ("do not add new code", "do not re-enable AppHost registration", "do not add ProjectReferences"). `chat-surfaces.md` updated to reflect the freeze. Two named decision triggers tell the next reviewer when to revisit: (a) concrete deploy reason for an AI-workload split, (b) next architecture review concludes reference value has decayed below maintenance cost.
 
-## What this session shipped (8 commits, 2026-05-07)
+## What this session shipped (commit ledger, 2026-05-07 to 2026-05-08)
 
 | Commit | Scope |
 |---|---|

--- a/docs/plans/2026-05-12-chatbot-cleanup-tracker.md
+++ b/docs/plans/2026-05-12-chatbot-cleanup-tracker.md
@@ -83,9 +83,16 @@ demo is served through GaApi SignalR.
 **Done when:** the decision is recorded in `chat-surfaces.md` and the codebase
 matches it.
 
-## 5. Reconcile Startup / Script References To Removed Chatbot Names
+## 5. Reconcile Startup / Script References To Removed Chatbot Names — resolved 2026-05-12
 
 **GitHub:** https://github.com/GuitarAlchemist/ga/issues/206
+
+**Resolution:** `docker-compose.yml` now builds `gaapi` from
+`Apps/ga-server/GaApi/Dockerfile` and no longer defines the removed
+`GuitarAlchemistChatbot` service. `Scripts/start-all.ps1` now builds
+`AllProjects.slnx` and describes the public chatbot demo as served by GaApi.
+`Scripts/health-check.ps1` now checks the GaApi-hosted `/chatbot/` demo instead
+of a deleted standalone Blazor service on port 7002.
 
 **Problem:** scripts and Docker Compose still reference historical
 `GuitarAlchemistChatbot` / `GA.AI.Service` names.

--- a/docs/plans/2026-05-12-chatbot-cleanup-tracker.md
+++ b/docs/plans/2026-05-12-chatbot-cleanup-tracker.md
@@ -1,0 +1,103 @@
+---
+date: 2026-05-12
+status: issue-ready cleanup tracker
+reversibility: two-way
+owners: needs assignment
+audience: GA chatbot maintainers
+---
+
+# Chatbot Cleanup Tracker
+
+This tracker converts the documentation sync findings into issue-ready work.
+No runtime behavior changes are implied by this document.
+
+## 1. Remove Or Implement `/api/chatbot/ask` — resolved 2026-05-12
+
+**GitHub:** https://github.com/GuitarAlchemist/ga/issues/202
+
+**Resolution:** `TriageDropZone.tsx` no longer calls `POST /api/chatbot/ask`.
+Its best-effort summary helper now calls `POST /api/chatbot/chat` and falls
+back to `POST /api/nebula/chat`.
+
+**Original problem:** `TriageDropZone.tsx` called `POST /api/chatbot/ask`, but
+no matching server endpoint was found under `Apps/`.
+
+**Evidence:** grep on 2026-05-12 found the caller at
+`ReactComponents/ga-react-components/src/components/PrimeRadiant/TriageDropZone.tsx`
+and no controller/route implementation.
+
+**Decision options:**
+
+- Add a real GaApi route if Prime Radiant still needs this action.
+- Remove or retarget the frontend caller if the workflow is obsolete.
+
+**Done when:** the caller either reaches a tested endpoint or is removed.
+
+## 2. Decide Fate Of Legacy REST/SSE Chatbot Routes
+
+**GitHub:** https://github.com/GuitarAlchemist/ga/issues/204
+
+**Problem:** `/api/chatbot/chat` and `/api/chatbot/chat/stream` remain useful
+parallel surfaces, but AG-UI and SignalR are the active public paths.
+
+**Decision options:**
+
+- Keep them as supported API surfaces and document wire parity expectations.
+- Deprecate them and move remaining callers to AG-UI or SignalR.
+
+**Done when:** `chat-surfaces.md` lists explicit support status and caller
+inventory for each route.
+
+## 3. Clean Up `ChatbotSessionOrchestrator`
+
+**GitHub:** https://github.com/GuitarAlchemist/ga/issues/205
+
+**Problem:** `NormalizeHistory` is used by `ChatbotHub`, but
+`GetResponseAsync` / `StreamResponseAsync` are registered and not on the
+canonical request path.
+
+**Decision options:**
+
+- Delete unused response methods and keep only history normalization.
+- Move history normalization into the hub/application-service path and delete
+  the class.
+- Keep the methods if a new consumer is named and tested.
+
+**Done when:** dead-code-adjacent methods are removed or have a documented
+consumer.
+
+## 4. Decide `GaChatbot.Api` Host Future
+
+**GitHub:** https://github.com/GuitarAlchemist/ga/issues/203
+
+**Problem:** `GaChatbot.Api` compiles and has useful patterns, but the public
+demo is served through GaApi SignalR.
+
+**Decision options:**
+
+- Promote `GaChatbot.Api` with AppHost + ingress + SPA route changes.
+- Keep it frozen as a reference host.
+- Delete it after porting any remaining useful code to GaApi/common
+  orchestration.
+
+**Done when:** the decision is recorded in `chat-surfaces.md` and the codebase
+matches it.
+
+## 5. Reconcile Startup / Script References To Removed Chatbot Names
+
+**GitHub:** https://github.com/GuitarAlchemist/ga/issues/206
+
+**Problem:** scripts and Docker Compose still reference historical
+`GuitarAlchemistChatbot` / `GA.AI.Service` names.
+
+**Evidence:** grep on 2026-05-12 found references in `docker-compose.yml` and
+several scripts under `Scripts/`.
+
+**Decision options:**
+
+- Remove stale references.
+- Mark scripts as historical.
+- Update scripts to use the current GaApi / GaChatbot.Api story.
+
+**Done when:** startup docs/scripts no longer imply deleted or frozen chatbot
+services are current defaults.


### PR DESCRIPTION
## Summary

Wires Inception Labs Mercury 2 as a keyed subagent \`IChatClient\` that \`LlmMusicalQueryExtractor\` uses for fuzzy-query parsing when both flags are set: \`Inception:EnableForQueryExtraction=true\` AND \`INCEPTION_API_KEY\` env var present. **Default OFF** in the committed config — a fresh clone preserves the existing Haiku/Ollama behavior unchanged.

Companion PR: **#207** (docs-only, the evaluation plan with full benchmark + design rationale).

## Benchmark (executed 2026-05-13, 25 voicing queries)

| Metric | Mercury 2 (tuned prompt) | Haiku 4.5 (current) |
|---|---:|---:|
| Median latency | **369 ms** | ~1,500–2,000 ms |
| P95 latency | 729 ms | ~3,000 ms |
| Cost per call | **\$0.000307** | ~\$0.003 |
| Quality (5/8 + 3 fixes) | 8/8 perfect on production-path queries | baseline |

3× latency improvement, 10× cost reduction. The pre-existing typed extractor handles ~96% of queries with zero LLM cost; this PR only affects the fuzzy-query fallback path.

## Two-flag opt-in design

The provider is wired but inactive unless **both** signals are set:

\`\`\`json
// appsettings.Development.json (committed)
\"Inception\": {
  \"EnableForQueryExtraction\": false   // operator flips locally to opt in
}
\`\`\`

\`\`\`pwsh
# Out-of-band — user/CI env var, never committed
setx INCEPTION_API_KEY \"sk_...\"
\`\`\`

\`InceptionProvider.IsEnabledForQueryExtraction\` returns true only when:
1. \`Inception:ApiKey\` resolves (from config OR env var)
2. \`Inception:EnableForQueryExtraction\` is true

A stray \`INCEPTION_API_KEY\` env var alone cannot silently re-route traffic. Same shape as \`AI:ChatProvider=claude\`.

## Tuned system prompt (validated against Mercury)

\`LlmMusicalQueryExtractor.SystemPrompt\` adds:
- **Root-keeps-priority rule** — \`F# Lydian\` → \`chord:\"F#\", mode:\"Lydian\"\` (was \`chord:null\`)
- **Mode-field-no-root rule** — \`D Dorian\` → \`mode:\"Dorian\"\` (was \`mode:\"D Dorian\"\`)
- **Iconic-chord-tag rule** — \`bill evans\` → \`bill-evans-chord\` as one tag, never split
- **Three few-shot examples** covering mode-with-root, iconic-tag, and chord-with-tags cases

Validated 4/4 mode-only-query misses fixed; cost increase \$0.00015/call. Out-of-prod-path cosmetic regression on iconic-chord queries (typed extractor catches them before LLM fallback fires).

## Files

| File | Δ |
|---|---:|
| \`Common/GA.Business.ML/Providers/InceptionProvider.cs\` (new) | +193 |
| \`Tests/Common/GA.Business.ML.Tests/Providers/InceptionProviderTests.cs\` (new) | +128 |
| \`Common/GA.Business.ML/Search/MusicalQueryExtractor.cs\` (tuned prompt) | +46 / -7 |
| \`Apps/ga-server/GaApi/Extensions/AIServiceExtensions.cs\` (DI wiring) | +41 |
| \`Apps/ga-server/GaApi/appsettings.Development.json\` (flag = false) | +15 |
| **Total** | **+423 / -7** |

## Test plan

- [x] \`dotnet build Apps/ga-server/GaApi/GaApi.csproj\` — 0 errors
- [x] Live benchmark via PowerShell HTTP client — 25 queries, 0 failures, median 369 ms
- [ ] \`dotnet test\` on \`InceptionProviderTests\` — **blocked by pre-existing build errors** in \`Tests/.../Integration/{OllamaProvider,HybridEmbeddingService}IntegrationTests.cs\` (since 2026-03-02 commit \`3dff78d0\`). The new tests compile via the language server but the project can't run until those unrelated files are repaired. Separate concern.
- [ ] End-to-end with GaApi: \`setx\` the key, flip the flag locally, restart, drive a fuzzy query through the chatbot, observe Mercury in the response path.

## Risks

- **API key handling.** The 2026-05-13 session's key was pasted in chat and remains in the conversation transcript. It's stored in the user-level Windows env var locally, but **should be rotated** before this PR merges. The integration reads from env exclusively — no key is in any committed file.
- **Pre-existing test breakage** blocks formal CI validation of \`InceptionProviderTests\`. Repairing the broken integration tests is the next dependency.
- **Mercury hasn't been tested on the main chat loop.** This integration is intentionally subagent-scoped (utility tier). The chatbot's main \`IChatClient\` stays on Anthropic Haiku where tool-use reliability matters more than per-call latency.

## Activation procedure (when ready)

1. Rotate the API key on Inception's dashboard
2. \`setx INCEPTION_API_KEY \"sk_new...\"\` on the dev machine
3. Edit \`appsettings.Development.json\` locally to set \`EnableForQueryExtraction: true\` (do not commit)
4. Restart GaApi
5. Run a fuzzy query and confirm latency in the \`Microsoft.Extensions.AI\` logs