### PR TITLE
feat(quality): chatbot-qa daily snapshot producer

### DIFF
--- a/.github/workflows/chatbot-qa-snapshot.yml
+++ b/.github/workflows/chatbot-qa-snapshot.yml
@@ -1,0 +1,86 @@
+name: Chatbot QA Snapshot
+
+# Daily snapshot producer for state/quality/chatbot-qa/. Closes the
+# trend gap surfaced 2026-05-16 (psychohistory trend dashboard showed
+# 0 chatbot-qa snapshots, so ix-quality-trend had no chatbot signal to
+# track). Schema consumed by ix/crates/ix-quality-trend/src/snapshot.rs
+# (ChatbotQaSnapshot — timestamp / total_prompts / pass_pct /
+# avg_response_ms / by_category).
+#
+# Producer: Scripts/run-prompt-corpus.ps1 -Snapshot
+# Output:   state/quality/chatbot-qa/YYYY-MM-DD.json
+#
+# Failure semantics:
+#   - The script's `-Snapshot` path writes the snapshot whether or not
+#     the corpus passes — pass_pct is the data point we care about.
+#   - It will NOT write a snapshot if the runner crashes before
+#     printing a completion marker (avoids fabricating pass_pct=100%
+#     for a host that never started). That case fails the workflow.
+#   - We do not fail the workflow on a low pass_pct; failures land
+#     as data, which the dashboard turns into a trend line.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # 06:00 UTC daily — keeps CI off peak hours
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: chatbot-qa-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj
+
+      - name: Build chatbot tests
+        run: dotnet build Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj -c Debug --no-restore
+
+      - name: Run corpus + emit snapshot
+        shell: pwsh
+        run: pwsh Scripts/run-prompt-corpus.ps1 -Snapshot -NoBuild
+        continue-on-error: true   # snapshot is the artifact; low pass_pct isn't a workflow failure
+
+      - name: Commit snapshot if produced
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          SNAP="state/quality/chatbot-qa/${DATE}.json"
+          if [ ! -f "$SNAP" ]; then
+            echo "No snapshot at $SNAP — runner-completed guard tripped or path mismatch. Failing workflow."
+            exit 1
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$SNAP"
+          if git diff --cached --quiet; then
+            echo "Snapshot identical to existing — nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore(quality): chatbot-qa snapshot ${DATE} [skip ci]"
+          git push
+
+      - name: Upload snapshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chatbot-qa-snapshot-${{ github.run_id }}
+          path: state/quality/chatbot-qa/
+          retention-days: 90

--- a/Scripts/run-prompt-corpus.ps1
+++ b/Scripts/run-prompt-corpus.ps1
@@ -4,11 +4,15 @@
 #   pwsh Scripts/run-prompt-corpus.ps1                  # run full corpus, summarize
 #   pwsh Scripts/run-prompt-corpus.ps1 -Worst 3         # only print the 3 worst failures
 #   pwsh Scripts/run-prompt-corpus.ps1 -Json out.json   # also write machine-readable summary
+#   pwsh Scripts/run-prompt-corpus.ps1 -Snapshot        # also write state/quality/chatbot-qa/YYYY-MM-DD.json
 #
-# Intended for two callers:
+# Intended for three callers:
 #   1. Humans running a quick health check on the deployed chatbot.
 #   2. The chatbot-improvement Cherny loop — picks the worst-scoring prompt
 #      each iteration as the next target to fix.
+#   3. The daily chatbot-qa-snapshot CI workflow — emits a trend-shaped
+#      JSON consumed by ix-quality-trend (ChatbotQaSnapshot schema in
+#      ix/crates/ix-quality-trend/src/snapshot.rs).
 #
 # The corpus and its invariants live in
 # Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml. PromptCorpusTests.cs
@@ -19,7 +23,8 @@
 param(
     [int]$Worst = 0,
     [string]$Json = "",
-    [switch]$NoBuild
+    [switch]$NoBuild,
+    [switch]$Snapshot
 )
 
 $ErrorActionPreference = "Stop"
