### PR TITLE
feat(#219): ImprovisationSkill — chord-scale recommendations for soloing

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -107,6 +107,11 @@ public sealed class GaPlugin : IChatPlugin
         // Closes the "show me voicings for Cmaj7" gap in chatbot routing.
         services.AddOrchestratorSkillIntent<ChordVoicingsSkill>();
 
+        // ImprovisationSkill (2026-05-16, #219) — "what scale can I use to
+        // solo over X" — single-chord chord-scale recommendations from a
+        // canonical quality→scales mapping. Pure domain compute, no LLM.
+        services.AddOrchestratorSkillIntent<ImprovisationSkill>();
+
         // Skills using IChatClient are Scoped (IChatClient lifetime is Scoped).
         services.AddOrchestratorSkillIntent<KeyIdentificationSkill>(ServiceLifetime.Scoped);
         services.AddOrchestratorSkillIntent<ProgressionCompletionSkill>(ServiceLifetime.Scoped);

--- a/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
@@ -1,0 +1,328 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using System.Text;
+using System.Text.RegularExpressions;
+using GA.Business.ML.Search;
+
+/// <summary>
+/// Answers "what scale can I use to solo over X" style prompts. Wraps the
+/// typed chord parser to extract a chord symbol from the user query, infers
+/// the chord quality, and returns matching modes / scales drawn from a
+/// canonical chord-scale mapping. Pure domain compute; no LLM at the skill
+/// layer. Single-chord queries only in v1 — progression handling (ii-V-I,
+/// minor blues, etc.) is documented as v2 scope.
+/// </summary>
+public sealed partial class ImprovisationSkill(
+    ILogger<ImprovisationSkill> logger,
+    IMusicalQueryExtractor extractor) : IOrchestratorSkill
+{
+    public string Name => "Improvisation";
+
+    public string Description =>
+        "Suggests scales and modes to improvise / solo over a given chord. " +
+        "Parses the chord symbol from the user query (e.g. 'Cmaj7', 'G7', " +
+        "'Am7b5') and returns canonical chord-scale candidates with their " +
+        "note spellings and a one-line color note. Single-chord queries only.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "what scale can I use to solo over Cmaj7?",
+        "what scales work over G7?",
+        "modes to solo over Dm7",
+        "which mode fits Cmaj7",
+        "chord-scale for G7",
+        "improvise over Am7",
+        "scale for Fmaj7#11",
+        "what to play over a Bm7b5",
+        "improvisation choices for E7alt",
+        "solo over a Cmaj9 chord",
+    ];
+
+    // Intent keywords. The CanHandle gate is "improvisation intent AND a
+    // chord-shaped token", same pattern as ChordVoicingsSkill (hardened in
+    // PR #251) so a bare lowercase article in normal English doesn't trigger.
+    private static readonly string[] ImprovKeywords =
+    [
+        "solo", "improvise", "improvisation", "improv", "improvising",
+        "what scale", "scale for", "scale over", "scale to use", "scales for",
+        "scales over", "scales work", "what to play over", "play over",
+        "modes for", "modes over", "modes to solo", "modal choice", "modal choices",
+    ];
+
+    public bool CanHandle(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return false;
+        var q = message.ToLowerInvariant();
+        var hasImprovIntent = ImprovKeywords.Any(k => q.Contains(k, StringComparison.Ordinal));
+        if (!hasImprovIntent) return false;
+        // Require a real chord token (uppercase root + accidental/quality/digit).
+        // Without IgnoreCase, bare lowercase "a"/"e" articles never trigger.
+        return ChordSuffixRegex().IsMatch(message)
+               || ChordWithSpacedQualityRegex().IsMatch(message);
+    }
+
+    public async Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var structured = await extractor.ExtractAsync(message, cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(structured.ChordSymbol))
+        {
+            return new AgentResponse
+            {
+                AgentId = $"skill.{Name.ToLowerInvariant()}",
+                Result =
+                    "I couldn't find a chord name in your request. Try naming a single " +
+                    "chord (e.g. 'Cmaj7', 'G7', 'Am7b5') and I'll suggest scales to " +
+                    "improvise over it. Progression-level questions (ii-V-I, minor blues) " +
+                    "aren't supported yet — name a specific chord.",
+                Confidence = 0.2f,
+                Evidence = [],
+                Assumptions = ["Typed parser produced no ChordSymbol from the query."],
+            };
+        }
+
+        var root = ExtractRoot(structured.ChordSymbol);
+        var quality = InferQuality(structured.ChordSymbol);
+        var candidates = ScalesFor(quality);
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"For **{structured.ChordSymbol}** (quality: {quality.Display}), try:");
+        sb.AppendLine();
+        foreach (var c in candidates)
+        {
+            sb.AppendLine($"- **{root} {c.Name}** — {c.Color}");
+        }
+        sb.AppendLine();
+        sb.AppendLine(quality.AdvisoryNote);
+
+        logger.LogDebug(
+            "ImprovisationSkill: {Chord} → quality {Quality} → {Count} scale(s)",
+            structured.ChordSymbol, quality.Display, candidates.Count);
+
+        return new AgentResponse
+        {
+            AgentId = $"skill.{Name.ToLowerInvariant()}",
+            Result = sb.ToString(),
+            Confidence = 0.85f,
+            Evidence = candidates.Select(c => $"{root} {c.Name}: {c.Color}").ToList(),
+            Assumptions = candidates.Count == 0
+                ? ["Chord quality not recognized; defaulted to chord root's major scale."]
+                : [],
+            Data = new
+            {
+                interpreted = structured,
+                chordRoot = root,
+                chordQuality = quality.Display,
+                scales = candidates.Select(c => new { name = c.Name, color = c.Color }).ToList(),
+            },
+        };
+    }
+
+    // -------------------------------------------------------------------
+    // Chord symbol → root + quality. Conservative: the parser already
+    // canonicalized the symbol, so we just classify it.
+    // -------------------------------------------------------------------
+
+    // Internal for unit-test coverage of the classifier directly (per multi-LLM
+    // review of this PR — driving each canonical symbol through a [TestCase]
+    // table catches ordering bugs that aren't visible from CanHandle alone).
+    internal static string ExtractRoot(string chordSymbol)
+    {
+        if (string.IsNullOrEmpty(chordSymbol)) return "C";
+        // Validate the first char is an actual chord-root letter. Parser
+        // glitches that produce pathological symbols ("7", "#G", "b") would
+        // otherwise yield garbage like "7 Ionian". Fall back to "C" so the
+        // skill's no-intent branch can flag the error upstream.
+        var first = chordSymbol[0];
+        if (first < 'A' || first > 'G') return "C";
+        // First char is the letter root; second char may be '#' or 'b'.
+        if (chordSymbol.Length >= 2 && (chordSymbol[1] == '#' || chordSymbol[1] == 'b'))
+            return chordSymbol[..2];
+        return chordSymbol[..1];
+    }
+
+    internal static QualityClass InferQuality(string chordSymbol)
+    {
+        if (string.IsNullOrEmpty(chordSymbol)) return QualityClass.Unknown;
+        if (chordSymbol[0] < 'A' || chordSymbol[0] > 'G') return QualityClass.Unknown;
+        // Strip the root from the front so we look only at the quality suffix.
+        var suffix = chordSymbol;
+        if (suffix.Length >= 2 && (suffix[1] == '#' || suffix[1] == 'b'))
+            suffix = suffix[2..];
+        else if (suffix.Length >= 1)
+            suffix = suffix[1..];
+
+        // Strip parentheses so canonicalized forms like "7(b9)" / "m7(b5)" /
+        // "(maj7)" still classify correctly. Without this, parenthesized
+        // alterations fall through to less-specific buckets.
+        var s = suffix.ToLowerInvariant().Replace("(", "", StringComparison.Ordinal).Replace(")", "", StringComparison.Ordinal);
+
+        // Most-specific first. Order matters: mMaj7 must be tested BEFORE the
+        // maj7 family (the lowercased "mmaj7" contains "maj7" and would
+        // short-circuit otherwise).
+        if (s.Contains("alt", StringComparison.Ordinal)) return QualityClass.Altered;
+        if (s.Contains("m7b5", StringComparison.Ordinal) || s.Contains("ø", StringComparison.Ordinal)) return QualityClass.HalfDiminished;
+        if (s.Contains("dim7", StringComparison.Ordinal) || s.Contains("°7", StringComparison.Ordinal)) return QualityClass.Diminished7;
+        if (s.StartsWith("dim", StringComparison.Ordinal) || s.StartsWith("°", StringComparison.Ordinal) || s.Contains("o7", StringComparison.Ordinal)) return QualityClass.Diminished7;
+        if (s.Contains("mmaj7", StringComparison.Ordinal) || s.Contains("minmaj7", StringComparison.Ordinal)) return QualityClass.MinorMajor7;
+        if (s.Contains("maj7#11", StringComparison.Ordinal) || s.Contains("maj7+11", StringComparison.Ordinal)) return QualityClass.LydianMaj7;
+        if (s.Contains("maj7", StringComparison.Ordinal) || s.Contains("maj9", StringComparison.Ordinal) || s.Contains("maj13", StringComparison.Ordinal) || s.Contains("δ", StringComparison.Ordinal)) return QualityClass.Major7;
+        // aug7 / +7 / 7#5 — augmented dominant. Less common than plain aug; flag
+        // as Augmented but the advisory note will steer toward whole tone.
+        if (s.Contains("aug", StringComparison.Ordinal) || s.StartsWith("+", StringComparison.Ordinal) || s.Contains("7#5", StringComparison.Ordinal)) return QualityClass.Augmented;
+        if (s.Contains("sus", StringComparison.Ordinal) && s.Contains("7", StringComparison.Ordinal)) return QualityClass.SuspendedDominant;
+        if (s.Contains("7b9", StringComparison.Ordinal) || s.Contains("7#9", StringComparison.Ordinal) || s.Contains("7b5", StringComparison.Ordinal) || s.Contains("13b9", StringComparison.Ordinal)) return QualityClass.AlteredDominant;
+        if (s.Contains("m6", StringComparison.Ordinal)) return QualityClass.MinorMajor7; // mel min territory
+        if (s.StartsWith("m7", StringComparison.Ordinal) || s.StartsWith("min7", StringComparison.Ordinal) || s.StartsWith("-7", StringComparison.Ordinal)) return QualityClass.Minor7;
+        if (s.StartsWith("m9", StringComparison.Ordinal) || s.StartsWith("m11", StringComparison.Ordinal) || s.StartsWith("m13", StringComparison.Ordinal)) return QualityClass.Minor7;
+        if (s.StartsWith("m", StringComparison.Ordinal) || s.StartsWith("min", StringComparison.Ordinal) || s.StartsWith("-", StringComparison.Ordinal)) return QualityClass.Minor;
+        if (s.StartsWith("7", StringComparison.Ordinal) || s.StartsWith("9", StringComparison.Ordinal) || s.StartsWith("11", StringComparison.Ordinal) || s.StartsWith("13", StringComparison.Ordinal)) return QualityClass.Dominant7;
+        if (s.Length == 0 || s.StartsWith("6", StringComparison.Ordinal) || s.StartsWith("69", StringComparison.Ordinal) || s.StartsWith("maj", StringComparison.Ordinal)) return QualityClass.Major;
+        return QualityClass.Unknown;
+    }
+
+    // -------------------------------------------------------------------
+    // Chord quality → ranked scale candidates. Order is best/most-common
+    // first. The "color" string is a one-line hint for the rendered output.
+    // -------------------------------------------------------------------
+
+    private static IReadOnlyList<Scale> ScalesFor(QualityClass q) => q.Kind switch
+    {
+        QualityKind.Major7 =>
+        [
+            new("Ionian (major)", "diatonic — the safe choice"),
+            new("Lydian", "bright — emphasize the #11 for color"),
+        ],
+        QualityKind.LydianMaj7 =>
+        [
+            new("Lydian", "the home scale — #11 is the defining note"),
+        ],
+        QualityKind.Major =>
+        [
+            new("Ionian (major)", "diatonic, includes the 7 — careful on the IV chord"),
+            new("Lydian", "raise the 4 to avoid the avoid-note"),
+            new("Major Pentatonic", "remove tension notes for blues feel"),
+        ],
+        QualityKind.Dominant7 =>
+        [
+            new("Mixolydian", "diatonic dominant — natural choice for V chords"),
+            new("Lydian Dominant", "raise the 4 (b7 + #11) for fusion / outside color"),
+            new("Mixolydian b6", "from melodic minor — leans tense without going altered"),
+        ],
+        QualityKind.AlteredDominant =>
+        [
+            new("Altered (Super Locrian)", "b9 #9 #11 b13 — covers every alteration"),
+            new("Half-Whole Diminished", "b9 #9 #11 13 — symmetric alternative"),
+            new("Phrygian Dominant", "use over 7b9 chords with Phrygian color"),
+        ],
+        QualityKind.Altered =>
+        [
+            new("Altered (Super Locrian)", "every extension is altered — the canonical alt scale"),
+        ],
+        QualityKind.SuspendedDominant =>
+        [
+            new("Mixolydian", "diatonic — strong"),
+            new("Phrygian", "darker color; works over sus7 with b9"),
+        ],
+        QualityKind.Minor7 =>
+        [
+            new("Dorian", "natural 6 — modern jazz default"),
+            new("Aeolian (minor)", "b6 — darker, fits ii in minor keys"),
+            new("Phrygian", "b2 — Spanish / modal flavor over static m7"),
+        ],
+        QualityKind.Minor =>
+        [
+            new("Aeolian (natural minor)", "diatonic minor — fits most i chords"),
+            new("Dorian", "raise the 6 for a brighter minor color"),
+            new("Minor Pentatonic", "subtract tension notes for blues / rock"),
+        ],
+        QualityKind.MinorMajor7 =>
+        [
+            new("Melodic Minor", "the home scale for mMaj7 / m6 chords"),
+        ],
+        QualityKind.HalfDiminished =>
+        [
+            new("Locrian", "diatonic — but b9 is an avoid note"),
+            new("Locrian #2", "raise the 2 from melodic minor — better tonal target"),
+        ],
+        QualityKind.Diminished7 =>
+        [
+            new("Whole-Half Diminished", "symmetric scale that contains all chord tones"),
+        ],
+        QualityKind.Augmented =>
+        [
+            new("Whole Tone", "every step is a whole step — covers the #5 / b13"),
+            new("Lydian Augmented", "from melodic minor — for major7#5 contexts"),
+        ],
+        _ =>
+        [
+            new("Major scale of the chord root", "fallback — chord quality not classified"),
+        ],
+    };
+
+    // -------------------------------------------------------------------
+    // Same regex pair as ChordVoicingsSkill (PR #251). Case-sensitive root,
+    // accidental/quality/digit required (strict) or " major/minor/dim/aug/sus"
+    // word-form (spaced).
+    // -------------------------------------------------------------------
+
+    [GeneratedRegex(@"\b[A-G][#b]?(?:maj|min|m|M|dim|aug|sus|add|alt|°|Δ|\d)\w*\b")]
+    private static partial Regex ChordSuffixRegex();
+
+    [GeneratedRegex(@"\b[A-G][#b]?\s+(?:[Mm]ajor|[Mm]inor|[Mm]aj|[Mm]in|[Dd]im|[Aa]ug|[Ss]us)\b")]
+    private static partial Regex ChordWithSpacedQualityRegex();
+
+    internal enum QualityKind
+    {
+        Unknown,
+        Major,
+        Major7,
+        LydianMaj7,
+        Dominant7,
+        AlteredDominant,
+        Altered,
+        SuspendedDominant,
+        Minor,
+        Minor7,
+        MinorMajor7,
+        HalfDiminished,
+        Diminished7,
+        Augmented,
+    }
+
+    internal readonly record struct QualityClass(QualityKind Kind, string Display, string AdvisoryNote)
+    {
+        public static readonly QualityClass Unknown = new(QualityKind.Unknown, "unknown",
+            "I couldn't classify the chord quality; defaulting to the chord-root major scale.");
+        public static readonly QualityClass Major = new(QualityKind.Major, "major triad",
+            "On a IV chord, prefer Lydian to dodge the avoid-note F over C.");
+        public static readonly QualityClass Major7 = new(QualityKind.Major7, "major 7",
+            "Lydian is the modern / modal choice; Ionian is the classical choice.");
+        public static readonly QualityClass LydianMaj7 = new(QualityKind.LydianMaj7, "major 7#11",
+            "Lydian is the home scale — the #11 is what makes this chord sound this way.");
+        public static readonly QualityClass Dominant7 = new(QualityKind.Dominant7, "dominant 7",
+            "Mixolydian for diatonic V chords; Lydian Dominant for static (non-resolving) dominants.");
+        public static readonly QualityClass AlteredDominant = new(QualityKind.AlteredDominant, "altered dominant",
+            "Altered scale (7th mode of melodic minor) is the workhorse for V chords with b9/#9/#11/b13.");
+        public static readonly QualityClass Altered = new(QualityKind.Altered, "altered",
+            "Use Altered — every extension is naturally a chord tone.");
+        public static readonly QualityClass SuspendedDominant = new(QualityKind.SuspendedDominant, "suspended dominant",
+            "Mixolydian for plain 7sus; Phrygian when the chart has a b9.");
+        public static readonly QualityClass Minor = new(QualityKind.Minor, "minor triad",
+            "Aeolian for diatonic i chords in minor keys; Dorian when the underlying progression suggests a major key.");
+        public static readonly QualityClass Minor7 = new(QualityKind.Minor7, "minor 7",
+            "Dorian is the modern jazz default; Aeolian if you want a darker, more diatonic-to-minor sound.");
+        public static readonly QualityClass MinorMajor7 = new(QualityKind.MinorMajor7, "minor major 7",
+            "Melodic Minor is the home scale; m6 chords also live here.");
+        public static readonly QualityClass HalfDiminished = new(QualityKind.HalfDiminished, "half-diminished (m7b5)",
+            "Locrian #2 (from melodic minor) is more usable than vanilla Locrian — the b9 is an avoid note.");
+        public static readonly QualityClass Diminished7 = new(QualityKind.Diminished7, "diminished 7",
+            "Whole-Half Diminished is symmetric and contains every chord tone of a dim7.");
+        public static readonly QualityClass Augmented = new(QualityKind.Augmented, "augmented",
+            "Whole Tone is the canonical aug choice; Lydian Augmented if the chord is a major7#5.");
+    }
+
+    // Implicit cast from kind to QualityClass via the static fields. The
+    // InferQuality method returns these directly.
+    private readonly record struct Scale(string Name, string Color);
+}

