### PR TITLE
fix(hooks): digest-stop-finalize respects trigger=digest-skill at any age

### DIFF
--- a/Scripts/digest-stop-finalize.ps1
+++ b/Scripts/digest-stop-finalize.ps1
@@ -33,7 +33,32 @@ $latest    = Join-Path $digestDir 'latest.md'
 
 if (Test-Path $latest) {
     $age = (Get-Date) - (Get-Item $latest).LastWriteTime
+
+    # Bypass 1: very recent write — protects against rapid re-stomps in the
+    # same session (a Stop hook firing seconds after a tool call wraps).
     if ($age.TotalMinutes -lt 10) { exit 0 }
+
+    # Bypass 2: model-driven digest written by /digest — these carry
+    # `trigger: digest-skill` in their frontmatter and represent
+    # intentional state capture. The fallback stub is meant ONLY as
+    # safety net for sessions that ended without /digest; it must
+    # never clobber a model-driven write, regardless of age.
+    # Observed problem: 4 stomps in one session on 2026-05-16 because
+    # the original 10-min guard was too narrow for long-running sessions.
+    try {
+        $head = Get-Content $latest -TotalCount 12 -ErrorAction Stop
+        $trigger = $head | Where-Object { $_ -match '^\s*trigger:\s*(\S+)' } |
+                   Select-Object -First 1
+        if ($trigger -and ($trigger -match '^\s*trigger:\s*digest-skill\s*$')) {
+            # Respect the model's authoritative write. The audit archive
+            # already captured the prior state via the Copy-Item below
+            # whenever a Stop hook DOES fire, so we lose nothing.
+            exit 0
+        }
+    } catch {
+        # Frontmatter unreadable — fall through to the stub write so a
+        # corrupt digest still gets replaced with a usable fallback.
+    }
 }
 
 New-Item -ItemType Directory -Path $digestDir, $archDir -Force | Out-Null


### PR DESCRIPTION
## Summary

Root-cause fix for the digest-stomp pattern observed 4 times today (`docs/solutions/...` if you want the longer write-up — the /correct rule that landed in PR #230 documented it as a workaround).

Before this commit, `Scripts/digest-stop-finalize.ps1` only protected against stomps younger than 10 min. After 10 min it would unconditionally overwrite `state/digests/latest.md` with a metadata-only stub — even if the existing content was an intentional model-driven /digest write.

This adds a second bypass: read the frontmatter \`trigger\` field; if it's \`digest-skill\`, exit 0 regardless of age. Falls through to the stub write only when (a) age < 10 min (existing fast-path), (b) the existing digest is corrupt/unreadable, or (c) the existing digest is itself a prior \`stop-hook-finalize\` stub.

## Why

Observed 4 stomps in one session (2026-05-16):
- 06:13Z — between digest writes during PR #228 merge
- 06:53Z — between hardening push and review-response on PR #229
- 10:38Z — between hardening commit a686184c and CI green
- 15:13Z — between #229 merge and digest refresh

The /correct rule landed in PR #230 told the model "re-write the digest after any further work". This commit makes that workaround unnecessary.

## Test plan

Verified via a 4-case smoke test (not retained in the diff since it's not CI-wired):

| Test | Setup | Expected | Result |
|---|---|---|---|
| 1 | Model-driven digest (\`trigger: digest-skill\`), age 30min | Preserved | ✅ PASS |
| 2 | Stop-finalize stub, age 60min | Replaced with fresh stub | ✅ PASS |
| 3 | Any digest, age 5min | Preserved by fast-path | ✅ PASS |
| 4 | Corrupt frontmatter | Replaced with stub | ✅ PASS |

## Pairs with

- PR #230 § \"Stop-hook digest stomp pattern (2026-05-16)\" — that PR documented the workaround; this PR removes the need for it.
- \`Scripts/precompact-digest.ps1\` already has an equivalent (time-based) guard on the PreCompact hook path. This brings the Stop-hook path to parity with better semantics (trigger-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)