### PR TITLE
chore(#176): scope SessionStart digest hook to compact|resume

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,7 +49,12 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -Command \"Write-Host ''; Write-Host 'Guitar Alchemist Session' -ForegroundColor Cyan; Write-Host ('  Branch: ' + (git branch --show-current)) -ForegroundColor Gray; try { $vite = (Invoke-WebRequest -Uri 'http://localhost:5176' -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop).StatusCode; Write-Host ('  Vite: OK (' + $vite + ')') -ForegroundColor Green } catch { Write-Host '  Vite: DOWN (port 5176) - run: pwsh Scripts/start-dev.ps1' -ForegroundColor Red }; try { $api = (Invoke-WebRequest -Uri 'http://localhost:5232/health' -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop).Content; Write-Host ('  API: ' + $api) -ForegroundColor $(if($api -eq 'Healthy'){'Green'}else{'Yellow'}) } catch { Write-Host '  API: DOWN (port 5232)' -ForegroundColor Red }; Write-Host ''\""
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "compact|resume",
+        "hooks": [
           {
             "type": "command",
             "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/Scripts/sessionstart-digest.ps1"


### PR DESCRIPTION
Verified via Claude Code 2.1.x docs: SessionStart `source` values are startup/resume/clear/compact. Digest hook only adds value on compact|resume — splits the matcher-less block into two so host-status check still fires on every start, but digest read is scoped.

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)