--- a/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
@@ -47,6 +47,11 @@ public sealed partial class ImprovisationSkill(
         "what scale", "scale for", "scale over", "scale to use", "scales for",
         "scales over", "scales work", "what to play over", "play over",
         "modes for", "modes over", "modes to solo", "modal choice", "modal choices",
+        // 2026-05-17 post-PR-253 feature-dev review: cover ExamplePrompts
+        // phrasings that the original keyword list missed in the CanHandle
+        // fallback path (semantic router catches them; fallback didn't).
+        "which mode", "which modes", "what mode", "what modes",
+        "chord-scale", "chord scale",
     ];
 
     public bool CanHandle(string message)

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
@@ -1,0 +1,170 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[TestFixture]
+public class ImprovisationSkillTests
+{
+    private static ImprovisationSkill MakeSkill() =>
+        new(NullLogger<ImprovisationSkill>.Instance, null!);
+
+    [Test]
+    public void Metadata_ExposesExamplePrompts()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.ExamplePrompts, Has.Count.GreaterThanOrEqualTo(6),
+            "skill must expose enough example prompts for the SemanticIntentRouter");
+        Assert.That(skill.Description.ToLowerInvariant(), Does.Contain("solo")
+            .Or.Contain("improvise").Or.Contain("scale").Or.Contain("mode"));
+    }
+
+    // ---------------------------------------------------------------
+    // CanHandle — positive cases (real improvisation queries).
+    // ---------------------------------------------------------------
+
+    [TestCase("what scale can I use to solo over Cmaj7?")]
+    [TestCase("what scales work over G7?")]
+    [TestCase("modes to solo over Dm7")]
+    [TestCase("improvise over Am7")]
+    [TestCase("scale for Fmaj7#11")]
+    [TestCase("what to play over a Bm7b5")]
+    [TestCase("improvisation choices for E7alt")]
+    [TestCase("solo over a Cmaj9 chord")]
+    [TestCase("scales for G7b9")]
+    [TestCase("what scale over D7sus")]
+    [TestCase("modes over F#m7")]
+    [TestCase("modal choices for Bbmaj7")]
+    public void CanHandle_True_OnRealImprovQueries(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.True,
+            $"expected ImprovisationSkill to claim: {message}");
+    }
+
+    // ---------------------------------------------------------------
+    // CanHandle — negative cases. Same regression cases as
+    // ChordVoicingsSkill (PR #251) plus improvisation-specific
+    // routing collisions.
+    // ---------------------------------------------------------------
+
+    [TestCase("show me a beginner-friendly shape for the open position")]
+    [TestCase("what's a good shape on the fretboard")]
+    [TestCase("explain the open shape system")]
+    public void CanHandle_False_OnLowercaseArticleFollowedByOtherKeyword(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.False,
+            $"bare lowercase article should not trigger improvisation routing: {message}");
+    }
+
+    [TestCase("give me a Cmaj7 chord")]
+    [TestCase("what are the notes in Cmaj7")]
+    [TestCase("voicings for Cmaj7")]
+    [TestCase("show me Dm7 shapes")]
+    [TestCase("tell me about a major seventh chord")]
+    [TestCase("explain the augmented triad")]
+    public void CanHandle_False_WhenNoImprovKeyword(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.False,
+            $"prompt has no solo/improvise/scale-over keyword: {message}");
+    }
+
+    // Keyword present, no chord token. Should not steal generic improv
+    // questions that lack a specific chord (those need different routing).
+    [TestCase("how do I improvise in general?")]
+    [TestCase("explain improvisation")]
+    [TestCase("what does it mean to solo")]
+    public void CanHandle_False_OnGenericImprovQuestionWithoutChord(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.False,
+            $"no chord token present, should not claim: {message}");
+    }
+
+    [Test]
+    public void CanHandle_False_OnEmptyOrWhitespace()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(""), Is.False);
+        Assert.That(skill.CanHandle("   "), Is.False);
+        Assert.That(skill.CanHandle(null!), Is.False);
+    }
+
+    // ---------------------------------------------------------------
+    // InferQuality — drive each canonical chord symbol through a
+    // [TestCase] table. The multi-LLM review of this PR explicitly
+    // flagged that ordering bugs (CmMaj7 → Major7) were invisible
+    // from CanHandle alone — these tests pin the classifier directly.
+    // ---------------------------------------------------------------
+
+    // Expected QualityKind passed as string (NUnit analyzer NUnit1026 rejects
+    // internal test methods, and we don't want to widen QualityKind to public
+    // just for tests — string-at-the-boundary keeps the API surface tight).
+    [TestCase("Cmaj7", "Major7")]
+    [TestCase("Cmaj9", "Major7")]
+    [TestCase("Cmaj13", "Major7")]
+    [TestCase("Cmaj7#11", "LydianMaj7")]
+    [TestCase("CmMaj7", "MinorMajor7")]
+    [TestCase("CminMaj7", "MinorMajor7")]
+    [TestCase("Cm(maj7)", "MinorMajor7")]
+    [TestCase("Cm7", "Minor7")]
+    [TestCase("Cm9", "Minor7")]
+    [TestCase("Cm11", "Minor7")]
+    [TestCase("Cm6", "MinorMajor7")]
+    [TestCase("C7", "Dominant7")]
+    [TestCase("C9", "Dominant7")]
+    [TestCase("C13", "Dominant7")]
+    [TestCase("C7b9", "AlteredDominant")]
+    [TestCase("C7#9", "AlteredDominant")]
+    [TestCase("C7b5", "AlteredDominant")]
+    [TestCase("C7(b9)", "AlteredDominant")]
+    [TestCase("Am7(b5)", "HalfDiminished")]
+    [TestCase("Cm7b5", "HalfDiminished")]
+    [TestCase("Cdim7", "Diminished7")]
+    [TestCase("Cdim", "Diminished7")]
+    [TestCase("Caug", "Augmented")]
+    [TestCase("C7#5", "Augmented")]
+    [TestCase("C7sus", "SuspendedDominant")]
+    [TestCase("C7sus4", "SuspendedDominant")]
+    [TestCase("C7alt", "Altered")]
+    [TestCase("Calt", "Altered")]
+    [TestCase("Cm", "Minor")]
+    [TestCase("C", "Major")]
+    [TestCase("C6", "Major")]
+    [TestCase("F#m7", "Minor7")]
+    [TestCase("Bbmaj7", "Major7")]
+    public void InferQuality_ClassifiesCanonicalChordSymbols(string chord, string expectedKind)
+    {
+        var result = ImprovisationSkill.InferQuality(chord);
+        Assert.That(result.Kind.ToString(), Is.EqualTo(expectedKind),
+            $"InferQuality({chord}) classified as {result.Kind}; expected {expectedKind}");
+    }
+
+    // ---------------------------------------------------------------
+    // ExtractRoot — handles accidentals + validates [A-G] root.
+    // ---------------------------------------------------------------
+
+    [TestCase("C", "C")]
+    [TestCase("Cmaj7", "C")]
+    [TestCase("F#", "F#")]
+    [TestCase("Bb", "Bb")]
+    [TestCase("F#m7", "F#")]
+    [TestCase("Bbmaj7", "Bb")]
+    [TestCase("", "C")] // empty fallback
+    [TestCase("7", "C")] // pathological parser output → safe fallback
+    [TestCase("#G", "C")] // accidental-prefix → fallback
+    public void ExtractRoot_HandlesValidAndPathological(string chord, string expected)
+    {
+        Assert.That(ImprovisationSkill.ExtractRoot(chord), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void InferQuality_OnPathologicalSymbol_ReturnsUnknown()
+    {
+        Assert.That(ImprovisationSkill.InferQuality("").Kind.ToString(), Is.EqualTo("Unknown"));
+        Assert.That(ImprovisationSkill.InferQuality("7").Kind.ToString(), Is.EqualTo("Unknown"));
+        Assert.That(ImprovisationSkill.InferQuality("#G").Kind.ToString(), Is.EqualTo("Unknown"));
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
@@ -35,6 +35,12 @@ public class ImprovisationSkillTests
     [TestCase("what scale over D7sus")]
     [TestCase("modes over F#m7")]
     [TestCase("modal choices for Bbmaj7")]
+    // 2026-05-17 post-PR-253 feature-dev review — the two ExamplePrompts
+    // that the original keyword list missed in the CanHandle fallback path:
+    [TestCase("which mode fits Cmaj7")]
+    [TestCase("chord-scale for G7")]
+    [TestCase("which mode works over Am7")]
+    [TestCase("chord scale options for D7")]
     public void CanHandle_True_OnRealImprovQueries(string message)
     {
         var skill = MakeSkill();


### PR DESCRIPTION
## Summary

Closes #219. New chatbot skill that answers \"what scale can I use to solo over X\" prompts via a canonical chord-quality → scales mapping. Pure domain compute, no LLM at the skill layer.

The chatbot-qa loop converged on the current skill set yesterday — this PR is the first new-capability bet since that convergence.

## Coverage (verified by 33-row TestCase table)

| Chord quality | Examples | Scales returned |
|---|---|---|
| Major 7 | Cmaj7, Cmaj9, Cmaj13 | Ionian, Lydian |
| Major 7#11 | Cmaj7#11 | Lydian |
| Minor Major 7 | CmMaj7, Cm6, Cm(maj7) | Melodic Minor |
| Minor 7 | Cm7, Cm9, Cm11 | Dorian, Aeolian, Phrygian |
| Dominant 7 | C7, C9, C13 | Mixolydian, Lydian Dominant, Mixolydian b6 |
| Altered Dominant | C7b9, C7#9, C7(b9) | Altered, Half-Whole Diminished |
| Altered | C7alt, Calt | Altered (Super Locrian) |
| Suspended Dominant | C7sus, C7sus4 | Mixolydian, Phrygian |
| Half-Diminished | Cm7b5, Am7(b5) | Locrian, Locrian #2 |
| Diminished 7 | Cdim, Cdim7 | Whole-Half Diminished |
| Augmented | Caug, C7#5 | Whole Tone, Lydian Augmented |
| Triads | C, Cm, C6 | Ionian/Aeolian/Pentatonic options |

## Multi-LLM review (per `feedback_multi_llm_review_pays_off` standing rule)

- **octo:droids:octo-security-auditor** — **clean**. ReDoS-safe, no DoS surface, no info disclosure, no prompt injection.
- **octo:droids:octo-code-reviewer** — found **2 HIGH + 3 MEDIUM**. All 2 HIGH fixed in this PR before commit:
  1. `CmMaj7` ordering bug — lowercased \"mmaj7\" contained \"maj7\" and short-circuited to Major7. Fixed: mMaj7 check moved BEFORE maj7 family. Verified by `[TestCase(\"CmMaj7\", \"MinorMajor7\")]`.
  2. Parenthesized symbols unreachable — `C7(b9)` / `Am7(b5)` fell to less-specific buckets. Fixed: strip parens from `s` before the contains-chain.
- MEDIUM findings addressed:
  - `ExtractRoot` now validates `[A-G]` root letter; pathological parser output returns `\"C\"` fallback.
  - `InferQuality` + `ExtractRoot` now `internal` (InternalsVisibleTo already set); 33-row test table pins each canonical symbol → expected QualityKind.
  - Routing collision with `ModesSkill` (\"modes to solo over Dm7\") mitigated by adding 3 improvisation-specific example prompts (\"modes to solo over Dm7\", \"which mode fits Cmaj7\", \"chord-scale for G7\") to anchor semantic routing.
- 1 MEDIUM accepted as v2: `Caug7` / `C+7` classify as Augmented (Whole Tone) instead of an aug-dominant flavor — Whole Tone covers the chord tones including b7, so the result is musically correct just not flavor-distinguished. Documented in commit message.

## Test plan

- [x] `dotnet test --filter ImprovisationSkillTests` — **69/69 pass** (11ms)
- [x] Build clean (`dotnet build Tests/Common/GA.Business.ML.Tests` — 0 errors)
- [ ] After merge: corpus-probe \"what scale can I use to solo over Cmaj7\" against the live chatbot to verify the skill routes here (not ModesSkill or ChordInfoSkill)

## What this PR does NOT include (deferred to v2)

- Progression-level queries (ii-V-I, minor blues) — current v1 returns the no-intent branch with a steer toward single-chord queries
- `Caug7` / `C+7` aug-dominant flavor (above)
- Mode comparison against the underlying key center (e.g. C7 in F major vs C7 standalone)

## Refs

- #219 — \"how do I solo over X\" — new skill
- PR #246 + PR #251 — ChordVoicingsSkill (template + the regex hardening pattern this skill mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)