### PR TITLE
fix(chatbot): set Chatbot:PathBase=/chatbot default — closes /chatbot/ 404

### DIFF
--- a/Apps/GaChatbot.Api/appsettings.json
+++ b/Apps/GaChatbot.Api/appsettings.json
@@ -35,6 +35,7 @@
     "Model": "llama3.2:3b",
     "HistoryLimit": 12,
     "StreamTimeoutSeconds": 180,
+    "PathBase": "/chatbot",
     "Memory": {
       "InjectContext": false,
       "PersistResponses": true


### PR DESCRIPTION
## Summary

Production fix — `https://demos.guitaralchemist.com/chatbot/` returns **404**. No launch path sets `Chatbot__PathBase`, so `Program.cs` reads it as empty and never calls `app.UsePathBase()`.

## What broke

Four places that *could* set PathBase, none do:

| Place | Status |
|---|---|
| `appsettings.json` `Chatbot` block | ❌ Missing |
| `launchSettings.json` | ❌ Only `ASPNETCORE_ENVIRONMENT` |
| `Scripts/start-chatbot-api.ps1` | ❌ Only `ASPNETCORE_URLS` |
| `Scripts/start-chatbot-dev.ps1` | ❌ Only `ASPNETCORE_ENVIRONMENT` + `ASPNETCORE_URLS` |

Running GaChatbot.Api process (PID 51928, started 2026-05-14) hit `Program.cs` line 44 empty-default branch → no `UsePathBase` → `/chatbot/` 404s → Cloudflare passes through → public 404.

## Fix

Single-line addition to `appsettings.json` `Chatbot` block:

```json
"PathBase": "/chatbot"
```

Single source of truth — applies to every launch (IDE, `dotnet run`, the two scripts, manual exe, Aspire, production).

## Safety

`Program.cs` lines 40-44 explicit: *"UsePathBase only strips the prefix when present, so BOTH access modes coexist."* Existing test `Root_DirectRoot_StillReturnsChatbotHtml_WhenPathBaseIsConfigured` pins this. Tests configure their own PathBase via `WebApplicationFactory` — appsettings default has no test-side impact.

## Verification

```powershell
# After rebuild + restart
curl http://localhost:5252/                          # 200 (root still works)
curl http://localhost:5252/chatbot/                  # 200 (NEW — fixed)
curl https://demos.guitaralchemist.com/chatbot/      # 200 (Cloudflare unchanged)
```

## Immediate unblock without waiting for merge

Either cherry-pick this one-line change locally + rebuild + restart, OR set `$env:Chatbot__PathBase = '/chatbot'` before launching `Scripts/start-chatbot-api.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)