### PR TITLE
chore: add CODEOWNERS for cross-repo schemas + Phase 0 discipline plans

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# CODEOWNERS — required reviewer rules
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Rules below are *additive* to branch protection. GitHub requires a CODEOWNERS
+# reviewer on PRs touching listed paths when branch protection enables it.
+#
+# Maintainer: @spareilleux. Add additional reviewers per path as the team grows.
+
+# ============================================================================
+# Cross-repo contracts — canonical source for ga / ix / tars / Demerzel
+# ============================================================================
+# These schemas are vendored into sibling repos and bumping them silently
+# invalidates downstream baselines. The 2026-05-15 octo security review
+# flagged auto-propagation of GA schema changes as a HIGH-severity gap:
+# a compromised PR could widen schema validation (e.g. add a permissive
+# `producer` enum value) and the vendored copies would pick it up without
+# scrutiny. Require human review on every schema change.
+
+/docs/contracts/                                  @spareilleux
+/docs/contracts/qa-verdict.schema.json            @spareilleux
+/docs/contracts/qa-verdict.contract.md            @spareilleux
+/docs/contracts/optick-sae-artifact.schema.json   @spareilleux
+/docs/contracts/optick-sae-artifact.contract.md   @spareilleux
+/docs/contracts/digest-schema.json                @spareilleux
+
+# ============================================================================
+# Cross-repo discipline plans
+# ============================================================================
+# Plan docs that lock cross-repo behaviour (deadlines, sign-off lists,
+# Phase 0 deliverables) — changes need explicit review so a stray edit
+# doesn't quietly re-open a closed sign-off.
+/docs/plans/2026-05-02-arch-qa-architect-tribunal-plan.md       @spareilleux
+/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md @spareilleux


### PR DESCRIPTION
## Summary

Phase 0 deliverable #2 of [v2 plan](docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md) — partial. Companion vendoring PR in [Demerzel](https://github.com/GuitarAlchemist/Demerzel/pulls).

## What ships

`.github/CODEOWNERS` covering:
- `/docs/contracts/` (full directory — all cross-repo contract schemas)
- `qa-verdict.schema.json` + `.contract.md`
- `optick-sae-artifact.schema.json` + `.contract.md`
- `digest-schema.json`
- The QA Tribunal plan v1 + v2 docs

Maintainer: `@spareilleux`.

## Why

The 2026-05-15 octo security review flagged HIGH severity on **auto-propagation of GA schema changes** to vendored copies in ga / ix / tars / Demerzel. A compromised PR widening schema validation (e.g. permissive `producer` enum value) would inherit silently in the sibling repos.

CODEOWNERS requires human review on the canonical source so vendored copies can't auto-update behind a malicious schema bump.

## Effective when

Becomes load-bearing when branch protection enables required CODEOWNERS review on `main` (admin action, Phase 3). Until then this is documentation; the file is still useful as a guide for reviewers.

## Reference

- Companion: Demerzel PR with vendored `qa-verdict.schema.json` pinned to ga `main` HEAD `9c368eee`
- Security review: see commit 8cf80f4a + commit ed13a2a9 for the original 2026-05-15 octo findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)