### PR TITLE
feat(chat): Mistral cascade fallback for IChatClient (closes #193)

### DIFF
--- a/Common/GA.Business.ML/Extensions/AiServiceExtensions.cs
+++ b/Common/GA.Business.ML/Extensions/AiServiceExtensions.cs
@@ -116,41 +116,63 @@ public static class AiServiceExtensions
     }
 
     /// <summary>
-    /// Adds an <see cref="IChatClient"/> based on the specified provider.
+    /// Adds an <see cref="IChatClient"/> based on the specified provider. If
+    /// <c>AI:CascadeProvider</c> is set (e.g. <c>mistral</c>), the primary
+    /// client is wrapped in a <see cref="Providers.CascadingChatClient"/>
+    /// that falls back to the secondary on timeout or network failure.
     /// </summary>
     public static IServiceCollection AddGuitarAlchemistChatClient(
         this IServiceCollection services,
         string provider,
         IConfiguration configuration)
     {
-        switch (provider.ToLowerInvariant())
+        IChatClient BuildPrimary() => provider.ToLowerInvariant() switch
         {
-            case "ollama":
-                services.TryAddSingleton<IChatClient>(_ =>
-                    Providers.OllamaProvider.CreateChatClientFromConfig(configuration));
-                break;
+            "ollama"  => Providers.OllamaProvider.CreateChatClientFromConfig(configuration),
+            "docker"  => Providers.DockerModelRunnerProvider.CreateChatClientFromConfig(configuration),
+            "mistral" => Providers.Mistral.MistralProvider.CreateChatClientFromConfig(configuration),
+            "github"  => Providers.GitHubModelsProvider.IsAvailable()
+                ? Providers.GitHubModelsProvider.CreateChatClientFromConfig(configuration)
+                : throw new InvalidOperationException("GitHub Models requires the GITHUB_TOKEN environment variable."),
+            _ => throw new ArgumentException($"Unknown chat provider: {provider}", nameof(provider)),
+        };
 
-            case "docker":
-                services.TryAddSingleton<IChatClient>(_ =>
-                    Providers.DockerModelRunnerProvider.CreateChatClientFromConfig(configuration));
-                break;
-
-            case "github":
-                if (!Providers.GitHubModelsProvider.IsAvailable())
-                {
-                    throw new InvalidOperationException(
-                        "GitHub Models requires the GITHUB_TOKEN environment variable.");
-                }
-                services.TryAddSingleton<IChatClient>(_ =>
-                    Providers.GitHubModelsProvider.CreateChatClientFromConfig(configuration));
-                break;
-
-            default:
-                throw new ArgumentException($"Unknown chat provider: {provider}", nameof(provider));
+        var cascadeProvider = configuration.GetValue<string>("AI:CascadeProvider");
+        if (string.IsNullOrWhiteSpace(cascadeProvider))
+        {
+            services.TryAddSingleton<IChatClient>(_ => BuildPrimary());
+            return services;
         }
+
+        // Cascade mode: primary + secondary, wrapped in CascadingChatClient.
+        // Secondary is constructed lazily inside the factory so a missing
+        // MISTRAL_API_KEY surfaces at first DI resolution (typically app
+        // startup) rather than at the cascade trigger point.
+        services.TryAddSingleton<IChatClient>(sp =>
+        {
+            var primary   = BuildPrimary();
+            var secondary = BuildCascadeSecondary(cascadeProvider, configuration);
+            var logger    = sp.GetService<ILogger<Providers.CascadingChatClient>>();
+            return new Providers.CascadingChatClient(primary, secondary, logger);
+        });
 
         return services;
     }
+
+    private static IChatClient BuildCascadeSecondary(string cascadeProvider, IConfiguration configuration) =>
+        cascadeProvider.ToLowerInvariant() switch
+        {
+            "mistral" => Providers.Mistral.MistralProvider.CreateChatClientFromConfig(configuration),
+            "ollama"  => Providers.OllamaProvider.CreateChatClientFromConfig(configuration),
+            "docker"  => Providers.DockerModelRunnerProvider.CreateChatClientFromConfig(configuration),
+            "github"  => Providers.GitHubModelsProvider.IsAvailable()
+                ? Providers.GitHubModelsProvider.CreateChatClientFromConfig(configuration)
+                : throw new InvalidOperationException(
+                    "GitHub Models cascade requires the GITHUB_TOKEN environment variable."),
+            _ => throw new ArgumentException(
+                $"Unknown AI:CascadeProvider '{cascadeProvider}'. Valid values: mistral, ollama, docker, github.",
+                nameof(cascadeProvider)),
+        };
 
     /// <summary>
     /// Adds a text embedding generator based on the specified provider.

