### PR TITLE
feat(#192): embeddings baseline.json + snapshot-cadence plan

### DIFF
--- a/docs/plans/2026-05-16-arch-embeddings-snapshot-pipeline-plan.md
+++ b/docs/plans/2026-05-16-arch-embeddings-snapshot-pipeline-plan.md
@@ -1,0 +1,107 @@
+---
+title: Embeddings snapshot pipeline — filename + cadence
+status: planned
+date: 2026-05-16
+reversibility: two-way door
+revisit_trigger: "next session implementing #182 (auto-optimize for embeddings) or whenever the quality dashboard shows the embedding panel as stale > 30 days"
+related:
+  - state/quality/embeddings/baseline.json
+  - .github/workflows/chatbot-qa-snapshot.yml (template)
+  - task #192
+  - task #182 (auto-optimize loop blocked on this)
+---
+
+# Embeddings snapshot pipeline — filename + cadence
+
+## The two gaps
+
+**Filename strictness.** `ix-quality-trend`'s loader silently skips any snapshot whose stem isn't `YYYY-MM-DD`. The existing `state/quality/embeddings/2026-04-17-postrefactor.json` is invisible to the trend dashboard even though it's the more recent / better measurement (full_classifier_accuracy 0.7522 vs the pre-refactor 0.7473 in `2026-04-17.json`).
+
+**Cadence.** The most recent embeddings snapshot is `2026-04-17`. No producer runs on a schedule. Compare with `chatbot-qa` which has a daily CI workflow (`.github/workflows/chatbot-qa-snapshot.yml`) and shipped fine. Without a cadence, the auto-optimize loop for this domain (#182) cannot baseline against anything fresh.
+
+## Why now is enough
+
+#192 has been pending since the trend gap surfaced 2026-05-16. The first deliverable (baseline.json — landed in this PR) unblocks the auto-optimize skill from refusing on missing-domain-contract. The producer workflow + filename fix remain.
+
+## Proposed approach
+
+### Step 1: producer CI workflow
+
+Mirror `chatbot-qa-snapshot.yml` but cross-repo. The producer is the Rust binary `ix-embedding-diagnostics 0.1.0` in the ix sibling. Two options:
+
+**Option A — checkout ix in the workflow, build it, run it.** Cleanest, no artifact storage. Adds ~3 min to the run for the Rust build.
+
+```yaml
+name: Embeddings Snapshot
+on:
+  schedule:
+    - cron: '0 7 * * *'  # 07:00 UTC daily, after chatbot-qa
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with: { token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }} }
+      - name: Checkout ix
+        uses: actions/checkout@v4
+        with:
+          repository: spareilleux/ix
+          path: ix
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build ix-embedding-diagnostics
+        run: cargo build --release -p ix-embedding-diagnostics
+        working-directory: ix
+      - name: Run + emit snapshot
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ix/target/release/ix-embedding-diagnostics \
+            --corpus state/voicings/optick.index \
+            --out "state/quality/embeddings/${DATE}.json"
+      - name: Commit if produced
+        env: { GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }} }
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          SNAP="state/quality/embeddings/${DATE}.json"
+          if [ ! -f "$SNAP" ]; then exit 1; fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$SNAP"
+          if git diff --cached --quiet; then exit 0; fi
+          git commit -m "chore(quality): embeddings snapshot ${DATE} [skip ci]"
+          git push
+```
+
+**Option B — schedule on the ix repo CI, push to ga via cross-repo PAT.** Adds the build dependency where it belongs (ix owns its tool). Requires a PAT scoped to write to ga; more secret surface.
+
+Recommend Option A. Build cost amortized across daily runs is fine.
+
+### Step 2: filename normalization
+
+The producer always writes `state/quality/embeddings/${DATE}.json`. If two runs in one day are valuable (e.g. before/after a refactor PR), use a SUFFIXED archive path (`state/quality/embeddings/archive/${DATE}-${tag}.json`) so the canonical YYYY-MM-DD slot is unambiguous.
+
+No retroactive rename of `2026-04-17-postrefactor.json` — it's a historical artifact, leave it in place.
+
+### Step 3: roundtrip validator skill
+
+Before #182's auto-optimize loop can run unattended on the embeddings domain, it needs a `chatbot-qa-roundtrip-validate`-style skill that confirms a proposed change didn't regress the metric. Without it, baseline.json's `_harness.rollback_metadata.roundtrip_validator` stays `null` and the loop refuses to commit.
+
+Out of scope for #192; lives under #182.
+
+## Success criteria
+
+- A daily CI workflow exists at `.github/workflows/embeddings-snapshot.yml`
+- It produces `state/quality/embeddings/YYYY-MM-DD.json` on schedule
+- The snapshot is loadable by `ix-quality-trend` (filename matches the strict pattern)
+- The quality dashboard's embedding panel updates within 24h of merge
+
+## Out of scope
+
+- Auto-optimize loop for embeddings domain (that's #182; baseline.json prepares for it)
+- Re-baselining the 0.7522 leak-detection threshold (only do after the producer is running and we have a few weeks of data)
+- Loader permissiveness fix in `ix-quality-trend` — the producer-writes-canonical-name path is cleaner than making the loader smarter

--- a/state/quality/embeddings/baseline.json
+++ b/state/quality/embeddings/baseline.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "domain": "embeddings",
+  "purpose": "Baseline + scope-boundary contract for the /auto-optimize loop on the OPTIC-K embedding-quality domain (the 240-dim partition-weighted geometry that powers RAG). Consumed by .claude/skills/auto-optimize/SKILL.md.",
+  "established_at": "2026-05-16T22:30:00Z",
+  "established_by": "embeddings-baseline-bootstrap (#192 follow-up to #182)",
+  "schema_pin": {
+    "OPTIC-K": "v1.8",
+    "ix_tool": "ix-embedding-diagnostics 0.1.0",
+    "snapshot_schema": "see state/quality/embeddings/2026-04-17.json"
+  },
+
+  "metric": "leak_detection_full_classifier_accuracy",
+  "metric_description": "Random-forest cross-validation accuracy on a 6000-sample balanced classifier predicting voicing instrument from embedding vector. LOWER is better — the OPTIC-K geometry should be T-invariant / instrument-agnostic, so a perfect embedding scores near baseline_random (~0.333). Higher = the embedding leaks instrument identity, a known regression direction tracked since OPTIC-K v1.3.",
+  "primary_baseline": 0.7522,
+  "primary_baseline_source": "post-refactor run 2026-04-17T04:50:22Z (state/quality/embeddings/2026-04-17-postrefactor.json). Pre-refactor was 0.7473; postrefactor improved by +0.005, so the post-refactor accuracy IS the more conservative baseline (later refactors should not regress past it).",
+  "metric_polarity": "lower-is-better",
+
+  "_harness": {
+    "rollback_metadata": {
+      "roundtrip_validator": null,
+      "reject_on_loss": true,
+      "reject_on_regression": true,
+      "regression_threshold": 0.01,
+      "note": "No roundtrip validator yet for this domain — embedding changes that move the metric must be hand-reviewed until #192 ships the producer CI workflow + a domain-specific validator."
+    },
+    "kill_switches": {
+      "global":     "state/.loop-halted",
+      "per_domain": "state/quality/embeddings/.STOP"
+    },
+    "lock_file":   "state/quality/embeddings/.lock",
+    "history_file":"state/quality/embeddings/loop-history.jsonl"
+  },
+
+  "scope_boundary": {
+    "allow_edit": [
+      "Common/GA.Business.ML/Embeddings/**/*.cs",
+      "Common/GA.Business.ML/Search/MusicalQueryEncoder.cs",
+      "Common/GA.Business.ML/Text/**/*.cs"
+    ],
+    "protected": [
+      "Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs",
+      "state/voicings/optick.index",
+      "state/quality/embeddings/baseline.json",
+      "Tests/**/*.cs",
+      "Scripts/run-prompt-corpus.ps1",
+      ".github/workflows/*"
+    ],
+    "note": "EmbeddingSchema.cs is the canonical 240-dim contract — changing TotalDimension or partition layout is a one-way door per CLAUDE.md. Schema changes must come through a coordinated /feature plan, not from the auto-loop."
+  },
+
+  "_open_gaps": {
+    "snapshot_cadence": "No daily producer yet — latest snapshot is 2026-04-17. Per docs/plans/2026-05-16-arch-embeddings-snapshot-pipeline-plan.md, a CI workflow that builds ix-embedding-diagnostics cross-repo and runs it against state/voicings/optick.index is the unblock.",
+    "loader_filename_strictness": "ix-quality-trend silently skips snapshots whose stem isn't YYYY-MM-DD. The existing 2026-04-17-postrefactor.json is invisible to the trend dashboard. Either the producer writes one canonical YYYY-MM-DD.json per day, or the loader becomes permissive about suffixes.",
+    "roundtrip_validator": "Not yet implemented — no skill mirrors chatbot-qa-roundtrip-validate for the embeddings domain. Until it exists, auto-optimize on this domain is operator-supervised only."
+  }
+}


### PR DESCRIPTION
## Summary

Closes the first half of #192. The second half (producer CI workflow + filename normalization at write time + roundtrip validator) is captured in the linked plan doc and stays open until a focused session implements the workflow.

- New baseline.json so auto-optimize can ever consider this domain (#182 prereq)
- Plan documents Option A cross-repo CI workflow design (~30 lines of YAML, ~3 min build cost, daily)
- _open_gaps section in baseline.json itemizes what remains and why

## Test plan
- [x] baseline.json valid JSON
- [x] schema_version=1 matches existing chatbot-qa contract
- [x] scope_boundary protects the one-way doors (EmbeddingSchema.cs, optick.index)
- [ ] Next session: ship .github/workflows/embeddings-snapshot.yml per the plan

## Partial close
- Closes nothing fully; #192 stays open until producer workflow ships
- Unblocks: #182 (auto-optimize for embeddings) — was refusing on missing baseline.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)