### PR TITLE
docs: chatbot-deploy runbook + Stop-hook /correct rule (split from #230)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,4 +115,21 @@ The hooks are validated in CI by `.github/workflows/karpathy-cherny-discipline.y
 
 _Appended by `/correct` when the user corrects an approach. Persists across sessions._
 
-(none yet)
+### Stop-hook digest stomp pattern (2026-05-16)
+
+The `Stop` hook auto-finalize (`Scripts/precompact-digest.ps1` and similar) writes a metadata-only fallback digest to `state/digests/latest.md` if `/digest` hasn't been invoked recently. This **overwrites** any model-driven digest written earlier in the same session, replacing rich content (in-flight, hypotheses, success criteria, "Do NOT carry forward") with a stub.
+
+**Rule:** after invoking `/digest` and writing a model-driven digest, expect the Stop hook to stomp it. Either:
+
+1. Re-write the model-driven digest as the final action of the session (the most recent write wins), OR
+2. Read `state/digests/latest.md` immediately after any tool-call lull or natural breakpoint, and if `trigger: stop-hook-finalize` appears in the frontmatter, rewrite from your in-memory content.
+
+**Why:** observed at least twice on 2026-05-16 — once during the PR #225 / #227 / #228 merge drive (digest stomped by Stop hook between merges), and once during the supervised `/auto-optimize` cycle 1 (digest stomped between cycle abort and the post-cycle digest refresh). Each stomp reverts the digest's `session_id` to `stop-finalize` and the body to a four-line stub starting with `_Session ended without a recent /digest._`.
+
+**How to apply:**
+
+- When you've just written a rich `state/digests/latest.md` and you're about to do any further work, plan to re-write it after that work concludes.
+- If a system-reminder says `state/digests/latest.md was modified, either by the user or by a linter`, treat that as the stomp signal — re-read and rewrite.
+- Don't argue with the Stop hook — fixing the hook itself is a separate concern (`Scripts/precompact-digest.ps1`). For now, just outlive it.
+
+This rule is the surface symptom; the root cause may merit its own fix once observed enough times to characterize. See `docs/solutions/tooling/2026-05-16-auto-optimize-oracle-silent-success-build-failure.md` for the family pattern (silent-output replaces real-output).

--- a/docs/runbooks/chatbot-deploy.md
+++ b/docs/runbooks/chatbot-deploy.md
@@ -1,0 +1,118 @@
+---
+title: Chatbot deploy runbook — demos.guitaralchemist.com
+status: living
+date: 2026-05-16
+related:
+  - docs/architecture/apps-and-processes.md
+  - docs/architecture/chat-surfaces.md
+  - Scripts/ga-service-wrapper.ps1
+  - Scripts/install-ga-service.ps1
+  - Scripts/start-chatbot-api.ps1
+---
+
+# Chatbot deploy runbook
+
+How to redeploy `https://demos.guitaralchemist.com/chatbot/` past the current main. There is **no CI/CD workflow** for this deploy — every push to main requires the operator to pull + build + restart on the demos host.
+
+## Topology
+
+| Surface | Host | Port | Notes |
+|---|---|---|---|
+| Public chat HTML | `GaChatbot.Api` wwwroot | 5252 | `Apps/GaChatbot.Api/wwwroot/index.html` |
+| Public chat REST | `POST /api/chatbot/chat` on GaChatbot.Api | 5252 | requires `Chatbot__PathBase=/chatbot` env var |
+| AG-UI streaming + hubs | `GaApi` | 5232 | unchanged by chatbot redeploy |
+| Cloudflare ingress | cloudflared `ga-demos` tunnel | n/a | routes `/chatbot/*` + `/api/chatbot/*` → :5252; root → :5232 |
+| Frontend (rest of site) | Vite | 5176 | unchanged by chatbot redeploy |
+
+The Windows service `GuitarAlchemist` (installed via `Scripts/install-ga-service.ps1`) manages GaApi + cloudflared + Vite + Ollama but **NOT** GaChatbot.Api — that needs to be launched separately. See memory `reference_dev_stack_three_services` for the long version.
+
+## Redeploy procedure
+
+Run on the demos host. Assumes repo at `C:\Users\spare\source\repos\ga`.
+
+```powershell
+# 1. Stop the currently-running chatbot API. The service-managed surfaces
+#    (GaApi, cloudflared, Vite, Ollama) can keep running — they don't
+#    depend on GaChatbot.Api's binary version.
+$chatbotPid = (Get-Process -Name 'GaChatbot.Api' -ErrorAction SilentlyContinue).Id
+if ($chatbotPid) { Stop-Process -Id $chatbotPid -Force }
+
+# 2. Pull main + verify head.
+Set-Location C:\Users\spare\source\repos\ga
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git log -1 --format='%h %s'   # confirm expected head sha
+
+# 3. Build the chatbot API (Release).
+dotnet build Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --nologo
+# Build MUST exit 0. If a DLL lock error appears, step 1 missed a process.
+
+# 4. Set required env vars + launch.
+$env:Chatbot__PathBase = '/chatbot'
+$env:AI__CascadeProvider = 'mistral'      # optional but recommended; needs MISTRAL_API_KEY
+$env:ASPNETCORE_URLS = 'http://localhost:5252'
+Start-Process -FilePath dotnet `
+  -ArgumentList 'run --project Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --no-build' `
+  -WindowStyle Hidden `
+  -RedirectStandardOutput "$PWD\logs\gachatbot-api.log" `
+  -RedirectStandardError "$PWD\logs\gachatbot-api-err.log"
+
+# 5. Smoke-check locally before declaring done.
+Start-Sleep -Seconds 5
+$health = Invoke-WebRequest -Uri http://localhost:5252/api/chatbot/health -UseBasicParsing
+if ($health.StatusCode -ne 200) { throw "Local health check failed: $($health.StatusCode)" }
+
+# 6. Probe the public surface end-to-end.
+Invoke-RestMethod `
+  -Uri https://demos.guitaralchemist.com/api/chatbot/chat `
+  -Method POST `
+  -ContentType 'application/json' `
+  -Body (@{ prompt = 'What is the difference between major and minor?' } | ConvertTo-Json) |
+  Select-Object -ExpandProperty trace |
+  Select-Object -ExpandProperty steps |
+  Select-Object name, status, @{n='agentId';e={$_.attributes.'agent.id'}} |
+  Format-Table -AutoSize
+```
+
+The probe should show the 6-step canonical shape:
+`chat.request → orchestration.answer → orchestration.route → agent.semantic_result → notation.vextab → response.emit`,
+with `agent.id = skill.theorycomparison` on the orchestration steps once #221 ships and the cascade is wired. **No `orchestration.fallback` step** means cascade isn't being triggered — that's the healthy path.
+
+## Rollback
+
+If step 5 health check or step 6 probe fails:
+
+```powershell
+# Kill the new process
+Stop-Process -Name 'GaChatbot.Api' -Force
+
+# Reset to the prior commit (verify $oldSha first)
+git checkout $oldSha
+dotnet build Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --nologo
+
+# Relaunch with the same env vars from step 4
+```
+
+Cloudflare ingress is unchanged by a rollback — only the local process binary changes. The Cloudflare tunnel keeps routing /chatbot/\* to :5252 regardless of which build runs there.
+
+## Common failures
+
+| Symptom | Most likely cause | Fix |
+|---|---|---|
+| `502` on `https://demos.guitaralchemist.com/chatbot/` while root returns 200 | GaChatbot.Api not running on :5252 | step 4 (relaunch) |
+| Build fails with `MSB3027 The file is locked by GaChatbot.Api (<pid>)` | step 1 missed a process | `Stop-Process -Id <pid> -Force` then retry step 3 |
+| Probe returns answer but `agentId = skill.modes` or fallback | new build not actually running (cached process) OR cascade not configured | check `gachatbot-api.log` head for "Now listening on: 5252" and verify env vars |
+| `/api/chatbot/chat` returns 404 | `Chatbot__PathBase` env var missing | step 4 — must be set BEFORE Start-Process |
+| Ollama timeout cascades produce `orchestration.fallback` step | Ollama is down OR no cascade configured | verify `ollama:11434` reachable AND `AI__CascadeProvider=mistral` set with valid `MISTRAL_API_KEY` |
+
+## Why no CI/CD?
+
+The demos host is a single workstation (Windows, not Linux). A GitHub Actions workflow would need either (a) a self-hosted Windows runner on this box, or (b) an SSH-based push pipeline. Both are bigger lifts than the operator-touch this runbook captures. Re-evaluate when the demo moves to a cloud VM.
+
+## Related
+
+- `docs/architecture/apps-and-processes.md` — full topology of every running process
+- `docs/architecture/chat-surfaces.md` — section "Canonical surfaces matrix (post-2026-05-13)" — which endpoint serves which surface
+- `Scripts/ga-service-wrapper.ps1` — what the `GuitarAlchemist` Windows service actually starts (and does NOT start)
+- memory `reference_dev_stack_three_services` — the missing-third-service gap that this runbook plugs

--- a/docs/runbooks/chatbot-deploy.md
+++ b/docs/runbooks/chatbot-deploy.md
@@ -37,12 +37,14 @@ Run on the demos host. Assumes repo at `C:\Users\spare\source\repos\ga`.
 $chatbotPid = (Get-Process -Name 'GaChatbot.Api' -ErrorAction SilentlyContinue).Id
 if ($chatbotPid) { Stop-Process -Id $chatbotPid -Force }
 
-# 2. Pull main + verify head.
+# 2. Pull main + verify head. Capture the CURRENT sha first so rollback
+#    in the "Rollback" section has a target to revert to.
 Set-Location C:\Users\spare\source\repos\ga
+$oldSha = (git rev-parse HEAD).Trim()        # save BEFORE pulling
 git fetch origin
 git checkout main
 git pull --ff-only origin main
-git log -1 --format='%h %s'   # confirm expected head sha
+git log -1 --format='%h %s'   # confirm expected new head sha
 
 # 3. Build the chatbot API (Release).
 dotnet build Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --nologo
@@ -58,17 +60,22 @@ Start-Process -FilePath dotnet `
   -RedirectStandardOutput "$PWD\logs\gachatbot-api.log" `
   -RedirectStandardError "$PWD\logs\gachatbot-api-err.log"
 
-# 5. Smoke-check locally before declaring done.
+# 5. Smoke-check locally before declaring done. Route is /status (see
+#    Apps/GaChatbot.Api/Controllers/ChatbotController.cs line 146 —
+#    [HttpGet("status")]). There is no /health endpoint.
 Start-Sleep -Seconds 5
-$health = Invoke-WebRequest -Uri http://localhost:5252/api/chatbot/health -UseBasicParsing
-if ($health.StatusCode -ne 200) { throw "Local health check failed: $($health.StatusCode)" }
+$status = Invoke-WebRequest -Uri http://localhost:5252/api/chatbot/status -UseBasicParsing
+if ($status.StatusCode -ne 200) { throw "Local status check failed: $($status.StatusCode)" }
 
-# 6. Probe the public surface end-to-end.
+# 6. Probe the public surface end-to-end. Body field is Message (see
+#    ChatRequest in Apps/GaChatbot.Api/Controllers/ChatbotController.cs
+#    line 264) — NOT 'prompt'. Wrong field name returns 400
+#    "Message cannot be empty.".
 Invoke-RestMethod `
   -Uri https://demos.guitaralchemist.com/api/chatbot/chat `
   -Method POST `
   -ContentType 'application/json' `
-  -Body (@{ prompt = 'What is the difference between major and minor?' } | ConvertTo-Json) |
+  -Body (@{ Message = 'What is the difference between major and minor?' } | ConvertTo-Json) |
   Select-Object -ExpandProperty trace |
   Select-Object -ExpandProperty steps |
   Select-Object name, status, @{n='agentId';e={$_.attributes.'agent.id'}} |
@@ -81,13 +88,16 @@ with `agent.id = skill.theorycomparison` on the orchestration steps once #221 sh
 
 ## Rollback
 
-If step 5 health check or step 6 probe fails:
+If step 5 status check or step 6 probe fails:
 
 ```powershell
 # Kill the new process
 Stop-Process -Name 'GaChatbot.Api' -Force
 
-# Reset to the prior commit (verify $oldSha first)
+# Reset to the prior commit. $oldSha was captured in step 2 BEFORE the
+# pull, so it points at the last known-good build. If you skipped that
+# step or this is a fresh terminal, recover the sha from `git reflog`
+# or look up the prior CI green commit in the deployment journal.
 git checkout $oldSha
 dotnet build Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --nologo
 
@@ -102,8 +112,11 @@ Cloudflare ingress is unchanged by a rollback — only the local process binary 
 |---|---|---|
 | `502` on `https://demos.guitaralchemist.com/chatbot/` while root returns 200 | GaChatbot.Api not running on :5252 | step 4 (relaunch) |
 | Build fails with `MSB3027 The file is locked by GaChatbot.Api (<pid>)` | step 1 missed a process | `Stop-Process -Id <pid> -Force` then retry step 3 |
+| Step 5 returns 404 on `/api/chatbot/status` | wrong path — earlier drafts referenced `/health` which does not exist | this runbook now uses `/status` correctly; if you forked an older copy, replace the URL |
+| Step 6 returns 400 `"Message cannot be empty."` | body field name is `Message`, not `prompt` (case-sensitive) | this runbook now sends `Message`; fork callers should mirror it |
 | Probe returns answer but `agentId = skill.modes` or fallback | new build not actually running (cached process) OR cascade not configured | check `gachatbot-api.log` head for "Now listening on: 5252" and verify env vars |
 | `/api/chatbot/chat` returns 404 | `Chatbot__PathBase` env var missing | step 4 — must be set BEFORE Start-Process |
+| Rollback step says `$oldSha` is null or unset | step 2's `$oldSha = (git rev-parse HEAD).Trim()` was skipped | recover the prior sha from `git reflog show HEAD` or the deployment journal; this runbook captures it pre-pull |
 | Ollama timeout cascades produce `orchestration.fallback` step | Ollama is down OR no cascade configured | verify `ollama:11434` reachable AND `AI__CascadeProvider=mistral` set with valid `MISTRAL_API_KEY` |
 
 ## Why no CI/CD?


### PR DESCRIPTION
## Summary

Extracted from PR #230 for immediate merge. The distillation plan (#195) stays in #230 awaiting D-teacher → D-deployment sign-off.

- **\`docs/runbooks/chatbot-deploy.md\`** — 6-step operator procedure to redeploy \`demos.guitaralchemist.com\` past current main. Captures rollback, common-failure matrix, and the missing-third-service pattern from memory \`reference_dev_stack_three_services\`. Unblocks the live-probe success criterion.

- **\`CLAUDE.md\` Session-learned rules** — Stop-hook digest stomp pattern (observed 4 times on 2026-05-16). Note: the root-cause fix lives in **PR #232**; once that merges, this /correct rule is historical context rather than an active workaround. Keeping it for posterity + so future similar patterns are easier to spot.

## Why now

PR #230 bundled three doc-only artifacts — runbook, distillation plan, /correct rule. User wanted to hold the distillation plan but ship the runbook + rule immediately. This split lands the immediate two; PR #230 will be rebased onto post-merge main once #195 sign-off is in.

## Test plan

Pure docs. No CI impact. Markdown lint is the only relevant check.

## Pairs with

- PR #230 — bundled original; will be rebased to retain only the distillation plan once signed off
- PR #232 — root-cause fix for the stop-hook stomp this rule documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)