### PR TITLE
feat(qa): offline validation pipeline + CI wire-up (closes #194)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,12 @@ state/quality/**/embedding-clusters-*.json
 # when weekly soaks start.
 state/quality/dsl-eval/[0-9]*-soak-results.json
 
+# Golden trace snapshots from Scripts/record-golden-traces.ps1.
+# Per-run captures (different traceId/elapsedMs each time); not a stable
+# baseline. Re-record locally when needed. Dominator analysis runs offline
+# against whatever's currently on disk.
+state/quality/chatbot-qa/golden-traces/
+
 # Chatbot claim traces — per-day JSONL, regenerable from MCP tool calls
 state/claims/
 state/chatbot/

--- a/.gitignore
+++ b/.gitignore
@@ -196,7 +196,11 @@ state/quality/dsl-eval/[0-9]*-soak-results.json
 # Per-run captures (different traceId/elapsedMs each time); not a stable
 # baseline. Re-record locally when needed. Dominator analysis runs offline
 # against whatever's currently on disk.
-state/quality/chatbot-qa/golden-traces/
+state/quality/chatbot-qa/golden-traces/**/run-*.json
+state/quality/chatbot-qa/golden-traces/**/_canonical.json
+# Note: _signature.json IS tracked — pruned to (name, status, agent.id)
+# per step, stable across runs, used as a CI test fixture by
+# PromptCorpusTests + CanonicalSignatureChecker.
 
 # Chatbot claim traces — per-day JSONL, regenerable from MCP tool calls
 state/claims/

--- a/Scripts/compare-trace-to-canonical.ps1
+++ b/Scripts/compare-trace-to-canonical.ps1
@@ -1,0 +1,293 @@
+# compare-trace-to-canonical.ps1 — detect regressions vs canonical trace shape
+#
+# Reads a fresh chatbot trace (either a saved run-*.json artifact or a live
+# response captured ad-hoc) and diffs it against the prompt's _canonical.json.
+# Reports each kind of divergence with a stable exit code so this can wire
+# into CI gates.
+#
+# Exit codes:
+#   0 — fresh trace matches canonical (no regressions)
+#   1 — regression detected (canonical step missing, status wrong, invariant
+#       attribute mismatch, or routing.confidence outside range)
+#   2 — usage error (canonical missing, fresh missing, etc.)
+#
+# Divergence types reported:
+#   - MissingStep         canonical step absent from fresh trace
+#   - StatusMismatch      step present but its status changed
+#   - InvariantViolated   invariantAttribute value differs from canonical
+#   - RangeViolated       rangeAttribute value outside captured [min, max]
+#   - ExtraStep           fresh trace has steps beyond the canonical sequence
+#                         (informational — not a hard regression by itself)
+#
+# Usage:
+#   pwsh Scripts/compare-trace-to-canonical.ps1 `
+#        -Canonical state/quality/chatbot-qa/golden-traces/what-is-locrian/_canonical.json `
+#        -Fresh     state/quality/chatbot-qa/golden-traces/what-is-locrian/run-1.json
+#
+#   pwsh Scripts/compare-trace-to-canonical.ps1 `
+#        -PromptSlug what-is-locrian `
+#        -Fresh     /tmp/probe.json
+#
+# Sweep mode (compare each prompt's most recent run against its canonical):
+#   pwsh Scripts/compare-trace-to-canonical.ps1 -Sweep
+
+[CmdletBinding(DefaultParameterSetName = "Single")]
+param(
+    [Parameter(ParameterSetName = "Single")]
+    [string]$Canonical = "",
+
+    [Parameter(ParameterSetName = "Single")]
+    [string]$PromptSlug = "",
+
+    [Parameter(ParameterSetName = "Single")]
+    [string]$Fresh = "",
+
+    [Parameter(ParameterSetName = "Sweep")]
+    [switch]$Sweep,
+
+    [string]$Root = "state/quality/chatbot-qa/golden-traces"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$rootPath = Join-Path $repoRoot $Root
+
+function Get-FreshTrace {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        throw "Fresh trace file not found: $Path"
+    }
+
+    $content = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+
+    # Accept two shapes: a record-golden-traces.ps1 artifact (top-level
+    # 'response' field) or a raw /chat response (top-level 'trace').
+    if ($null -ne $content.response -and $null -ne $content.response.trace) {
+        return @($content.response.trace.steps)
+    }
+    if ($null -ne $content.trace -and $null -ne $content.trace.steps) {
+        return @($content.trace.steps)
+    }
+    throw "Cannot find trace.steps in $Path — expected either response.trace.steps or trace.steps"
+}
+
+function Compare-Trace {
+    param(
+        [Parameter(Mandatory)] [string]$CanonicalPath,
+        [Parameter(Mandatory)] [string]$FreshPath
+    )
+
+    if (-not (Test-Path $CanonicalPath)) {
+        throw "Canonical not found: $CanonicalPath"
+    }
+
+    $canonical = Get-Content -LiteralPath $CanonicalPath -Raw | ConvertFrom-Json
+    $freshSteps = Get-FreshTrace -Path $FreshPath
+
+    $divergences = New-Object 'System.Collections.Generic.List[object]'
+    $canonicalSteps = @($canonical.canonicalSteps)
+
+    for ($i = 0; $i -lt $canonicalSteps.Count; $i++) {
+        $canonStep = $canonicalSteps[$i]
+        if ($i -ge $freshSteps.Count) {
+            $divergences.Add([pscustomobject]@{
+                kind     = "MissingStep"
+                position = $i
+                detail   = "canonical expects '$($canonStep.name)' at position $i but fresh trace ended after $($freshSteps.Count) step(s)"
+            }) | Out-Null
+            continue
+        }
+        $freshStep = $freshSteps[$i]
+
+        if ($freshStep.name -ne $canonStep.name) {
+            $divergences.Add([pscustomobject]@{
+                kind     = "MissingStep"
+                position = $i
+                detail   = "canonical expects '$($canonStep.name)' at position $i but fresh has '$($freshStep.name)'"
+            }) | Out-Null
+            # When the sequence diverges, downstream comparisons would all
+            # be noise — stop the per-step diff here.
+            break
+        }
+
+        if ($freshStep.status -ne $canonStep.status) {
+            $divergences.Add([pscustomobject]@{
+                kind     = "StatusMismatch"
+                position = $i
+                step     = $canonStep.name
+                detail   = "canonical status '$($canonStep.status)' vs fresh '$($freshStep.status)'"
+            }) | Out-Null
+        }
+
+        # Invariant attribute check
+        if ($null -ne $canonStep.invariantAttributes) {
+            foreach ($prop in $canonStep.invariantAttributes.PSObject.Properties) {
+                $canonVal = $prop.Value
+                $freshAttrs = $freshStep.attributes
+                if ($null -eq $freshAttrs) {
+                    $divergences.Add([pscustomobject]@{
+                        kind     = "InvariantViolated"
+                        position = $i
+                        step     = $canonStep.name
+                        attr     = $prop.Name
+                        detail   = "expected '$canonVal' but fresh step has no attributes block"
+                    }) | Out-Null
+                    continue
+                }
+                $freshProp = $freshAttrs.PSObject.Properties[$prop.Name]
+                if ($null -eq $freshProp) {
+                    $divergences.Add([pscustomobject]@{
+                        kind     = "InvariantViolated"
+                        position = $i
+                        step     = $canonStep.name
+                        attr     = $prop.Name
+                        detail   = "expected '$canonVal' but fresh trace doesn't carry this attribute"
+                    }) | Out-Null
+                    continue
+                }
+                if ("$($freshProp.Value)" -ne "$canonVal") {
+                    $divergences.Add([pscustomobject]@{
+                        kind     = "InvariantViolated"
+                        position = $i
+                        step     = $canonStep.name
+                        attr     = $prop.Name
+                        detail   = "expected '$canonVal' but fresh has '$($freshProp.Value)'"
+                    }) | Out-Null
+                }
+            }
+        }
+
+        # Range attribute check
+        if ($null -ne $canonStep.rangeAttributes) {
+            foreach ($prop in $canonStep.rangeAttributes.PSObject.Properties) {
+                $range = $prop.Value
+                $freshAttrs = $freshStep.attributes
+                if ($null -eq $freshAttrs) { continue }
+                $freshProp = $freshAttrs.PSObject.Properties[$prop.Name]
+                if ($null -eq $freshProp) { continue }
+
+                [double]$freshNum = 0
+                if (-not [double]::TryParse([string]$freshProp.Value, [ref]$freshNum)) {
+                    continue
+                }
+
+                $min = [double]$range.min
+                $max = [double]$range.max
+                if ($freshNum -lt $min -or $freshNum -gt $max) {
+                    $divergences.Add([pscustomobject]@{
+                        kind     = "RangeViolated"
+                        position = $i
+                        step     = $canonStep.name
+                        attr     = $prop.Name
+                        detail   = "fresh value $freshNum outside canonical range [$min, $max]"
+                    }) | Out-Null
+                }
+            }
+        }
+    }
+
+    if ($freshSteps.Count -gt $canonicalSteps.Count) {
+        $extra = $freshSteps[$canonicalSteps.Count..($freshSteps.Count - 1)] | ForEach-Object { $_.name }
+        $divergences.Add([pscustomobject]@{
+            kind     = "ExtraStep"
+            position = $canonicalSteps.Count
+            detail   = "fresh trace has $($freshSteps.Count - $canonicalSteps.Count) step(s) beyond canonical: $($extra -join ', ')"
+        }) | Out-Null
+    }
+
+    return $divergences.ToArray()
+}
+
+# ── Mode dispatch ────────────────────────────────────────────────────────
+if ($Sweep) {
+    $dirs = Get-ChildItem -Path $rootPath -Directory
+    $totalDiverged = 0
+    $totalMatched  = 0
+    $totalSkipped  = 0
+
+    Write-Host "─── Trace-vs-canonical sweep ───" -ForegroundColor Cyan
+
+    foreach ($dir in $dirs) {
+        $canonPath = Join-Path $dir.FullName "_canonical.json"
+        if (-not (Test-Path $canonPath)) {
+            $totalSkipped++
+            continue
+        }
+
+        # Use the most recent run-*.json as the fresh trace.
+        $latestRun = Get-ChildItem -Path $dir.FullName -Filter "run-*.json" |
+                     Sort-Object LastWriteTime -Descending |
+                     Select-Object -First 1
+        if ($null -eq $latestRun) {
+            $totalSkipped++
+            continue
+        }
+
+        $divs = Compare-Trace -CanonicalPath $canonPath -FreshPath $latestRun.FullName
+        if ($divs.Count -eq 0) {
+            $totalMatched++
+        } else {
+            $totalDiverged++
+            $regressions = @($divs | Where-Object { $_.kind -ne "ExtraStep" })
+            $extras      = @($divs | Where-Object { $_.kind -eq "ExtraStep" })
+            $tag = if ($regressions.Count -gt 0) { "✗" } else { "⚠" }
+            $color = if ($regressions.Count -gt 0) { "Red" } else { "Yellow" }
+            Write-Host "  $tag $($dir.Name) — $($regressions.Count) regression(s), $($extras.Count) extra-step warning(s)" -ForegroundColor $color
+            foreach ($d in $divs) {
+                Write-Host "      [$($d.kind)] $($d.detail)" -ForegroundColor DarkGray
+            }
+        }
+    }
+
+    Write-Host ""
+    Write-Host "─── Sweep complete ───" -ForegroundColor Cyan
+    Write-Host "  Matched   : $totalMatched"
+    Write-Host "  Diverged  : $totalDiverged"
+    Write-Host "  Skipped   : $totalSkipped (no canonical)"
+
+    if ($totalDiverged -gt 0) { exit 1 } else { exit 0 }
+}
+
+# Single mode — resolve canonical from PromptSlug if not given directly.
+if (-not $Canonical -and $PromptSlug) {
+    $Canonical = Join-Path $rootPath "$PromptSlug/_canonical.json"
+}
+if (-not $Canonical) {
+    Write-Error "Provide -Canonical, -PromptSlug, or -Sweep."
+    exit 2
+}
+if (-not $Fresh) {
+    Write-Error "Provide -Fresh (path to a saved run JSON or chat response JSON)."
+    exit 2
+}
+
+$divs = Compare-Trace -CanonicalPath $Canonical -FreshPath $Fresh
+
+Write-Host "─── Trace comparison ───" -ForegroundColor Cyan
+Write-Host "Canonical : $Canonical"
+Write-Host "Fresh     : $Fresh"
+Write-Host ""
+
+if ($divs.Count -eq 0) {
+    Write-Host "✓ No divergences — fresh trace matches canonical shape." -ForegroundColor Green
+    exit 0
+}
+
+$regressions = @($divs | Where-Object { $_.kind -ne "ExtraStep" })
+$extras      = @($divs | Where-Object { $_.kind -eq "ExtraStep" })
+
+if ($regressions.Count -gt 0) {
+    Write-Host "✗ $($regressions.Count) regression(s):" -ForegroundColor Red
+    foreach ($d in $regressions) {
+        Write-Host "    [$($d.kind)] $($d.detail)" -ForegroundColor Yellow
+    }
+}
+if ($extras.Count -gt 0) {
+    Write-Host "⚠ $($extras.Count) extra-step warning(s):" -ForegroundColor Yellow
+    foreach ($d in $extras) {
+        Write-Host "    [$($d.kind)] $($d.detail)" -ForegroundColor DarkGray
+    }
+}
+
+if ($regressions.Count -gt 0) { exit 1 } else { exit 0 }

--- a/Scripts/extract-trace-dominators.ps1
+++ b/Scripts/extract-trace-dominators.ps1
@@ -261,6 +261,36 @@ foreach ($dir in $dirs) {
         $outPath = Join-Path $dir.FullName "_canonical.json"
         $artifact | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $outPath -Encoding UTF8
 
+        # Also emit a pruned signature — just (name, status, agent.id) per
+        # canonical step. Strips run-dependent values (routing.confidence,
+        # response.length, traceId, etc.) so signatures are stable across
+        # environments and can be committed as CI test fixtures.
+        $signatureSteps = New-Object 'System.Collections.Generic.List[object]'
+        foreach ($step in $canonical) {
+            $agentId = $null
+            if ($null -ne $step.invariantAttributes) {
+                if ($step.invariantAttributes.Contains("agent.id")) {
+                    $agentId = $step.invariantAttributes["agent.id"]
+                }
+            }
+            $signatureSteps.Add([ordered]@{
+                name    = $step.name
+                status  = $step.status
+                agentId = $agentId
+            }) | Out-Null
+        }
+
+        $signature = [ordered]@{
+            schemaVersion = 1
+            promptId      = $dir.Name
+            prompt        = if ($meta) { $meta.prompt } else { $null }
+            category      = if ($meta) { $meta.category } else { $null }
+            steps         = $signatureSteps.ToArray()
+        }
+
+        $sigPath = Join-Path $dir.FullName "_signature.json"
+        $signature | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $sigPath -Encoding UTF8
+
         $extracted++
         $summary += [pscustomobject]@{
             promptId   = $dir.Name

--- a/Scripts/extract-trace-dominators.ps1
+++ b/Scripts/extract-trace-dominators.ps1
@@ -1,0 +1,294 @@
+# extract-trace-dominators.ps1 — derive canonical trace shapes from golden runs
+#
+# Reads golden-trace artifacts captured by record-golden-traces.ps1 and emits
+# a per-prompt canonical-trace JSON capturing what every successful run had
+# in common: the dominator step sequence and the invariant attributes.
+#
+# Output: state/quality/chatbot-qa/golden-traces/<prompt-slug>/_canonical.json
+#
+# Schema (v1):
+#   {
+#     "schemaVersion":   1,
+#     "promptId":        "<slug>",
+#     "runCount":        N,
+#     "extractedAt":     "<UTC ISO>",
+#     "canonicalSteps":  [
+#       {
+#         "name":             "orchestration.answer",
+#         "status":           "completed",
+#         "invariantAttributes": { "agent.id": "skill.modes", ... },
+#         "rangeAttributes":    { "routing.confidence": { "min": 0.91, "max": 0.99 }, ... }
+#       },
+#       ...
+#     ]
+#   }
+#
+# Definitions:
+#   - canonicalSteps  : step (name, status) pairs present in EVERY run, in the
+#                       common order. Any step missing from one run is excluded.
+#   - invariantAttributes : attribute keys whose value is identical across
+#                       every run for that step.
+#   - rangeAttributes : numeric attribute keys that vary; min/max captured.
+#
+# Usage:
+#   pwsh Scripts/extract-trace-dominators.ps1                          # all prompts
+#   pwsh Scripts/extract-trace-dominators.ps1 -Filter "modes"          # filter by category or slug
+#   pwsh Scripts/extract-trace-dominators.ps1 -PromptDir what-is-locrian
+#   pwsh Scripts/extract-trace-dominators.ps1 -MinRuns 2               # require >=2 golden runs to extract
+
+[CmdletBinding()]
+param(
+    [string]$Root      = "state/quality/chatbot-qa/golden-traces",
+    [string]$PromptDir = "",
+    [string]$Filter    = "",
+    [int]$MinRuns      = 1
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$rootPath = Join-Path $repoRoot $Root
+
+if (-not (Test-Path $rootPath)) {
+    Write-Error "Golden-trace root not found: $rootPath`nRun Scripts/record-golden-traces.ps1 first."
+    exit 1
+}
+
+# ── Collect prompt directories to process ────────────────────────────────
+function Get-PromptDirs {
+    param([string]$Root, [string]$Filter, [string]$Single)
+
+    if ($Single) {
+        $p = Join-Path $Root $Single
+        if (-not (Test-Path $p)) {
+            Write-Error "Prompt directory not found: $p"
+            exit 1
+        }
+        return @(Get-Item -LiteralPath $p)
+    }
+
+    $all = Get-ChildItem -Path $Root -Directory
+    if ($Filter) {
+        # Match against folder name OR the prompt/category stored in _meta.json
+        $all = $all | Where-Object {
+            $name = $_.Name
+            $meta = Join-Path $_.FullName "_meta.json"
+            $matched = $name -like "*$Filter*"
+            if (-not $matched -and (Test-Path $meta)) {
+                $m = Get-Content -LiteralPath $meta -Raw | ConvertFrom-Json
+                if ($m.category -like "*$Filter*" -or $m.prompt -like "*$Filter*") {
+                    $matched = $true
+                }
+            }
+            return $matched
+        }
+    }
+    return $all
+}
+
+# ── Load run files for a prompt directory ────────────────────────────────
+function Get-RunArtifacts {
+    param([string]$DirPath)
+
+    Get-ChildItem -Path $DirPath -Filter "run-*.json" |
+        Sort-Object Name |
+        ForEach-Object {
+            try {
+                $content = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
+                [pscustomobject]@{
+                    Path     = $_.FullName
+                    Artifact = $content
+                }
+            }
+            catch {
+                Write-Warning "Failed to parse $($_.FullName): $($_.Exception.Message)"
+                $null
+            }
+        } | Where-Object { $null -ne $_ }
+}
+
+# ── Extract canonical steps from N runs ──────────────────────────────────
+function Get-CanonicalSteps {
+    param([System.Collections.IEnumerable]$Runs)
+
+    $runList = @($Runs)
+    if ($runList.Count -eq 0) { return @() }
+
+    # Pull steps from each run into a list-of-lists. PowerShell unwraps
+    # single-element foreach output, so we build a List<object[]> explicitly
+    # to keep array shape regardless of run count.
+    $perRunSteps = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($r in $runList) {
+        $steps = $r.Artifact.response.trace.steps
+        if ($null -eq $steps) {
+            $perRunSteps.Add(@()) | Out-Null
+        } else {
+            $perRunSteps.Add(@($steps)) | Out-Null
+        }
+    }
+
+    # Step sequence intersection: a step (name, status) is canonical only if
+    # it appears in every run in the SAME ordered position. Walk the shortest
+    # sequence and verify each (name, status) pair matches across all runs.
+    $shortestLen = [int]::MaxValue
+    foreach ($run in $perRunSteps) {
+        if ($run.Count -lt $shortestLen) { $shortestLen = $run.Count }
+    }
+    if ($shortestLen -eq [int]::MaxValue) { $shortestLen = 0 }
+
+    $canonical = New-Object 'System.Collections.Generic.List[object]'
+
+    for ($i = 0; $i -lt $shortestLen; $i++) {
+        $refStep = $perRunSteps[0][$i]
+        $allMatch = $true
+        foreach ($run in $perRunSteps) {
+            $s = $run[$i]
+            if ($s.name -ne $refStep.name -or $s.status -ne $refStep.status) {
+                $allMatch = $false
+                break
+            }
+        }
+        if (-not $allMatch) {
+            # Shape diverged at this position — stop the canonical sequence.
+            # Future enhancement: try longest-common-subsequence instead of
+            # strict prefix match. v1 is conservative.
+            break
+        }
+
+        # Collect attribute analysis across runs for this step position.
+        $attrInvariants = [ordered]@{}
+        $attrRanges     = [ordered]@{}
+
+        $allAttrKeys = @{}
+        foreach ($run in $perRunSteps) {
+            $attrs = $run[$i].attributes
+            if ($null -ne $attrs) {
+                foreach ($prop in $attrs.PSObject.Properties) {
+                    $allAttrKeys[$prop.Name] = $true
+                }
+            }
+        }
+
+        foreach ($key in $allAttrKeys.Keys) {
+            $values = New-Object 'System.Collections.Generic.List[object]'
+            $allPresent = $true
+            foreach ($run in $perRunSteps) {
+                $attrs = $run[$i].attributes
+                if ($null -eq $attrs) { $allPresent = $false; break }
+                $prop = $attrs.PSObject.Properties[$key]
+                if ($null -eq $prop) { $allPresent = $false; break }
+                $values.Add($prop.Value) | Out-Null
+            }
+            if (-not $allPresent) { continue }
+
+            $unique = @($values | Select-Object -Unique)
+            if ($unique.Count -eq 1) {
+                $attrInvariants[$key] = $unique[0]
+            }
+            else {
+                # Range only meaningful for numeric values.
+                $allNumeric = $true
+                $numericValues = New-Object 'System.Collections.Generic.List[double]'
+                foreach ($v in $values) {
+                    [double]$num = 0
+                    if ([double]::TryParse([string]$v, [ref]$num)) {
+                        $numericValues.Add($num) | Out-Null
+                    } else {
+                        $allNumeric = $false
+                        break
+                    }
+                }
+                if ($allNumeric -and $numericValues.Count -eq $values.Count) {
+                    $attrRanges[$key] = [ordered]@{
+                        min = ($numericValues | Measure-Object -Minimum).Minimum
+                        max = ($numericValues | Measure-Object -Maximum).Maximum
+                    }
+                }
+                # else: non-numeric variable attribute — intentionally not captured
+                # (varies meaningfully run-to-run; not a useful invariant).
+            }
+        }
+
+        $canonical.Add([ordered]@{
+            name                 = $refStep.name
+            status               = $refStep.status
+            invariantAttributes  = $attrInvariants
+            rangeAttributes      = $attrRanges
+        }) | Out-Null
+    }
+
+    return $canonical.ToArray()
+}
+
+# ── Main loop ────────────────────────────────────────────────────────────
+$dirs = Get-PromptDirs -Root $rootPath -Filter $Filter -Single $PromptDir
+
+Write-Host "─── Trace dominator extraction ───" -ForegroundColor Cyan
+Write-Host "Root        : $rootPath"
+Write-Host "Prompt dirs : $($dirs.Count)"
+Write-Host "MinRuns     : $MinRuns"
+
+$extracted = 0
+$skippedTooFew = 0
+$failed = 0
+$summary = @()
+
+foreach ($dir in $dirs) {
+    $runs = @(Get-RunArtifacts -DirPath $dir.FullName)
+    if ($runs.Count -lt $MinRuns) {
+        $skippedTooFew++
+        continue
+    }
+
+    try {
+        $canonical = Get-CanonicalSteps -Runs $runs
+
+        $meta = $null
+        $metaPath = Join-Path $dir.FullName "_meta.json"
+        if (Test-Path $metaPath) {
+            $meta = Get-Content -LiteralPath $metaPath -Raw | ConvertFrom-Json
+        }
+
+        $artifact = [ordered]@{
+            schemaVersion   = 1
+            promptId        = $dir.Name
+            prompt          = if ($meta) { $meta.prompt } else { $null }
+            category        = if ($meta) { $meta.category } else { $null }
+            runCount        = $runs.Count
+            extractedAt     = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ" -AsUTC)
+            canonicalSteps  = $canonical
+        }
+
+        $outPath = Join-Path $dir.FullName "_canonical.json"
+        $artifact | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $outPath -Encoding UTF8
+
+        $extracted++
+        $summary += [pscustomobject]@{
+            promptId   = $dir.Name
+            runs       = $runs.Count
+            stepCount  = $canonical.Count
+        }
+
+        Write-Host "  ✓ $($dir.Name) — $($runs.Count) run(s), $($canonical.Count) canonical step(s)"
+    }
+    catch {
+        $failed++
+        Write-Host "  ✗ $($dir.Name): $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+Write-Host ""
+Write-Host "─── Done ───" -ForegroundColor Cyan
+Write-Host "  Extracted        : $extracted"
+Write-Host "  Skipped (too few): $skippedTooFew (had <$MinRuns runs)"
+Write-Host "  Failed           : $failed"
+
+# Cross-prompt summary — quick scan for outliers (very short canonicals
+# often mean the trace shape diverged early, which is itself useful signal).
+if ($summary.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Canonical-step distribution:" -ForegroundColor Cyan
+    $byStepCount = $summary | Group-Object stepCount | Sort-Object Name
+    foreach ($g in $byStepCount) {
+        Write-Host "  $($g.Count) prompt(s) with $($g.Name) step(s)"
+    }
+}

--- a/Scripts/record-golden-traces.ps1
+++ b/Scripts/record-golden-traces.ps1
@@ -1,0 +1,216 @@
+# record-golden-traces.ps1 — capture successful chatbot runs as golden traces
+#
+# Hits the chatbot HTTP endpoint with each prompt from the corpus N times,
+# saves successful traces (no orchestration.fallback step) to disk under
+# state/quality/chatbot-qa/golden-traces/<prompt-slug>/run-<N>.json.
+#
+# Downstream consumers (next session): dominator extractor + CI diff against
+# canonical trace shape. v1 is the recorder only.
+#
+# Usage:
+#   pwsh Scripts/record-golden-traces.ps1                          # 1 run/prompt against localhost:5252
+#   pwsh Scripts/record-golden-traces.ps1 -RunsPerPrompt 3
+#   pwsh Scripts/record-golden-traces.ps1 -ChatbotUrl https://demos.guitaralchemist.com
+#   pwsh Scripts/record-golden-traces.ps1 -Filter "modes"          # only categories containing "modes"
+#
+# Output structure:
+#   state/quality/chatbot-qa/golden-traces/
+#     <prompt-slug>/
+#       run-1.json
+#       run-2.json
+#       _meta.json   ← prompt + category + recording metadata
+
+[CmdletBinding()]
+param(
+    [string]$ChatbotUrl     = "http://localhost:5252",
+    [int]$RunsPerPrompt     = 1,
+    [int]$TimeoutSeconds    = 60,
+    [string]$Filter         = "",
+    [string]$CorpusPath     = "Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml",
+    [string]$OutputDir      = "state/quality/chatbot-qa/golden-traces",
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$corpus   = Join-Path $repoRoot $CorpusPath
+$outRoot  = Join-Path $repoRoot $OutputDir
+
+if (-not (Test-Path $corpus)) {
+    Write-Error "Corpus not found at $corpus"
+    exit 1
+}
+
+# ── Parse prompts.yaml without a YAML library ──────────────────────────
+# Corpus format is strictly line-based; we only need (prompt, category, skip).
+# This is lossy by design — when we need the full schema we'll port the
+# C# parser in PromptCorpusTests.cs. For trace recording the prompt string
+# and category bucket are sufficient.
+
+function Parse-Corpus {
+    param([string]$Path)
+
+    $entries = @()
+    $current = $null
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        # Strip comments
+        $stripped = $line -replace '#.*$', ''
+
+        # New prompt entry
+        if ($stripped -match '^\s*-\s+prompt:\s*"(.+)"\s*$') {
+            if ($null -ne $current -and -not [string]::IsNullOrWhiteSpace($current.prompt)) {
+                $entries += [pscustomobject]$current
+            }
+            $current = @{
+                prompt   = $matches[1]
+                category = "uncategorized"
+                skip     = $false
+            }
+            continue
+        }
+
+        if ($null -eq $current) { continue }
+
+        if ($stripped -match '^\s+category:\s*"?([^"\r\n]+?)"?\s*$') {
+            $current.category = $matches[1].Trim()
+        }
+        elseif ($stripped -match '^\s+skip:\s*(true|false)\s*$') {
+            $current.skip = $matches[1] -eq 'true'
+        }
+    }
+
+    if ($null -ne $current -and -not [string]::IsNullOrWhiteSpace($current.prompt)) {
+        $entries += [pscustomobject]$current
+    }
+
+    return $entries
+}
+
+function ConvertTo-Slug {
+    param([string]$Text)
+    $s = $Text.ToLowerInvariant() -replace "[^a-z0-9]+", "-"
+    $s = $s.Trim('-')
+    if ($s.Length -gt 64) { $s = $s.Substring(0, 64).TrimEnd('-') }
+    return $s
+}
+
+function Trace-HasFallback {
+    param($Trace)
+    if ($null -eq $Trace -or $null -eq $Trace.steps) { return $false }
+    foreach ($step in $Trace.steps) {
+        if ($step.name -eq "orchestration.fallback" -or $step.name -eq "gen_ai.chat.fallback") {
+            return $true
+        }
+    }
+    return $false
+}
+
+# ── Load corpus and filter ─────────────────────────────────────────────
+$all = Parse-Corpus -Path $corpus
+$active = @($all | Where-Object { -not $_.skip })
+if ($Filter) {
+    $active = @($active | Where-Object {
+        $_.category -like "*$Filter*" -or $_.prompt -like "*$Filter*"
+    })
+}
+
+Write-Host "─── Golden trace recorder ───" -ForegroundColor Cyan
+Write-Host "Corpus       : $corpus"
+Write-Host "Chatbot URL  : $ChatbotUrl"
+Write-Host "Output dir   : $outRoot"
+Write-Host "Total prompts: $($all.Count) ($($all.Count - $active.Count) skipped/filtered)"
+Write-Host "Active       : $($active.Count) × $RunsPerPrompt run(s) = $($active.Count * $RunsPerPrompt) HTTP calls"
+
+if ($DryRun) {
+    Write-Host ""
+    Write-Host "Dry run — first 5 active prompts:" -ForegroundColor Yellow
+    $active | Select-Object -First 5 | ForEach-Object {
+        Write-Host "  [$($_.category)] $($_.prompt)"
+    }
+    return
+}
+
+if (-not (Test-Path $outRoot)) {
+    New-Item -ItemType Directory -Path $outRoot -Force | Out-Null
+}
+
+# ── Record loop ────────────────────────────────────────────────────────
+$recorded = 0
+$skipped  = 0
+$errored  = 0
+$sw       = [System.Diagnostics.Stopwatch]::StartNew()
+
+foreach ($entry in $active) {
+    $slug    = ConvertTo-Slug -Text $entry.prompt
+    $promptDir = Join-Path $outRoot $slug
+
+    for ($run = 1; $run -le $RunsPerPrompt; $run++) {
+        $sessionId = "golden-trace-$slug-run$run-$(Get-Date -Format yyyyMMddHHmmss)"
+        $body = @{
+            message   = $entry.prompt
+            sessionId = $sessionId
+        } | ConvertTo-Json -Compress
+
+        try {
+            $resp = Invoke-RestMethod `
+                -Method Post `
+                -Uri "$ChatbotUrl/api/chatbot/chat" `
+                -ContentType "application/json" `
+                -Body $body `
+                -TimeoutSec $TimeoutSeconds
+        }
+        catch {
+            $errored++
+            Write-Host "  ✗ [$($entry.category)] $($entry.prompt) (run $run): $($_.Exception.Message)" -ForegroundColor Red
+            continue
+        }
+
+        if (Trace-HasFallback -Trace $resp.trace) {
+            $skipped++
+            Write-Host "  ↩ [$($entry.category)] $($entry.prompt) (run $run): fell back, not golden" -ForegroundColor DarkYellow
+            continue
+        }
+
+        if (-not (Test-Path $promptDir)) {
+            New-Item -ItemType Directory -Path $promptDir -Force | Out-Null
+        }
+
+        $artifact = [ordered]@{
+            schemaVersion = 1
+            recordedAt    = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ" -AsUTC)
+            promptId      = $slug
+            prompt        = $entry.prompt
+            category      = $entry.category
+            runIndex      = $run
+            response      = $resp
+        }
+
+        $runPath  = Join-Path $promptDir "run-$run.json"
+        $artifact | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $runPath -Encoding UTF8
+
+        # Write or refresh _meta.json with prompt + category once per dir
+        $metaPath = Join-Path $promptDir "_meta.json"
+        if (-not (Test-Path $metaPath)) {
+            ([ordered]@{
+                promptId         = $slug
+                prompt           = $entry.prompt
+                category         = $entry.category
+                schemaVersion    = 1
+                firstRecordedAt  = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ" -AsUTC)
+            } | ConvertTo-Json) | Set-Content -LiteralPath $metaPath -Encoding UTF8
+        }
+
+        $recorded++
+        Write-Host "  ✓ [$($entry.category)] $($entry.prompt) (run $run) → $slug/run-$run.json"
+    }
+}
+
+$sw.Stop()
+
+Write-Host ""
+Write-Host "─── Done in $($sw.Elapsed.TotalSeconds.ToString('0.0'))s ───" -ForegroundColor Cyan
+Write-Host "  Recorded : $recorded"
+Write-Host "  Skipped  : $skipped (fell back)"
+Write-Host "  Errored  : $errored"
+Write-Host ""
+Write-Host "Artifacts in: $outRoot"

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/CanonicalSignatureChecker.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/CanonicalSignatureChecker.cs
@@ -1,0 +1,124 @@
+namespace GaChatbot.Api.Tests.Corpus;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Reads pruned canonical-trace signatures emitted by
+/// <c>Scripts/extract-trace-dominators.ps1</c> and asserts a live trace's
+/// step shape matches per (name, agent.id) per position.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Signatures are committed under <c>state/quality/chatbot-qa/golden-traces/&lt;slug&gt;/_signature.json</c>.
+/// Each signature captures the *stable* subset of the canonical: step name,
+/// status, and the routing agent.id per step. Run-dependent values
+/// (routing.confidence, response.length, traceId, elapsedMs) are intentionally
+/// excluded so signatures are stable across environments and CI runs.
+/// </para>
+/// <para>
+/// The slug derivation matches PowerShell's <c>ConvertTo-Slug</c> in the
+/// recorder so file lookups round-trip between the .NET test and the
+/// PowerShell tooling. Tests assert both directions in
+/// <see cref="CanonicalSignatureCheckerTests"/>.
+/// </para>
+/// </remarks>
+internal static class CanonicalSignatureChecker
+{
+    public sealed record StepSignature(string Name, string Status, string? AgentId);
+
+    public sealed record Signature(
+        int SchemaVersion,
+        string PromptId,
+        string? Prompt,
+        string? Category,
+        IReadOnlyList<StepSignature> Steps);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        ReadCommentHandling  = JsonCommentHandling.Skip,
+        AllowTrailingCommas  = true,
+    };
+
+    private static readonly Regex SlugReplace =
+        new("[^a-z0-9]+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Mirrors PowerShell's <c>ConvertTo-Slug</c> in <c>record-golden-traces.ps1</c>:
+    /// lowercase, replace non-alphanumeric runs with "-", trim, truncate to 64.
+    /// Identical output is essential — signatures are looked up by slug.
+    /// </summary>
+    public static string ToSlug(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        var lower = text.ToLowerInvariant();
+        var slug  = SlugReplace.Replace(lower, "-").Trim('-');
+        if (slug.Length > 64) slug = slug[..64].TrimEnd('-');
+        return slug;
+    }
+
+    public static string? ResolveSignaturePath(string goldenTracesRoot, string promptText)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(goldenTracesRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(promptText);
+        var slug = ToSlug(promptText);
+        var path = Path.Combine(goldenTracesRoot, slug, "_signature.json");
+        return File.Exists(path) ? path : null;
+    }
+
+    public static Signature Load(string path)
+    {
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<Signature>(json, JsonOptions)
+            ?? throw new InvalidOperationException($"Signature at {path} deserialized to null");
+    }
+
+    /// <summary>
+    /// Returns <c>null</c> if the trace matches the signature, otherwise a
+    /// short human-readable diagnostic suitable for embedding in a test
+    /// failure message.
+    /// </summary>
+    public static string? Compare(
+        IReadOnlyList<(string Name, IDictionary<string, string?>? Attributes)> traceSteps,
+        Signature signature)
+    {
+        ArgumentNullException.ThrowIfNull(traceSteps);
+        ArgumentNullException.ThrowIfNull(signature);
+
+        for (var i = 0; i < signature.Steps.Count; i++)
+        {
+            var canon = signature.Steps[i];
+
+            if (i >= traceSteps.Count)
+            {
+                return $"signature expects step '{canon.Name}' at position {i} but trace has only {traceSteps.Count} step(s)";
+            }
+
+            var actual = traceSteps[i];
+            if (!string.Equals(actual.Name, canon.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return $"position {i}: signature expects '{canon.Name}' but trace has '{actual.Name}'";
+            }
+
+            // agent.id check fires only when the signature recorded one for
+            // this position. Framing steps (chat.request, response.emit) have
+            // null agentId in the signature and intentionally skip this check.
+            if (canon.AgentId is not null)
+            {
+                var actualAgentId =
+                    actual.Attributes is not null
+                    && actual.Attributes.TryGetValue("agent.id", out var a)
+                        ? a : null;
+
+                if (!string.Equals(actualAgentId, canon.AgentId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return $"step '{canon.Name}': signature expects agent.id '{canon.AgentId}' but trace has '{actualAgentId ?? "<null>"}'";
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/CanonicalSignatureCheckerTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/CanonicalSignatureCheckerTests.cs
@@ -1,0 +1,208 @@
+namespace GaChatbot.Api.Tests.Corpus;
+
+using NUnit.Framework;
+using static CanonicalSignatureChecker;
+
+[TestFixture]
+public class CanonicalSignatureCheckerTests
+{
+    [TestCase("What is Locrian",                "what-is-locrian")]
+    [TestCase("What chord is C E G",            "what-chord-is-c-e-g")]
+    [TestCase("WHAT IS MIXOLYDIAN",             "what-is-mixolydian")]
+    [TestCase("modes of melodi minor",          "modes-of-melodi-minor")]
+    [TestCase("---hello---",                    "hello")]
+    [TestCase("a/b\\c.d?e!",                    "a-b-c-d-e")]
+    public void ToSlug_MatchesPowershellRecorder(string input, string expected)
+    {
+        // Round-trips with ConvertTo-Slug in record-golden-traces.ps1.
+        // If you change either, change both.
+        Assert.That(ToSlug(input), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ToSlug_TruncatesAt64Chars()
+    {
+        var long_ = new string('a', 80);
+        Assert.That(ToSlug(long_).Length, Is.LessThanOrEqualTo(64));
+    }
+
+    [Test]
+    public void Compare_MatchingTrace_ReturnsNull()
+    {
+        var sig = new Signature(
+            SchemaVersion: 1,
+            PromptId: "test",
+            Prompt: "x",
+            Category: "test",
+            Steps:
+            [
+                new StepSignature("chat.request",        "completed", null),
+                new StepSignature("orchestration.answer","completed", "skill.modes"),
+                new StepSignature("response.emit",       "completed", null),
+            ]);
+
+        var trace = ToTrace(
+            ("chat.request",         null),
+            ("orchestration.answer", new Dictionary<string, string?> { ["agent.id"] = "skill.modes" }),
+            ("response.emit",        null));
+
+        Assert.That(Compare(trace, sig), Is.Null);
+    }
+
+    [Test]
+    public void Compare_AgentIdMismatch_Diagnostic()
+    {
+        var sig = new Signature(1, "test", "x", "test",
+        [
+            new StepSignature("orchestration.answer", "completed", "skill.modes"),
+        ]);
+
+        var trace = ToTrace(
+            ("orchestration.answer",
+                new Dictionary<string, string?> { ["agent.id"] = "skill.relativekey" }));
+
+        var msg = Compare(trace, sig);
+        Assert.That(msg, Is.Not.Null);
+        Assert.That(msg!, Does.Contain("skill.modes"));
+        Assert.That(msg, Does.Contain("skill.relativekey"));
+    }
+
+    [Test]
+    public void Compare_TraceTooShort_Diagnostic()
+    {
+        var sig = new Signature(1, "test", "x", "test",
+        [
+            new StepSignature("chat.request",       "completed", null),
+            new StepSignature("orchestration.answer","completed", "skill.modes"),
+            new StepSignature("response.emit",      "completed", null),
+        ]);
+
+        var trace = ToTrace(("chat.request", null));
+
+        var msg = Compare(trace, sig);
+        Assert.That(msg, Is.Not.Null);
+        Assert.That(msg!, Does.Contain("orchestration.answer"));
+        Assert.That(msg, Does.Contain("position 1"));
+    }
+
+    [Test]
+    public void Compare_WrongStepName_Diagnostic()
+    {
+        var sig = new Signature(1, "test", "x", "test",
+        [
+            new StepSignature("chat.request",        "completed", null),
+            new StepSignature("orchestration.answer","completed", "skill.modes"),
+        ]);
+
+        var trace = ToTrace(
+            ("chat.request",            null),
+            ("orchestration.fallback",  null));
+
+        var msg = Compare(trace, sig);
+        Assert.That(msg, Is.Not.Null);
+        Assert.That(msg!, Does.Contain("orchestration.answer"));
+        Assert.That(msg, Does.Contain("orchestration.fallback"));
+        Assert.That(msg, Does.Contain("position 1"));
+    }
+
+    [Test]
+    public void Compare_NullAgentIdInSignature_SkipsAgentCheck()
+    {
+        // Framing steps (chat.request, response.emit) have no agent.id in
+        // the signature; comparison must not require one from the trace.
+        var sig = new Signature(1, "test", "x", "test",
+        [
+            new StepSignature("chat.request",  "completed", null),
+            new StepSignature("response.emit", "completed", null),
+        ]);
+
+        var traceWithNoAttrs = ToTrace(
+            ("chat.request",  null),
+            ("response.emit", null));
+        Assert.That(Compare(traceWithNoAttrs, sig), Is.Null);
+
+        var traceWithIncidentalAgentId = ToTrace(
+            ("chat.request",  new Dictionary<string, string?> { ["agent.id"] = "something" }),
+            ("response.emit", null));
+        Assert.That(Compare(traceWithIncidentalAgentId, sig), Is.Null,
+            "signature with null agent.id must not constrain the trace's agent.id");
+    }
+
+    [Test]
+    public void Compare_TraceLongerThanSignature_StillMatches()
+    {
+        // Extra steps beyond the signature length are NOT a regression by
+        // themselves — they're informational. The signature only constrains
+        // the prefix it covers.
+        var sig = new Signature(1, "test", "x", "test",
+        [
+            new StepSignature("chat.request", "completed", null),
+        ]);
+
+        var trace = ToTrace(
+            ("chat.request",         null),
+            ("orchestration.answer", new Dictionary<string, string?> { ["agent.id"] = "skill.modes" }),
+            ("response.emit",        null));
+
+        Assert.That(Compare(trace, sig), Is.Null);
+    }
+
+    [Test]
+    public void ResolveSignaturePath_MissingFile_ReturnsNull()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        try
+        {
+            var path = ResolveSignaturePath(tmp, "no such prompt");
+            Assert.That(path, Is.Null);
+        }
+        finally
+        {
+            Directory.Delete(tmp, true);
+        }
+    }
+
+    [Test]
+    public void Load_ParsesGoldenSignature_RoundTrip()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        try
+        {
+            var slug = "what-is-locrian";
+            var dir  = Path.Combine(tmp, slug);
+            Directory.CreateDirectory(dir);
+            var file = Path.Combine(dir, "_signature.json");
+            File.WriteAllText(file, """
+            {
+              "schemaVersion": 1,
+              "promptId": "what-is-locrian",
+              "prompt": "What is Locrian",
+              "category": "modes",
+              "steps": [
+                { "name": "chat.request",         "status": "completed", "agentId": null },
+                { "name": "orchestration.answer", "status": "completed", "agentId": "skill.modes" },
+                { "name": "response.emit",        "status": "completed", "agentId": null }
+              ]
+            }
+            """);
+
+            var resolved = ResolveSignaturePath(tmp, "What is Locrian");
+            Assert.That(resolved, Is.EqualTo(file));
+
+            var sig = Load(resolved!);
+            Assert.That(sig.PromptId, Is.EqualTo("what-is-locrian"));
+            Assert.That(sig.Steps.Count, Is.EqualTo(3));
+            Assert.That(sig.Steps[1].AgentId, Is.EqualTo("skill.modes"));
+        }
+        finally
+        {
+            Directory.Delete(tmp, true);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+    private static IReadOnlyList<(string Name, IDictionary<string, string?>? Attributes)> ToTrace(
+        params (string Name, IDictionary<string, string?>? Attributes)[] steps) => steps;
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/PromptCorpusTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/PromptCorpusTests.cs
@@ -26,6 +26,7 @@ public class PromptCorpusTests
     private WebApplicationFactory<Program>? _factory;
     private HttpClient? _client;
     private CorpusFile? _corpus;
+    private string? _goldenTracesRoot;
 
     /// <summary>
     ///     Universally-banned substrings — any answer containing these is a
@@ -75,6 +76,24 @@ public class PromptCorpusTests
             .Build();
         _corpus = deserializer.Deserialize<CorpusFile>(yaml)
             ?? throw new InvalidOperationException("prompts.yaml deserialized to null");
+
+        // Resolve the golden-traces root if it exists. The path is optional —
+        // when a signature file is committed for a prompt, the trace-vs-
+        // signature check fires; otherwise it skips silently. This is the
+        // .NET counterpart to Scripts/compare-trace-to-canonical.ps1 so the
+        // same shape contract runs both in CI and in local PowerShell.
+        // Candidates cover both the source-tree path (developer test run)
+        // and any future test fixture co-location.
+        var goldenCandidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..",
+                "state", "quality", "chatbot-qa", "golden-traces"),
+            Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "..",
+                "state", "quality", "chatbot-qa", "golden-traces"),
+        };
+        _goldenTracesRoot = goldenCandidates
+            .Select(p => Path.GetFullPath(p))
+            .FirstOrDefault(Directory.Exists);
     }
 
     [OneTimeTearDown]
@@ -286,6 +305,30 @@ public class PromptCorpusTests
                 && conf < minConf)
             {
                 return ($"{label} → routing.confidence {conf:F3} below required minimum {minConf:F3}", null);
+            }
+        }
+
+        // ── Canonical signature check ───────────────────────────────────────
+        // If a _signature.json file is committed for this prompt's slug
+        // under state/quality/chatbot-qa/golden-traces/, assert the live
+        // trace's (name, agent.id) per step matches. This is the offline-
+        // validation pipeline's CI wire-up — produced by
+        // Scripts/extract-trace-dominators.ps1 and committed once vetted.
+        // Prompts without a signature file silently skip this check, so
+        // the gate is opt-in per prompt by file presence (no YAML field
+        // needed).
+        if (_goldenTracesRoot is not null)
+        {
+            var sigPath = CanonicalSignatureChecker.ResolveSignaturePath(_goldenTracesRoot, entry.Prompt);
+            if (sigPath is not null)
+            {
+                var signature = CanonicalSignatureChecker.Load(sigPath);
+                var trace = traceSteps.Select(s => (s.Name, s.Attributes)).ToList();
+                var sigDiff = CanonicalSignatureChecker.Compare(trace, signature);
+                if (sigDiff is not null)
+                {
+                    return ($"{label} → canonical signature mismatch: {sigDiff}", null);
+                }
             }
         }
 

--- a/state/quality/chatbot-qa/golden-traces/are-0146-and-0137-z-related/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/are-0146-and-0137-z-related/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "are-0146-and-0137-z-related",
+  "prompt": "Are 0146 and 0137 z-related",
+  "category": "operations",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "algebra"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "algebra"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "algebra"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/are-pitch-classes-0-1-4-and-0-1-6-equivalent-under-inversion/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/are-pitch-classes-0-1-4-and-0-1-6-equivalent-under-inversion/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "are-pitch-classes-0-1-4-and-0-1-6-equivalent-under-inversion",
+  "prompt": "Are pitch classes 0,1,4 and 0,1,6 equivalent under inversion",
+  "category": "operations",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.settheoryequivalence"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.settheoryequivalence"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.settheoryequivalence"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/common-tones-between-g7-and-dm7/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/common-tones-between-g7-and-dm7/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "common-tones-between-g7-and-dm7",
+  "prompt": "Common tones between G7 and Dm7",
+  "category": "operations",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.commontones"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.commontones"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.commontones"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/diatnic-chords-in-g-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/diatnic-chords-in-g-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "diatnic-chords-in-g-major",
+  "prompt": "diatnic chords in G major",
+  "category": "typo-tolerance",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/diatonic-chords-in-a-minor/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/diatonic-chords-in-a-minor/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "diatonic-chords-in-a-minor",
+  "prompt": "Diatonic chords in A minor",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/diatonic-chords-in-f-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/diatonic-chords-in-f-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "diatonic-chords-in-f-major",
+  "prompt": "Diatonic chords in F major",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/diatonic-chords-in-g-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/diatonic-chords-in-g-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "diatonic-chords-in-g-major",
+  "prompt": "DIATONIC CHORDS IN G MAJOR",
+  "category": "case-variants",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/explain-the-circle-of-fifths/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/explain-the-circle-of-fifths/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "explain-the-circle-of-fifths",
+  "prompt": "Explain the circle of fifths",
+  "category": "theory",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.circleoffifths"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.circleoffifths"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.circleoffifths"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/list-atonal-modal-families/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/list-atonal-modal-families/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "list-atonal-modal-families",
+  "prompt": "List atonal modal families",
+  "category": "atonal",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/list-symmetric-atonal-families/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/list-symmetric-atonal-families/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "list-symmetric-atonal-families",
+  "prompt": "List symmetric atonal families",
+  "category": "atonal",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/modes-of-melodi-minor/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/modes-of-melodi-minor/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "modes-of-melodi-minor",
+  "prompt": "modes of melodi minor",
+  "category": "typo-tolerance",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/notes-in-c-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/notes-in-c-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "notes-in-c-major",
+  "prompt": "notes in c major",
+  "category": "case-variants",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.scaleinfo"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.scaleinfo"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.scaleinfo"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/phrygian-dominant/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/phrygian-dominant/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "phrygian-dominant",
+  "prompt": "Phrygian dominant",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/show-me-a-cmaj9-chord/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/show-me-a-cmaj9-chord/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "show-me-a-cmaj9-chord",
+  "prompt": "Show me a Cmaj9 chord",
+  "category": "extended-chords",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/show-me-some-easy-beginner-chords/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/show-me-some-easy-beginner-chords/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "show-me-some-easy-beginner-chords",
+  "prompt": "Show me some easy beginner chords",
+  "category": "getting-started",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.beginnerchords"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.beginnerchords"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.beginnerchords"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/show-me-the-notes-in-c-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/show-me-the-notes-in-c-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "show-me-the-notes-in-c-major",
+  "prompt": "Show me the notes in C major",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.scaleinfo"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.scaleinfo"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.scaleinfo"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/suggest-substitutions-for-g7-in-a-ii-v-i/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/suggest-substitutions-for-g7-in-a-ii-v-i/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "suggest-substitutions-for-g7-in-a-ii-v-i",
+  "prompt": "Suggest substitutions for G7 in a ii-V-I",
+  "category": "progressions",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.chordsubstitution"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.chordsubstitution"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.chordsubstitution"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/tell-me-about-hijaz/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/tell-me-about-hijaz/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "tell-me-about-hijaz",
+  "prompt": "Tell me about Hijaz",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/tell-me-about-phrygian/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/tell-me-about-phrygian/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "tell-me-about-phrygian",
+  "prompt": "tell me about phrygian",
+  "category": "typo-tolerance",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/transpose-a-minor-to-c-minor/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/transpose-a-minor-to-c-minor/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "transpose-a-minor-to-c-minor",
+  "prompt": "Transpose A minor to C minor",
+  "category": "operations",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/transpose-c-e-g-to-d/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/transpose-c-e-g-to-d/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "transpose-c-e-g-to-d",
+  "prompt": "Transpose C E G to D",
+  "category": "operations",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/transpose-c-major-to-e/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/transpose-c-major-to-e/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "transpose-c-major-to-e",
+  "prompt": "Transpose C major to E",
+  "category": "operations",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.transpose"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-are-the-byzantine-modes/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-are-the-byzantine-modes/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-are-the-byzantine-modes",
+  "prompt": "What are the byzantine modes",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-are-the-common-tones-between-cmaj7-and-am7/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-are-the-common-tones-between-cmaj7-and-am7/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-are-the-common-tones-between-cmaj7-and-am7",
+  "prompt": "What are the common tones between Cmaj7 and Am7",
+  "category": "operations",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.commontones"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.commontones"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.commontones"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-are-the-diatonic-chords-in-d-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-are-the-diatonic-chords-in-d-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-are-the-diatonic-chords-in-d-major",
+  "prompt": "What are the diatonic chords in D major",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-are-the-diatonic-chords-in-g-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-are-the-diatonic-chords-in-g-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-are-the-diatonic-chords-in-g-major",
+  "prompt": "What are the diatonic chords in G major",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.diatonicchords"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-are-the-modes-of-harmonic-minor/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-are-the-modes-of-harmonic-minor/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-are-the-modes-of-harmonic-minor",
+  "prompt": "What are the modes of harmonic minor",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-are-the-modes-of-melodic-minor/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-are-the-modes-of-melodic-minor/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-are-the-modes-of-melodic-minor",
+  "prompt": "What are the modes of melodic minor",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-are-the-modes-of-the-major-scale/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-are-the-modes-of-the-major-scale/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-are-the-modes-of-the-major-scale",
+  "prompt": "What are the modes of the major scale",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-chord-is-c-e-g-bb-d/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-chord-is-c-e-g-bb-d/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-chord-is-c-e-g-bb-d",
+  "prompt": "What chord is C E G Bb D",
+  "category": "chord-from-notes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-chord-is-c-e-g/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-chord-is-c-e-g/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-chord-is-c-e-g",
+  "prompt": "What chord is C E G",
+  "category": "chord-from-notes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-chord-is-d-f-a-c-e/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-chord-is-d-f-a-c-e/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-chord-is-d-f-a-c-e",
+  "prompt": "What chord is D F A C E",
+  "category": "chord-from-notes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-chord-is-f-a-c-e/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-chord-is-f-a-c-e/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-chord-is-f-a-c-e",
+  "prompt": "What chord is F A C E",
+  "category": "chord-from-notes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.chordinfo"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-forte-number-4-z29/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-forte-number-4-z29/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-forte-number-4-z29",
+  "prompt": "What is Forte number 4-Z29",
+  "category": "atonal",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-hungarian-minor/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-hungarian-minor/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-hungarian-minor",
+  "prompt": "What is Hungarian minor",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-locrian/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-locrian/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-locrian",
+  "prompt": "What is Locrian",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-lydian-dominant/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-lydian-dominant/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-lydian-dominant",
+  "prompt": "What is Lydian dominant",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-mixolydian/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-mixolydian/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-mixolydian",
+  "prompt": "What is Mixolydian",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-the-altered-scale/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-the-altered-scale/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-the-altered-scale",
+  "prompt": "What is the altered scale",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-the-diminished-scale/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-the-diminished-scale/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-the-diminished-scale",
+  "prompt": "What is the diminished scale",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-the-interval-class-vector-of-c-e-g/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-the-interval-class-vector-of-c-e-g/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-the-interval-class-vector-of-c-e-g",
+  "prompt": "What is the interval class vector of C E G",
+  "category": "atonal",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.intervalclassvector"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.intervalclassvector"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.intervalclassvector"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-the-parallel-minor-of-c-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-the-parallel-minor-of-c-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-the-parallel-minor-of-c-major",
+  "prompt": "What is the parallel minor of C major",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-the-relative-major-of-a-minor/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-the-relative-major-of-a-minor/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-the-relative-major-of-a-minor",
+  "prompt": "What is the relative major of A minor",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-the-relative-minor-of-g-major/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-the-relative-minor-of-g-major/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-the-relative-minor-of-g-major",
+  "prompt": "What is the relative minor of G major",
+  "category": "scales-keys",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.relativekey"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}

--- a/state/quality/chatbot-qa/golden-traces/what-is-the-whole-tone-scale/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-the-whole-tone-scale/_signature.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "promptId": "what-is-the-whole-tone-scale",
+  "prompt": "What is the whole tone scale",
+  "category": "modes",
+  "steps": [
+    {
+      "name": "chat.request",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "orchestration.answer",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "orchestration.route",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "agent.semantic_result",
+      "status": "completed",
+      "agentId": "skill.modes"
+    },
+    {
+      "name": "notation.vextab",
+      "status": "completed",
+      "agentId": null
+    },
+    {
+      "name": "response.emit",
+      "status": "completed",
+      "agentId": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Four compounding commits that ship the **complete** offline-validation pipeline for the chatbot corpus, modeled on GitHub Engineering's [\"Validating agentic behavior when correct isn't deterministic\"](https://github.blog/ai-and-ml/generative-ai/validating-agentic-behavior-when-correct-isnt-deterministic/) pattern:

1. **\`Scripts/record-golden-traces.ps1\`** — POSTs each corpus prompt at the chatbot HTTP endpoint, saves successful (no-fallback) traces.
2. **\`Scripts/extract-trace-dominators.ps1\`** — derives canonical execution shape per prompt + emits a pruned \`_signature.json\` (stable across runs).
3. **\`Scripts/compare-trace-to-canonical.ps1\`** — local diff with regression classification + sweep mode (exit 1 on any divergence).
4. **CI wire-up**:
   - \`CanonicalSignatureChecker.cs\` — .NET helper, same comparison logic as the PowerShell comparator
   - \`CanonicalSignatureCheckerTests.cs\` — 15 fast unit tests, 31ms total
   - \`PromptCorpusTests.cs\` extension — applies signature gate automatically when \`_signature.json\` exists for the prompt's slug
   - 45 committed \`_signature.json\` fixtures = the regression contract for the current corpus state

Together: **recorder → extractor → signature → committed fixture → CI gate**.

## Empirical finding

Every healthy prompt in the corpus converges on the same 6-step canonical shape:

\`\`\`
chat.request → orchestration.answer → orchestration.route →
agent.semantic_result → notation.vextab → response.emit
\`\`\`

\`agent.id\` is the per-prompt-stable invariant on steps 2-4. The broken \"major vs minor\" trace captured earlier in this session was a 4-step shape with \`orchestration.fallback\` + \`gen_ai.chat.fallback\` — which the signature checker would catch as **wrong step at position 2** + **agent.id mismatch**.

## Local validation

**Recorder** (full corpus, 1 run each):
- 45/50 active prompts recorded (90% golden-pass baseline)
- 3 fell back, 2 errored, ~194s wall time

**Extractor + signature emission**:
- 100% extraction, all 45 converge on the same 6-step canonical
- Signatures ~1KB each, ~45KB total committed

**Comparator (PowerShell)**:
- Happy: 0 div, exit 0
- Cross-prompt: 8 InvariantViolated, exit 1
- Sweep: 45 matched / 0 diverged

**C# helper + PromptCorpusTests**:
- 15/15 unit tests pass (31ms)
- Full \`EveryPrompt_SatisfiesItsInvariants\` run against local Ollama: **0 signature failures across 45 signature-gated prompts**. The 2 unrelated failures (typo-tolerance \"What is dorian\" missing 'Dorian' substring, extended-chords \"What is C7b9\" missing 'Bb' substring) are pre-existing LLM-wording-variance issues unrelated to signatures.

## Signature schema

Each committed \`_signature.json\` captures the **stable** subset of the canonical:

\`\`\`json
{
  \"schemaVersion\": 1,
  \"promptId\": \"what-is-locrian\",
  \"prompt\": \"What is Locrian\",
  \"category\": \"modes\",
  \"steps\": [
    { \"name\": \"chat.request\",         \"status\": \"completed\", \"agentId\": null },
    { \"name\": \"orchestration.answer\", \"status\": \"completed\", \"agentId\": \"skill.modes\" },
    { \"name\": \"orchestration.route\",  \"status\": \"completed\", \"agentId\": \"skill.modes\" },
    { \"name\": \"agent.semantic_result\",\"status\": \"completed\", \"agentId\": \"skill.modes\" },
    { \"name\": \"notation.vextab\",      \"status\": \"completed\", \"agentId\": null },
    { \"name\": \"response.emit\",        \"status\": \"completed\", \"agentId\": null }
  ]
}
\`\`\`

Run-dependent fields (routing.confidence, response.length, traceId, elapsedMs) are deliberately excluded.

## Gate behavior

The signature check is **opt-in per prompt by file presence**, no YAML field needed:
- Prompts with a committed \`_signature.json\` for their slug → signature gate fires
- Prompts without → gate silently skips

This means the user controls which prompts are signature-gated by curating which signatures get committed. The 45 in this PR are the empirically-stable ones from the initial corpus capture.

## Companion to #225 (Mistral cascade)

The two halves of the QA story:
- **#225** = runtime resilience (cascade catches Ollama failures)
- **#227** (this PR) = offline validation (canonical traces catch trajectory regressions before merge)

Once #225 lands and cascade is enabled on demos, the golden-pass rate climbs toward 100%, and any future routing change that breaks a deterministic prompt fails CI with a clear signature diagnostic.

Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)