### PR TITLE
fix(music-hierarchy): GraphQL schema drift + column realignment

### DIFF
--- a/ReactComponents/ga-react-components/src/api/musicHierarchyApi.ts
+++ b/ReactComponents/ga-react-components/src/api/musicHierarchyApi.ts
@@ -6,6 +6,27 @@ import { MusicHierarchyItem, MusicHierarchyLevel, MusicHierarchyLevelInfo } from
 // Music Hierarchy Navigator on 2026-05-16.
 const GRAPHQL_ENDPOINT = import.meta.env.VITE_GA_GRAPHQL_URL ?? '/graphql';
 
+// HotChocolate emits enum values in SCREAMING_SNAKE_CASE by default
+// (`SET_CLASS`), but the UI was written against the PascalCase C# names
+// (`SetClass`). Translate at the API boundary so the rest of the page
+// keeps working without a 600-line rename.
+const UI_TO_WIRE_LEVEL: Record<MusicHierarchyLevel, string> = {
+  SetClass:     'SET_CLASS',
+  ForteNumber:  'FORTE_NUMBER',
+  PrimeForm:    'PRIME_FORM',
+  Chord:        'CHORD',
+  ChordVoicing: 'CHORD_VOICING',
+  Scale:        'SCALE',
+};
+
+const WIRE_TO_UI_LEVEL: Record<string, MusicHierarchyLevel> = Object.fromEntries(
+  Object.entries(UI_TO_WIRE_LEVEL).map(([ui, wire]) => [wire, ui as MusicHierarchyLevel]),
+);
+
+function toUiLevel(wire: string): MusicHierarchyLevel {
+  return WIRE_TO_UI_LEVEL[wire] ?? (wire as MusicHierarchyLevel);
+}
+
 interface GraphQLResponse<T> {
   data?: T;
   errors?: { message: string }[];
@@ -50,8 +71,8 @@ export async function fetchHierarchyLevels(): Promise<MusicHierarchyLevelInfo[]>
     }
   `;
 
-  const data = await postGraphQL<{ musicHierarchyLevels: MusicHierarchyLevelInfo[] }>(query);
-  return data.musicHierarchyLevels;
+  const data = await postGraphQL<{ musicHierarchyLevels: Array<MusicHierarchyLevelInfo & { level: string }> }>(query);
+  return data.musicHierarchyLevels.map((l) => ({ ...l, level: toUiLevel(l.level) }));
 }
 
 export interface HierarchyItemsVariables extends Record<string, unknown> {
@@ -59,6 +80,51 @@ export interface HierarchyItemsVariables extends Record<string, unknown> {
   parentId?: string;
   take?: number;
   search?: string;
+}
+
+// Wire shape returned by GraphQL — `metadata` is a list of KeyValuePair
+// objects, not a scalar map. We flatten it to Record<string, string> at the
+// API boundary so the UI keeps the original lookup-by-key contract
+// (`item.metadata['Cardinality']`).
+interface MusicHierarchyItemWire {
+  id: string;
+  name: string;
+  level: string;
+  category: string;
+  description?: string | null;
+  tags: string[];
+  metadata: Array<{ key: string; value: string }>;
+}
+
+// The page reads metadata under the PascalCase names it was originally
+// designed against. The GraphQL schema now emits camelCase keys
+// (HotChocolate default), and a few keys were renamed entirely (e.g.
+// `icv` is the historical "IntervalVector"). Alias both forms so the
+// existing column renderers keep working without a UI rewrite.
+const METADATA_ALIASES: Record<string, string> = {
+  cardinality:       'Cardinality',
+  icv:               'IntervalVector',
+  primeFormId:       'PrimeFormId',
+  parentSetClassId:  'ParentSetClassId',
+  setClassId:        'SetClassId',
+  noteCount:         'NoteCount',
+  extension:         'Extension',
+  frets:             'Frets',
+  strings:           'Strings',
+  root:              'Root',
+  isModal:           'IsModal',
+};
+
+function fromWire(item: MusicHierarchyItemWire): MusicHierarchyItem {
+  const meta: Record<string, string> = {};
+  for (const { key, value } of item.metadata ?? []) {
+    meta[key] = value;
+    const alias = METADATA_ALIASES[key];
+    if (alias && !(alias in meta)) {
+      meta[alias] = value;
+    }
+  }
+  return { ...item, level: toUiLevel(item.level), metadata: meta };
 }
 
 export async function fetchHierarchyItems(variables: HierarchyItemsVariables): Promise<MusicHierarchyItem[]> {
@@ -71,13 +137,17 @@ export async function fetchHierarchyItems(variables: HierarchyItemsVariables): P
         category
         description
         tags
-        metadata
+        metadata {
+          key
+          value
+        }
       }
     }
   `;
 
