### PR TITLE
feat: install agent-blackbox PR risk-report workflow + policy

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -1,0 +1,89 @@
+name: Agent Blackbox
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+env:
+  VERIFY_COMMAND: "dotnet test AllProjects.slnx"
+
+jobs:
+  risk-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout Agent Blackbox
+        uses: actions/checkout@v4
+        with:
+          repository: GuitarAlchemist/agent-blackbox
+          path: .agent-blackbox
+          token: ${{ secrets.AGENT_BLACKBOX_TOKEN || github.token }}
+
+      - name: Collect PR evidence
+        shell: bash
+        run: |
+          mkdir -p dist
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > dist/changed-files.txt
+          git diff "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > dist/diff.patch
+          set +e
+          bash -lc "$VERIFY_COMMAND" > dist/test-output.txt 2>&1
+          verify_exit=$?
+          set -e
+          echo "verify_exit=$verify_exit" >> "$GITHUB_ENV"
+          echo "verify command exited with code $verify_exit" >> dist/test-output.txt
+          cat dist/test-output.txt
+
+      - name: Generate risk report
+        shell: bash
+        run: |
+          PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox analyze \
+            --policy agent-blackbox.policy.json \
+            --changed-files dist/changed-files.txt \
+            --diff dist/diff.patch \
+            --test-output dist/test-output.txt \
+            --out-dir dist
+
+      - name: Comment risk report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- agent-blackbox-risk-report -->';
+            const body = marker + '\n' + fs.readFileSync('dist/risk-report.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.data.find(comment =>
+              comment.user.type === 'Bot' && comment.body && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Upload risk artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-blackbox-risk-report
+          path: dist/
+
+      - name: Enforce verdict
+        shell: bash
+        env:
+          AGENT_BLACKBOX_REVIEWED: ${{ contains(github.event.pull_request.labels.*.name, 'agent-blackbox-reviewed') }}
+        run: |
+          if [ "$AGENT_BLACKBOX_REVIEWED" = "true" ]; then
+            echo "Agent Blackbox human-review override label present; skipping hard enforcement."
+            exit 0
+          fi
+          PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox enforce --report dist/risk-report.json

--- a/agent-blackbox.policy.json
+++ b/agent-blackbox.policy.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.1.0",
+  "risk_thresholds": {
+    "pass": 0.25,
+    "warn": 0.6
+  },
+  "blocked_paths": [
+    ".github/workflows/**",
+    "infra/production/**",
+    "billing/**",
+    "legal/**",
+    "security/**",
+    "Directory.Packages.props",
+    "global.json"
+  ],
+  "one_way_door_paths": [
+    "schemas/**",
+    "contracts/**",
+    "migrations/**",
+    "**/*.sln",
+    "**/*.slnx",
+    "**/*.csproj",
+    "**/*.fsproj"
+  ],
+  "required_evidence": [
+    "changed_files",
+    "test_output",
+    "risk_report"
+  ]
+}


### PR DESCRIPTION
## Summary

Installs [Agent Blackbox](https://github.com/GuitarAlchemist/agent-blackbox) on GA per [docs/install.md](https://github.com/GuitarAlchemist/agent-blackbox/blob/main/docs/install.md) "Dogfood Targets" — turns every PR into an auditable agent risk report grounded in IX primitives.

> *agent trace + diff + tests + repo policy -> risk report + coherence score + PR verdict*

## What's installed

| File | Purpose |
|---|---|
| `.github/workflows/agent-blackbox.yml` | Runs on `pull_request` events. Checks out agent-blackbox alongside, collects changed-files + diff + `dotnet test AllProjects.slnx` output, runs `cli.agent_blackbox analyze + enforce`, posts an idempotent risk-report comment on the PR, and gates merge via `enforce` unless the `agent-blackbox-reviewed` label is set as a human override. |
| `agent-blackbox.policy.json` | .NET policy template — `blocked_paths` includes `.github/workflows/**`, `infra/production/**`, `billing/**`, `legal/**`, `security/**`, `Directory.Packages.props`, `global.json`. `one_way_door_paths` includes `schemas/**`, `contracts/**`, `migrations/**`, `**/*.sln(x)`, `**/*.csproj`, `**/*.fsproj` (GA's existing one-way-door surface). `required_evidence: [changed_files, test_output, risk_report]`. |

`VERIFY_COMMAND` is set to `dotnet test AllProjects.slnx` (full backend test suite — per CLAUDE.md "Verify before claiming success").

## ⚠️ Prerequisite — needs admin action

Add `AGENT_BLACKBOX_TOKEN` to **GA's repo secrets** (Settings → Secrets and variables → Actions → New repository secret) with read scope on `GuitarAlchemist/agent-blackbox`. This is required because agent-blackbox is private and GA's default `GITHUB_TOKEN` can't read another repo.

Without that secret, the workflow falls back to `github.token` (will fail on the agent-blackbox checkout step).

## How to test

1. Add the `AGENT_BLACKBOX_TOKEN` secret (above)
2. Open this PR (or any PR) — workflow fires on `pull_request: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]`
3. Within ~10 min you should see:
   - A risk-report comment posted by the action (idempotent — updates in place on re-runs)
   - `agent-blackbox-risk-report` artifact uploaded
   - `enforce` step pass/fail based on risk thresholds (`pass: 0.25`, `warn: 0.6`)
4. If you accept a fail verdict deliberately, label the PR with `agent-blackbox-reviewed` to skip enforcement on that PR only

## Out of scope (deferred)

- Agent trace ingestion (`--trace` flag) — needs Claude Code trace exporter
- Cross-repo IX integration (blast radius, code metrics) — agent-blackbox CLI handles it locally for v0.1
- Dashboard / SaaS surface — repo's product roadmap, separate effort

## Reference

- Source: `../agent-blackbox/` (locally) / [GuitarAlchemist/agent-blackbox](https://github.com/GuitarAlchemist/agent-blackbox)
- Install guide: [`docs/install.md`](https://github.com/GuitarAlchemist/agent-blackbox/blob/main/docs/install.md)
- Product brief: [`docs/product-brief.md`](https://github.com/GuitarAlchemist/agent-blackbox/blob/main/docs/product-brief.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)