### PR TITLE
fix(ecosystem-roadmap): responsive layout + tree panel polish

### DIFF
--- a/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/DetailPanel.tsx
+++ b/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/DetailPanel.tsx
@@ -16,25 +16,31 @@ import { DOMAIN_COLORS, DOMAIN_LABELS } from './types';
 import type { RoadmapNode } from './types';
 import { getAncestors } from './roadmapData';
 
-const PANEL_STYLE = {
-  bgcolor: '#161b22',
-  border: '1px solid #30363d',
-  borderRadius: 1,
-  p: 1.5,
-  minHeight: 200,
-  maxHeight: 200,
-  overflowY: 'auto' as const,
-  color: '#c9d1d9',
-};
+interface DetailPanelProps {
+  /** When true, render a tighter version (less vertical space, shorter cap). */
+  compact?: boolean;
+}
 
-export const DetailPanel: React.FC = () => {
+const panelStyle = (compact: boolean) =>
+  ({
+    bgcolor: '#161b22',
+    borderTop: '1px solid #30363d',
+    p: { xs: 1, sm: 1.5 },
+    minHeight: compact ? 96 : 140,
+    maxHeight: compact ? 180 : 240,
+    overflowY: 'auto' as const,
+    color: '#c9d1d9',
+    flexShrink: 0,
+  }) as const;
+
+export const DetailPanel: React.FC<DetailPanelProps> = ({ compact = false }) => {
   const [selectedNode, setSelectedNode] = useAtom(selectedNodeAtom);
 
   if (!selectedNode) {
     return (
-      <Box sx={PANEL_STYLE}>
-        <Typography variant="body2" sx={{ color: '#8b949e', fontStyle: 'italic', mt: 1 }}>
-          Select a node to view details
+      <Box sx={panelStyle(compact)}>
+        <Typography variant="body2" sx={{ color: '#8b949e', fontStyle: 'italic' }}>
+          Tap a node in the visualization or open the tree to view details.
         </Typography>
       </Box>
     );
@@ -53,7 +59,7 @@ export const DetailPanel: React.FC = () => {
   };
 
   return (
-    <Box sx={PANEL_STYLE}>
+    <Box sx={panelStyle(compact)}>
       {/* Breadcrumb */}
       {ancestors.length > 0 && (
         <Breadcrumbs

--- a/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/EcosystemRoadmapExplorer.tsx
+++ b/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/EcosystemRoadmapExplorer.tsx
@@ -1,33 +1,54 @@
 // src/components/EcosystemRoadmap/EcosystemRoadmapExplorer.tsx
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Provider, useSetAtom } from 'jotai';
-import { Box } from '@mui/material';
+import { Provider, useAtom, useSetAtom } from 'jotai';
+import {
+  Box,
+  Drawer,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 
 import { NavigationPanel } from './NavigationPanel';
 import { DetailPanel } from './DetailPanel';
 import { StatsBar } from './StatsBar';
 import { Toolbar } from './Toolbar';
 import VisualizationCanvas from './VisualizationCanvas';
-import { selectedNodeAtom, expandedTreeNodesAtom, panelWidthAtom } from './atoms';
+import {
+  selectedNodeAtom,
+  expandedTreeNodesAtom,
+  panelWidthAtom,
+  navDrawerOpenAtom,
+} from './atoms';
 import { getAncestors } from './roadmapData';
 import type { RoadmapNode } from './types';
+
+const MIN_PANEL_WIDTH = 220;
+const MAX_PANEL_WIDTH = 480;
 
 // ---------------------------------------------------------------------------
 // Inner component — must be inside Provider to use atoms
 // ---------------------------------------------------------------------------
 const EcosystemRoadmapExplorerInner: React.FC = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
   const setSelectedNode = useSetAtom(selectedNodeAtom);
   const setExpandedNodes = useSetAtom(expandedTreeNodesAtom);
-  const setPanelWidth = useSetAtom(panelWidthAtom);
+  const [panelWidth, setPanelWidth] = useAtom(panelWidthAtom);
+  const [drawerOpen, setDrawerOpen] = useAtom(navDrawerOpenAtom);
 
   const [isDragging, setIsDragging] = useState(false);
   const [hoveredNode, setHoveredNode] = useState<RoadmapNode | null>(null);
 
-  // Handle node selection from the tree (NavigationPanel already sets selectedNodeAtom)
-  const handleNodeSelect = useCallback((_node: RoadmapNode) => {
-    // NavigationPanel already calls setSelectedNode internally; nothing extra needed
-  }, []);
+  const handleNodeSelect = useCallback(
+    (_node: RoadmapNode) => {
+      // NavigationPanel already calls setSelectedNode internally.
+      // Close the drawer on mobile so the user sees the visualization.
+      if (isMobile) setDrawerOpen(false);
+    },
+    [isMobile, setDrawerOpen],
+  );
 
   // Handle node click from the visualization canvas
   const handleNodeClick = useCallback(
@@ -37,7 +58,7 @@ const EcosystemRoadmapExplorerInner: React.FC = () => {
       const ancestors = getAncestors(node);
       const ancestorIds = ancestors.map((a) => a.id);
       setExpandedNodes((prev) => {
-        const merged = new Set([...prev, ...ancestorIds]);
+        const merged = new Set([...prev, ...ancestorIds, node.id]);
         return Array.from(merged);
       });
     },
@@ -49,18 +70,17 @@ const EcosystemRoadmapExplorerInner: React.FC = () => {
     setHoveredNode(node);
   }, []);
 
-  // Drag divider: track mousemove/mouseup on window while dragging
+  // Drag divider: track mousemove/mouseup on window while dragging.
+  // Desktop only — mobile uses the drawer instead.
   useEffect(() => {
-    if (!isDragging) return;
+    if (!isDragging || isMobile) return;
 
     const onMouseMove = (e: MouseEvent) => {
-      const clamped = Math.min(500, Math.max(200, e.clientX));
+      const clamped = Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, e.clientX));
       setPanelWidth(clamped);
     };
 
-    const onMouseUp = () => {
-      setIsDragging(false);
-    };
+    const onMouseUp = () => setIsDragging(false);
 
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
@@ -69,7 +89,26 @@ const EcosystemRoadmapExplorerInner: React.FC = () => {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
     };
-  }, [isDragging, setPanelWidth]);
+  }, [isDragging, isMobile, setPanelWidth]);
+
+  // Close the drawer automatically when crossing the desktop breakpoint up.
+  useEffect(() => {
+    if (!isMobile && drawerOpen) setDrawerOpen(false);
+  }, [isMobile, drawerOpen, setDrawerOpen]);
+
+  const treePanel = (
+    <Box
+      sx={{
+        width: isMobile ? '85vw' : panelWidth,
+        maxWidth: isMobile ? 360 : MAX_PANEL_WIDTH,
+        minWidth: MIN_PANEL_WIDTH,
+        height: '100%',
+        borderRight: isMobile ? 'none' : '1px solid #30363d',
+      }}
+    >
+      <NavigationPanel onNodeSelect={handleNodeSelect} />
+    </Box>
+  );
 
   return (
     <Box
@@ -77,38 +116,61 @@ const EcosystemRoadmapExplorerInner: React.FC = () => {
       height="100%"
       sx={{
         bgcolor: '#0d1117',
-        cursor: isDragging ? 'col-resize' : (hoveredNode ? 'pointer' : 'default'),
+        cursor: isDragging ? 'col-resize' : hoveredNode ? 'pointer' : 'default',
       }}
     >
-      {/* Left: Navigation panel */}
-      <NavigationPanel onNodeSelect={handleNodeSelect} />
+      {/* Left: tree panel — inline on desktop, drawer on mobile */}
+      {!isMobile && treePanel}
 
-      {/* Drag divider */}
-      <Box
-        sx={{
-          width: 4,
-          flexShrink: 0,
-          bgcolor: '#30363d',
-          cursor: 'col-resize',
-          transition: 'background-color 0.15s',
-          '&:hover': { bgcolor: '#58a6ff' },
-          userSelect: 'none',
-        }}
-        onMouseDown={() => setIsDragging(true)}
-      />
+      {/* Drag divider — desktop only */}
+      {!isMobile && (
+        <Box
+          aria-label="resize navigation panel"
+          role="separator"
+          sx={{
+            width: 4,
+            flexShrink: 0,
+            bgcolor: '#30363d',
+            cursor: 'col-resize',
+            transition: 'background-color 0.15s',
+            '&:hover': { bgcolor: '#58a6ff' },
+            userSelect: 'none',
+          }}
+          onMouseDown={() => setIsDragging(true)}
+        />
+      )}
 
       {/* Right: main area */}
       <Box flex={1} display="flex" flexDirection="column" minWidth={0}>
-        <Toolbar />
-        <Box flex={1} position="relative" sx={{ overflow: 'hidden' }}>
+        <Toolbar
+          showMenuButton={isMobile}
+          onMenuClick={() => setDrawerOpen(true)}
+        />
+        <Box flex={1} position="relative" sx={{ overflow: 'hidden', minHeight: 0 }}>
           <VisualizationCanvas
             onNodeClick={handleNodeClick}
             onNodeHover={handleNodeHover}
           />
         </Box>
-        <DetailPanel />
+        <DetailPanel compact={isMobile} />
         <StatsBar />
       </Box>
+
+      {/* Mobile drawer */}
+      <Drawer
+        anchor="left"
+        open={isMobile && drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        PaperProps={{
+          sx: {
+            bgcolor: '#161b22',
+            backgroundImage: 'none',
+            borderRight: '1px solid #30363d',
+          },
+        }}
+      >
+        {treePanel}
+      </Drawer>
     </Box>
   );
 };
@@ -123,3 +185,4 @@ export const EcosystemRoadmapExplorer: React.FC = () => {
     </Provider>
   );
 };
+

--- a/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/NavigationPanel.tsx
+++ b/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/NavigationPanel.tsx
@@ -1,11 +1,22 @@
 // src/components/EcosystemRoadmap/NavigationPanel.tsx
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
-import { TextField, InputAdornment, Box, Typography } from '@mui/material';
+import {
+  TextField,
+  InputAdornment,
+  Box,
+  Typography,
+  IconButton,
+} from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { selectedNodeAtom, expandedTreeNodesAtom, searchFilterAtom, panelWidthAtom } from './atoms';
+import ClearIcon from '@mui/icons-material/Clear';
+import { useAtom, useSetAtom } from 'jotai';
+import {
+  selectedNodeAtom,
+  expandedTreeNodesAtom,
+  searchFilterAtom,
+} from './atoms';
 import { ROADMAP_TREE, searchTree } from './roadmapData';
 import type { RoadmapNode } from './types';
 
@@ -17,12 +28,23 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({ onNodeSelect }
   const [expanded, setExpanded] = useAtom(expandedTreeNodesAtom);
   const setSelectedNode = useSetAtom(selectedNodeAtom);
   const [filter, setFilter] = useAtom(searchFilterAtom);
-  const width = useAtomValue(panelWidthAtom);
 
   const visibleIds = useMemo(
     () => (filter ? searchTree(ROADMAP_TREE, filter) : null),
-    [filter]
+    [filter],
   );
+
+  // When the user searches, expand every matching node's ancestors so the
+  // hits are actually visible (otherwise filtered children sit hidden
+  // under a still-collapsed parent — the original tree-panel bug).
+  useEffect(() => {
+    if (!visibleIds) return;
+    setExpanded((prev) => {
+      const merged = new Set(prev);
+      visibleIds.forEach((id) => merged.add(id));
+      return Array.from(merged);
+    });
+  }, [visibleIds, setExpanded]);
 
   const handleSelect = (_event: React.SyntheticEvent, itemId: string | null) => {
     if (!itemId) return;
@@ -40,19 +62,45 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({ onNodeSelect }
         key={node.id}
         itemId={node.id}
         label={
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, py: 0.25 }}>
-            <Box sx={{
-              width: 8, height: 8, borderRadius: '50%',
-              bgcolor: node.color, flexShrink: 0,
-            }} />
-            <Typography variant="body2" noWrap>{node.name}</Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, py: 0.25 }}>
+            <Box
+              sx={{
+                width: 9,
+                height: 9,
+                borderRadius: '50%',
+                bgcolor: node.color,
+                flexShrink: 0,
+                boxShadow: `0 0 6px ${node.color}55`,
+              }}
+            />
+            <Typography
+              variant="body2"
+              noWrap
+              sx={{ color: '#e6edf3', fontSize: '0.85rem' }}
+            >
+              {node.name}
+            </Typography>
             {node.sub && (
-              <Typography variant="caption" sx={{ color: '#8b949e', ml: 0.5 }}>
+              <Typography
+                variant="caption"
+                sx={{ color: '#8b949e', ml: 0.5, fontSize: '0.7rem' }}
+              >
                 {node.sub}
               </Typography>
             )}
           </Box>
         }
+        sx={{
+          '& .MuiTreeItem-content': {
+            borderRadius: 0.75,
+            py: 0.25,
+            '&:hover': { bgcolor: '#1f2937' },
+            '&.Mui-selected, &.Mui-selected.Mui-focused': {
+              bgcolor: '#1f6feb33',
+            },
+          },
+          '& .MuiTreeItem-iconContainer svg': { color: '#8b949e' },
+        }}
       >
         {node.children?.map(renderTree)}
       </TreeItem>
@@ -60,25 +108,69 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({ onNodeSelect }
   };
 
   return (
-    <Box sx={{ width, minWidth: 200, maxWidth: 500, overflow: 'auto', bgcolor: '#161b22',
-               borderRight: '1px solid #30363d', height: '100%' }}>
-      <Box sx={{ p: 1 }}>
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        bgcolor: '#161b22',
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        sx={{
+          p: 1,
+          borderBottom: '1px solid #30363d',
+          flexShrink: 0,
+        }}
+      >
         <TextField
-          fullWidth size="small" placeholder="Search..."
-          value={filter} onChange={(e) => setFilter(e.target.value)}
+          fullWidth
+          size="small"
+          placeholder="Search the ecosystem…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
           InputProps={{
-            startAdornment: <InputAdornment position="start"><SearchIcon fontSize="small" /></InputAdornment>,
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" sx={{ color: '#8b949e' }} />
+              </InputAdornment>
+            ),
+            endAdornment: filter ? (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  aria-label="clear search"
+                  onClick={() => setFilter('')}
+                  sx={{ color: '#8b949e' }}
+                >
+                  <ClearIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
           }}
-          sx={{ '& .MuiOutlinedInput-root': { bgcolor: '#0d1117' } }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              bgcolor: '#0d1117',
+              color: '#e6edf3',
+              fontSize: '0.85rem',
+              '& fieldset': { borderColor: '#30363d' },
+              '&:hover fieldset': { borderColor: '#484f58' },
+              '&.Mui-focused fieldset': { borderColor: '#58a6ff' },
+            },
+          }}
         />
       </Box>
