### PR TITLE
feat(quality): schema-pin sidecar for state/quality/** artifacts

### DIFF
--- a/state/quality/_schema.json
+++ b/state/quality/_schema.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "Schema pin declaration for state/quality/** artifacts in this repo. Phase 0 deliverable #5 of docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md. Closes the silent-baseline-invalidation gap surfaced in the 2026-05-14 octo brainstorm: when OPTIC-K bumps (e.g. v1.8 -> v1.9), this file MUST be updated *before* consumers re-tune against new artifacts.",
+  "schema_version": 1,
+  "applies_to_path": "state/quality/**",
+  "pins": {
+    "OPTIC-K": "v1.8",
+    "dotnet": "10.0.1xx",
+    "qa_verdict_schema": "docs/contracts/qa-verdict.schema.json",
+    "digest_schema": "docs/contracts/digest-schema.json"
+  },
+  "policy": {
+    "scope": "Quality artifacts produced AFTER this file's git introduction are considered pinned to these versions. Artifacts pre-dating this file are implicitly draft/v0.",
+    "bump_rule": "On any pin version bump, the autonomous improvement loop MUST refuse to compare new outputs against pre-bump baselines. Cascade invalidation enforced via per-domain .lock + manual rebaselining.",
+    "owner": "GA + cross-repo coordinator (Demerzel tribunal)"
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0 deliverable #5 of [v2 plan](docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md). Closes the **silent-baseline-invalidation gap** surfaced in the 2026-05-14 octo brainstorm: when OPTIC-K bumps (e.g. v1.8 → v1.9), this sidecar MUST be updated *before* consumers re-tune against new artifacts.

## What ships

One file: `state/quality/_schema.json` declaring:

| Pin | Value |
|---|---|
| OPTIC-K | v1.8 |
| dotnet | 10.0.1xx |
| qa_verdict_schema | docs/contracts/qa-verdict.schema.json |
| digest_schema | docs/contracts/digest-schema.json |

## Pragmatic deviation from literal v2 plan

The v2 plan text says "add `_schema` field per file." Most `state/quality/` artifacts are regenerable dated snapshots (e.g. `chatbot-baseline-2026-05-03.json`, daily `routing-eval-*`). Editing each one would touch ~30 files and would need to be re-applied every time a snapshot regenerates.

**Sidecar pattern** achieves the same semantic outcome (loops compare new outputs against the pinned version; refuse on mismatch) with one file instead of editing dozens. The policy text explicitly handles the cascade-invalidation rule.

## Companion PRs

- ix#TBD — `state/quality/_schema.json` (OPTIC-K v1.8, rust 1.80+)
- Demerzel#TBD — `state/quality-trend/_schema.json` (canonical coordinator role)
- tars#TBD — `v2/baselines/_schema.json` (per-model overrides via `models` map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)