--- a/Common/GA.Business.ML/Providers/CascadingChatClient.cs
+++ b/Common/GA.Business.ML/Providers/CascadingChatClient.cs
@@ -78,6 +78,13 @@ public sealed class CascadingChatClient(
             {
                 enumerator = _primary.GetStreamingResponseAsync(snapshot, options, cancellationToken).GetAsyncEnumerator(cancellationToken);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller-driven cancellation — must not cascade. Mirrors the
+                // MoveNextAsync guard below; Codex P1 review #225 caught this
+                // pre-enumerator path violating the documented contract.
+                throw;
+            }
             catch (Exception ex) when (ShouldCascade(ex))
             {
                 primaryFailure = ex;

--- a/Common/GA.Business.ML/Providers/CascadingChatClient.cs
+++ b/Common/GA.Business.ML/Providers/CascadingChatClient.cs
@@ -1,0 +1,155 @@
+namespace GA.Business.ML.Providers;
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Wraps a primary <see cref="IChatClient"/> with a secondary fallback. The
+/// secondary is invoked when the primary either cancels (timeout) or throws
+/// a network-level exception before producing any output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Built for #193 to address the demos.guitaralchemist.com Ollama timeout
+/// (15s) that turns every low-confidence orchestration path into a dead end.
+/// With a cascade in place, Ollama failures fall through to Mistral instead
+/// of surfacing the "reasoning service unavailable" message to the user.
+/// </para>
+/// <para>
+/// For streaming, the fallback only fires if the primary throws before
+/// yielding any tokens — partial streams stay with the primary, because
+/// switching mid-stream would emit a confusing concatenation of two
+/// different models' wording. Callers that need a guaranteed fallback
+/// after partial output must implement their own retry policy on top.
+/// </para>
+/// </remarks>
+public sealed class CascadingChatClient(
+    IChatClient primary,
+    IChatClient secondary,
+    ILogger<CascadingChatClient>? logger = null) : IChatClient
+{
+    private readonly IChatClient _primary   = primary   ?? throw new ArgumentNullException(nameof(primary));
+    private readonly IChatClient _secondary = secondary ?? throw new ArgumentNullException(nameof(secondary));
+    private readonly ILogger<CascadingChatClient>? _logger = logger;
+
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Materialize once so we can replay against the secondary without
+        // re-enumerating a single-use IEnumerable (e.g. a yielded sequence).
+        var snapshot = messages as IReadOnlyList<ChatMessage> ?? messages.ToList();
+
+        try
+        {
+            return await _primary.GetResponseAsync(snapshot, options, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller-driven cancellation — do not cascade.
+            throw;
+        }
+        catch (Exception primaryEx) when (ShouldCascade(primaryEx))
+        {
+            _logger?.LogWarning(
+                primaryEx,
+                "Primary chat client failed ({Kind}); cascading to secondary",
+                primaryEx.GetType().Name);
+
+            return await _secondary.GetResponseAsync(snapshot, options, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var snapshot = messages as IReadOnlyList<ChatMessage> ?? messages.ToList();
+
+        var primarySucceededAtLeastOnce = false;
+        IAsyncEnumerator<ChatResponseUpdate>? enumerator = null;
+        Exception? primaryFailure = null;
+
+        try
+        {
+            try
+            {
+                enumerator = _primary.GetStreamingResponseAsync(snapshot, options, cancellationToken).GetAsyncEnumerator(cancellationToken);
+            }
+            catch (Exception ex) when (ShouldCascade(ex))
+            {
+                primaryFailure = ex;
+            }
+
+            while (enumerator is not null)
+            {
+                ChatResponseUpdate? next = null;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false)) break;
+                    next = enumerator.Current;
+                    primarySucceededAtLeastOnce = true;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (!primarySucceededAtLeastOnce && ShouldCascade(ex))
+                {
+                    primaryFailure = ex;
+                    break;
+                }
+
+                if (next is not null) yield return next;
+            }
+        }
+        finally
+        {
+            if (enumerator is not null) await enumerator.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (primaryFailure is not null)
+        {
+            _logger?.LogWarning(
+                primaryFailure,
+                "Primary streaming chat client failed before yielding any tokens ({Kind}); cascading to secondary",
+                primaryFailure.GetType().Name);
+
+            await foreach (var update in _secondary.GetStreamingResponseAsync(snapshot, options, cancellationToken)
+                .WithCancellation(cancellationToken)
+                .ConfigureAwait(false))
+            {
+                yield return update;
+            }
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        if (serviceType == typeof(CascadingChatClient)) return this;
+        // Surface the primary's metadata so observers see the headline provider.
+        return _primary.GetService(serviceType, serviceKey)
+            ?? _secondary.GetService(serviceType, serviceKey);
+    }
+
+    public void Dispose()
+    {
+        _primary.Dispose();
+        _secondary.Dispose();
+    }
+
+    private static bool ShouldCascade(Exception ex) => ex switch
+    {
+        // OperationCanceledException covers TaskCanceledException too (the
+        // shape HttpClient uses for its own timeouts). We treat any non-
+        // caller-driven cancellation here as a primary-side failure — the
+        // caller-driven case is filtered at each catch site.
+        OperationCanceledException => true,
+        HttpRequestException       => true,       // network / non-2xx
+        TimeoutException           => true,
+        _                          => false,
+    };
+}

--- a/Common/GA.Business.ML/Providers/Mistral/MistralChatClient.cs
+++ b/Common/GA.Business.ML/Providers/Mistral/MistralChatClient.cs
@@ -41,7 +41,7 @@ public sealed class MistralChatClient : IChatClient
         ArgumentNullException.ThrowIfNull(baseUrl);
 
         _model    = model;
-        _endpoint = new Uri(baseUrl, "v1/chat/completions");
+        _endpoint = ResolveChatCompletionsEndpoint(baseUrl);
         _http     = httpClient ?? new HttpClient();
         _ownsHttp = httpClient is null;
 
@@ -50,6 +50,30 @@ public sealed class MistralChatClient : IChatClient
             _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
         _metadata = new ChatClientMetadata("mistral", baseUrl, model);
+    }
+
+    /// <summary>
+    /// Composes the <c>chat/completions</c> endpoint from a configurable base
+    /// URL. Operators sometimes set <c>Mistral:BaseUrl</c> to the bare host
+    /// (<c>https://api.mistral.ai</c>) and sometimes to the already-versioned
+    /// form (<c>https://api.mistral.ai/v1/</c>); naively concatenating
+    /// <c>v1/chat/completions</c> against the latter produces
+    /// <c>/v1/v1/chat/completions</c>. Codex P2 review on #225 caught this.
+    /// </summary>
+    private static Uri ResolveChatCompletionsEndpoint(Uri baseUrl)
+    {
+        var path = baseUrl.AbsolutePath.TrimEnd('/');
+        var suffix = path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
+            ? "chat/completions"
+            : "v1/chat/completions";
+
+        // Append the suffix to the base — preserves scheme/host/port and any
+        // existing path (e.g. an OpenAI-compatible proxy sitting on a subpath).
+        var normalized = path.Length == 0
+            ? new Uri(baseUrl, "/")
+            : new UriBuilder(baseUrl) { Path = path + "/" }.Uri;
+
+        return new Uri(normalized, suffix);
     }
 
     public async Task<ChatResponse> GetResponseAsync(

--- a/Common/GA.Business.ML/Providers/Mistral/MistralChatClient.cs
+++ b/Common/GA.Business.ML/Providers/Mistral/MistralChatClient.cs
@@ -1,0 +1,327 @@
+namespace GA.Business.ML.Providers.Mistral;
+
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Hand-rolled <see cref="IChatClient"/> implementation against Mistral's
+/// OpenAI-compatible <c>/v1/chat/completions</c> endpoint. Built for #193
+/// (cascade fallback when the primary Ollama-backed client times out)
+/// because <c>Microsoft.Extensions.AI.OpenAI</c> is deferred in this csproj
+/// per the SDK-version-mismatch note on
+/// <see cref="GA.Business.ML"/>'s package list.
+/// </summary>
+/// <remarks>
+/// Streaming uses SSE per Mistral's spec. The implementation deliberately
+/// stays minimal: no function calling, no tool use, no JSON mode — just the
+/// text round-trip the cascade needs.
+/// </remarks>
+public sealed class MistralChatClient : IChatClient
+{
+    private readonly HttpClient _http;
+    private readonly bool _ownsHttp;
+    private readonly string _model;
+    private readonly Uri _endpoint;
+    private readonly ChatClientMetadata _metadata;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public MistralChatClient(string apiKey, string model, Uri baseUrl, HttpClient? httpClient = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(model);
+        ArgumentNullException.ThrowIfNull(baseUrl);
+
+        _model    = model;
+        _endpoint = new Uri(baseUrl, "v1/chat/completions");
+        _http     = httpClient ?? new HttpClient();
+        _ownsHttp = httpClient is null;
+
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        if (_http.DefaultRequestHeaders.Accept.Count == 0)
+            _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        _metadata = new ChatClientMetadata("mistral", baseUrl, model);
+    }
+
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var payload = BuildRequest(messages, options, stream: false);
+        using var response = await _http.PostAsJsonAsync(_endpoint, payload, JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"Mistral chat completion failed: HTTP {(int)response.StatusCode} {response.ReasonPhrase}. Body: {Truncate(body, 500)}",
+                inner: null,
+                statusCode: response.StatusCode);
+        }
+
+        var completion = await response.Content
+            .ReadFromJsonAsync<MistralChatCompletion>(JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (completion?.Choices is not { Count: > 0 } choices)
+        {
+            return new ChatResponse([new ChatMessage(ChatRole.Assistant, string.Empty)])
+            {
+                ModelId = _model,
+            };
+        }
+
+        var first = choices[0];
+        var content = first.Message?.Content ?? string.Empty;
+        var role = string.IsNullOrEmpty(first.Message?.Role)
+            ? ChatRole.Assistant
+            : new ChatRole(first.Message!.Role!);
+
+        var chatResponse = new ChatResponse([new ChatMessage(role, content)])
+        {
+            ModelId      = completion.Model ?? _model,
+            ResponseId   = completion.Id,
+            FinishReason = MapFinishReason(first.FinishReason),
+        };
+
+        if (completion.Usage is { } usage)
+        {
+            chatResponse.Usage = new UsageDetails
+            {
+                InputTokenCount  = usage.PromptTokens,
+                OutputTokenCount = usage.CompletionTokens,
+                TotalTokenCount  = usage.TotalTokens,
+            };
+        }
+
+        return chatResponse;
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var payload = BuildRequest(messages, options, stream: true);
+        using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint)
+        {
+            Content = JsonContent.Create(payload, options: JsonOptions),
+        };
+
+        using var response = await _http.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"Mistral streaming chat completion failed: HTTP {(int)response.StatusCode} {response.ReasonPhrase}. Body: {Truncate(body, 500)}",
+                inner: null,
+                statusCode: response.StatusCode);
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        while (!reader.EndOfStream)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(line)) continue;
+            if (!line.StartsWith("data:", StringComparison.Ordinal)) continue;
+
+            var payloadJson = line["data:".Length..].Trim();
+            if (payloadJson.Length == 0 || payloadJson == "[DONE]") continue;
+
+            MistralStreamChunk? chunk;
+            try
+            {
+                chunk = JsonSerializer.Deserialize<MistralStreamChunk>(payloadJson, JsonOptions);
+            }
+            catch (JsonException)
+            {
+                // Skip malformed SSE frames rather than abort the stream — the
+                // primary client may still be partway through useful content.
+                continue;
+            }
+
+            if (chunk?.Choices is not { Count: > 0 } choices) continue;
+
+            var delta = choices[0].Delta;
+            if (delta is null) continue;
+
+            var text = delta.Content;
+            if (string.IsNullOrEmpty(text)) continue;
+
+            yield return new ChatResponseUpdate(ChatRole.Assistant, text)
+            {
+                ModelId      = chunk.Model ?? _model,
+                ResponseId   = chunk.Id,
+                FinishReason = MapFinishReason(choices[0].FinishReason),
+            };
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        if (serviceKey is not null) return null;
+        if (serviceType == typeof(ChatClientMetadata)) return _metadata;
+        if (serviceType == typeof(MistralChatClient))  return this;
+        return null;
+    }
+
+    public void Dispose()
+    {
+        if (_ownsHttp) _http.Dispose();
+    }
+
+    private MistralChatRequest BuildRequest(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options,
+        bool stream)
+    {
+        var wire = messages.Select(ToWireMessage).ToList();
+
+        return new MistralChatRequest
+        {
+            Model       = options?.ModelId ?? _model,
+            Messages    = wire,
+            Stream      = stream,
+            Temperature = options?.Temperature,
+            TopP        = options?.TopP,
+            MaxTokens   = options?.MaxOutputTokens,
+        };
+    }
+
+    private static MistralChatMessage ToWireMessage(ChatMessage message)
+    {
+        var role = message.Role.Value switch
+        {
+            "system"    => "system",
+            "user"      => "user",
+            "assistant" => "assistant",
+            "tool"      => "tool",
+            _           => message.Role.Value,
+        };
+
+        // ChatMessage exposes .Text as the concatenated text of any TextContent parts.
+        return new MistralChatMessage { Role = role, Content = message.Text ?? string.Empty };
+    }
+
+    private static ChatFinishReason? MapFinishReason(string? reason) => reason switch
+    {
+        null or ""        => null,
+        "stop"            => ChatFinishReason.Stop,
+        "length"          => ChatFinishReason.Length,
+        "tool_calls"      => ChatFinishReason.ToolCalls,
+        "content_filter"  => ChatFinishReason.ContentFilter,
+        _                 => new ChatFinishReason(reason),
+    };
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max] + "…";
+
+    // ── Wire DTOs ────────────────────────────────────────────────────────────
+    private sealed class MistralChatRequest
+    {
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = "";
+
+        [JsonPropertyName("messages")]
+        public List<MistralChatMessage> Messages { get; set; } = [];
+
+        [JsonPropertyName("stream")]
+        public bool Stream { get; set; }
+
+        [JsonPropertyName("temperature")]
+        public float? Temperature { get; set; }
+
+        [JsonPropertyName("top_p")]
+        public float? TopP { get; set; }
+
+        [JsonPropertyName("max_tokens")]
+        public int? MaxTokens { get; set; }
+    }
+
+    private sealed class MistralChatMessage
+    {
+        [JsonPropertyName("role")]
+        public string Role { get; set; } = "";
+
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = "";
+    }
+
+    private sealed class MistralChatCompletion
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("choices")]
+        public List<MistralChoice>? Choices { get; set; }
+
+        [JsonPropertyName("usage")]
+        public MistralUsage? Usage { get; set; }
+    }
+
+    private sealed class MistralChoice
+    {
+        [JsonPropertyName("index")]
+        public int Index { get; set; }
+
+        [JsonPropertyName("message")]
+        public MistralChatMessage? Message { get; set; }
+
+        [JsonPropertyName("delta")]
+        public MistralChatMessage? Delta { get; set; }
+
+        [JsonPropertyName("finish_reason")]
+        public string? FinishReason { get; set; }
+    }
+
+    private sealed class MistralUsage
+    {
+        [JsonPropertyName("prompt_tokens")]
+        public int PromptTokens { get; set; }
+
+        [JsonPropertyName("completion_tokens")]
+        public int CompletionTokens { get; set; }
+
+        [JsonPropertyName("total_tokens")]
+        public int TotalTokens { get; set; }
+    }
+
+    private sealed class MistralStreamChunk
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("choices")]
+        public List<MistralChoice>? Choices { get; set; }
+    }
+}

