### PR TITLE
fix(#218): tighten ChordVoicings routing + retry without filters

### DIFF
--- a/Common/GA.Business.ML/Agents/Skills/ChordVoicingsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ChordVoicingsSkill.cs
@@ -58,14 +58,19 @@ public sealed partial class ChordVoicingsSkill(
         var q = message.ToLowerInvariant();
         var hasVoicingIntent = VoicingKeywords.Any(k => q.Contains(k, StringComparison.Ordinal));
         if (!hasVoicingIntent) return false;
-        // Guard: at least one chord-shaped token (letter + optional accidental
-        // + optional quality). Avoids matching "voicing" alone.
-        return ChordTokenRegex().IsMatch(message);
+        // Require a real chord token. The two regexes are case-sensitive on the
+        // root so bare lowercase "a"/"e" in normal English ("show me a shape")
+        // won't trigger. Strict form requires an accidental/quality/digit
+        // immediately after the root (Cmaj7, G7, F#m); spaced form allows
+        // "[A-G] major/minor/dim/aug/sus" with whitespace between root and
+        // quality (Bb major, C minor).
+        return ChordSuffixRegex().IsMatch(message)
+               || ChordWithSpacedQualityRegex().IsMatch(message);
     }
 
     public async Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
     {
-        var structured = await extractor.ExtractAsync(message, cancellationToken);
+        var structured = await extractor.ExtractAsync(message, cancellationToken).ConfigureAwait(false);
         var hasIntent = structured.ChordSymbol is not null
                         || structured.PitchClasses is { Length: > 0 }
                         || structured.ModeName is not null
@@ -90,7 +95,19 @@ public sealed partial class ChordVoicingsSkill(
         var filters = VoicingAgent.BuildSearchFilters(structured);
 
         Task<double[]> Generator(string _) => Task.FromResult(queryVector);
-        var results = await voicingSearch.SearchAsync(message, Generator, topK: 8, filters, cancellationToken);
+        var results = await voicingSearch.SearchAsync(message, Generator, topK: 8, filters, cancellationToken).ConfigureAwait(false);
+
+        // Corpus-tagging mismatch workaround (docs/solutions/architecture/2026-05-08-
+        // voicing-search-corpus-tagging-mismatch.md): filters target Tags/ChordName
+        // fields the corpus doesn't populate, so filter-bearing queries reliably
+        // return 0 hits. Retry without filters before reporting failure.
+        if (results.Count == 0 && filters is not null)
+        {
+            logger.LogDebug(
+                "ChordVoicingsSkill: zero hits with filters for {Intent}, retrying without filters",
+                structured.ChordSymbol ?? structured.ModeName ?? "(tags)");
+            results = await voicingSearch.SearchAsync(message, Generator, topK: 8, null, cancellationToken).ConfigureAwait(false);
+        }
 
         if (results.Count == 0)
         {
@@ -145,8 +162,16 @@ public sealed partial class ChordVoicingsSkill(
         };
     }
 
-    // Chord-shape detector: letter + optional accidental + optional
-    // quality suffix. Conservative — only matches what looks like a chord.
-    [GeneratedRegex(@"\b[A-G][#b]?(maj|min|m|M|dim|aug|sus|add|alt|°|Δ)?\d*\b", RegexOptions.IgnoreCase)]
-    private static partial Regex ChordTokenRegex();
+    // Chord-shape detector: uppercase root (no IgnoreCase) followed by an
+    // accidental/quality/digit immediately. Matches "Cmaj7", "G7", "F#m",
+    // "Calt", "C7b9". Case-sensitive root prevents false positives on bare
+    // lowercase "a" / "e" in normal English ("show me a beginner shape").
+    [GeneratedRegex(@"\b[A-G][#b]?(?:maj|min|m|M|dim|aug|sus|add|alt|°|Δ|\d)\w*\b")]
+    private static partial Regex ChordSuffixRegex();
+
+    // Spaced quality form: "C major", "Bb minor", "F# augmented". Quality word
+    // accepts upper- and lower-case first letters but requires the root to be
+    // an uppercase chord letter.
+    [GeneratedRegex(@"\b[A-G][#b]?\s+(?:[Mm]ajor|[Mm]inor|[Mm]aj|[Mm]in|[Dd]im|[Aa]ug|[Ss]us)\b")]
+    private static partial Regex ChordWithSpacedQualityRegex();
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ChordVoicingsSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ChordVoicingsSkillTests.cs
@@ -1,0 +1,95 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[TestFixture]
+public class ChordVoicingsSkillTests
+{
+    private static ChordVoicingsSkill MakeSkill() =>
+        new(NullLogger<ChordVoicingsSkill>.Instance, null!, null!, null!);
+
+    [Test]
+    public void Metadata_ExposesExamplePrompts()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.ExamplePrompts, Has.Count.GreaterThanOrEqualTo(8),
+            "skill must expose enough example prompts for the SemanticIntentRouter");
+        Assert.That(skill.Description.ToLowerInvariant(), Does.Contain("voicing")
+            .Or.Contain("shape").Or.Contain("fingering"));
+    }
+
+    // ---------------------------------------------------------------
+    // CanHandle — positive cases (real voicing-intent queries).
+    // ---------------------------------------------------------------
+
+    [TestCase("voicings for Cmaj7")]
+    [TestCase("show me Dm7 voicings")]
+    [TestCase("shapes for F major")]
+    [TestCase("fingerings for G7")]
+    [TestCase("drop2 voicings of Cmaj7")]
+    [TestCase("shell voicing for Dm7")]
+    [TestCase("rootless A7 voicings")]
+    [TestCase("barre voicings for Bb major")]
+    [TestCase("open chord shape for E minor")]
+    [TestCase("show me a shape for G7")]
+    [TestCase("Cmaj9 voicings on guitar")]
+    [TestCase("F#m fingering")]
+    public void CanHandle_True_OnRealVoicingQueries(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.True,
+            $"expected ChordVoicingsSkill to claim: {message}");
+    }
+
+    // ---------------------------------------------------------------
+    // CanHandle — negative cases from the 2026-05-16 multi-LLM review.
+    // Each one is a genuine bug or a known-ambiguous boundary.
+    // ---------------------------------------------------------------
+
+    // HIGH from /octo-code-reviewer: IgnoreCase made bare "a"/"e" match [A-G]
+    // even though English routinely uses lowercase "a"/"e" as articles.
+    [TestCase("show me a beginner-friendly shape for the open position")]
+    [TestCase("what's a good shape on the fretboard")]
+    [TestCase("show me a beginner-friendly shape")]
+    [TestCase("explain the open shape system")]
+    public void CanHandle_False_OnLowercaseArticleFollowedByShapeKeyword(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.False,
+            $"bare lowercase article should not be treated as a chord root in: {message}");
+    }
+
+    // No voicing intent — must yield to ChordInfoSkill / ModesSkill / etc.
+    [TestCase("give me a Cmaj7 chord")]
+    [TestCase("what are the notes in Cmaj7")]
+    [TestCase("tell me about a major seventh chord")]
+    [TestCase("explain the augmented triad")]
+    [TestCase("what is C7b9")]
+    public void CanHandle_False_WhenNoVoicingKeyword(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.False,
+            $"prompt has no voicing/shape/fingering keyword, should not claim: {message}");
+    }
+
+    // English words starting with uppercase A-G that contain quality-shaped
+    // substrings — the regex must reject these so noisy chat doesn't trigger.
+    [TestCase("Add some shape to this voicing line")]
+    [TestCase("Dim the lights and show me a shape")]
+    public void CanHandle_False_OnEnglishWordsStartingWithChordLetter(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.False,
+            $"English word starting with A-G uppercase shouldn't be parsed as a chord root: {message}");
+    }
+
+    [Test]
+    public void CanHandle_False_OnEmptyOrWhitespace()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(""), Is.False);
+        Assert.That(skill.CanHandle("   "), Is.False);
+        Assert.That(skill.CanHandle(null!), Is.False);
+    }
+}