@@ -96,6 +101,118 @@ if ($Json) {
     $summary | ConvertTo-Json -Depth 4 | Set-Content $Json -Encoding UTF8
     Write-Host ""
     Write-Host "Wrote summary to $Json" -ForegroundColor Cyan
+}
+
+if ($Snapshot) {
+    # Trend-shaped snapshot for ix-quality-trend. Schema lives in
+    # ix/crates/ix-quality-trend/src/snapshot.rs (ChatbotQaSnapshot,
+    # ChatbotCategoryStats). Field names are snake_case to match serde
+    # default deserialization (no rename_all attribute on the struct).
+
+    # Guard: only emit a snapshot if the runner actually completed.
+    # Otherwise we'd report `pass_pct: 100` for a crashed run with
+    # zero parsed failures — actively misleading.
+    $runnerCompleted = $out -match 'Prompts violating invariants \(\d+\):' `
+                    -or $out -match '✓ All prompts passed' `
+                    -or $out -match 'Passed!\s*-?\s*Failed:\s*0' `
+                    -or $out -match 'Test Run Successful'
+    if (-not $runnerCompleted) {
+        Write-Host ""
+        Write-Host "Snapshot skipped: corpus runner did not complete (test output did not match a known completion marker). Inspect the run before trusting any pass-rate number." -ForegroundColor Red
+        exit $proc.ExitCode
+    }
+
+    # Walk prompts.yaml to recover totals and per-category populations.
+    # The corpus is the source of truth for "what was attempted"; the
+    # parsed test output gives us "what failed".
+    $promptsYaml = Join-Path $repoRoot "Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml"
+    $categoryTotals = @{}
+    $totalPrompts = 0
+    $skippedPrompts = 0
+    $inPromptBlock = $false
+    $currentCategory = $null
+    $currentSkip = $false
+
+    function _Flush {
+        if (-not $script:inPromptBlock) { return }
+        if ($script:currentSkip) {
+            $script:skippedPrompts++
+        } else {
+            $script:totalPrompts++
+            if ($script:currentCategory) {
+                if (-not $script:categoryTotals.ContainsKey($script:currentCategory)) {
+                    $script:categoryTotals[$script:currentCategory] = 0
+                }
+                $script:categoryTotals[$script:currentCategory]++
+            }
+        }
+    }
+
+    Get-Content $promptsYaml | ForEach-Object {
+        if ($_ -match '^\s*-\s*prompt:') {
+            _Flush
+            $script:inPromptBlock = $true
+            $script:currentCategory = $null
+            $script:currentSkip = $false
+        }
+        elseif ($script:inPromptBlock -and $_ -match '^\s+category:\s*"?([^"#]+?)"?\s*(#.*)?$') {
+            if ($null -eq $script:currentCategory) {
+                $script:currentCategory = $matches[1].Trim()
+            }
+        }
+        elseif ($script:inPromptBlock -and $_ -match '^\s+skip:\s*true') {
+            $script:currentSkip = $true
+        }
+    }
+    _Flush  # flush the last entry
+
+    # Failures carry their category in a "[category] 'prompt'" prefix
+    # emitted by PromptCorpusTests.EvaluatePromptAsync (line ~160).
+    $categoryFailures = @{}
+    foreach ($f in $failures) {
+        if ($f -match '^\[([^\]]+)\]') {
+            $cat = $matches[1].Trim()
+            if (-not $categoryFailures.ContainsKey($cat)) {
+                $categoryFailures[$cat] = 0
+            }
+            $categoryFailures[$cat]++
+        }
+    }
+
+    $byCategory = [ordered]@{}
+    foreach ($k in ($categoryTotals.Keys | Sort-Object)) {
+        $total = $categoryTotals[$k]
+        $fails = if ($categoryFailures.ContainsKey($k)) { $categoryFailures[$k] } else { 0 }
+        $passPct = if ($total -gt 0) {
+            [math]::Round((($total - $fails) / $total) * 100, 2)
+        } else { 0 }
+        $byCategory[$k] = [ordered]@{
+            pass_pct = $passPct
+            total   = $total
+        }
+    }
+
+    $overallPassPct = if ($totalPrompts -gt 0) {
+        [math]::Round((($totalPrompts - $failures.Count) / $totalPrompts) * 100, 2)
+    } else { 0 }
+
+    $date = Get-Date -Format "yyyy-MM-dd"
+    $snapshotDir = Join-Path $repoRoot "state/quality/chatbot-qa"
+    if (-not (Test-Path $snapshotDir)) {
+        New-Item -ItemType Directory -Path $snapshotDir -Force | Out-Null
+    }
+    $snapshotPath = Join-Path $snapshotDir "$date.json"
+
+    $snap = [ordered]@{
+        timestamp     = (Get-Date -Format "o")
+        total_prompts = $totalPrompts
+        pass_pct      = $overallPassPct
+        by_category   = $byCategory
+    }
+    $snap | ConvertTo-Json -Depth 4 | Set-Content $snapshotPath -Encoding UTF8
+    Write-Host ""
+    Write-Host "Wrote trend snapshot to $snapshotPath" -ForegroundColor Cyan
+    Write-Host "  total=$totalPrompts (+$skippedPrompts skipped)  failed=$($failures.Count)  pass_pct=$overallPassPct%" -ForegroundColor Cyan
 }
 
 exit $proc.ExitCode


### PR DESCRIPTION
Closes the trend-signal gap surfaced 2026-05-16 — `docs/quality/README.md` showed **0 chatbot-qa snapshots**, so `ix-quality-trend` had no chatbot data to plot. Without a producer, all the chatbot improvement work since 2026-05-12 has been invisible to the dashboard.

## What this PR does

- **Extends `Scripts/run-prompt-corpus.ps1` with `-Snapshot`**
  - Walks `Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml` to recover total + per-category populations (skipped prompts excluded from the denominator).
  - Parses failure categories from the runner's `[category] 'prompt'` prefix.
  - Writes `state/quality/chatbot-qa/YYYY-MM-DD.json` in the schema `ix-quality-trend` already expects: `timestamp`, `total_prompts`, `pass_pct`, `by_category[*].{pass_pct, total}` (snake_case, matches `ChatbotQaSnapshot` in `ix/crates/ix-quality-trend/src/snapshot.rs`).
  - Guard: skips the write if the runner didn't print a known completion marker — prevents fabricating `pass_pct=100%` when the test host fails to start.

- **`.github/workflows/chatbot-qa-snapshot.yml`** — daily 06:00 UTC cron + `workflow_dispatch`. Commits the snapshot with `[skip ci]`. `continue-on-error` on the run step so low pass_pct lands as data instead of as a workflow failure.

## Validated locally

- YAML parse stand-alone: 50 active / 4 skipped / 11 categories, matches task #148 ("Grow prompt corpus to ~50 prompts").
- Field names match the Rust struct (`snake_case`, all `Option<...>` via `#[serde(default)]`).

## Knock-on effects

Once one snapshot lands, the next `ix-quality-trend` run picks it up, and the "Chatbot QA detail" section of `docs/quality/README.md` populates. Two snapshots are needed before the Δ-vs-7d trend column has signal.

## Out of scope

- `avg_response_ms` field — `PromptCorpusTests` already times prompts via stopwatch but doesn't emit them to test output yet. Follow-up to surface that.
- Backfill of pre-2026-05-16 snapshots — we have no historical pass-rate data to reconstruct from.