### PR TITLE
fix(#235): add GaChatbot.Api + Tests to AllProjects.slnx

### DIFF
--- a/AllProjects.slnx
+++ b/AllProjects.slnx
@@ -5,6 +5,7 @@
         <Platform Name="x86" />
     </Configurations>
     <Folder Name="/Apps/">
+        <Project Path="Apps/GaChatbot.Api/GaChatbot.Api.csproj" />
         <Project Path="Apps/GaChatbotCli/GaChatbotCli.csproj" />
         <Project Path="Apps/GaCli/GaCli.fsproj" />
         <Project Path="Apps/GaMemoryCli/GaMemoryCli.csproj" />
@@ -252,6 +253,7 @@
     </Folder>
     <Folder Name="/Tests/">
         <Project Path="Tests/Apps/GaApi.Tests/GaApi.Tests.csproj" />
+        <Project Path="Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj" />
         <Project Path="Tests/Common/GA.Business.Core.Tests/GA.Business.Core.Tests.csproj" />
         <Project Path="Tests/Common/GA.Core.Tests/GA.Core.Tests.csproj" />
         <Project Path="Tests/Common/GA.InteractiveExtension/GA.InteractiveExtension.Tests.csproj" />


### PR DESCRIPTION
## Summary

Closes part of #235 (concern 3): \`Apps/GaChatbot.Api/\` and \`Tests/Apps/GaChatbot.Api.Tests/\` were committed but missing from \`AllProjects.slnx\`. The service that actually serves \`/chatbot/*\` on demos was orphaned from CI builds.

## Diff

\`\`\`
+        <Project Path=\"Apps/GaChatbot.Api/GaChatbot.Api.csproj\" />
+        <Project Path=\"Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj\" />
\`\`\`

Both inserted alphabetically in their natural folders.

## Verification

- \`dotnet sln AllProjects.slnx list | grep GaChatbot.Api\` → both shown
- \`dotnet build Apps/GaChatbot.Api/GaChatbot.Api.csproj\` → 0 errors
- \`dotnet build Tests/Apps/GaChatbot.Api.Tests/...\` → 0 errors

## Out of scope (still in #235)

- Concern 1: 4 untracked \`docs/architecture/\` files (\`README.md\`, \`chat-surfaces.md\`, \`apps-and-processes.md\`, \`audit-2026-04-25.md\`) — needs user decision on commit-vs-discard
- Concern 2: 8 untracked \`Scripts/chatbot-*.ps1\` / \`measure-qa-architect-baseline.ps1\` / \`write-qa-diff-verdict.ps1\` — same decision needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)