### PR DESCRIPTION
## Summary

Retroactive multi-LLM review of merged PR #246 (`octo-code-reviewer` + `octo-security-auditor` in parallel) found **2 HIGH + 3 MEDIUM** in the code reviewer, **clean** on security. This PR addresses 4 of the 5 findings; defers the lowest-leverage extraction (which the retry path obviates).

### What changed

- **Regex tightening (HIGH #1+#2).** Dropped `RegexOptions.IgnoreCase` from the chord-token detector. Bare lowercase \"a\"/\"e\" in prompts like \"show me a beginner-friendly shape\" no longer triggers. Now requires uppercase root + (accidental OR quality OR digit) immediately, with a separate regex for spaced quality like \"C major\".
- **Zero-hits retry without filters (MEDIUM #3).** Per [`docs/solutions/architecture/2026-05-08-voicing-search-corpus-tagging-mismatch.md`](../blob/main/docs/solutions/architecture/2026-05-08-voicing-search-corpus-tagging-mismatch.md), filters target `Tags`/`ChordName` fields the corpus doesn't populate, so filtered queries reliably return 0 hits. Skill now retries once without filters before reporting failure.
- **`ConfigureAwait(false)` (MEDIUM #4).** Added on both library-layer awaits.
- **25 new adversarial test cases** in `ChordVoicingsSkillTests.cs` covering both regressions and positives. All pass locally (1.3s).

### What was NOT changed

- **MEDIUM #5** — extract `VoicingAgent.BuildSearchFilters` out of internal-static. The retry-without-filters path sidesteps the architectural concern when the filtered query returns 0; we'll revisit when the upstream corpus tagging is fixed.

### Security audit

`octo-security-auditor` came back clean. Verified: no ReDoS in either regex (no nested quantifiers, no overlapping alternation under `+`/`*`); no information disclosure (outer handler at `OrchestratedChatApplicationService.cs:109` catches exceptions); no DoS (`topK: 8` hardcoded, in-memory k-NN over pre-loaded vectors); cancellation token propagated to both awaits.

One non-finding worth recording: safety properties depend on the outer catch at `OrchestratedChatApplicationService.cs:109-123`. If a future refactor removes that, `Data.interpreted` payload + uncaught exceptions become a leak vector.

## Test plan

- [x] `dotnet test --filter ChordVoicingsSkillTests` — 25/25 pass
- [x] Build clean (`dotnet build Tests/Common/GA.Business.ML.Tests` — 0 errors, 155 unrelated style warnings)
- [ ] After merge: verify in live chatbot that \"voicings for Cmaj7\" still routes here and that \"show me a beginner-friendly shape\" routes elsewhere

## Why this matters

User's standing rule (`feedback_multi_llm_review_pays_off.md`): \"Multi-LLM review is load-bearing — octo-code-reviewer + octo-security-auditor in parallel caught 9 real bugs in chatbot migration. Mandatory for music-theory / MCP / DI / parser PRs.\" PR #246 shipped without it; this PR closes that gap retroactively. The IgnoreCase bug was a real routing collision waiting to happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)