### PR TITLE
fix(ik): anatomical wrist position + reachable parked fingers

### DIFF
--- a/ReactComponents/ga-react-components/src/components/InverseKinematics/InverseKinematics.tsx
+++ b/ReactComponents/ga-react-components/src/components/InverseKinematics/InverseKinematics.tsx
@@ -453,11 +453,15 @@ const InverseKinematics: React.FC<InverseKinematicsProps> = ({
           const p = fretted[i];
           finger.target.copy(targetForFret(p.string, p.fret));
         } else {
-          // Park unused fingers above the fretboard near the lowest fret.
+          // Park unused fingers just above the fretboard near the lowest
+          // fret. y-float kept small (was 0.4 + 0.1*i = up to 0.7 above
+          // surface) so parked targets stay within bone reach — pinky has
+          // only 0.72 units of total chain length and was hitting the
+          // "stretched straight" FABRIK branch on every parked frame.
           const restFret = Math.max(1, (fretted[0]?.fret ?? 1));
           const restString = 1 + i; // line them up over high strings
           finger.target.copy(targetForFret(restString, restFret));
-          finger.target.y += 0.4 + i * 0.1; // float up a little
+          finger.target.y += 0.12 + i * 0.04; // gentle float, not a launch
         }
       }
 
@@ -476,7 +480,22 @@ const InverseKinematics: React.FC<InverseKinematicsProps> = ({
       const cz = fretted.length > 0
         ? fretted.reduce((s, p) => s + stringZ(p.string), 0) / fretted.length
         : 0;
-      wrist.position.set(cx + 0.25, -0.05, cz - 0.35);
+      // Anatomically correct LEFT-hand fretting pose:
+      //   - Wrist sits BELOW the neck and OFFSET to the low-E side
+      //     (-Z direction) — that's where a player's hand approaches.
+      //   - Wrist X is aligned with the chord centroid (not offset toward
+      //     nut as before) so the knuckle row sits roughly OVER the chord.
+      //   - Palm faces UP (+Y) toward the strings.
+      //   - Palm-forward = +Z (across the strings, away from the player)
+      //     so fingers chain perpendicular to the neck and span string 1-6.
+      //
+      // Geometry check (C major: index str2/fret1 / middle str4/fret2 /
+      // ring str5/fret3): every MCP→target distance lands at 0.31–0.52
+      // units vs bone budgets of 0.88–0.98, leaving 0.36–0.46 units of
+      // slack for a comfortable curl rather than a stretched-straight line.
+      const wristZOffset = -0.55;   // tucked under the low-E side
+      const wristYOffset = -0.15;   // just below the neck plane
+      wrist.position.set(cx, wristYOffset, cz + wristZOffset);
 
       // Initialize each finger's joint chain in a pre-curled "above
       // the fretboard" pose. FABRIK has no joint constraints — it


### PR DESCRIPTION
## Summary

User asked for \"palm well positioned and fingers comfortable\" after PRs #240 + #241 left the hand still floating awkwardly off-fretboard.

Two coordinated changes that together produce a recognisable guitarist-shaped pose:

1. **Wrist position**: aligned with chord centroid in X (not offset toward nut by +0.25), Y just below the neck plane (-0.15), Z tucked under the low-E side (cz − 0.55). Math: index/middle/ring MCP→target distances 0.31–0.52, bone budgets 0.88–0.98 → 0.36–0.46 units slack for curl.

2. **Parked-finger y-float**: reduced from `0.4 + 0.1*i` (up to 0.7 above surface) to `0.12 + 0.04*i` (up to 0.24). The original launch put pinky's parked target at 1.01 units from its MCP vs only 0.72 units of pinky bone — FABRIK fell into stretch-mode every frame and the pinky drew as a straight line shooting off the fretboard.

## Verified

Live on demos via Vite HMR — C Major now shows palm under the neck, fingers arching up onto the frets, knuckles spanning across the strings.

Evidence: \`state/ik-anatomical-fix.png\`.

## Pairs with

- **#240** (wrist orientation + initial reach)
- **#241** (curl-init bias)

This trio addresses the user's original \"fingertips not on the fretboard\" report. Remaining polish via task **#222** (joint angle constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)