### PR TITLE
chore: lower auto-compact threshold to 40% (CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=40)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE": "40"
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
Sets `CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=40` in `.claude/settings.json`'s `env` block. Claude Code now auto-compacts at 40% of the model's context window instead of the default ~85-95%.

## Why

Context degradation past ~30-40% fill is well-documented (Compound's "Context Rot" notebook). Letting context grow to 98% before compaction means we ship the worst version of the assistant during the last 60% of the session. 40% keeps the cache warm, the working set focused, and forces an explicit `/digest` checkpoint before each compaction.

## Schema

The setting name `autoCompactThreshold` does **not** exist (verified against https://www.schemastore.org/claude-code-settings.json on 2026-05-15). The documented env var is `CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE` — integer 1-100 (percent).

## Rollback

Delete the `env` block. Default behaviour returns on next session.

## Cross-repo

This PR is one of four — sibling PRs land in `ix`, `Demerzel`, and `tars` on the same `chore/auto-compact-threshold` branch.