-  const data = await postGraphQL<{ musicHierarchyItems: MusicHierarchyItem[] }>(query, variables);
-  return data.musicHierarchyItems;
+  const wireVars = { ...variables, level: UI_TO_WIRE_LEVEL[variables.level] ?? variables.level };
+  const data = await postGraphQL<{ musicHierarchyItems: MusicHierarchyItemWire[] }>(query, wireVars);
+  return data.musicHierarchyItems.map(fromWire);
 }
 
 export const fetchAllHierarchyItems = fetchHierarchyItems;

--- a/ReactComponents/ga-react-components/src/pages/MusicHierarchyDemo.tsx
+++ b/ReactComponents/ga-react-components/src/pages/MusicHierarchyDemo.tsx
@@ -81,40 +81,49 @@ function findParentId(item: MusicHierarchyItem): string | undefined {
   return undefined;
 }
 
+// Column definitions align with what the GraphQL backend actually emits.
+// SetClass/Forte/Prime/Scale are wired against the real domain repository;
+// Chord and ChordVoicing currently return placeholder rows (see backend
+// `ChordRepository` TODOs), so their tables intentionally stay sparse.
+//
+// Metadata key lookups use BOTH the new wire form (e.g. `icv`,
+// `cardinality`) and the historical PascalCase aliases (`IntervalVector`,
+// `Cardinality`) — the API layer in musicHierarchyApi.ts adds the aliases.
+const meta = (key: string) => (item: MusicHierarchyItem) => item.metadata?.[key] ?? '—';
+
 const baseTableColumns: Record<MusicHierarchyLevel, TableColumn[]> = {
   SetClass: [
     { key: 'name', label: 'Set Class' },
     { key: 'category', label: 'Category' },
-    { key: 'metadata.Cardinality', label: 'Cardinality', render: item => item.metadata?.['Cardinality'] ?? '—' },
-    { key: 'metadata.IntervalVector', label: 'Interval Vector', render: item => item.metadata?.['IntervalVector'] ?? '—' },
+    { key: 'metadata.Cardinality',    label: 'Cardinality',     render: meta('Cardinality') },
+    { key: 'metadata.IntervalVector', label: 'Interval Vector', render: meta('IntervalVector') },
+    { key: 'metadata.IsModal',        label: 'Modal',           render: meta('IsModal') },
   ],
   ForteNumber: [
-    { key: 'name', label: 'Forte Number' },
-    { key: 'metadata.Cardinality', label: 'Cardinality', render: item => item.metadata?.['Cardinality'] ?? '—' },
-    { key: 'metadata.ParentSetClassId', label: 'Set Class', render: item => item.metadata?.['ParentSetClassId'] ?? '—' },
+    { key: 'name',                 label: 'Forte Number' },
+    { key: 'metadata.Cardinality', label: 'Cardinality', render: meta('Cardinality') },
+    { key: 'metadata.index',       label: 'Index in Cardinality', render: meta('index') },
   ],
   PrimeForm: [
-    { key: 'name', label: 'Prime Form' },
-    { key: 'category', label: 'Category' },
-    { key: 'metadata.Cardinality', label: 'Cardinality', render: item => item.metadata?.['Cardinality'] ?? '—' },
+    { key: 'name',           label: 'Prime Form' },
+    { key: 'category',       label: 'Category' },
+    { key: 'metadata.count', label: 'Cardinality', render: meta('count') },
+    { key: 'metadata.forte', label: 'Forte',       render: meta('forte') },
   ],
   Chord: [
-    { key: 'name', label: 'Chord' },
+    { key: 'name',     label: 'Chord' },
     { key: 'category', label: 'Family' },
-    { key: 'metadata.Extension', label: 'Extension', render: item => item.metadata?.['Extension'] ?? '—' },
-    { key: 'metadata.NoteCount', label: '# Notes', render: item => item.metadata?.['NoteCount'] ?? '—' },
   ],
   ChordVoicing: [
-    { key: 'name', label: 'Position' },
-    { key: 'metadata.Frets', label: 'Frets', render: item => item.metadata?.['Frets'] ?? '—' },
-    { key: 'metadata.Strings', label: 'Strings', render: item => item.metadata?.['Strings'] ?? '—' },
-    { key: 'metadata.Root', label: 'Root', render: item => item.metadata?.['Root'] ?? '—' },
+    { key: 'name',     label: 'Position' },
+    { key: 'category', label: 'Family' },
   ],
   Scale: [
-    { key: 'name', label: 'Scale / Mode' },
-    { key: 'category', label: 'Family' },
-    { key: 'metadata.Root', label: 'Root', render: item => item.metadata?.['Root'] ?? '—' },
-    { key: 'metadata.NoteCount', label: '# Notes', render: item => item.metadata?.['NoteCount'] ?? '—' },
+    { key: 'name',                  label: 'Scale / Mode' },
+    { key: 'category',              label: 'Family' },
+    { key: 'metadata.notes',        label: 'Notes',  render: meta('notes') },
+    { key: 'metadata.forte',        label: 'Forte',  render: meta('forte') },
+    { key: 'metadata.common',       label: 'Common', render: meta('common') },
   ],
 };
 


