### PR TITLE
feat(skill): TheoryComparisonSkill — fix major-vs-minor without Ollama

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -63,6 +63,14 @@ public sealed class GaPlugin : IChatPlugin
         // Built 2026-05-13 to close "parallel minor of C major" corpus failure.
         services.AddOrchestratorSkillIntent<RelativeKeySkill>();
 
+        // Deterministic theory-comparison skill. Built 2026-05-16 to close
+        // "What is the difference between major and minor" — that prompt
+        // was being semantically misrouted to RelativeKeySkill, returning
+        // 0.1 confidence, then timing out at the Ollama fallback. This
+        // skill's description scores higher for "difference / compare /
+        // vs" queries so the semantic router picks it first.
+        services.AddOrchestratorSkillIntent<TheoryComparisonSkill>();
+
         // Domain-backed set-theory equivalence skill — deterministic Y/N for
         // "are two PC-sets equivalent under T / I / TI" via SetClass prime
         // form. Built 2026-05-13 to close the pitch-class equivalence corpus

--- a/Common/GA.Business.ML/Agents/Skills/TheoryComparisonSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/TheoryComparisonSkill.cs
@@ -1,0 +1,165 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Deterministic theory-comparison skill. Answers "what is the difference
+/// between X and Y" style questions where X and Y are music-theory
+/// concepts (scale qualities, modes, etc.) — no LLM call required.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Built 2026-05-16 to close the corpus failure "What is the difference
+/// between major and minor" — the 2026-05-15 live probe trace showed
+/// <c>skill.relativekey</c> semantically grabbing it (because
+/// "major / minor / key" embed close to RelativeKeySkill's description),
+/// then returning 0.1-confidence canned text, then Ollama timing out at
+/// 15s. This skill exists so the semantic router has a higher-scoring
+/// match for "difference / compare / vs" queries.
+/// </para>
+/// <para>
+/// v1 scope: major vs minor (the broken prompt). Future extensions follow
+/// the same pattern — add a regex pair and a comparison body. The skill
+/// is intentionally narrow: deterministic structural comparisons only.
+/// Open-ended "explain X" goes through the LLM.
+/// </para>
+/// </remarks>
+public sealed class TheoryComparisonSkill(ILogger<TheoryComparisonSkill> logger) : IOrchestratorSkill
+{
+    public string Name => "TheoryComparison";
+
+    public string Description =>
+        "Compares two music theory concepts and explains their structural " +
+        "differences. Answers 'what is the difference between major and minor', " +
+        "'compare major and minor', 'major vs minor' and similar comparison " +
+        "queries with deterministic structural content (scale formulas, " +
+        "interval differences, characteristic intervals). No LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "What is the difference between major and minor",
+        "Compare major and minor",
+        "Major vs minor",
+        "Major versus minor",
+        "Difference between major and minor scales",
+        "Explain the difference between major and minor",
+        "How do major and minor differ",
+    ];
+
+    public bool CanHandle(string message) => false;  // semantic-routing only
+
+    // Match "difference between X and Y", "compare X and Y", "X vs Y",
+    // "X versus Y", "how do X and Y differ", "X and Y difference".
+    // Quality tokens are kept narrow so unrelated comparisons
+    // ("C major vs F major", "Hendrix vs Clapton") do not route here.
+    private const string QualityTokens = "major|minor";
+
+    private static readonly Regex DifferencePattern =
+        new(@"\b(?:what(?:'s|\s+is)?\s+the\s+)?(?:difference|distinction)\s+between\s+(?<a>" + QualityTokens + @")\s+and\s+(?<b>" + QualityTokens + @")\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex ComparePattern =
+        new(@"\bcompare\s+(?<a>" + QualityTokens + @")\s+(?:and|with|vs|versus)\s+(?<b>" + QualityTokens + @")\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex VsPattern =
+        // Negative lookbehind keeps "C major vs C minor" out — that's a
+        // parallel-key question handled by RelativeKeySkill. Bare
+        // "major vs minor" with no preceding key letter falls through.
+        new(@"(?<![A-Ga-g][b#♭♯]?\s)\b(?<a>" + QualityTokens + @")\s+(?:vs\.?|versus)\s+(?<b>" + QualityTokens + @")\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex HowDifferPattern =
+        new(@"\bhow\s+do\s+(?<a>" + QualityTokens + @")\s+and\s+(?<b>" + QualityTokens + @")\s+differ\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var (a, b) = MatchPair(message);
+
+        if (a is null || b is null) return Task.FromResult(CannotHandle());
+
+        // Normalize: order doesn't matter for the comparison body, but we
+        // canonicalize to (major, minor) so the lookup is single-keyed.
+        var (left, right) = NormalizePair(a, b);
+        if (left == right) return Task.FromResult(SamePair(left));
+
+        return Task.FromResult(Compare(left, right));
+    }
+
+    private static (string? a, string? b) MatchPair(string message)
+    {
+        foreach (var pattern in new[] { DifferencePattern, ComparePattern, VsPattern, HowDifferPattern })
+        {
+            var match = pattern.Match(message);
+            if (match.Success)
+            {
+                return (
+                    match.Groups["a"].Value.ToLowerInvariant(),
+                    match.Groups["b"].Value.ToLowerInvariant());
+            }
+        }
+        return (null, null);
+    }
+
+    private static (string left, string right) NormalizePair(string a, string b)
+    {
+        // Canonicalize so (major, minor) and (minor, major) hit the same body.
+        if (a == "major" || b == "minor") return (a, b);
+        return (b, a);
+    }
+
+    private AgentResponse Compare(string a, string b)
+    {
+        var evidence = $"TheoryComparisonSkill: matched pair ({a}, {b})";
+        logger.LogDebug("{Evidence}", evidence);
+
+        // The canonical major-vs-minor body. Designed to satisfy the
+        // 2026-05-13 corpus invariants on the matching prompt:
+        // contains: ["major", "minor"]
+        // contains_any: ["third", "interval", "scale", "chord", "quality",
+        //                "tonality", "sad", "happy", "key", "semitone"]
+        // min_length: 150
+        var body =
+            "Major and minor differ primarily in the **third scale degree**, " +
+            "with secondary differences at the 6th and 7th depending on the minor form.\n\n" +
+            "**Scale formulas (semitones from root):**\n" +
+            "- Major:   2 2 1 2 2 2 1 — degrees `1 2 3 4 5 6 7` (major third = 4 semitones)\n" +
+            "- Minor:   2 1 2 2 1 2 2 — degrees `1 2 b3 4 5 b6 b7` (minor third = 3 semitones, natural minor)\n\n" +
+            "The single interval that flips is the **third**: a major third (4 semitones) versus a minor third (3 semitones). " +
+            "That one-semitone shift changes the entire harmonic and emotional character of the key — chords built on the same root come out major or minor accordingly.\n\n" +
+            "**Common associations:** major sounds bright and stable (often \"happy\"); minor sounds darker and more ambiguous (often \"sad\" but really just emotionally richer). These are cultural shorthand, not absolutes.\n\n" +
+            "**Minor variants:**\n" +
+            "- Natural minor: `1 2 b3 4 5 b6 b7`\n" +
+            "- Harmonic minor: `1 2 b3 4 5 b6 7` — raised 7th for stronger dominant resolution\n" +
+            "- Melodic minor: `1 2 b3 4 5 6 7` ascending (raised 6th and 7th), natural minor descending\n\n" +
+            "**In context:**\n" +
+            "- Relative pairs share a key signature (C major ↔ A minor, G major ↔ E minor)\n" +
+            "- Parallel pairs share a root but flip quality (C major ↔ C minor)\n" +
+            "- Diatonic chords differ: I IV V (major-quality) vs i iv V (minor with raised 7th in V)";
+
+        return new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = body,
+            Confidence = 1.0f,
+            Evidence   = [$"Source: TheoryComparisonSkill (deterministic pair comparison)", evidence],
+        };
+    }
+
+    private AgentResponse SamePair(string label) => new()
+    {
+        AgentId    = AgentIds.Theory,
+        Result     = $"You asked to compare {label} to itself — there's no difference. Try comparing {label} to its opposite (major↔minor) or to a specific mode (e.g. \"{label} vs dorian\").",
+        Confidence = 0.7f,
+        Evidence   = ["TheoryComparisonSkill: same-token pair"],
+    };
+
+    private AgentResponse CannotHandle() => new()
+    {
+        AgentId    = AgentIds.Theory,
+        Result     = string.Empty,
+        Confidence = 0.0f,
+        Evidence   = ["TheoryComparisonSkill: no recognised comparison pattern"],
+    };
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
@@ -17,6 +17,17 @@
 #   skip                     — if true, prompt is documented but not run
 #   skip_reason              — why it's skipped (must be set when skip=true)
 #
+# Trace-shape invariants (process validation, opt-in per prompt; PR #222):
+#   must_not_fallback        — fail if trace visits orchestration.fallback
+#                              or gen_ai.chat.fallback (i.e. orchestrator
+#                              gave up on skills and called LLM directly)
+#   forbidden_agent_ids      — fail if any trace step's agent.id is in
+#                              this list (catches semantic-similarity
+#                              misroutes like "major vs minor" →
+#                              skill.relativekey)
+#   min_routing_confidence   — fail if orchestration.answer step's
+#                              routing.confidence is below this value
+#
 # Universally-banned phrases (any answer with these is a regression):
 #   - "Reproduce the catalog below verbatim"   ← leaked SKILL.md preamble
 #   - "Pure pedagogy"                          ← leaked SKILL.md preamble
@@ -132,6 +143,16 @@ prompts:
     contains_any: ["third", "interval", "scale", "chord", "quality", "tonality", "sad", "happy", "key", "semitone"]
     min_length: 150
     max_elapsed_ms: 45000
+    # Trace-shape invariants (added 2026-05-16, infra from PR #222).
+    # The 2026-05-15 live probe trace showed skill.relativekey grabbing
+    # this prompt via semantic similarity ("major / minor / key" embed
+    # close to its description) → routing.confidence 0.1 →
+    # orchestration.fallback → gen_ai.chat.fallback timeout. Asserting
+    # the trajectory turns that 18-second timeout into a clear named
+    # failure ("trace visited forbidden agent.id 'skill.relativekey'")
+    # at the moment of the misroute.
+    forbidden_agent_ids: ["skill.relativekey"]
+    must_not_fallback: true
 
   # ── chord operations (ga_dsl_eval-backed) ───────────────────────────────
   - prompt: "Transpose C E G to D"


### PR DESCRIPTION
**Real fix** for the chatbot's "What is the difference between major and minor" failure surfaced 2026-05-15. Deterministic pitch-class answer, no LLM call, confidence 1.0 when the regex matches.

## How this beats RelativeKeySkill in routing

Both skills participate in the semantic router (`CanHandle => false`). The router picks based on embedding similarity to Description. RelativeKeySkill's Description mentions "relative-key, parallel-key, and key-signature". TheoryComparisonSkill's Description specifically mentions "difference / compare / vs / versus" — those tokens are in the failing prompt itself, so similarity scores higher.

## Patterns covered (v1)

| Phrasing | Example |
|---|---|
| difference between | "What is the difference between major and minor" |
| compare X and Y | "Compare major and minor" |
| X vs Y | "Major vs minor" |
| how do X and Y differ | "How do major and minor differ" |

X and Y are constrained to {major, minor}. A negative lookbehind keeps "C major vs C minor" (parallel-key question) out — that still routes to `RelativeKeySkill`.

## Test surface

PR #223 added `forbidden_agent_ids: [skill.relativekey]` and `must_not_fallback: true` to that prompt. Both turn green once this skill ships and the router picks it.

## Out of scope

Extending to ionian vs aeolian, dorian vs mixolydian, etc. Same template — add a regex pair and a body. Deferred until the broken prompt is closed.

## Verified

`dotnet build Common/GA.Business.ML -c Release` → 0 errors.