-      <SimpleTreeView
-        expandedItems={expanded}
-        onExpandedItemsChange={(_e, ids) => setExpanded(ids)}
-        onSelectedItemsChange={handleSelect}
-      >
-        {renderTree(ROADMAP_TREE)}
-      </SimpleTreeView>
+      <Box sx={{ flex: 1, overflow: 'auto', p: 0.5 }}>
+        <SimpleTreeView
+          expandedItems={expanded}
+          onExpandedItemsChange={(_e, ids) => setExpanded(ids)}
+          onSelectedItemsChange={handleSelect}
+        >
+          {renderTree(ROADMAP_TREE)}
+        </SimpleTreeView>
+      </Box>
     </Box>
   );
 };

--- a/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/StatsBar.tsx
+++ b/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/StatsBar.tsx
@@ -11,10 +11,14 @@ export const StatsBar: React.FC = () => {
         display: 'flex',
         flexDirection: 'row',
         flexWrap: 'wrap',
-        gap: 1,
+        gap: 0.75,
         justifyContent: 'center',
         alignItems: 'center',
-        py: 0.75,
+        px: 1,
+        py: { xs: 0.5, sm: 0.75 },
+        bgcolor: '#0d1117',
+        borderTop: '1px solid #30363d',
+        flexShrink: 0,
       }}
     >
       {STATS.map((stat) => (

--- a/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/Toolbar.tsx
+++ b/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/Toolbar.tsx
@@ -10,6 +10,7 @@ import {
   ToggleButtonGroup,
   Typography,
 } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import AdjustIcon from '@mui/icons-material/Adjust';
 import PublicIcon from '@mui/icons-material/Public';
@@ -23,7 +24,17 @@ const ZOOM_MIN = 0.25;
 const ZOOM_MAX = 4.0;
 const ZOOM_STEP = 0.25;
 
-export const Toolbar: React.FC = () => {
+interface ToolbarProps {
+  /** Show the burger menu (mobile drawer trigger). */
+  showMenuButton?: boolean;
+  /** Called when the burger menu is tapped. */
+  onMenuClick?: () => void;
+}
+
+export const Toolbar: React.FC<ToolbarProps> = ({
+  showMenuButton = false,
+  onMenuClick,
+}) => {
   const [viewMode, setViewMode] = useAtom(viewModeAtom);
   const [zoomLevel, setZoomLevel] = useAtom(zoomLevelAtom);
   const rendererType = useAtomValue(rendererTypeAtom);
@@ -56,7 +67,9 @@ export const Toolbar: React.FC = () => {
         display: 'flex',
         flexDirection: 'row',
         alignItems: 'center',
-        gap: 2,
+        flexWrap: 'wrap',
+        rowGap: 0.5,
+        columnGap: { xs: 1, sm: 2 },
         px: 1,
         py: 0.5,
         backgroundColor: '#161b22',
@@ -65,6 +78,21 @@ export const Toolbar: React.FC = () => {
         flexShrink: 0,
       }}
     >
+      {showMenuButton && (
+        <IconButton
+          aria-label="open navigation"
+          onClick={onMenuClick}
+          size="small"
+          sx={{
+            color: '#c9d1d9',
+            mr: 0.5,
+            '&:hover': { color: '#fff', backgroundColor: '#21262d' },
+          }}
+        >
+          <MenuIcon fontSize="small" />
+        </IconButton>
+      )}
+
       {/* View Mode Toggle */}
       <ToggleButtonGroup
         value={viewMode}

--- a/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/atoms.ts
+++ b/ReactComponents/ga-react-components/src/components/EcosystemRoadmap/atoms.ts
@@ -2,11 +2,22 @@
 
 import { atom } from 'jotai';
 import type { RoadmapNode, ViewMode, RendererType } from './types';
+import { ROADMAP_TREE } from './roadmapData';
+
+// Default expansion: root + every depth-1 child so the tree reveals
+// the top-level structure (Constitution, Repos, Personas, ...) on
+// first render instead of a single collapsed bullet.
+const DEFAULT_EXPANDED: string[] = [
+  ROADMAP_TREE.id,
+  ...(ROADMAP_TREE.children?.map((c) => c.id) ?? []),
+];
 
 export const selectedNodeAtom = atom<RoadmapNode | null>(null);
 export const viewModeAtom = atom<ViewMode>('disk');
 export const zoomLevelAtom = atom<number>(1.0);
-export const expandedTreeNodesAtom = atom<string[]>([]); // string[] for MUI TreeView compat
+export const expandedTreeNodesAtom = atom<string[]>(DEFAULT_EXPANDED);
 export const searchFilterAtom = atom<string>('');
 export const rendererTypeAtom = atom<RendererType>('webgpu');
-export const panelWidthAtom = atom<number>(280);
+export const panelWidthAtom = atom<number>(300);
+// Mobile-only: tree is in a drawer, default closed. Desktop ignores this.
+export const navDrawerOpenAtom = atom<boolean>(false);


### PR DESCRIPTION
## Summary

The `/test/ecosystem-roadmap` page on demos was broken on mobile (tree column hard-coded to 280 px squashed the visualization into ~150 px) and the tree panel itself rendered as a single collapsed bullet with no clear way to see the top-level structure.

- **Layout:** breakpoint at `md` (900 px). Below it the tree moves into a `Drawer` triggered by a burger menu in the toolbar; the visualization gets the full viewport width.
- **Tree default state:** auto-expand root + every depth-1 child so the top-level domains (Constitution, Tetravalent, Streeling Univ., …) appear immediately. Searching now also expands the ancestors of every match so filtered hits are actually visible.
- **Tree style:** high-contrast labels (`#e6edf3`), per-row hover and selected backgrounds, dot glow tinted from the node's own domain colour, clear-`X` button in the search field, full GA dark palette on the input.
- **Detail / stats:** `DetailPanel` relaxed from a rigid 200/200 px box to a min/max range that grows to fit content; `StatsBar` pinned to a bordered footer so it stops floating mid-canvas; `Toolbar` wraps gracefully and exposes the burger only when mobile.

## Test plan

- [x] Local build green (`npm run build` in `ReactComponents/ga-react-components/`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Chrome live-verified at 390 / 820 / 1440 px against the dev server
- [x] Search → filter → ancestors auto-expand → click → detail panel populates with breadcrumb + children chips
- [x] Drawer opens on burger click and closes on node select (mobile)
- [ ] Demos host re-deploy (`git pull && npm run build` on demos.guitaralchemist.com — host-controlled)

## Screenshots

| Before | After |
|---|---|
| `state/ecosystem-roadmap-mobile.png` (tree squashes viz) | `state/ecosystem-roadmap-mobile-v2.png` (viz fills width) |
| `state/ecosystem-roadmap-desktop.png` (single collapsed bullet) | `state/ecosystem-roadmap-desktop-v2.png` (tree fully revealed) |
| — | `state/ecosystem-roadmap-mobile-drawer.png` (drawer w/ glowing dots) |
| — | `state/ecosystem-roadmap-search.png` (clear-X + ancestor expansion) |
| — | `state/ecosystem-roadmap-selected.png` (detail panel + breadcrumb + children chips) |
| — | `state/ecosystem-roadmap-tablet.png` (820 px in mobile mode) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)