### PR DESCRIPTION
## Summary

The Music Hierarchy Navigator at \`/test/music-hierarchy\` was rendering an empty page behind a red \"GraphQL request failed with status 400\" banner. Three independent schema-drift bugs stacked together:

| # | Symptom | Wire reality |
|---|---|---|
| 1 | Items query returns 400 \"Leaf selections … disallowed\" | \`metadata\` is \`[KeyValuePairOfStringAndString!]!\`, not a scalar map |
| 2 | Item-level filter returns 500 \"\`MusicHierarchyLevel\` cannot parse\" | GraphQL enum is \`SET_CLASS\` (SCREAMING_SNAKE), page sends \`'SetClass'\` |
| 3 | Cardinality / Interval Vector / etc. columns all read \"—\" | Backend now emits camelCase keys (\`cardinality\`, \`icv\`, \`notes\`, …); page reads PascalCase |

## Fix

- \`musicHierarchyApi.ts\` selects \`metadata { key value }\` and flattens to \`Record<string,string>\` at the API boundary.
- API translates UI ↔ wire enum so the 600-line page keeps its existing PascalCase contract.
- \`fromWire\` aliases well-known wire keys to PascalCase (\`cardinality\` → \`Cardinality\`, \`icv\` → \`IntervalVector\`, …).
- Column defs realigned against what the backend exposes today: added Modal / Notes / Common, dropped Frets/Strings/Root for the still-placeholder Chord and ChordVoicing levels (those remain TODO in \`ChordRepository\`).

## Result

Set Classes, Forte Numbers, Prime Forms, and Scales tabs now display real data end-to-end. Chord and ChordVoicing tables stay sparse pending backend repository work.

## Test plan

- [x] Local build green
- [x] TypeScript clean
- [x] Chrome live-verified at 1440×900 against the Vite dev server with hot reload
- [x] All four data-bearing tabs render real columns
- [ ] Demos host re-deploy (\`git pull && npm run build\` on demos.guitaralchemist.com — host-controlled)

## Screenshots

| Before | After |
|---|---|
| \`state/music-hierarchy-desktop.png\` (400 banner, all dropdowns empty) | \`state/music-hierarchy-final-set.png\` (Set Classes filled) |
| — | \`state/music-hierarchy-prime.png\` (Prime Forms tab) |
| — | \`state/music-hierarchy-scales.png\` (Scales tab w/ Notes + Forte + Common) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)