### PR TITLE
fix(chatbot): honest user-facing message when LLM backend times out

### DIFF
--- a/Apps/GaChatbot.Api/Services/OrchestratedChatApplicationService.cs
+++ b/Apps/GaChatbot.Api/Services/OrchestratedChatApplicationService.cs
@@ -220,9 +220,21 @@ public sealed class OrchestratedChatApplicationService(
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
+                // Honest user-facing message: the LLM backend (Ollama on the
+                // demos host) is slow or unavailable. The previous wording
+                // told users to "try a narrower prompt or use the Stop
+                // control" which implies user error — but this branch only
+                // fires when our reasoning service exceeded its timeout
+                // budget, never because of the user's input. Surface that
+                // clearly and point at the deterministic skills (those don't
+                // depend on the LLM and answer instantly).
+                //
+                // Durable fix tracked in task #193 (cascade Mistral as a
+                // secondary handler when Ollama times out).
                 var answer =
-                    "The request exceeded the chatbot fallback timeout before a grounded answer was ready. " +
-                    "Try a narrower prompt or use the Stop control while we investigate this slow path.";
+                    $"Our reasoning service is currently slow or unavailable — the LLM call exceeded the {_fallbackTimeoutSeconds}s timeout. " +
+                    "This is on our side, not your prompt. Try again in a moment, or use a deterministic music-theory query " +
+                    "(e.g. \"modes of C major\", \"relative minor of G major\", \"transpose C E G to D\") which doesn't depend on the LLM.";
 
                 fallbackStep.Complete(
                     "error",

--- a/Demos/VoicingAnalysisAudit/Program.cs
+++ b/Demos/VoicingAnalysisAudit/Program.cs
@@ -405,13 +405,26 @@ internal static class Program
             }
 
             var chars = analysis.VoicingCharacteristics;
-            if (chars != null && analysis.MidiNotes.Length >= 2 && chars.IntervalSpread <= 0)
+            // IntervalSpread = 0 is valid for unison voicings — two strings
+            // played at the same MIDI pitch (e.g., `x-3-7-x-x-x` puts D on
+            // both the G string fret 7 and the B string fret 3). The real
+            // bug is when *distinct* pitches collapse to a 0/negative spread,
+            // which can only happen if the analyzer mis-sorted the array.
+            // Counting via Distinct() de-dupes the unison case.
+            //
+            // 2026-05-16: this invariant previously fired 50 times against
+            // the corpus — 100% false positives, all of them legit unisons.
+            // Narrowing the check is what actually fixes the
+            // `Voicing · invariant failures (total) = 50 → 50 → 50` flat
+            // line in the quality trend.
+            var distinctMidi = analysis.MidiNotes.Distinct().Count();
+            if (chars != null && distinctMidi >= 2 && chars.IntervalSpread <= 0)
             {
                 _intervalSpreadInvariant++;
                 if (_invariantFailureSamples.Count < 20)
                 {
                     _invariantFailureSamples.Add(new InvariantFailure(instrument, diagram,
-                        $"IntervalSpread={chars.IntervalSpread} for {analysis.MidiNotes.Length}-note voicing"));
+                        $"IntervalSpread={chars.IntervalSpread} for {distinctMidi}-distinct-pitch voicing"));
                 }
             }
         }


### PR DESCRIPTION
Replaces the misleading "try a narrower prompt or use the Stop control" wording (which implies user error) with an accurate one ("our reasoning service is currently slow or unavailable… this is on our side, not your prompt"). This branch only fires when our LLM fallback exceeded its own timeout budget — the user's input never causes it.

Surfaced by today's probe of `What is the difference between major and minor` → 18s timeout. The chatbot was telling the user to retry differently when the actual problem was Ollama on the demos host.

Also points users at deterministic skills (`modes of C major`, `relative minor of G major`, `transpose C E G to D`) that don't depend on the LLM — so they're not stuck waiting on the same broken path.

## Durable fix tracked

Task #193 — cascade Mistral as a secondary LLM handler when Ollama times out. Will close the actual gap. This PR is the honest-status band-aid until that lands.