### PR TITLE
feat(bsp-doom): v2 rebuild — usable scene + GA palette + key/mode rooms

### DIFF
--- a/ReactComponents/ga-react-components/src/components/BSP/v2/BSPDoomExplorerV2.tsx
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/BSPDoomExplorerV2.tsx
@@ -1,35 +1,28 @@
 /**
- * BSP DOOM Explorer — v2 rewrite.
+ * BSP DOOM Explorer — v2 rewrite (2026-05-15) + musical rebuild (2026-05-17).
  *
- * Replaces the 6,250-line BSPDoomExplorer.tsx with a ~120-line
- * orchestrator that composes ~10 focused components built on
+ * Replaces the 6,250-line BSPDoomExplorer.tsx with a ~180-line
+ * orchestrator that composes a handful of focused components built on
  * react-three-fiber + drei. Same public props; same `/test/bsp-doom-
- * explorer` route (via index.ts re-export); same behavior end-to-end
- * but renders even when the backend BSP API is unreachable (the root
- * cause of the original "broken" live page).
+ * explorer` route (via index.ts re-export).
  *
- * Architecture:
- *
- *   useBSPTree ──► layoutTree ──► BSPScene
- *                                  ├─ BSPRegionVolume (x N leaves)
- *                                  ├─ BSPPartitionWall (x M splits)
- *                                  └─ Player (PointerLockControls + WASD)
- *                                            │
- *                                            └─► onPositionChange ──► regionAt
- *                                                                        │
- *                                                                ┌───────┴───────┐
- *                                                              HUD             Minimap
+ * The 2026-05-15 v2 fixed the rendering (procedural fallback so the
+ * page is never blank). The 2026-05-17 musical rebuild made it useful
+ * — each room is a real key+mode, the HUD shows scale notes + Roman
+ * numerals, and "modulate to →" chips teleport the camera through
+ * harmonic neighbours.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { BSPRegion } from '../BSPApiService';
 import { useBSPTree } from './useBSPTree';
-import { layoutTree, regionAt } from './layoutTree';
+import { layoutTree, regionAt, type LaidOutRegion } from './layoutTree';
 import { BSPScene } from './BSPScene';
 import { HUD } from './HUD';
 import { Minimap } from './Minimap';
+import type { PlayerHandle } from './Player';
 
 export interface BSPDoomExplorerV2Props {
   width?: number;
@@ -40,6 +33,10 @@ export interface BSPDoomExplorerV2Props {
   showMinimap?: boolean;
   onRegionChange?: (region: BSPRegion) => void;
 }
+
+/** The ii–V–I tour path through the curated tree. */
+const TOUR_PATH = ['D minor', 'G major', 'C major'];
+const TOUR_STEP_MS = 2200;
 
 export function BSPDoomExplorerV2({
   width = 1200,
@@ -58,11 +55,27 @@ export function BSPDoomExplorerV2({
 
   const [playerPosition, setPlayerPosition] = useState(() => new THREE.Vector3(0, 4, 20));
   const [currentRegion, setCurrentRegion] = useState<BSPRegion | null>(null);
+  const [tourActive, setTourActive] = useState(false);
   const lastRegionName = useRef<string | null>(null);
+  const playerRef = useRef<PlayerHandle>(null);
+  const tourTimer = useRef<number | null>(null);
+
+  // Index leaves by *both* short name ("C maj") and full key name ("C major").
+  // Neighbours are listed by full key name; minimap/short floor labels use
+  // the short name. We need lookups for either.
+  const regionsByName = useMemo(() => {
+    if (!layout) return new Map<string, LaidOutRegion>();
+    const map = new Map<string, LaidOutRegion>();
+    for (const r of layout.regions) {
+      map.set(r.node.region.name, r);
+      const music = (r.node.region as { music?: { key: string } }).music;
+      if (music?.key) map.set(music.key, r);
+    }
+    return map;
+  }, [layout]);
 
   const handlePositionChange = useCallback(
     (pos: THREE.Vector3) => {
-      // Cheap clone — `useFrame` reuses the same vector instance per frame.
       setPlayerPosition(pos.clone());
       if (!layout) return;
       const r = regionAt(layout, pos);
@@ -77,18 +90,69 @@ export function BSPDoomExplorerV2({
     [layout, onRegionChange],
   );
 
+  const teleportTo = useCallback(
+    (keyName: string) => {
+      const target = regionsByName.get(keyName);
+      if (!target || !playerRef.current) return;
+      // Stand in the middle of the room, eye-height above the floor.
+      const dest = new THREE.Vector3(
+        target.center.x,
+        target.center.y - target.size.y / 2 + 4,
+        target.center.z,
+      );
+      playerRef.current.teleportTo(dest);
+      // Optimistic update — region detector will catch up next frame.
+      lastRegionName.current = target.node.region.name;
+      setCurrentRegion(target.node.region);
+      onRegionChange?.(target.node.region);
+    },
+    [regionsByName, onRegionChange],
+  );
+
+  // ---- Tour ----
+  // Walks D minor → G major → C major on a 2.2 s cadence. Stops on its
+  // own at the end of the path; user can stop early by re-clicking the
+  // toggle.
+  useEffect(() => {
+    if (!tourActive) {
+      if (tourTimer.current !== null) {
+        window.clearInterval(tourTimer.current);
+        tourTimer.current = null;
+      }
+      return;
+    }
+    let i = 0;
+    teleportTo(TOUR_PATH[i]);
+    tourTimer.current = window.setInterval(() => {
+      i += 1;
+      if (i >= TOUR_PATH.length) {
+        setTourActive(false);
+        return;
+      }
+      teleportTo(TOUR_PATH[i]);
+    }, TOUR_STEP_MS);
+    return () => {
+      if (tourTimer.current !== null) {
+        window.clearInterval(tourTimer.current);
+        tourTimer.current = null;
+      }
+    };
+  }, [tourActive, teleportTo]);
+
+  const handleTourToggle = useCallback(() => setTourActive((v) => !v), []);
+
   if (treeState.loading || !layout || !treeState.tree) {
     return (
       <div
         style={{
           width,
           height,
-          background: '#000',
-          color: '#0f0',
+          background: '#0d1117',
+          color: '#8b949e',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          fontFamily: 'monospace',
+          fontFamily: 'ui-monospace, monospace',
         }}
       >
         loading BSP tree…
@@ -97,13 +161,14 @@ export function BSPDoomExplorerV2({
   }
 
   return (
-    <div style={{ width, height, position: 'relative', background: '#000' }}>
+    <div style={{ width, height, position: 'relative', background: '#0d1117' }}>
       <Canvas
         shadows
         camera={{ fov: 75, near: 0.1, far: 500, position: [0, 4, 20] }}
         gl={{ antialias: true, powerPreference: 'high-performance' }}
       >
         <BSPScene
+          ref={playerRef}
           layout={layout}
           currentRegionName={currentRegion?.name ?? null}
           moveSpeed={moveSpeed}
@@ -118,6 +183,9 @@ export function BSPDoomExplorerV2({
           source={treeState.source}
           regionCount={treeState.tree.regionCount}
           treeDepth={treeState.tree.maxDepth}
+          onTeleport={teleportTo}
+          tourActive={tourActive}
+          onTourToggle={handleTourToggle}
         />
       )}
 

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/BSPRegionVolume.tsx
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/BSPRegionVolume.tsx
@@ -3,12 +3,18 @@
  * solid floor plate. The floor anchors the player visually; the
  * translucent volume signals "you are in region X" without occluding
  * the partition walls.
+ *
+ * When the region is a curated musical leaf, the floor also carries a
+ * tonic letter — overlaid via drei's <Text> so a guitarist sees the
+ * key from a distance even before the HUD updates.
  */
 
 import { useRef } from 'react';
 import * as THREE from 'three';
+import { Text } from '@react-three/drei';
 import type { LaidOutRegion } from './layoutTree';
-import { colorFor } from './tonalityColors';
+import { colorForRegion } from './tonalityColors';
+import type { MusicalRegion } from './musicalTree';
 
 interface Props {
   region: LaidOutRegion;
@@ -17,10 +23,11 @@ interface Props {
 
 export function BSPRegionVolume({ region, active }: Props) {
   const meshRef = useRef<THREE.Mesh>(null);
-  const color = colorFor(region.node.region.tonalityType);
+  const color = colorForRegion(region.node.region);
+  const music = (region.node.region as MusicalRegion).music;
 
-  // Floor plate sits at the bottom of the region volume.
   const floorY = region.center.y - region.size.y / 2 + 0.05;
+  const labelY = floorY + 0.02;
 
   return (
     <group>
@@ -33,11 +40,27 @@ export function BSPRegionVolume({ region, active }: Props) {
         <meshStandardMaterial
           color={color}
           emissive={color}
-          emissiveIntensity={active ? 0.35 : 0.08}
+          emissiveIntensity={active ? 0.5 : 0.12}
           roughness={0.7}
           metalness={0.1}
         />
       </mesh>
+
+      {/* Tonic letter on the floor — readable from the air. */}
+      {music && (
+        <Text
+          position={[region.center.x, labelY, region.center.z]}
+          rotation={[-Math.PI / 2, 0, 0]}
+          fontSize={Math.min(region.size.x, region.size.z) * 0.35}
+          color={active ? '#ffffff' : '#0d1117'}
+          anchorX="center"
+          anchorY="middle"
+          outlineWidth={0.03}
+          outlineColor={active ? '#0d1117' : '#ffffff'}
+        >
+          {music.shortName}
+        </Text>
+      )}
 
       {/* Atmospheric volume — translucent envelope. */}
       <mesh ref={meshRef} position={region.center.toArray()}>
@@ -45,7 +68,7 @@ export function BSPRegionVolume({ region, active }: Props) {
         <meshBasicMaterial
           color={color}
           transparent
-          opacity={active ? 0.12 : 0.04}
+          opacity={active ? 0.16 : 0.05}
           depthWrite={false}
         />
       </mesh>

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/BSPScene.tsx
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/BSPScene.tsx
@@ -4,13 +4,13 @@
  * of the laid-out tree.
  */
 
-import { useMemo } from 'react';
+import { forwardRef, useMemo } from 'react';
 import { Sky } from '@react-three/drei';
 import * as THREE from 'three';
 import type { BSPLayout, LaidOutRegion } from './layoutTree';
 import { BSPRegionVolume } from './BSPRegionVolume';
 import { BSPPartitionWall } from './BSPPartitionWall';
-import { Player } from './Player';
+import { Player, type PlayerHandle } from './Player';
 
 interface Props {
   layout: BSPLayout;
@@ -20,13 +20,13 @@ interface Props {
   onPositionChange: (p: THREE.Vector3) => void;
 }
 
-export function BSPScene({
+export const BSPScene = forwardRef<PlayerHandle, Props>(function BSPScene({
   layout,
   currentRegionName,
   moveSpeed,
   lookSpeed,
   onPositionChange,
-}: Props) {
+}, playerRef) {
   const groundSize = useMemo(() => {
     const s = layout.worldBounds.getSize(new THREE.Vector3());
     return Math.max(s.x, s.z) * 1.5;
@@ -34,28 +34,28 @@ export function BSPScene({
 
   return (
     <>
-      {/* DOOM-style sector lighting: dim ambient + one strong directional. */}
-      <ambientLight intensity={0.35} color={0xbcd0ff} />
+      {/* Dim ambient + one directional, matching GA's dark aesthetic. */}
+      <ambientLight intensity={0.45} color={0xc9d1d9} />
       <directionalLight
         position={[40, 80, 40]}
-        intensity={1.1}
+        intensity={0.9}
         castShadow
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
       />
-      <fog attach="fog" args={[0x0a0a14, 30, 220]} />
+      <fog attach="fog" args={[0x0d1117, 40, 260]} />
 
-      {/* Faint sky for orientation. */}
-      <Sky distance={450000} sunPosition={[40, 80, 40]} turbidity={6} rayleigh={2} />
+      {/* Faint, low-turbidity sky — dawn over a dark world. */}
+      <Sky distance={450000} sunPosition={[40, 80, 40]} turbidity={10} rayleigh={1} />
 
-      {/* Ground plate underneath everything. */}
+      {/* Ground plate underneath everything (GA bg colour). */}
       <mesh
         rotation={[-Math.PI / 2, 0, 0]}
         position={[0, -0.05, 0]}
         receiveShadow
       >
         <planeGeometry args={[groundSize, groundSize]} />
-        <meshStandardMaterial color={0x0e0e1a} roughness={0.95} />
+        <meshStandardMaterial color={0x0d1117} roughness={0.95} />
       </mesh>
 
       {/* BSP regions (rooms) */}
@@ -73,6 +73,7 @@ export function BSPScene({
       ))}
 
       <Player
+        ref={playerRef}
         moveSpeed={moveSpeed}
         lookSpeed={lookSpeed}
         initialPosition={[0, 4, layout.worldBounds.max.z - 8]}
@@ -80,4 +81,4 @@ export function BSPScene({
       />
     </>
   );
-}
+});

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/HUD.tsx
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/HUD.tsx
@@ -1,35 +1,72 @@
 /**
- * Heads-up display: stats, current region, controls cheat-sheet. DOM
- * overlay (not part of the Three scene) so text stays crisp at any
- * canvas resolution.
+ * Heads-up display for the BSP DOOM Explorer.
  *
- * The DOOM aesthetic (#0f0 mono on black with light borders) is
- * carried over from the v1 component for visual continuity.
+ * The legacy DOOM-green HUD told you almost nothing musical. This one
+ * is built around the question "where am I, harmonically?" — the
+ * payload is the *current key*, its scale, its diatonic chords with
+ * Roman numerals, and a list of click-to-teleport neighbour keys
+ * representing real modulation moves.
+ *
+ * Palette matches the GA dark theme (`#0d1117` / `#161b22` / `#30363d`
+ * / `#e6edf3`) so this demo stops looking like a different product.
  */
 
 import { type CSSProperties, useEffect, useState } from 'react';
 import type { BSPRegion } from '../BSPApiService';
+import type { MusicalLeafMeta, MusicalRegion } from './musicalTree';
 
 interface Props {
   currentRegion: BSPRegion | null;
-  source: 'api' | 'demo' | 'pending';
+  source: 'api' | 'demo' | 'pending' | 'curated';
   regionCount: number;
   treeDepth: number;
+  onTeleport?: (keyName: string) => void;
+  tourActive?: boolean;
+  onTourToggle?: () => void;
   showControls?: boolean;
 }
 
 const PANEL: CSSProperties = {
   position: 'absolute',
-  color: '#0f0',
-  background: 'rgba(0, 0, 0, 0.55)',
-  border: '1px solid rgba(0, 255, 0, 0.35)',
+  color: '#e6edf3',
+  background: 'rgba(13, 17, 23, 0.88)',
+  border: '1px solid #30363d',
   fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
   fontSize: 12,
-  padding: '8px 12px',
-  borderRadius: 4,
-  backdropFilter: 'blur(2px)',
-  pointerEvents: 'none',
-  lineHeight: 1.4,
+  padding: '10px 12px',
+  borderRadius: 6,
+  backdropFilter: 'blur(4px)',
+  lineHeight: 1.5,
+};
+
+const HEADER: CSSProperties = {
+  color: '#79c0ff',
+  fontWeight: 700,
+  letterSpacing: 0.4,
+  textTransform: 'uppercase',
+  fontSize: 10,
+  marginBottom: 4,
+};
+
+const CHIP: CSSProperties = {
+  display: 'inline-block',
+  padding: '2px 7px',
+  borderRadius: 3,
+  marginRight: 4,
+  marginTop: 4,
+  fontSize: 11,
+  border: '1px solid #30363d',
+  background: '#161b22',
+  color: '#e6edf3',
+};
+
+const TELE_CHIP: CSSProperties = {
+  ...CHIP,
+  cursor: 'pointer',
+  pointerEvents: 'auto',
+  background: '#161b22',
+  borderColor: '#388bfd',
+  color: '#79c0ff',
 };
 
 export function HUD({
@@ -37,6 +74,9 @@ export function HUD({
   source,
   regionCount,
   treeDepth,
+  onTeleport,
+  tourActive,
+  onTourToggle,
   showControls = true,
 }: Props) {
   const [fps, setFps] = useState(0);
@@ -59,31 +99,128 @@ export function HUD({
     return () => cancelAnimationFrame(rafId);
   }, []);
 
+  const music: MusicalLeafMeta | undefined = (currentRegion as MusicalRegion | null)?.music;
+
   return (
     <>
-      <div style={{ ...PANEL, top: 12, left: 12 }}>
-        <div style={{ color: '#7CFC7C', fontWeight: 600 }}>BSP DOOM EXPLORER</div>
+      {/* Top-left: stats. */}
+      <div style={{ ...PANEL, top: 12, left: 12, pointerEvents: 'none' }}>
+        <div style={HEADER}>BSP Doom Explorer</div>
         <div>fps: {fps}</div>
         <div>regions: {regionCount} · depth: {treeDepth}</div>
-        <div>source: {source}{source === 'demo' && ' (api unreachable)'}</div>
+        <div style={{ color: '#8b949e' }}>source: {source}</div>
       </div>
 
-      {currentRegion && (
-        <div style={{ ...PANEL, top: 12, right: 12, textAlign: 'right' }}>
-          <div style={{ color: '#7CFC7C', fontWeight: 600 }}>{currentRegion.name}</div>
-          <div>type: {currentRegion.tonalityType}</div>
-          <div>center: {currentRegion.tonalCenter}</div>
-          <div>pitches: {currentRegion.pitchClasses.join(' ')}</div>
+      {/* Top-right: "Where am I" card.
+       *  Always renders something — even before the player enters a
+       *  room — so the page never looks empty.                       */}
+      <div
+        style={{
+          ...PANEL,
+          top: 12,
+          right: 12,
+          width: 280,
+          pointerEvents: 'auto',
+        }}
+      >
+        <div style={HEADER}>Where am I</div>
+        {music ? (
+          <>
+            <div style={{ fontSize: 16, fontWeight: 700, color: '#e6edf3', marginBottom: 4 }}>
+              {music.key}
+            </div>
+            <div style={{ color: '#8b949e', fontSize: 11, marginBottom: 6 }}>
+              mode: {music.mode} · tonic: {music.tonic}
+            </div>
+
+            <div style={{ marginTop: 6 }}>
+              <div style={{ color: '#8b949e', fontSize: 10 }}>scale</div>
+              <div>
+                {music.scaleNotes.map((n) => (
+                  <span key={n} style={CHIP}>{n}</span>
+                ))}
+              </div>
+            </div>
+
+            <div style={{ marginTop: 6 }}>
+              <div style={{ color: '#8b949e', fontSize: 10 }}>diatonic chords</div>
+              {music.diatonicChords.map((c, i) => (
+                <span key={c} style={{ ...CHIP, display: 'inline-flex', flexDirection: 'column', alignItems: 'center', padding: '2px 8px' }}>
+                  <span style={{ color: '#79c0ff', fontSize: 10 }}>{music.diatonicRoman[i]}</span>
+                  <span>{c}</span>
+                </span>
+              ))}
+            </div>
+
+            {music.neighbours.length > 0 && onTeleport && (
+              <div style={{ marginTop: 8 }}>
+                <div style={{ color: '#8b949e', fontSize: 10 }}>modulate to →</div>
+                {music.neighbours.map((n) => (
+                  <span
+                    key={`${n.label}:${n.key}`}
+                    style={TELE_CHIP}
+                    onClick={() => onTeleport(n.key)}
+                    role="button"
+                    tabIndex={0}
+                    title={`Teleport to ${n.key} — ${n.label}`}
+                  >
+                    {n.key}
+                    <span style={{ color: '#8b949e', marginLeft: 4, fontSize: 10 }}>
+                      {n.label}
+                    </span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </>
+        ) : (
+          <div style={{ color: '#8b949e', fontSize: 12 }}>
+            Click the canvas to lock the pointer, then walk into a room
+            with WASD. Each room is a key. The HUD will show its scale,
+            diatonic chords, and where you can modulate next.
+          </div>
+        )}
+      </div>
+
+      {/* Bottom-left: controls cheat-sheet (one line each, no walls of text). */}
+      {showControls && (
+        <div style={{ ...PANEL, bottom: 12, left: 12, pointerEvents: 'none' }}>
+          <div style={HEADER}>controls</div>
+          <div><b>click</b> canvas to lock pointer · <b>esc</b> to release</div>
+          <div><b>WASD</b> / arrows to move · <b>space/shift</b> for up/down</div>
+          <div><b>click a neighbour key</b> to modulate (teleport)</div>
         </div>
       )}
 
-      {showControls && (
-        <div style={{ ...PANEL, bottom: 12, left: 12 }}>
-          <div style={{ color: '#7CFC7C', fontWeight: 600 }}>controls</div>
-          <div>click canvas → lock pointer</div>
-          <div>WASD / arrows · move</div>
-          <div>space · up &nbsp;·&nbsp; shift · down</div>
-          <div>esc · release pointer</div>
+      {/* Bottom-centre: Tour toggle. */}
+      {onTourToggle && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 12,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            pointerEvents: 'auto',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onTourToggle}
+            style={{
+              padding: '6px 14px',
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 12,
+              color: tourActive ? '#0d1117' : '#79c0ff',
+              background: tourActive ? '#79c0ff' : '#161b22',
+              border: '1px solid #388bfd',
+              borderRadius: 6,
+              cursor: 'pointer',
+            }}
+            aria-pressed={tourActive}
+            title="Auto-walk through a ii–V–I progression in the key world"
+          >
+            {tourActive ? '■ stop tour' : '▶ ii–V–I tour'}
+          </button>
         </div>
       )}
     </>

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/Minimap.tsx
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/Minimap.tsx
@@ -7,7 +7,7 @@
 
 import { type CSSProperties, useMemo } from 'react';
 import type { BSPLayout } from './layoutTree';
-import { hexFor } from './tonalityColors';
+import { hexForRegion } from './tonalityColors';
 import * as THREE from 'three';
 
 interface Props {
@@ -21,11 +21,11 @@ const PANEL: CSSProperties = {
   position: 'absolute',
   bottom: 12,
   right: 12,
-  background: 'rgba(0, 0, 0, 0.55)',
-  border: '1px solid rgba(0, 255, 0, 0.35)',
-  borderRadius: 4,
+  background: 'rgba(13, 17, 23, 0.85)',
+  border: '1px solid #30363d',
+  borderRadius: 6,
   pointerEvents: 'none',
-  padding: 4,
+  padding: 6,
 };
 
 export function Minimap({ layout, playerPosition, currentRegionName, size = 180 }: Props) {
@@ -46,24 +46,40 @@ export function Minimap({ layout, playerPosition, currentRegionName, size = 180 
       <svg width={size} height={size} style={{ display: 'block' }}>
         <rect width={size} height={size} fill="#070710" />
 
+        <rect width={size} height={size} fill="#0d1117" />
+
         {regions.map((r) => {
           const x = w2s(r.center.x - r.size.x / 2);
           const y = w2s(r.center.z - r.size.z / 2);
           const w = (r.size.x / worldSize) * size;
           const h = (r.size.z / worldSize) * size;
           const isActive = r.node.region.name === currentRegionName;
+          const fill = `#${hexForRegion(r.node.region).toString(16).padStart(6, '0')}`;
           return (
-            <rect
-              key={r.node.region.name}
-              x={x}
-              y={y}
-              width={w - 1}
-              height={h - 1}
-              fill={`#${hexFor(r.node.region.tonalityType).toString(16).padStart(6, '0')}`}
-              opacity={isActive ? 0.85 : 0.35}
-              stroke={isActive ? '#fff' : 'transparent'}
-              strokeWidth={1}
-            />
+            <g key={r.node.region.name}>
+              <rect
+                x={x}
+                y={y}
+                width={w - 1}
+                height={h - 1}
+                fill={fill}
+                opacity={isActive ? 0.9 : 0.45}
+                stroke={isActive ? '#e6edf3' : '#30363d'}
+                strokeWidth={isActive ? 1.5 : 0.5}
+              />
+              <text
+                x={x + w / 2}
+                y={y + h / 2 + 3}
+                textAnchor="middle"
+                fontSize={9}
+                fontFamily="ui-monospace, monospace"
+                fontWeight={isActive ? 700 : 500}
+                fill={isActive ? '#0d1117' : '#e6edf3'}
+                pointerEvents="none"
+              >
+                {r.node.region.name}
+              </text>
+            </g>
           );
         })}
 
@@ -72,14 +88,14 @@ export function Minimap({ layout, playerPosition, currentRegionName, size = 180 
           const cz = w2s(wall.position.z);
           if (wall.axis === 'x') {
             const h = (wall.size.z / worldSize) * size;
-            return <line key={i} x1={cx} y1={cz - h / 2} x2={cx} y2={cz + h / 2} stroke="#7CFC7C" strokeWidth={1} opacity={0.4} />;
+            return <line key={i} x1={cx} y1={cz - h / 2} x2={cx} y2={cz + h / 2} stroke="#8b949e" strokeWidth={1} opacity={0.5} />;
           }
           const w = (wall.size.x / worldSize) * size;
-          return <line key={i} x1={cx - w / 2} y1={cz} x2={cx + w / 2} y2={cz} stroke="#7CFC7C" strokeWidth={1} opacity={0.4} />;
+          return <line key={i} x1={cx - w / 2} y1={cz} x2={cx + w / 2} y2={cz} stroke="#8b949e" strokeWidth={1} opacity={0.5} />;
         })}
 
         {/* Player dot */}
-        <circle cx={w2s(playerPosition.x)} cy={w2s(playerPosition.z)} r={3} fill="#0f0" />
+        <circle cx={w2s(playerPosition.x)} cy={w2s(playerPosition.z)} r={3} fill="#e6edf3" stroke="#0d1117" strokeWidth={0.5} />
       </svg>
     </div>
   );

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/Player.tsx
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/Player.tsx
@@ -7,11 +7,16 @@
  * legacy implementation reimplemented this inline 4 times.
  *
  * `onPositionChange` fires every frame with the camera world position
- * so the region detector can find the current room and the minimap can
- * track the player.
+ * so the region detector can find the current room and the minimap
+ * can track the player.
+ *
+ * `teleportTo` (via the ref forwarded as `controllerRef`) lets the
+ * HUD/Tour modulate to a specific world-space position without the
+ * player having to walk there — this is what powers click-to-teleport
+ * on the "modulate to →" chips.
  */
 
-import { useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import { PointerLockControls as DreiPointerLockControls } from '@react-three/drei';
 import * as THREE from 'three';
@@ -21,6 +26,11 @@ interface Props {
   lookSpeed: number;
   initialPosition?: [number, number, number];
   onPositionChange?: (position: THREE.Vector3) => void;
+}
+
+export interface PlayerHandle {
+  teleportTo: (target: THREE.Vector3) => void;
+  getPosition: () => THREE.Vector3;
 }
 
 interface KeyState {
@@ -46,12 +56,10 @@ const KEY_MAP: Record<string, keyof KeyState> = {
   ShiftRight: 'down',
 };
 
-export function Player({
-  moveSpeed,
-  lookSpeed,
-  initialPosition = [0, 4, 20],
-  onPositionChange,
-}: Props) {
+export const Player = forwardRef<PlayerHandle, Props>(function Player(
+  { moveSpeed, lookSpeed, initialPosition = [0, 4, 20], onPositionChange },
+  ref,
+) {
   const { camera } = useThree();
   const keys = useRef<KeyState>({
     forward: false,
@@ -65,7 +73,6 @@ export function Player({
   const forward = useRef(new THREE.Vector3());
   const right = useRef(new THREE.Vector3());
 
-  // Seed initial camera pose once.
   useEffect(() => {
     camera.position.set(...initialPosition);
   }, [camera, initialPosition]);
@@ -75,7 +82,6 @@ export function Player({
       const k = KEY_MAP[e.code];
       if (k) {
         keys.current[k] = true;
-        // Prevent space-scrolls-page.
         if (e.code === 'Space') e.preventDefault();
       }
     };
@@ -91,8 +97,21 @@ export function Player({
     };
   }, []);
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      teleportTo(target: THREE.Vector3) {
+        camera.position.copy(target);
+      },
+      getPosition() {
+        return camera.position.clone();
+      },
+    }),
+    [camera],
+  );
+
   useFrame((_, delta) => {
-    const dt = Math.min(delta, 0.1); // clamp to avoid teleport on tab-resume
+    const dt = Math.min(delta, 0.1);
     const k = keys.current;
 
     camera.getWorldDirection(forward.current);
@@ -117,4 +136,4 @@ export function Player({
   });
 
   return <DreiPointerLockControls pointerSpeed={lookSpeed * 500} />;
-}
+});

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/Player.tsx
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/Player.tsx
@@ -73,9 +73,17 @@ export const Player = forwardRef<PlayerHandle, Props>(function Player(
   const forward = useRef(new THREE.Vector3());
   const right = useRef(new THREE.Vector3());
 
+  // Apply the spawn position exactly once on mount. We deliberately do
+  // NOT include `initialPosition` (or `camera`) in the dep array: callers
+  // pass a fresh tuple literal every render (e.g. `[0, 4, layout.max.z]`),
+  // which would otherwise re-fire this effect on every parent re-render
+  // and yank the camera back to spawn *after* a click-to-teleport — the
+  // HUD `currentRegion` would then flicker to null because the region
+  // detector sees the player back outside every room. See PR #264.
   useEffect(() => {
     camera.position.set(...initialPosition);
-  }, [camera, initialPosition]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/musicalTree.ts
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/musicalTree.ts
@@ -1,0 +1,259 @@
+/**
+ * Musically-meaningful BSP tree for the Doom Explorer.
+ *
+ * Each leaf is a real key+mode that a guitarist might play in. Each
+ * partition is a real harmonic boundary (circle-of-fifths distance,
+ * mode-of-relative, common-tone count). The tree shape is hand-tuned
+ * so the floor layout puts harmonically adjacent keys in adjacent
+ * rooms — walking forward through a doorway models a real modulation.
+ *
+ * Why hand-tuned rather than auto-generated: the backend BSP tree is
+ * topologically faithful but it doesn't ship to the demo (the live page
+ * runs without a backend). The whole point of the rebuild is to make
+ * the demo *useful* — so we ship a curated 8-leaf world that teaches
+ * something a guitarist actually wants to learn (the ii-V-I orbit and
+ * its near neighbours).
+ */
+
+import type { BSPNode, BSPRegion, BSPTreeStructureResponse } from '../BSPApiService';
+
+/** Extra musical metadata we attach onto each leaf's region.
+ *  Stored under a non-conflicting property so the original BSPRegion
+ *  contract is untouched. */
+export interface MusicalLeafMeta {
+  key: string;              // "C major", "A minor", "D dorian"
+  mode: string;             // "Ionian", "Aeolian", "Dorian", ...
+  shortName: string;        // "C maj", "A min" — for HUD/minimap
+  tonic: string;            // "C", "A", "F#"
+  scaleNotes: string[];     // ["C", "D", "E", "F", "G", "A", "B"]
+  diatonicRoman: string[];  // ["I", "ii", "iii", "IV", "V", "vi", "vii°"]
+  diatonicChords: string[]; // ["C", "Dm", "Em", "F", "G", "Am", "Bdim"]
+  /** Names of leaves you can modulate to from here.
+   *  Keys = labels shown to the user ("relative minor", "V", "parallel"). */
+  neighbours: { label: string; key: string }[];
+  /** Hue 0-360 for chromatic colour wheel (circle-of-fifths position). */
+  hue: number;
+}
+
+export interface MusicalRegion extends BSPRegion {
+  music?: MusicalLeafMeta;
+}
+
+// ---- Curated key set ---------------------------------------------------
+//
+// Chosen so the natural BFS layout (depth-3 balanced) keeps neighbours
+// adjacent. Left half = the C major family + its closest dominant-side
+// neighbours; right half = the parallel minor side + a couple of jazz
+// modes (D Dorian, A Mixolydian) that share notes with C major.
+//
+// Floor cells (depth 3) walking forward (z-) from the player spawn:
+//   row back (-z):    [F maj] [C maj]  ‖  [G maj] [D dor]
+//   row front (+z):   [D min] [A min]  ‖  [E min] [A mix]
+
+const PCS = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+const MAJOR_STEPS = [0,2,4,5,7,9,11];          // Ionian
+const MINOR_STEPS = [0,2,3,5,7,8,10];          // Aeolian
+const DORIAN_STEPS = [0,2,3,5,7,9,10];
+const MIXOLYDIAN_STEPS = [0,2,4,5,7,9,10];
+
+function notesFor(tonic: string, steps: number[]): string[] {
+  const start = PCS.indexOf(tonic);
+  return steps.map((s) => PCS[(start + s) % 12]);
+}
+
+const TRIAD_QUALITIES_MAJOR = ['', 'm', 'm', '', '', 'm', 'dim'];
+const TRIAD_QUALITIES_MINOR = ['m', 'dim', '', 'm', 'm', '', ''];
+const TRIAD_QUALITIES_DORIAN = ['m', 'm', '', '', 'm', 'dim', ''];
+const TRIAD_QUALITIES_MIXOLYDIAN = ['', 'm', 'dim', '', 'm', 'm', ''];
+
+const ROMAN_MAJOR = ['I', 'ii', 'iii', 'IV', 'V', 'vi', 'vii°'];
+const ROMAN_MINOR = ['i', 'ii°', 'III', 'iv', 'v', 'VI', 'VII'];
+const ROMAN_DORIAN = ['i', 'ii', 'III', 'IV', 'v', 'vi°', 'VII'];
+const ROMAN_MIXOLYDIAN = ['I', 'ii', 'iii°', 'IV', 'v', 'vi', 'VII'];
+
+function diatonicChords(notes: string[], qualities: string[]): string[] {
+  return notes.map((n, i) => `${n}${qualities[i]}`);
+}
+
+// Hue on circle of fifths. 0 = C, +30° per fifth clockwise.
+function circleOfFifthsHue(tonic: string): number {
+  const order = ['C','G','D','A','E','B','F#','C#','G#','D#','A#','F'];
+  const idx = order.indexOf(tonic);
+  return idx === -1 ? 0 : idx * 30;
+}
+
+function buildKey(
+  key: string,
+  mode: 'Ionian' | 'Aeolian' | 'Dorian' | 'Mixolydian',
+  tonic: string,
+  shortName: string,
+  neighbours: { label: string; key: string }[],
+): MusicalLeafMeta {
+  const steps =
+    mode === 'Ionian' ? MAJOR_STEPS :
+    mode === 'Aeolian' ? MINOR_STEPS :
+    mode === 'Dorian' ? DORIAN_STEPS : MIXOLYDIAN_STEPS;
+  const qualities =
+    mode === 'Ionian' ? TRIAD_QUALITIES_MAJOR :
+    mode === 'Aeolian' ? TRIAD_QUALITIES_MINOR :
+    mode === 'Dorian' ? TRIAD_QUALITIES_DORIAN : TRIAD_QUALITIES_MIXOLYDIAN;
+  const roman =
+    mode === 'Ionian' ? ROMAN_MAJOR :
+    mode === 'Aeolian' ? ROMAN_MINOR :
+    mode === 'Dorian' ? ROMAN_DORIAN : ROMAN_MIXOLYDIAN;
+  const scaleNotes = notesFor(tonic, steps);
+
+  return {
+    key,
+    mode,
+    shortName,
+    tonic,
+    scaleNotes,
+    diatonicRoman: roman,
+    diatonicChords: diatonicChords(scaleNotes, qualities),
+    neighbours,
+    hue: circleOfFifthsHue(tonic),
+  };
+}
+
+// Ordering matters: index = floor cell index in the BFS layout.
+const KEYS: MusicalLeafMeta[] = [
+  buildKey('F major', 'Ionian', 'F', 'F maj', [
+    { label: 'V (dominant)', key: 'C major' },
+    { label: 'relative minor', key: 'D minor' },
+  ]),
+  buildKey('C major', 'Ionian', 'C', 'C maj', [
+    { label: 'V (dominant)', key: 'G major' },
+    { label: 'IV (subdominant)', key: 'F major' },
+    { label: 'relative minor', key: 'A minor' },
+    { label: 'parallel minor', key: 'A minor' },
+  ]),
+  buildKey('G major', 'Ionian', 'G', 'G maj', [
+    { label: 'V (dominant)', key: 'D dorian' },
+    { label: 'IV (subdominant)', key: 'C major' },
+    { label: 'relative minor', key: 'E minor' },
+  ]),
+  buildKey('D dorian', 'Dorian', 'D', 'D dor', [
+    { label: 'parent major', key: 'C major' },
+    { label: 'common tones', key: 'A minor' },
+    { label: 'ii of C maj', key: 'C major' },
+  ]),
+  buildKey('D minor', 'Aeolian', 'D', 'D min', [
+    { label: 'relative major', key: 'F major' },
+    { label: 'common tones', key: 'A minor' },
+  ]),
+  buildKey('A minor', 'Aeolian', 'A', 'A min', [
+    { label: 'relative major', key: 'C major' },
+    { label: 'parallel major', key: 'A mixolydian' },
+    { label: 'iv (subdominant)', key: 'D minor' },
+    { label: 'v (dominant)', key: 'E minor' },
+  ]),
+  buildKey('E minor', 'Aeolian', 'E', 'E min', [
+    { label: 'relative major', key: 'G major' },
+    { label: 'iv (subdominant)', key: 'A minor' },
+  ]),
+  buildKey('A mixolydian', 'Mixolydian', 'A', 'A mix', [
+    { label: 'parent major', key: 'D dorian' },
+    { label: 'parallel minor', key: 'A minor' },
+  ]),
+];
+
+const PARTITION_STRATEGIES = [
+  'CircleOfFifths',          // depth 0: major/dominant side vs minor/modal side
+  'TonalCentre',             // depth 1: split by tonic distance
+  'ModeFamily',              // depth 2: Ionian vs modal-cousin
+];
+
+function leafNode(meta: MusicalLeafMeta, depth: number): BSPNode {
+  const region: MusicalRegion = {
+    name: meta.shortName,
+    tonalityType:
+      meta.mode === 'Ionian' ? 'Major' :
+      meta.mode === 'Aeolian' ? 'Minor' :
+      'Modal',
+    tonalCenter: PCS.indexOf(meta.tonic),
+    pitchClasses: meta.scaleNotes.map((n) => n.replace('#', 'Sharp')),
+    music: meta,
+  };
+  return {
+    region,
+    isLeaf: true,
+    depth,
+    elements: [],
+  };
+}
+
+function branchNode(left: BSPNode, right: BSPNode, depth: number, strategyIdx: number, label: string): BSPNode {
+  return {
+    region: {
+      name: label,
+      tonalityType: 'Internal',
+      tonalCenter: 0,
+      pitchClasses: [],
+    },
+    partition: {
+      strategy: PARTITION_STRATEGIES[strategyIdx % PARTITION_STRATEGIES.length],
+      referencePoint: depth,
+      threshold: 0.5,
+      normal: [depth % 2, 0, (depth + 1) % 2],
+    },
+    left,
+    right,
+    isLeaf: false,
+    depth,
+    elements: [],
+  };
+}
+
+/**
+ * Build an 8-leaf BSP tree of real keys. Tree shape carefully chosen so
+ * the deterministic depth-3 BFS layout places harmonically adjacent
+ * leaves in spatially adjacent rooms.
+ *
+ * Tree (depth-first):
+ *
+ *   root [CircleOfFifths]
+ *   ├── L: major-side [TonalCentre]
+ *   │   ├── L: F maj  ┊ C maj          (siblings: I↔IV)
+ *   │   └── R: G maj  ┊ D dor          (siblings: V↔modal)
+ *   └── R: minor-side [TonalCentre]
+ *       ├── L: D min  ┊ A min          (siblings: iv↔i)
+ *       └── R: E min  ┊ A mix          (siblings: v↔parallel-modal)
+ */
+export function buildMusicalTree(): BSPTreeStructureResponse {
+  const leaves = KEYS.map((k) => leafNode(k, 3));
+
+  const d2 = [
+    branchNode(leaves[0], leaves[1], 2, 2, 'IV ↔ I'),
+    branchNode(leaves[2], leaves[3], 2, 2, 'V ↔ modal'),
+    branchNode(leaves[4], leaves[5], 2, 2, 'iv ↔ i'),
+    branchNode(leaves[6], leaves[7], 2, 2, 'v ↔ parallel-modal'),
+  ];
+
+  const d1 = [
+    branchNode(d2[0], d2[1], 1, 1, 'major side'),
+    branchNode(d2[2], d2[3], 1, 1, 'minor side'),
+  ];
+
+  const root = branchNode(d1[0], d1[1], 0, 0, 'major ↔ minor');
+
+  return {
+    root,
+    nodeCount: 15,
+    maxDepth: 3,
+    regionCount: 8,
+    partitionCount: 7,
+  };
+}
+
+/**
+ * O(K) lookup by display name; used by the "click-to-teleport" feature
+ * in the HUD's neighbour-keys card.
+ */
+export function findKeyByName(name: string): MusicalLeafMeta | null {
+  return KEYS.find((k) => k.key === name) ?? null;
+}
+
+export function getAllKeys(): MusicalLeafMeta[] {
+  return KEYS.slice();
+}

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/tonalityColors.ts
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/tonalityColors.ts
@@ -1,12 +1,22 @@
 /**
  * Color mapping for BSP tonal regions.
  *
- * The DOOM aesthetic uses high-saturation hues so each region is identifiable
- * at a glance. Colors are HSL-anchored for consistency: each tonality type
- * occupies a 30°-wide slice of the hue wheel.
+ * Two-tier strategy:
+ *   1. If the region carries `MusicalLeafMeta` (curated tree), colour by
+ *      the leaf's circle-of-fifths hue — adjacent keys get adjacent
+ *      colours. This is the chromatic colour wheel a guitarist already
+ *      visualises (Lerdahl, Krumhansl) projected into the world.
+ *   2. Otherwise (legacy or API tree), fall back to a tonality-type
+ *      palette so existing consumers still get something sensible.
+ *
+ * Saturation and lightness are kept consistent with the GA dark
+ * palette (#0d1117 backdrop) — high-saturation pastels at L≈55% give
+ * good contrast against the floor without being eye-watering.
  */
 
 import * as THREE from 'three';
+import type { BSPRegion } from '../BSPApiService';
+import type { MusicalRegion } from './musicalTree';
 
 export type TonalityType =
   | 'Major'
@@ -20,23 +30,54 @@ export type TonalityType =
   | 'Unknown';
 
 const PALETTE: Record<TonalityType, number> = {
-  Major:      0x4ade80, // green   — stable / consonant
-  Minor:      0x60a5fa, // blue    — melancholic
-  Modal:      0xd946ef, // magenta — exotic
-  Atonal:     0xef4444, // red     — chaotic
-  Chromatic:  0xfacc15, // yellow  — transitional
-  Dominant:   0xfb923c, // orange  — tense / unresolved
-  Diminished: 0x06b6d4, // cyan    — unstable
-  Augmented:  0xec4899, // pink    — ambiguous
-  Unknown:    0x9ca3af, // gray    — fallback
+  Major:      0x4ade80,
+  Minor:      0x60a5fa,
+  Modal:      0xd946ef,
+  Atonal:     0xef4444,
+  Chromatic:  0xfacc15,
+  Dominant:   0xfb923c,
+  Diminished: 0x06b6d4,
+  Augmented:  0xec4899,
+  Unknown:    0x9ca3af,
 };
 
-export function colorFor(tonalityType: string): THREE.Color {
-  const key = (tonalityType as TonalityType) in PALETTE ? (tonalityType as TonalityType) : 'Unknown';
-  return new THREE.Color(PALETTE[key]);
+function hslToHex(h: number, s: number, l: number): number {
+  const c = new THREE.Color();
+  c.setHSL((h % 360) / 360, s, l);
+  return c.getHex();
 }
 
-export function hexFor(tonalityType: string): number {
+function isMusicalRegion(r: BSPRegion): r is MusicalRegion {
+  return (r as MusicalRegion).music !== undefined;
+}
+
+export function colorForRegion(region: BSPRegion): THREE.Color {
+  if (isMusicalRegion(region) && region.music) {
+    return new THREE.Color(hslToHex(region.music.hue, 0.55, 0.55));
+  }
+  return new THREE.Color(hexForTonality(region.tonalityType));
+}
+
+export function hexForRegion(region: BSPRegion): number {
+  if (isMusicalRegion(region) && region.music) {
+    return hslToHex(region.music.hue, 0.55, 0.55);
+  }
+  return hexForTonality(region.tonalityType);
+}
+
+export function hexForTonality(tonalityType: string): number {
   const key = (tonalityType as TonalityType) in PALETTE ? (tonalityType as TonalityType) : 'Unknown';
   return PALETTE[key];
+}
+
+// --- Backwards-compatible aliases (legacy callsites) -------------------
+
+/** @deprecated use `colorForRegion(region)` instead. */
+export function colorFor(tonalityType: string): THREE.Color {
+  return new THREE.Color(hexForTonality(tonalityType));
+}
+
+/** @deprecated use `hexForRegion(region)` instead. */
+export function hexFor(tonalityType: string): number {
+  return hexForTonality(tonalityType);
 }

--- a/ReactComponents/ga-react-components/src/components/BSP/v2/useBSPTree.ts
+++ b/ReactComponents/ga-react-components/src/components/BSP/v2/useBSPTree.ts
@@ -1,18 +1,26 @@
 /**
- * Fetch the BSP tree from the backend; fall back to a procedural demo
- * tree when the API is unreachable. The fallback is what makes the
- * "broken" live page work — the previous component depended on the API
- * landing successfully and showed nothing if it didn't.
+ * Build the BSP tree the explorer renders.
+ *
+ * Originally tried to fetch from the backend `/api/bsp/tree-structure`
+ * endpoint and fell back to a procedural demo tree when the API was
+ * unreachable. After the 2026-05-17 rebuild this hook *only* serves the
+ * curated musical tree — the backend tree is topologically faithful but
+ * not musically useful (no key/scale/Roman-numeral metadata), and the
+ * point of the page is to teach harmony, not to mirror a server's data
+ * structure. We keep the same return shape so callers don't notice.
+ *
+ * If you need to inspect the live backend BSP tree, use
+ * `BSPTreeVisualization` instead — that one stays API-driven.
  */
 
 import { useEffect, useState } from 'react';
-import { BSPApiService, type BSPTreeStructureResponse } from '../BSPApiService';
-import { buildDemoTree } from './demoTree';
+import type { BSPTreeStructureResponse } from '../BSPApiService';
+import { buildMusicalTree } from './musicalTree';
 
 export interface BSPTreeState {
   tree: BSPTreeStructureResponse | null;
   loading: boolean;
-  source: 'api' | 'demo' | 'pending';
+  source: 'curated';
   error: string | null;
 }
 
@@ -20,33 +28,20 @@ export function useBSPTree(): BSPTreeState {
   const [state, setState] = useState<BSPTreeState>({
     tree: null,
     loading: true,
-    source: 'pending',
+    source: 'curated',
     error: null,
   });
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const tree = await BSPApiService.getTreeStructure();
-        if (!cancelled) {
-          setState({ tree, loading: false, source: 'api', error: null });
-        }
-      } catch (err) {
-        // Demo-mode fallback so the page always renders.
-        if (!cancelled) {
-          setState({
-            tree: buildDemoTree(),
-            loading: false,
-            source: 'demo',
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    // Synchronous, but kept in an effect so the loading flag flips
+    // once after mount — keeps the SSR-safe pattern and gives the
+    // R3F canvas a clean mount sequence.
+    setState({
+      tree: buildMusicalTree(),
+      loading: false,
+      source: 'curated',
+      error: null,
+    });
   }, []);
 
   return state;

--- a/ReactComponents/ga-react-components/src/pages/BSPDoomExplorerTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/BSPDoomExplorerTest.tsx
@@ -1,29 +1,111 @@
 /**
- * BSP DOOM Explorer Test Page
- * 
- * Test page for the DOOM-like BSP tree explorer component.
- * Navigate through the Binary Space Partitioning tree structure
- * in first-person view like exploring a DOOM level.
+ * BSP DOOM Explorer test page.
+ *
+ * Walks a guitarist through a curated 8-key world. Each room = a real
+ * key+mode; each partition = a real harmonic boundary; the HUD's
+ * "modulate to →" chips teleport between neighbouring keys.
+ *
+ * Earlier this page wore a retro DOOM-green theme with a 400px panel
+ * full of duplicated controls. That's been replaced with the GA dark
+ * palette (`#0d1117` / `#161b22` / `#30363d` / `#e6edf3`) and a single
+ * collapsible settings drawer; on mobile we serve a clean "best on
+ * desktop" landing card with a 2D map preview instead of forcing FPS
+ * controls onto a touch screen.
  */
 
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Container,
   Box,
-  Typography,
-  Paper,
   Stack,
-  Button,
-  Divider,
-  Alert,
-  Chip,
+  Typography,
+  Drawer,
+  IconButton,
+  Slider,
   Switch,
   FormControlLabel,
-  Slider,
+  Divider,
+  Chip,
+  useMediaQuery,
+  Tooltip,
 } from '@mui/material';
+import SettingsIcon from '@mui/icons-material/Settings';
+import CloseIcon from '@mui/icons-material/Close';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import DesktopMacIcon from '@mui/icons-material/DesktopMac';
 import { BSPDoomExplorer } from '../components/BSP';
 import type { BSPRegion } from '../components/BSP/BSPApiService';
 import { DemoErrorBoundary } from '../components/Common/DemoErrorBoundary';
+import { getAllKeys } from '../components/BSP/v2/musicalTree';
+
+const GA_BG = '#0d1117';
+const GA_PANEL = '#161b22';
+const GA_BORDER = '#30363d';
+const GA_TEXT = '#e6edf3';
+const GA_MUTED = '#8b949e';
+const GA_ACCENT = '#79c0ff';
+
+function MobileMapPreview() {
+  const keys = useMemo(() => getAllKeys(), []);
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        background: GA_BG,
+        color: GA_TEXT,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        p: 3,
+        gap: 2,
+        overflowY: 'auto',
+      }}
+    >
+      <DesktopMacIcon sx={{ fontSize: 48, color: GA_ACCENT }} />
+      <Typography variant="h6" sx={{ color: GA_TEXT, fontFamily: 'ui-monospace, monospace' }}>
+        Best on desktop
+      </Typography>
+      <Typography variant="body2" sx={{ color: GA_MUTED, textAlign: 'center', maxWidth: 360 }}>
+        The BSP DOOM Explorer is a first-person walk through eight musical
+        keys — it needs a mouse for look and WASD for movement. Here's a flat
+        preview of the eight rooms; open this page on a desktop for the full
+        experience.
+      </Typography>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          gap: 1,
+          mt: 2,
+          width: '100%',
+          maxWidth: 360,
+        }}
+      >
+        {keys.map((k) => (
+          <Box
+            key={k.key}
+            sx={{
+              background: GA_PANEL,
+              border: `1px solid ${GA_BORDER}`,
+              borderRadius: 1,
+              p: 1,
+              textAlign: 'center',
+              fontFamily: 'ui-monospace, monospace',
+            }}
+          >
+            <Typography sx={{ color: GA_ACCENT, fontSize: 11, fontWeight: 700 }}>
+              {k.shortName}
+            </Typography>
+            <Typography sx={{ color: GA_MUTED, fontSize: 9 }}>
+              {k.mode}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
 
 const BSPDoomExplorerTest: React.FC = () => {
   const [showHUD, setShowHUD] = useState(true);
@@ -31,308 +113,234 @@ const BSPDoomExplorerTest: React.FC = () => {
   const [moveSpeed, setMoveSpeed] = useState(5.0);
   const [lookSpeed, setLookSpeed] = useState(0.002);
   const [currentRegion, setCurrentRegion] = useState<BSPRegion | null>(null);
-  const [regionHistory, setRegionHistory] = useState<string[]>([]);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [viewport, setViewport] = useState({ w: 1200, h: 800 });
 
-  const handleRegionChange = (region: BSPRegion) => {
+  const isMobile = useMediaQuery('(max-width: 767px)');
+
+  useEffect(() => {
+    function update() {
+      // Layout: full-bleed canvas, header takes ~48px.
+      setViewport({ w: window.innerWidth, h: Math.max(400, window.innerHeight - 96) });
+    }
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  const handleRegionChange = useCallback((region: BSPRegion) => {
     setCurrentRegion(region);
-    setRegionHistory(prev => [...prev, region.name].slice(-10)); // Keep last 10
-  };
+  }, []);
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     setShowHUD(true);
     setShowMinimap(true);
     setMoveSpeed(5.0);
     setLookSpeed(0.002);
-    setRegionHistory([]);
-  };
+  }, []);
 
   return (
     <DemoErrorBoundary demoName="BSP DOOM Explorer">
-    <Container maxWidth={false} disableGutters sx={{ height: 'calc(100vh - 48px)', overflow: 'hidden' }}>
-      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-        {/* Header */}
-        <Paper
-          elevation={3}
+      <Box
+        sx={{
+          height: 'calc(100vh - 48px)',
+          display: 'flex',
+          flexDirection: 'column',
+          background: GA_BG,
+          color: GA_TEXT,
+          overflow: 'hidden',
+        }}
+      >
+        {/* Toolbar — matches the EcosystemRoadmap toolbar pattern. */}
+        <Box
           sx={{
-            p: 2,
-            borderRadius: 0,
-            backgroundColor: '#1a1a1a',
-            color: '#0f0',
-            fontFamily: 'monospace',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            px: 2,
+            py: 1,
+            background: GA_PANEL,
+            borderBottom: `1px solid ${GA_BORDER}`,
+            minHeight: 48,
           }}
         >
-          <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
-            <Box>
-              <Typography variant="h4" sx={{ fontFamily: 'monospace', color: '#0f0' }}>
-                🎮 BSP DOOM EXPLORER
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#888' }}>
-                First-person navigation through Binary Space Partitioning tree structure
-              </Typography>
-            </Box>
-            <Button
-              variant="outlined"
-              onClick={handleReset}
+          <Typography
+            variant="subtitle1"
+            sx={{ color: GA_TEXT, fontFamily: 'ui-monospace, monospace', fontWeight: 600 }}
+          >
+            BSP DOOM Explorer
+          </Typography>
+          <Chip
+            label="Binary Space Partitioning of tonal regions"
+            size="small"
+            sx={{
+              background: 'transparent',
+              border: `1px solid ${GA_BORDER}`,
+              color: GA_MUTED,
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 11,
+            }}
+          />
+          {currentRegion && (
+            <Chip
+              label={currentRegion.name}
+              size="small"
               sx={{
-                color: '#0f0',
-                borderColor: '#0f0',
-                '&:hover': {
-                  borderColor: '#0f0',
-                  backgroundColor: 'rgba(0, 255, 0, 0.1)',
-                },
+                background: GA_PANEL,
+                border: `1px solid ${GA_ACCENT}`,
+                color: GA_ACCENT,
+                fontFamily: 'ui-monospace, monospace',
+                fontSize: 11,
               }}
+            />
+          )}
+          <Box sx={{ flexGrow: 1 }} />
+          <Tooltip title="Reset settings">
+            <IconButton
+              onClick={handleReset}
+              size="small"
+              sx={{ color: GA_MUTED, '&:hover': { color: GA_TEXT, background: '#21262d' } }}
             >
-              Reset Settings
-            </Button>
-          </Stack>
-        </Paper>
+              <RestartAltIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Settings">
+            <IconButton
+              onClick={() => setSettingsOpen(true)}
+              size="small"
+              sx={{ color: GA_MUTED, '&:hover': { color: GA_TEXT, background: '#21262d' } }}
+            >
+              <SettingsIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
 
-        {/* Main Content */}
-        <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-          {/* Explorer */}
-          <Box sx={{ flex: 1, position: 'relative', backgroundColor: '#000' }}>
+        {/* Canvas / mobile fallback. */}
+        <Box sx={{ flex: 1, position: 'relative', background: GA_BG }}>
+          {isMobile ? (
+            <MobileMapPreview />
+          ) : (
             <BSPDoomExplorer
-              width={window.innerWidth - 400}
-              height={window.innerHeight - 148}
+              width={viewport.w}
+              height={viewport.h}
               moveSpeed={moveSpeed}
               lookSpeed={lookSpeed}
               showHUD={showHUD}
               showMinimap={showMinimap}
               onRegionChange={handleRegionChange}
             />
-          </Box>
-
-          {/* Side Panel */}
-          <Paper
-            sx={{
-              width: 400,
-              p: 3,
-              backgroundColor: '#1a1a1a',
-              color: '#0f0',
-              fontFamily: 'monospace',
-              overflowY: 'auto',
-              borderRadius: 0,
-            }}
-          >
-            <Stack spacing={3}>
-              {/* Info */}
-              <Box>
-                <Typography variant="h6" sx={{ color: '#0f0', mb: 2 }}>
-                  ℹ️ About
-                </Typography>
-                <Alert
-                  severity="info"
-                  sx={{
-                    backgroundColor: 'rgba(0, 255, 0, 0.1)',
-                    color: '#0f0',
-                    '& .MuiAlert-icon': { color: '#0f0' },
-                  }}
-                >
-                  Navigate through the BSP tree structure like exploring a DOOM level.
-                  Each partition plane is a wall, and tonal regions are colored rooms.
-                </Alert>
-              </Box>
-
-              <Divider sx={{ borderColor: '#0f0' }} />
-
-              {/* Controls Info */}
-              <Box>
-                <Typography variant="h6" sx={{ color: '#0f0', mb: 2 }}>
-                  🎮 Controls
-                </Typography>
-                <Stack spacing={1}>
-                  <Typography variant="body2" sx={{ color: '#888' }}>
-                    <strong style={{ color: '#0f0' }}>WASD</strong> - Move forward/back/left/right
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: '#888' }}>
-                    <strong style={{ color: '#0f0' }}>Mouse</strong> - Look around (click to lock)
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: '#888' }}>
-                    <strong style={{ color: '#0f0' }}>Space</strong> - Move up
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: '#888' }}>
-                    <strong style={{ color: '#0f0' }}>Shift</strong> - Move down
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: '#888' }}>
-                    <strong style={{ color: '#0f0' }}>ESC</strong> - Release pointer lock
-                  </Typography>
-                </Stack>
-              </Box>
-
-              <Divider sx={{ borderColor: '#0f0' }} />
-
-              {/* Settings */}
-              <Box>
-                <Typography variant="h6" sx={{ color: '#0f0', mb: 2 }}>
-                  ⚙️ Settings
-                </Typography>
-                <Stack spacing={2}>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={showHUD}
-                        onChange={(e) => setShowHUD(e.target.checked)}
-                        sx={{
-                          '& .MuiSwitch-switchBase.Mui-checked': {
-                            color: '#0f0',
-                          },
-                          '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                            backgroundColor: '#0f0',
-                          },
-                        }}
-                      />
-                    }
-                    label={<Typography sx={{ color: '#888' }}>Show HUD</Typography>}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={showMinimap}
-                        onChange={(e) => setShowMinimap(e.target.checked)}
-                        sx={{
-                          '& .MuiSwitch-switchBase.Mui-checked': {
-                            color: '#0f0',
-                          },
-                          '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                            backgroundColor: '#0f0',
-                          },
-                        }}
-                      />
-                    }
-                    label={<Typography sx={{ color: '#888' }}>Show Minimap</Typography>}
-                  />
-
-                  <Box>
-                    <Typography variant="body2" sx={{ color: '#888', mb: 1 }}>
-                      Move Speed: {moveSpeed.toFixed(1)}
-                    </Typography>
-                    <Slider
-                      value={moveSpeed}
-                      onChange={(_, value) => setMoveSpeed(value as number)}
-                      min={1}
-                      max={20}
-                      step={0.5}
-                      sx={{
-                        color: '#0f0',
-                        '& .MuiSlider-thumb': {
-                          backgroundColor: '#0f0',
-                        },
-                        '& .MuiSlider-track': {
-                          backgroundColor: '#0f0',
-                        },
-                        '& .MuiSlider-rail': {
-                          backgroundColor: '#333',
-                        },
-                      }}
-                    />
-                  </Box>
-
-                  <Box>
-                    <Typography variant="body2" sx={{ color: '#888', mb: 1 }}>
-                      Look Speed: {(lookSpeed * 1000).toFixed(1)}
-                    </Typography>
-                    <Slider
-                      value={lookSpeed * 1000}
-                      onChange={(_, value) => setLookSpeed((value as number) / 1000)}
-                      min={0.5}
-                      max={5}
-                      step={0.1}
-                      sx={{
-                        color: '#0f0',
-                        '& .MuiSlider-thumb': {
-                          backgroundColor: '#0f0',
-                        },
-                        '& .MuiSlider-track': {
-                          backgroundColor: '#0f0',
-                        },
-                        '& .MuiSlider-rail': {
-                          backgroundColor: '#333',
-                        },
-                      }}
-                    />
-                  </Box>
-                </Stack>
-              </Box>
-
-              <Divider sx={{ borderColor: '#0f0' }} />
-
-              {/* Current Region */}
-              {currentRegion && (
-                <Box>
-                  <Typography variant="h6" sx={{ color: '#0f0', mb: 2 }}>
-                    📍 Current Region
-                  </Typography>
-                  <Paper
-                    sx={{
-                      p: 2,
-                      backgroundColor: 'rgba(0, 255, 0, 0.1)',
-                      border: '1px solid #0f0',
-                    }}
-                  >
-                    <Typography variant="h6" sx={{ color: '#0f0' }}>
-                      {currentRegion.name}
-                    </Typography>
-                    <Typography variant="body2" sx={{ color: '#888', mt: 1 }}>
-                      Type: {currentRegion.tonalityType}
-                    </Typography>
-                    <Typography variant="body2" sx={{ color: '#888' }}>
-                      Center: {currentRegion.tonalCenter}
-                    </Typography>
-                  </Paper>
-                </Box>
-              )}
-
-              {/* Region History */}
-              {regionHistory.length > 0 && (
-                <Box>
-                  <Typography variant="h6" sx={{ color: '#0f0', mb: 2 }}>
-                    📜 Region History
-                  </Typography>
-                  <Stack spacing={0.5}>
-                    {regionHistory.slice().reverse().map((region, index) => (
-                      <Chip
-                        key={index}
-                        label={region}
-                        size="small"
-                        sx={{
-                          backgroundColor: 'rgba(0, 255, 0, 0.2)',
-                          color: '#0f0',
-                          borderColor: '#0f0',
-                          fontFamily: 'monospace',
-                        }}
-                        variant="outlined"
-                      />
-                    ))}
-                  </Stack>
-                </Box>
-              )}
-
-              <Divider sx={{ borderColor: '#0f0' }} />
-
-              {/* Features */}
-              <Box>
-                <Typography variant="h6" sx={{ color: '#0f0', mb: 2 }}>
-                  ✨ Features
-                </Typography>
-                <Stack spacing={1}>
-                  <Chip label="First-Person Camera" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                  <Chip label="WASD Movement" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                  <Chip label="Mouse Look" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                  <Chip label="BSP Partition Walls" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                  <Chip label="Tonal Region Rooms" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                  <Chip label="WebGPU Rendering" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                  <Chip label="Real-time HUD" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                  <Chip label="Minimap" size="small" sx={{ backgroundColor: '#0f0', color: '#000' }} />
-                </Stack>
-              </Box>
-            </Stack>
-          </Paper>
+          )}
         </Box>
+
+        {/* Settings drawer. */}
+        <Drawer
+          anchor="right"
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          PaperProps={{
+            sx: {
+              width: 320,
+              background: GA_PANEL,
+              color: GA_TEXT,
+              borderLeft: `1px solid ${GA_BORDER}`,
+              fontFamily: 'ui-monospace, monospace',
+            },
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', p: 2, borderBottom: `1px solid ${GA_BORDER}` }}>
+            <Typography variant="subtitle1" sx={{ color: GA_TEXT, fontWeight: 600, flexGrow: 1 }}>
+              Settings
+            </Typography>
+            <IconButton size="small" onClick={() => setSettingsOpen(false)} sx={{ color: GA_MUTED }}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <Stack spacing={2.5} sx={{ p: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showHUD}
+                  onChange={(e) => setShowHUD(e.target.checked)}
+                  size="small"
+                />
+              }
+              label={<Typography sx={{ color: GA_TEXT, fontSize: 13 }}>HUD</Typography>}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showMinimap}
+                  onChange={(e) => setShowMinimap(e.target.checked)}
+                  size="small"
+                />
+              }
+              label={<Typography sx={{ color: GA_TEXT, fontSize: 13 }}>Minimap</Typography>}
+            />
+
+            <Box>
+              <Typography variant="caption" sx={{ color: GA_MUTED }}>
+                Move speed: {moveSpeed.toFixed(1)}
+              </Typography>
+              <Slider
+                value={moveSpeed}
+                onChange={(_, v) => setMoveSpeed(v as number)}
+                min={1}
+                max={20}
+                step={0.5}
+                size="small"
+                sx={{ color: GA_ACCENT }}
+              />
+            </Box>
+
+            <Box>
+              <Typography variant="caption" sx={{ color: GA_MUTED }}>
+                Look sensitivity: {(lookSpeed * 1000).toFixed(1)}
+              </Typography>
+              <Slider
+                value={lookSpeed * 1000}
+                onChange={(_, v) => setLookSpeed((v as number) / 1000)}
+                min={0.5}
+                max={5}
+                step={0.1}
+                size="small"
+                sx={{ color: GA_ACCENT }}
+              />
+            </Box>
+
+            <Divider sx={{ borderColor: GA_BORDER }} />
+
+            <Box>
+              <Typography variant="caption" sx={{ color: GA_MUTED, display: 'block', mb: 1 }}>
+                Controls
+              </Typography>
+              <Typography sx={{ color: GA_TEXT, fontSize: 11.5, lineHeight: 1.7 }}>
+                <b>click canvas</b> · lock pointer<br />
+                <b>WASD</b> / arrows · move<br />
+                <b>space</b> / <b>shift</b> · up / down<br />
+                <b>esc</b> · release pointer<br />
+                click a <b>modulate to</b> chip · teleport
+              </Typography>
+            </Box>
+
+            <Box>
+              <Typography variant="caption" sx={{ color: GA_MUTED, display: 'block', mb: 1 }}>
+                What you'll see
+              </Typography>
+              <Typography sx={{ color: GA_MUTED, fontSize: 11.5, lineHeight: 1.6 }}>
+                Eight rooms — each one a key+mode. Floor colour encodes
+                circle-of-fifths position. Walls are BSP partition planes
+                (harmonic boundaries). The HUD names the key you're in,
+                its scale, its diatonic chords with Roman numerals, and
+                the keys you can modulate to from here. Try the
+                <b style={{ color: GA_ACCENT }}> ii–V–I tour</b> at the
+                bottom of the canvas.
+              </Typography>
+            </Box>
+          </Stack>
+        </Drawer>
       </Box>
-    </Container>
     </DemoErrorBoundary>
   );
 };
 
 export default BSPDoomExplorerTest;
-


### PR DESCRIPTION
## Status: DRAFT — one open bug, not yet shippable

The source autonomous agent stalled mid-debug after producing substantial working output. The scene now renders correctly and the page is broadly usable, but one HUD-state bug remains (see "Open bug" below). Pushing as draft so the work is preserved and the user can decide between finishing manually, dispatching a follow-up agent, or merging as-is.

## What it looks like now

Compared to the previous version (broken scene, retro-green DOOM theme that didn't match the rest of GA):

| | Before | After |
|---|---|---|
| Scene | Non-functional / black | Renders at ~57 fps with 8 rooms at depth 3 |
| Theme | Lime-green-on-black DOOM | GA dark palette (\`#0d1117\` / \`#161b22\` / \`#e6edf3\`) |
| Rooms | "BSPRegion" placeholders | Labeled key+mode (F maj, C maj, D min, A min, G maj, D dor, E min, A mix), floor colour encoded by tonal centre |
| Minimap | Generic dots | Bottom-right grid showing all rooms by key name |
| Useful for guitarist? | No | Each room represents a key+mode; click a neighbour key to modulate (teleport) |
| Tour mode | None | "ii-V-I tour" button bottom-centre |
| Controls help | Wall of text in side panel | One-line legend bottom-left |

Screenshot at \`state/bsp-doom-wip.png\`.

## What changed

10 files, +1000 / -433.

- New module: \`src/components/BSP/v2/musicalTree.ts\` — owns the key/mode hierarchy
- Reworked: \`BSPDoomExplorerV2.tsx\`, \`BSPRegionVolume.tsx\`, \`BSPScene.tsx\`, \`HUD.tsx\`, \`Minimap.tsx\`, \`Player.tsx\`, \`tonalityColors.ts\`, \`useBSPTree.ts\`
- Page: \`src/pages/BSPDoomExplorerTest.tsx\` retargeted to v2 + GA palette
- The 6,250-line legacy \`BSPDoomExplorer.tsx\` is untouched and unused by this page; quarantining to \`.legacy.tsx\` is a follow-up cleanup

## Open bug — blocking merge

**HUD \`currentRegion\` does not refresh after teleport.** Walking organically through doorways updates it correctly; the click-to-teleport path sets the player position but the \`regionAt\` y-check + state propagation settles on a stale value.

Last diagnosis notes from the agent (paraphrased):
> \`regionAt\` y-bounds appear correct (room range 24–30, teleport target y = 28, so dy = 1 ≤ 3). The toolbar correctly shows the new region name. So setRegion is firing in \`onPositionChange\`. The HUD card receives \`currentRegion\` as a prop. Likely a setState closure / stale-region-name issue in Player.tsx's \`onPositionChange\` or the parent's debouncer.

Suspect files: \`Player.tsx\` (the \`onPositionChange\` callback + \`lastRegionName\` closure), \`BSPDoomExplorerV2.tsx\` (the parent's region debouncer).

## Outstanding before this can land

- [ ] Fix the post-teleport HUD-refresh bug above
- [ ] Confirm WASD / pointer-lock / scene render still good after \`npm run build\` (not just dev-server)
- [ ] Mobile fallback — today the page is desktop-only; the original prompt asked for either a 2D top-down map fallback or a "best on desktop" message. Not yet wired.
- [ ] Decide whether to quarantine the legacy 6,250-line \`BSPDoomExplorer.tsx\` in a follow-up

## How this PR was produced

This is the third concurrent autonomous-agent rebuild from a parallel-dispatch session. The other two agents (\`agent-blackbox\` issue-plan CLI and supervised-loop kit) completed and PR'd; this one stalled at the watchdog after 600s of no progress while still trying to converge on the HUD bug. The orchestrator committed the WIP and opened this draft so the work isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)