### PR TITLE
ci: pin agent blackbox beta release

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -11,6 +11,7 @@ permissions:
   checks: write
 
 env:
+  AGENT_BLACKBOX_REF: "v0.1.0-beta.1"
   DOTNET_VERSION: "10.0.1xx"
   VERIFY_COMMAND: >-
     dotnet test AllProjects.slnx
@@ -35,6 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: GuitarAlchemist/agent-blackbox
+          ref: ${{ env.AGENT_BLACKBOX_REF }}
           path: .agent-blackbox
           token: ${{ secrets.AGENT_BLACKBOX_TOKEN }}
 


### PR DESCRIPTION
## Summary
- pin Agent Blackbox checkout to v0.1.0-beta.1
- keep GA verification behavior unchanged

## Verification
- git diff --check