### PR TITLE
fix(chatbot): 4 findings from multi-LLM review of skill code

### DIFF
--- a/Common/GA.Business.ML/Agents/Skills/CatalogSkillMdLoader.cs
+++ b/Common/GA.Business.ML/Agents/Skills/CatalogSkillMdLoader.cs
@@ -83,7 +83,7 @@ internal static class CatalogSkillMdLoader
             var trimmed = line.TrimStart();
 
             // H1 — title; starts the preamble zone.
-            if (trimmed.StartsWith("# "))
+            if (trimmed.StartsWith("# ", StringComparison.Ordinal))
             {
                 inPreambleZone = true;
                 preambleDone   = false;
@@ -94,7 +94,7 @@ internal static class CatalogSkillMdLoader
 
             // H2 — ends preamble zone, and decides whether the new section
             // is meta (drop) or content (keep).
-            if (trimmed.StartsWith("## "))
+            if (trimmed.StartsWith("## ", StringComparison.Ordinal))
             {
                 preambleDone   = true;
                 inPreambleZone = false;

--- a/Common/GA.Business.ML/Agents/Skills/ChordSubstitutionSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ChordSubstitutionSkill.cs
@@ -219,8 +219,8 @@ public sealed class ChordSubstitutionSkill(
 
         foreach (var rel in rels)
         {
-            var stars = rel.Type.Contains("Tritone") ? "★★★" :
-                        rel.Type.StartsWith("ICV")   ? "★"   : "★★";
+            var stars = rel.Type.Contains("Tritone", StringComparison.Ordinal) ? "★★★" :
+                        rel.Type.StartsWith("ICV", StringComparison.Ordinal)   ? "★"   : "★★";
             sb.AppendLine($"{stars} **{rel.Type}**");
             sb.AppendLine($"  {rel.Explanation}");
             sb.AppendLine();

--- a/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
@@ -167,8 +167,14 @@ public sealed partial class ImprovisationSkill(
         // short-circuit otherwise).
         if (s.Contains("alt", StringComparison.Ordinal)) return QualityClass.Altered;
         if (s.Contains("m7b5", StringComparison.Ordinal) || s.Contains("ø", StringComparison.Ordinal)) return QualityClass.HalfDiminished;
-        if (s.Contains("dim7", StringComparison.Ordinal) || s.Contains("°7", StringComparison.Ordinal)) return QualityClass.Diminished7;
-        if (s.StartsWith("dim", StringComparison.Ordinal) || s.StartsWith("°", StringComparison.Ordinal) || s.Contains("o7", StringComparison.Ordinal)) return QualityClass.Diminished7;
+        // Diminished family — order matters: check the 4-note (dim7 / °7 / o7)
+        // form first, then fall to the 3-note triad. Pre-fix, `Cdim` (triad)
+        // matched the `StartsWith("dim")` branch and returned Diminished7 — a
+        // category error: the canonical scale for a dim TRIAD is Locrian,
+        // while dim7 takes Whole-Half Diminished. Caught by multi-LLM review
+        // 2026-05-17 (same family as the pre-#253 CmMaj7→major7 bug).
+        if (s.Contains("dim7", StringComparison.Ordinal) || s.Contains("°7", StringComparison.Ordinal) || s.Contains("o7", StringComparison.Ordinal)) return QualityClass.Diminished7;
+        if (s.StartsWith("dim", StringComparison.Ordinal) || s.StartsWith("°", StringComparison.Ordinal)) return QualityClass.Diminished;
         if (s.Contains("mmaj7", StringComparison.Ordinal) || s.Contains("minmaj7", StringComparison.Ordinal)) return QualityClass.MinorMajor7;
         if (s.Contains("maj7#11", StringComparison.Ordinal) || s.Contains("maj7+11", StringComparison.Ordinal)) return QualityClass.LydianMaj7;
         if (s.Contains("maj7", StringComparison.Ordinal) || s.Contains("maj9", StringComparison.Ordinal) || s.Contains("maj13", StringComparison.Ordinal) || s.Contains("δ", StringComparison.Ordinal)) return QualityClass.Major7;
@@ -250,6 +256,11 @@ public sealed partial class ImprovisationSkill(
             new("Locrian", "diatonic — but b9 is an avoid note"),
             new("Locrian #2", "raise the 2 from melodic minor — better tonal target"),
         ],
+        QualityKind.Diminished =>
+        [
+            new("Locrian", "the diatonic mode whose 1-b3-b5 triad IS the dim chord"),
+            new("Half-Whole Diminished", "symmetric — works when the chord moves like a passing dim"),
+        ],
         QualityKind.Diminished7 =>
         [
             new("Whole-Half Diminished", "symmetric scale that contains all chord tones"),
@@ -291,6 +302,7 @@ public sealed partial class ImprovisationSkill(
         Minor7,
         MinorMajor7,
         HalfDiminished,
+        Diminished,
         Diminished7,
         Augmented,
     }
@@ -321,6 +333,8 @@ public sealed partial class ImprovisationSkill(
             "Melodic Minor is the home scale; m6 chords also live here.");
         public static readonly QualityClass HalfDiminished = new(QualityKind.HalfDiminished, "half-diminished (m7b5)",
             "Locrian #2 (from melodic minor) is more usable than vanilla Locrian — the b9 is an avoid note.");
+        public static readonly QualityClass Diminished = new(QualityKind.Diminished, "diminished triad",
+            "Locrian is the diatonic home; Half-Whole works for passing-dim contexts.");
         public static readonly QualityClass Diminished7 = new(QualityKind.Diminished7, "diminished 7",
             "Whole-Half Diminished is symmetric and contains every chord tone of a dim7.");
         public static readonly QualityClass Augmented = new(QualityKind.Augmented, "augmented",

--- a/Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs
@@ -62,7 +62,7 @@ public sealed class KeyIdentificationSkill(IChatClient chatClient, ILogger<KeyId
         var topCandidates = candidates.Where(c => c.MatchCount == topScore).ToList();
 
         var prompt       = BuildPrompt(message, chords, topCandidates, candidates);
-        var responseText = await ChatAsync(message, prompt, cancellationToken);
+        var responseText = await ChatAsync(message, prompt, cancellationToken).ConfigureAwait(false);
         var result       = ParseStructuredResponse(responseText, BuildFallback(chords, topCandidates));
 
         return result with

--- a/Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs
@@ -64,7 +64,7 @@ public sealed class ProgressionCompletionSkill(IChatClient chatClient, ILogger<P
 
         var top          = candidates[0];
         var prompt       = BuildPrompt(message, chords, top, candidates);
-        var responseText = await ChatAsync(message, prompt, cancellationToken);
+        var responseText = await ChatAsync(message, prompt, cancellationToken).ConfigureAwait(false);
         var result       = ParseStructuredResponse(responseText, BuildFallback(chords, top));
 
         return result with

--- a/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs
@@ -53,6 +53,12 @@ public sealed class SkillMdDrivenSkill : IOrchestratorSkill
 
     public bool CanHandle(string message)
     {
+        // Reject null/empty/whitespace before any string work — mirrors the
+        // guard in peer skills (ImprovisationSkill, ChordVoicingsSkill, etc).
+        // Without this, `message.ToLowerInvariant()` on null throws NRE and
+        // tanks the entire skill enumeration loop. Caught by multi-LLM
+        // review 2026-05-17.
+        if (string.IsNullOrWhiteSpace(message)) return false;
         if (_skillMd.Triggers.Count == 0) return false;
         var lower = message.ToLowerInvariant();
         return _skillMd.Triggers.Any(t => lower.Contains(t.ToLowerInvariant()));
@@ -60,7 +66,7 @@ public sealed class SkillMdDrivenSkill : IOrchestratorSkill
 
     public async Task<AgentResponse> ExecuteAsync(string message, CancellationToken ct = default)
     {
-        var tools = await _toolsProvider.GetToolsAsync(ct);
+        var tools = await _toolsProvider.GetToolsAsync(ct).ConfigureAwait(false);
         var options = new ChatOptions { Tools = [.. tools] };
 
         ChatMessage[] messages =
@@ -78,7 +84,7 @@ public sealed class SkillMdDrivenSkill : IOrchestratorSkill
                 "SkillMdDrivenSkill [{Skill}] → tools={ToolCount}",
                 _skillMd.Name, tools.Count);
 
-            var response = await _chatClient.Value.GetResponseAsync(messages, options, ct);
+            var response = await _chatClient.Value.GetResponseAsync(messages, options, ct).ConfigureAwait(false);
             var text = response.Text ?? string.Empty;
 
             // Walk response.Messages to collect every tool call the LLM

--- a/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenWrapperBase.cs
+++ b/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenWrapperBase.cs
@@ -101,7 +101,7 @@ public abstract class SkillMdDrivenWrapperBase : IOrchestratorSkill
 
         try
         {
-            var inner = await _inner.Value.ExecuteAsync(message, cancellationToken);
+            var inner = await _inner.Value.ExecuteAsync(message, cancellationToken).ConfigureAwait(false);
 
             // The inner skill records every tool call as a "tools.invoked: <name>"
             // entry in Evidence. Path B should always go through ga_dsl_eval —

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
@@ -129,7 +129,13 @@ public class ImprovisationSkillTests
     [TestCase("Am7(b5)", "HalfDiminished")]
     [TestCase("Cm7b5", "HalfDiminished")]
     [TestCase("Cdim7", "Diminished7")]
-    [TestCase("Cdim", "Diminished7")]
+    // Cdim is the triad, NOT the 7th chord. Fixed 2026-05-17 (PR for
+    // multi-LLM finding-5): pre-fix returned Diminished7 due to
+    // StartsWith("dim") match order. Now returns the dedicated triad class.
+    [TestCase("Cdim", "Diminished")]
+    [TestCase("C°", "Diminished")]
+    [TestCase("Co7", "Diminished7")]
+    [TestCase("C°7", "Diminished7")]
     [TestCase("Caug", "Augmented")]
     [TestCase("C7#5", "Augmented")]
     [TestCase("C7sus", "SuspendedDominant")]


### PR DESCRIPTION
## Summary

Code-reviewer audit of \`Common/GA.Business.ML/Agents/Skills/\` on 2026-05-17 surfaced 5 findings. Security auditor returned clean. This PR ships **4 of 5**; the 5th (chord-regex false-positives) deferred to its own PR because the fix needs adversarial-test design.

| # | Confidence | Category | Files |
|---|---|---|---|
| 2 | medium | correctness | ChordSubstitutionSkill, CatalogSkillMdLoader — add \`StringComparison.Ordinal\` to 3 \`StartsWith\` calls |
| 3 | **high** | concurrency | 5 awaits in 4 files — add missing \`.ConfigureAwait(false)\` (per #251 convention) |
| 4 | medium | correctness | \`SkillMdDrivenSkill.CanHandle(null)\` → NRE — add \`IsNullOrWhiteSpace\` guard |
| 5 | medium | correctness | \`Cdim\` triad mis-classified as \`Diminished7\` → returned W-H Diminished instead of Locrian. Same family as pre-#253 \`CmMaj7\` ordering bug. |

## Test results

\`\`\`
dotnet build Common/GA.Business.ML/...        → 0 errors
dotnet test --filter ImprovisationSkillTests  → 76 passed (was 73, +3 new dim/° cases + 1 corrected Cdim)
\`\`\`

## Deferred to follow-up

**Finding 1** — \`ChordSuffixRegex\` in ChordVoicings + Improvisation accepts \`[A-G]\d\` so \`B12 molecule\`, \`G7 highway\`, \`A4 paper size\` all match. Reviewer marked high-confidence. The naive fix (drop bare \`\d\` from quality alternation) breaks valid chord queries \`C7\`, \`Dm7\`, \`G13\`. Real fix is context-sensitive routing (require chord-context words AND a chord-like token), which deserves its own design + adversarial test corpus. Filing a tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)