### PR TITLE
fix(ik): wrist perpendicular to fretboard (per-frame basis uses centroid, not fingers[0])

### DIFF
--- a/ReactComponents/ga-react-components/src/components/InverseKinematics/InverseKinematics.tsx
+++ b/ReactComponents/ga-react-components/src/components/InverseKinematics/InverseKinematics.tsx
@@ -724,12 +724,28 @@ const InverseKinematics: React.FC<InverseKinematicsProps> = ({
       // Per-frame palm basis recomputation: same tilted-down convention as
       // updateTargetsFromChord. Recomputing each frame lets the wrist slerp
       // smoothly when the chord changes (instead of snapping to the new
-      // basis instantly). Uses fingers[0].target as the anchor — that's
-      // always the first fretted target, which dominates the chord shape.
+      // basis instantly).
+      //
+      // CRITICAL: use the centroid of finger targets, NOT fingers[0]. The
+      // first fretted target may be far along the neck (e.g., C Major has
+      // index on string-2 fret-1 at high X, ring on string-5 fret-3 at low X)
+      // and using it as the anchor pulls the basis along the +X (neck) axis —
+      // visually parallel to the fretboard. The centroid sits at ~wrist.x,
+      // so the horizontal vector wrist→centroid is dominated by Z (across
+      // the strings), keeping the wrist perpendicular to the neck the way
+      // a real guitarist holds it. (2026-05-17 fix per user observation
+      // "wrist should be perpendicular to fretboard, not parallel".)
+      let cTx = 0, cTz = 0;
+      for (let i = 0; i < fingers.length; i++) {
+        cTx += fingers[i].target.x;
+        cTz += fingers[i].target.z;
+      }
+      cTx /= fingers.length;
+      cTz /= fingers.length;
       tmpDir.set(
-        fingers[0].target.x - wrist.position.x,
+        cTx - wrist.position.x,
         0,
-        fingers[0].target.z - wrist.position.z,
+        cTz - wrist.position.z,
       );
       if (tmpDir.lengthSq() > 1e-6) {
         const basis = computePalmBasis(tmpDir);


### PR DESCRIPTION
## Summary

User observation 2026-05-17 on https://demos.guitaralchemist.com/test/inverse-kinematics: \"the wrist should be perpendicular to the fretboard, not parallel\".

Verified via the MCP control surface (\`window.__gaIK.getSceneState()\`): live basis showed \`forward\` (wrist→palm direction) = (0.896, -0.434, 0.093), dominated by world **+X** (the neck axis). Should be along world **+Z** (perpendicular to neck).

## Root cause

The per-frame basis recompute in \`animate()\` at line 729 uses \`fingers[0].target\` as the anchor for \`tmpDir\`. For chords spread along the fretboard:

- **C Major**: index on string-2 fret-1 at x≈2.83; ring on string-5 fret-3 at x≈2.20. fingers[0] = index = far from wrist on the +X axis.
- ΔX from wrist (x=2.35) to index = 0.48. ΔZ = 0.05. → \`tmpDir\` is dominated by **+X**, pulls the basis along the neck.

The init basis (\`updateTargetsFromChord\`, line 524) uses \`(0, 0, -wristZOffset) = (0, 0, 0.35)\` which is purely +Z — correct (perpendicular to neck). But the per-frame slerp at line 729 rotates away from that toward fingers[0] within ~12 frames at the 0.08 slerp factor. Steady state was parallel-to-neck.

## Fix

Use the **centroid of all finger targets** instead of \`fingers[0]\`. Centroid X equals \`wrist.x\` by construction (the chord-update pass positions wrist at \`cx\`), so the horizontal vector \`wrist→centroid\` is dominated by ΔZ.

For C Major after the fix:
- centroid_x ≈ 2.51, wrist.x = 2.35, ΔX ≈ 0.16
- centroid_z ≈ 0.03, wrist.z = -0.32, ΔZ ≈ 0.35
- \`tmpDir\` now Z-dominant ✓

## Verification

- [x] \`npm run build\` clean (22.95s, no errors)
- [x] Math traced for C Major (above)
- [ ] **After demos host pulls main**: re-run \`window.__gaIK.getSceneState()\` and confirm \`forward\` returns to ≈ (0, -0.43, 0.90)
- [ ] Visual: hand wrist should extend AWAY from the fretboard (perpendicular), not ALONG it

## Why this wasn't caught before

The validate() MCP probe checks geometric constraints (no fingertip inside wood, etc.) but doesn't assert basis-axis alignment with the world axes. The earlier IK fixes (#243, #245) addressed the basis MATH (right-handed determinant, palm tilt angle) but not the per-frame input vector. Worth adding an MCP assertion like \`validate({ checkBasisOrientation: true })\` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)