--- a/Common/GA.Business.ML/Providers/Mistral/MistralProvider.cs
+++ b/Common/GA.Business.ML/Providers/Mistral/MistralProvider.cs
@@ -1,0 +1,51 @@
+namespace GA.Business.ML.Providers.Mistral;
+
+using Microsoft.Extensions.AI;
+
+/// <summary>
+/// Factory for the Mistral-backed <see cref="IChatClient"/>. Mirrors the
+/// Ollama/Docker/GitHub provider pattern in <see cref="GA.Business.ML.Providers"/>.
+/// </summary>
+public static class MistralProvider
+{
+    public const string DefaultBaseUrl = "https://api.mistral.ai";
+    public const string DefaultChatModel = "mistral-medium-latest";
+    public const string ApiKeyEnvVar = "MISTRAL_API_KEY";
+
+    /// <summary>
+    /// Resolves the Mistral API key from <c>Mistral:ApiKey</c> first, then the
+    /// <c>MISTRAL_API_KEY</c> environment variable. Returns <c>null</c> if neither
+    /// is set so callers can decide whether to fail loudly or skip cascade wiring.
+    /// </summary>
+    public static string? ResolveApiKey(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var fromConfig = configuration.GetValue<string>("Mistral:ApiKey");
+        if (!string.IsNullOrWhiteSpace(fromConfig)) return fromConfig;
+
+        var fromEnv = Environment.GetEnvironmentVariable(ApiKeyEnvVar);
+        return string.IsNullOrWhiteSpace(fromEnv) ? null : fromEnv;
+    }
+
+    public static bool IsAvailable(IConfiguration configuration) =>
+        ResolveApiKey(configuration) is not null;
+
+    public static IChatClient CreateChatClientFromConfig(
+        IConfiguration configuration,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var apiKey = ResolveApiKey(configuration)
+            ?? throw new InvalidOperationException(
+                "Mistral cascade requires Mistral:ApiKey config or MISTRAL_API_KEY env var.");
+
+        var baseUrl = configuration.GetValue<string>("Mistral:BaseUrl") ?? DefaultBaseUrl;
+        var model   = configuration.GetValue<string>("Mistral:Model")   ?? DefaultChatModel;
+
+        logger?.LogInformation("Creating Mistral chat client at {BaseUrl} for model: {Model}", baseUrl, model);
+
+        return new MistralChatClient(apiKey, model, new Uri(baseUrl));
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/CascadingChatClientTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/CascadingChatClientTests.cs
@@ -1,0 +1,225 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Providers;
+using Microsoft.Extensions.AI;
+using Moq;
+
+[TestFixture]
+public class CascadingChatClientTests
+{
+    private static ChatMessage SystemMessage(string content) => new(ChatRole.System, content);
+    private static ChatMessage UserMessage(string content)   => new(ChatRole.User, content);
+
+    private static ChatResponse FakeResponse(string text, string modelId = "primary-model") =>
+        new([new ChatMessage(ChatRole.Assistant, text)]) { ModelId = modelId };
+
+    [Test]
+    public async Task GetResponseAsync_PrimarySucceeds_SecondaryNeverCalled()
+    {
+        var primary   = new Mock<IChatClient>(MockBehavior.Strict);
+        var secondary = new Mock<IChatClient>(MockBehavior.Strict);
+
+        primary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeResponse("hello from primary"));
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+        var response = await cascade.GetResponseAsync([UserMessage("hi")]);
+
+        Assert.That(response.Messages[0].Text, Is.EqualTo("hello from primary"));
+        secondary.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task GetResponseAsync_PrimaryTimesOut_FallsBackToSecondary()
+    {
+        var primary   = new Mock<IChatClient>(MockBehavior.Strict);
+        var secondary = new Mock<IChatClient>(MockBehavior.Strict);
+
+        // Primary cancels via its own inner CTS (not the caller's token).
+        primary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("primary timed out"));
+
+        secondary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeResponse("recovered by secondary", "secondary-model"));
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+        var response = await cascade.GetResponseAsync([UserMessage("hi")]);
+
+        Assert.That(response.Messages[0].Text, Is.EqualTo("recovered by secondary"));
+        Assert.That(response.ModelId,          Is.EqualTo("secondary-model"));
+    }
+
+    [Test]
+    public async Task GetResponseAsync_PrimaryHttpFailure_FallsBackToSecondary()
+    {
+        var primary   = new Mock<IChatClient>();
+        var secondary = new Mock<IChatClient>();
+
+        primary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("connection refused"));
+
+        secondary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeResponse("from secondary"));
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+        var response = await cascade.GetResponseAsync([UserMessage("hi")]);
+
+        Assert.That(response.Messages[0].Text, Is.EqualTo("from secondary"));
+    }
+
+    [Test]
+    public void GetResponseAsync_CallerCancels_DoesNotCascade()
+    {
+        var primary   = new Mock<IChatClient>();
+        var secondary = new Mock<IChatClient>(MockBehavior.Strict);
+
+        primary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("cancelled by caller"));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+
+        Assert.That(
+            async () => await cascade.GetResponseAsync([UserMessage("hi")], cancellationToken: cts.Token),
+            Throws.InstanceOf<OperationCanceledException>());
+
+        // Strict mock ensures secondary was never invoked.
+        secondary.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task GetResponseAsync_NonRecoverableException_PropagatesWithoutCascade()
+    {
+        var primary   = new Mock<IChatClient>();
+        var secondary = new Mock<IChatClient>(MockBehavior.Strict);
+
+        primary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("bug in primary, not network"));
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+
+        Assert.That(
+            async () => await cascade.GetResponseAsync([UserMessage("hi")]),
+            Throws.InstanceOf<InvalidOperationException>());
+
+        secondary.VerifyNoOtherCalls();
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task GetResponseAsync_MaterializesMessagesOnce_AllowsCascadeReplay()
+    {
+        var primary   = new Mock<IChatClient>();
+        var secondary = new Mock<IChatClient>();
+
+        primary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("primary down"));
+
+        IEnumerable<ChatMessage>? capturedFromSecondary = null;
+        secondary
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>((msgs, _, _) => capturedFromSecondary = msgs)
+            .ReturnsAsync(FakeResponse("recovered"));
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+
+        // Pass a deliberately single-use enumerable to prove materialization is happening.
+        IEnumerable<ChatMessage> Stream()
+        {
+            yield return SystemMessage("you are helpful");
+            yield return UserMessage("hello");
+        }
+
+        await cascade.GetResponseAsync(Stream());
+
+        Assert.That(capturedFromSecondary, Is.Not.Null);
+        Assert.That(capturedFromSecondary!.Count(), Is.EqualTo(2), "secondary must receive the same messages the primary saw");
+    }
+
+    [Test]
+    public async Task GetStreamingResponseAsync_PrimaryYieldsTokens_DoesNotCascadeOnLaterFailure()
+    {
+        var primary   = new Mock<IChatClient>();
+        var secondary = new Mock<IChatClient>(MockBehavior.Strict);
+
+        primary
+            .Setup(c => c.GetStreamingResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(YieldThenFail("hello ", "world", new HttpRequestException("connection dropped mid-stream")));
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+
+        var collected = new List<string>();
+        Assert.That(async () =>
+        {
+            await foreach (var update in cascade.GetStreamingResponseAsync([UserMessage("hi")]))
+            {
+                if (!string.IsNullOrEmpty(update.Text)) collected.Add(update.Text);
+            }
+        }, Throws.InstanceOf<HttpRequestException>(),
+        "mid-stream failures must surface, not silently cascade to a different model");
+
+        Assert.That(collected, Is.EquivalentTo(new[] { "hello ", "world" }));
+        secondary.VerifyNoOtherCalls();
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task GetStreamingResponseAsync_PrimaryFailsBeforeFirstToken_CascadesToSecondary()
+    {
+        var primary   = new Mock<IChatClient>();
+        var secondary = new Mock<IChatClient>();
+
+        primary
+            .Setup(c => c.GetStreamingResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(FailBeforeYielding(new OperationCanceledException("primary inner timeout")));
+
+        secondary
+            .Setup(c => c.GetStreamingResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(YieldThenComplete("from ", "mistral"));
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+
+        var collected = new List<string>();
+        await foreach (var update in cascade.GetStreamingResponseAsync([UserMessage("hi")]))
+        {
+            if (!string.IsNullOrEmpty(update.Text)) collected.Add(update.Text);
+        }
+
+        Assert.That(string.Concat(collected), Is.EqualTo("from mistral"));
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> YieldThenFail(string a, string b, Exception throwAfter)
+    {
+        yield return new ChatResponseUpdate(ChatRole.Assistant, a);
+        await Task.Yield();
+        yield return new ChatResponseUpdate(ChatRole.Assistant, b);
+        await Task.Yield();
+        throw throwAfter;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> FailBeforeYielding(Exception toThrow)
+    {
+        await Task.Yield();
+        if (toThrow is not null) throw toThrow;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> YieldThenComplete(params string[] parts)
+    {
+        foreach (var p in parts)
+        {
+            await Task.Yield();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, p);
+        }
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/CascadingChatClientTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/CascadingChatClientTests.cs
@@ -174,6 +174,35 @@ public class CascadingChatClientTests
     }
 
     [Test]
+    public void GetStreamingResponseAsync_CallerCancelsBeforeFirstToken_DoesNotCascade()
+    {
+        // Codex P1 review on PR #225: the pre-enumerator catch must distinguish
+        // caller-driven cancellation from primary-internal failures. Otherwise
+        // a cancelled caller still gets a wasted outbound request to secondary.
+        var primary   = new Mock<IChatClient>();
+        var secondary = new Mock<IChatClient>(MockBehavior.Strict);
+
+        primary
+            .Setup(c => c.GetStreamingResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(FailBeforeYielding(new OperationCanceledException("caller cancelled")));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var cascade = new CascadingChatClient(primary.Object, secondary.Object);
+
+        Assert.That(async () =>
+        {
+            await foreach (var _ in cascade.GetStreamingResponseAsync([UserMessage("hi")], cancellationToken: cts.Token))
+            {
+                // empty
+            }
+        }, Throws.InstanceOf<OperationCanceledException>());
+
+        secondary.VerifyNoOtherCalls();
+    }
+
+    [Test]
     public async Task GetStreamingResponseAsync_PrimaryFailsBeforeFirstToken_CascadesToSecondary()
     {
         var primary   = new Mock<IChatClient>();

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MistralChatClientTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MistralChatClientTests.cs
@@ -1,0 +1,93 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Net;
+using System.Text;
+using GA.Business.ML.Providers.Mistral;
+using Microsoft.Extensions.AI;
+
+[TestFixture]
+public class MistralChatClientTests
+{
+    [Test]
+    public async Task GetResponseAsync_ParsesOpenAiCompatibleBody()
+    {
+        const string jsonBody = """
+        {
+            "id":"chatcmpl-abc",
+            "model":"mistral-medium-latest",
+            "choices":[
+                {"index":0,"message":{"role":"assistant","content":"Hello from Mistral"},"finish_reason":"stop"}
+            ],
+            "usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}
+        }
+        """;
+
+        var handler = new RecordingHandler((req, _) =>
+        {
+            Assert.That(req.RequestUri!.AbsoluteUri, Is.EqualTo("https://api.mistral.ai/v1/chat/completions"));
+            Assert.That(req.Headers.Authorization?.Scheme,    Is.EqualTo("Bearer"));
+            Assert.That(req.Headers.Authorization?.Parameter, Is.EqualTo("test-key"));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(jsonBody, Encoding.UTF8, "application/json"),
+            };
+        });
+
+        using var http = new HttpClient(handler);
+        using var client = new MistralChatClient("test-key", "mistral-medium-latest", new Uri("https://api.mistral.ai"), http);
+
+        var response = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+
+        Assert.That(response.Messages[0].Text,          Is.EqualTo("Hello from Mistral"));
+        Assert.That(response.ModelId,                   Is.EqualTo("mistral-medium-latest"));
+        Assert.That(response.FinishReason,              Is.EqualTo(ChatFinishReason.Stop));
+        Assert.That(response.Usage?.TotalTokenCount,    Is.EqualTo(12));
+    }
+
+    [Test]
+    public void GetResponseAsync_NonSuccessStatus_ThrowsWithoutEchoingApiKey()
+    {
+        var handler = new RecordingHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("""{"message":"Invalid API key"}""", Encoding.UTF8, "application/json"),
+            });
+
+        using var http = new HttpClient(handler);
+        using var client = new MistralChatClient("sk-secret-key-do-not-leak", "mistral-medium-latest", new Uri("https://api.mistral.ai"), http);
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]));
+
+        Assert.That(ex!.Message, Does.Not.Contain("sk-secret-key-do-not-leak"),
+            "exception message must never echo the API key from the request headers");
+        Assert.That(ex.Message, Does.Contain("401").Or.Contain("Unauthorized"));
+    }
+
+    [Test]
+    public void GetService_ReturnsMetadataForChatClientMetadata()
+    {
+        using var client = new MistralChatClient("test-key", "mistral-medium-latest", new Uri("https://api.mistral.ai"));
+
+        var metadata = client.GetService(typeof(ChatClientMetadata));
+
+        Assert.That(metadata, Is.InstanceOf<ChatClientMetadata>());
+        var m = (ChatClientMetadata)metadata!;
+        Assert.That(m.ProviderName, Is.EqualTo("mistral"));
+        Assert.That(m.DefaultModelId, Is.EqualTo("mistral-medium-latest"));
+    }
+
+    [Test]
+    public void Constructor_NullArgs_Throws()
+    {
+        Assert.That(() => new MistralChatClient(null!, "model",  new Uri("https://x")), Throws.InstanceOf<ArgumentNullException>().Or.InstanceOf<ArgumentException>());
+        Assert.That(() => new MistralChatClient("k",  null!,     new Uri("https://x")), Throws.InstanceOf<ArgumentNullException>().Or.InstanceOf<ArgumentException>());
+        Assert.That(() => new MistralChatClient("k",  "m",       null!),                Throws.InstanceOf<ArgumentNullException>());
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request, cancellationToken));
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MistralChatClientTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MistralChatClientTests.cs
@@ -77,6 +77,35 @@ public class MistralChatClientTests
         Assert.That(m.DefaultModelId, Is.EqualTo("mistral-medium-latest"));
     }
 
+    [TestCase("https://api.mistral.ai",      "https://api.mistral.ai/v1/chat/completions")]
+    [TestCase("https://api.mistral.ai/",     "https://api.mistral.ai/v1/chat/completions")]
+    [TestCase("https://api.mistral.ai/v1",   "https://api.mistral.ai/v1/chat/completions")]
+    [TestCase("https://api.mistral.ai/v1/",  "https://api.mistral.ai/v1/chat/completions")]
+    [TestCase("https://api.mistral.ai/V1/",  "https://api.mistral.ai/V1/chat/completions")]  // case-insensitive v1 detection
+    [TestCase("https://proxy.example/openai/v1/", "https://proxy.example/openai/v1/chat/completions")]
+    public async Task GetResponseAsync_NormalizesVersionedBaseUrl(string baseUrl, string expectedAbsoluteUri)
+    {
+        // Codex P2 review on PR #225: operators commonly set Mistral:BaseUrl to
+        // either the bare host or the already-versioned `/v1/` form. The
+        // hand-rolled client must produce the same endpoint either way.
+        Uri? observed = null;
+        var handler = new RecordingHandler((req, _) =>
+        {
+            observed = req.RequestUri;
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        using var http = new HttpClient(handler);
+        using var client = new MistralChatClient("test-key", "mistral-medium-latest", new Uri(baseUrl), http);
+
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+
+        Assert.That(observed!.AbsoluteUri, Is.EqualTo(expectedAbsoluteUri));
+    }
+
     [Test]
     public void Constructor_NullArgs_Throws()
     {

--- a/Tests/Common/GA.Business.ML.Tests/Unit/MistralProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/MistralProviderTests.cs
@@ -1,0 +1,107 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Providers.Mistral;
+using Microsoft.Extensions.Configuration;
+
+[TestFixture]
+public class MistralProviderTests
+{
+    private string? _savedEnv;
+
+    [SetUp]
+    public void SaveEnv()
+    {
+        _savedEnv = Environment.GetEnvironmentVariable(MistralProvider.ApiKeyEnvVar);
+        Environment.SetEnvironmentVariable(MistralProvider.ApiKeyEnvVar, null);
+    }
+
+    [TearDown]
+    public void RestoreEnv() =>
+        Environment.SetEnvironmentVariable(MistralProvider.ApiKeyEnvVar, _savedEnv);
+
+    private static IConfiguration Config(IDictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    [Test]
+    public void ResolveApiKey_PrefersConfigOverEnv()
+    {
+        Environment.SetEnvironmentVariable(MistralProvider.ApiKeyEnvVar, "env-value");
+
+        var key = MistralProvider.ResolveApiKey(Config(new Dictionary<string, string?>
+        {
+            ["Mistral:ApiKey"] = "config-value",
+        }));
+
+        Assert.That(key, Is.EqualTo("config-value"));
+    }
+
+    [Test]
+    public void ResolveApiKey_FallsBackToEnv_WhenConfigMissing()
+    {
+        Environment.SetEnvironmentVariable(MistralProvider.ApiKeyEnvVar, "env-value");
+
+        var key = MistralProvider.ResolveApiKey(Config(new Dictionary<string, string?>()));
+
+        Assert.That(key, Is.EqualTo("env-value"));
+    }
+
+    [Test]
+    public void ResolveApiKey_ReturnsNull_WhenNeitherSet()
+    {
+        var key = MistralProvider.ResolveApiKey(Config(new Dictionary<string, string?>()));
+        Assert.That(key, Is.Null);
+    }
+
+    [Test]
+    public void ResolveApiKey_TreatsWhitespaceConfigAsAbsent()
+    {
+        Environment.SetEnvironmentVariable(MistralProvider.ApiKeyEnvVar, "env-value");
+
+        var key = MistralProvider.ResolveApiKey(Config(new Dictionary<string, string?>
+        {
+            ["Mistral:ApiKey"] = "   ",
+        }));
+
+        Assert.That(key, Is.EqualTo("env-value"));
+    }
+
+    [Test]
+    public void IsAvailable_ReturnsFalse_WhenNeitherKeySource()
+    {
+        Assert.That(MistralProvider.IsAvailable(Config(new Dictionary<string, string?>())), Is.False);
+    }
+
+    [Test]
+    public void IsAvailable_ReturnsTrue_WhenConfigPresent()
+    {
+        var available = MistralProvider.IsAvailable(Config(new Dictionary<string, string?>
+        {
+            ["Mistral:ApiKey"] = "config-value",
+        }));
+
+        Assert.That(available, Is.True);
+    }
+
+    [Test]
+    public void CreateChatClientFromConfig_NoKey_ThrowsSafeMessage()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => MistralProvider.CreateChatClientFromConfig(Config(new Dictionary<string, string?>())));
+
+        Assert.That(ex!.Message, Does.Contain("MISTRAL_API_KEY"));
+        Assert.That(ex.Message, Does.Not.Contain("="),
+            "error message must not echo env-var values that could leak secrets");
+    }
+
+    [Test]
+    public void CreateChatClientFromConfig_WithKey_Succeeds()
+    {
+        var client = MistralProvider.CreateChatClientFromConfig(Config(new Dictionary<string, string?>
+        {
+            ["Mistral:ApiKey"] = "sk-mistral-fake-test-key",
+            ["Mistral:Model"]  = "mistral-medium-latest",
+        }));
+
+        Assert.That(client, Is.Not.Null);
+    }
+}


### PR DESCRIPTION
## Summary

- Wraps the primary `IChatClient` (Ollama / Docker / GitHub Models) with a new `CascadingChatClient` that falls through to a secondary when the primary times out or hits a network error
- First secondary: hand-rolled `MistralChatClient` against `https://api.mistral.ai/v1/chat/completions` (the OpenAI-compatible path), since `Microsoft.Extensions.AI.OpenAI` is explicitly deferred in `GA.Business.ML.csproj`
- Gated behind a new `AI:CascadeProvider` config flag — defaults to off, no behavioral change for hosts that don't opt in

Direct response to the live probe trace from `state/digests/latest.md`:

\`\`\`
gen_ai.chat.fallback status=error elapsedMs=15006 timeout.seconds=15
\`\`\`

With cascade enabled, that 15s timeout becomes the trigger point to retry against Mistral instead of returning the unavailability message to the user.

## How to enable

\`\`\`json
{
  \"AI\": { \"CascadeProvider\": \"mistral\" },
  \"Mistral\": {
    \"Model\":   \"mistral-medium-latest\",
    \"BaseUrl\": \"https://api.mistral.ai\"
  }
}
\`\`\`

Plus `MISTRAL_API_KEY` env (or `Mistral:ApiKey` config — the env is already set on the user's machine per memory).

## Cascade behavior

- **Non-streaming**: primary tried first; on `OperationCanceledException` (not caller-driven), `HttpRequestException`, or `TimeoutException`, the same materialized message list is replayed against the secondary
- **Streaming**: cascade only fires if the primary fails **before yielding the first token**. Mid-stream failures propagate so we never concatenate two models' wording into one user-visible response
- **Caller cancellation** (the outer `CancellationToken`): never cascades — surfaces normally

## Tests

20 new tests, all passing:

- `CascadingChatClientTests` (8) — happy path, timeout fallback, HTTP failure fallback, caller-cancel pass-through, non-recoverable exception pass-through, single-use enumerable materialization, streaming mid-stream failure, streaming pre-token failure
- `MistralProviderTests` (7) — config precedence over env, whitespace handling, `IsAvailable`, safe error messages (no key echo)
- `MistralChatClientTests` (5) — OpenAI-compatible JSON parse, 401 error never echoes API key, `GetService` metadata, constructor guards

## Build verification

- \`dotnet build Common/GA.Business.ML -c Release\` — **0 errors** (the named success criterion for #193 in \`state/digests/latest.md\`)
- \`dotnet build AllProjects.slnx -c Release\` — **0 errors**
- \`dotnet test --filter \"CascadingChatClient|MistralProvider|MistralChatClient\"\` — **20/20 passing**
- \`dotnet test --filter \"AddGuitarAlchemistAiRegistration|DefaultChatClientFactory\"\` — **10/10 passing** (no regression in existing registration tests)

## Out of scope

- Mistral **agents** endpoint (\`/v1/agents/completions\`) — there's a pre-trained \`guitar-alchemist\` agent at \`ag_019d3c30528e716fa8a5efeb9c8ae49c\` per memory that could supply theory-tuned answers. Adding agent support is a follow-up because v1 needs to handle every fallback prompt, not just theory ones.
- \`Microsoft.Extensions.AI.OpenAI\` package re-add — deferred per the csproj comment, blocked on upstream SDK version stabilization. The hand-rolled client is the workaround.

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)