### PR TITLE
fix(ik): pre-curl finger joints on chord change

### DIFF
--- a/ReactComponents/ga-react-components/src/components/InverseKinematics/InverseKinematics.tsx
+++ b/ReactComponents/ga-react-components/src/components/InverseKinematics/InverseKinematics.tsx
@@ -477,6 +477,44 @@ const InverseKinematics: React.FC<InverseKinematicsProps> = ({
         ? fretted.reduce((s, p) => s + stringZ(p.string), 0) / fretted.length
         : 0;
       wrist.position.set(cx + 0.25, -0.05, cz - 0.35);
+
+      // Initialize each finger's joint chain in a pre-curled "above
+      // the fretboard" pose. FABRIK has no joint constraints — it
+      // finds the shortest 3D path from MCP to target, which routes
+      // UNDER the fretboard (Y < 0) for the natural straight-line
+      // solution. Pre-curling biases the steady state UP-AND-OVER:
+      // PIP arches up, DIP comes back down, TIP rests on the target.
+      // Without this, the lerp-from-zero start meant FABRIK never
+      // converged to a guitarist-shaped curl.
+      wrist.updateMatrixWorld(true);
+      for (const finger of fingers) {
+        const mcp = finger.mcpLocal.clone().applyMatrix4(wrist.matrixWorld);
+        const target = finger.target;
+        // Vector from MCP to target in the horizontal plane.
+        const dx = target.x - mcp.x;
+        const dz = target.z - mcp.z;
+        const horiz = Math.hypot(dx, dz);
+        const fx = horiz > 1e-4 ? dx / horiz : 0;
+        const fz = horiz > 1e-4 ? dz / horiz : 1;
+        // Bone lengths.
+        const [b0, b1, b2] = finger.bones;
+        // PIP arched up + 40% of horizontal travel.
+        finger.joints[0].copy(mcp);
+        finger.joints[1].set(
+          mcp.x + fx * (horiz * 0.4),
+          mcp.y + b0 * 0.7,
+          mcp.z + fz * (horiz * 0.4),
+        );
+        // DIP at peak of arc, ~75% of horizontal travel.
+        finger.joints[2].set(
+          mcp.x + fx * (horiz * 0.75),
+          mcp.y + b0 * 0.7 + b1 * 0.4,
+          mcp.z + fz * (horiz * 0.75),
+        );
+        // TIP on the target (so first frame already shows fingertip on fret).
+        finger.joints[3].copy(target);
+        // Knuckle / mesh transforms catch up the next animation frame.
+      }
     };
 
     updateTargetsFromChord(chordRef.current);


### PR DESCRIPTION
## Summary

PR #240 fixed the wrist orientation (no more "fingers sweep across the neck") + brought the wrist within bone-reach so FABRIK doesn't stretch fingertips into a straight line. But fingertips still floated off the fretboard because FABRIK has no joint constraints — it finds the shortest 3D path from MCP to target, which routes through (or under) the fretboard plane on the first lerp-from-zero frame.

This commit pre-arches each finger's joint chain whenever the chord changes:
- **PIP** arched up (b0 × 0.7 above MCP), 40% of horizontal travel
- **DIP** at peak of arc (b0×0.7 + b1×0.4), 75% of horizontal travel
- **TIP** on the target (frame 1 already shows fingertip on fret)

Lerp damping (0.18) then keeps subsequent FABRIK passes close to this curl pose.

## Verified

Live via Vite HMR on \`demos.guitaralchemist.com/test/inverse-kinematics\` — hand now visibly arches up toward fret targets on C Major + E Minor. Screenshot evidence: \`state/ik-after-curl-init.png\`.

## Remaining (out of scope)

Full anatomical correctness requires per-joint angle constraints (~30-60 lines). The curl-init fixes the common case (open-position chords from CHORD_LIBRARY) but doesn't constrain the math. Tracking as task #221 follow-up.

## Pairs with

- PR #240 (the original IK fix — wrist + palm basis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)