### PR TITLE
fix(prime-radiant): probe /api/health instead of /api/chatbot/status

### DIFF
--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/ForceRadiant.tsx
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/ForceRadiant.tsx
@@ -3520,6 +3520,13 @@ export const ForceRadiant: React.FC<ForceRadiantProps> = ({
   }, []);
 
   // ─── Backend connectivity check ───
+  // Probes /api/health (GaApi) as the primary "is the API up" signal.
+  // /api/chatbot/status used to be the primary probe, but GaChatbot.Api
+  // is a separate service on :5252 (cloudflared routes /chatbot and
+  // /api/chatbot/* to it on demos). When GaChatbot.Api was down but
+  // GaApi was up, the badge flipped to "Offline" even though the bulk
+  // of the API was healthy. The chatbot service is now a secondary
+  // capability surface — see the popover below.
   useEffect(() => {
     // Use VITE env var, or same origin as the page (works for deployed demo), or localhost fallback
     const envBase = typeof import.meta !== 'undefined'
@@ -3529,7 +3536,7 @@ export const ForceRadiant: React.FC<ForceRadiantProps> = ({
 
     const checkBackend = async () => {
       try {
-        const url = `${baseUrl}/api/chatbot/status`;
+        const url = `${baseUrl}/api/health`;
         console.log('[PrimeRadiant] Checking backend at:', url);
         const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
         console.log('[PrimeRadiant] Backend status:', res.status);


### PR DESCRIPTION
## Symptom

\`https://demos.guitaralchemist.com/test/prime-radiant\` shows "API Offline" in the top status bar even though the GA API itself is up.

## Root cause

The connectivity check in \`ForceRadiant.tsx\` probes \`/api/chatbot/status\` as the **primary** backend signal. That endpoint is served by **GaChatbot.Api** on :5252 — a separate service from the main **GaApi** on :5232. Cloudflared routes \`/chatbot\` and \`/api/chatbot/*\` to the chatbot service. When the chatbot service is down (which it is on demos right now), the badge flips to "Offline" even though everything else is healthy.

## Fix

Switch the primary probe to \`/api/health\` (GaApi). One-line change. Chatbot status remains visible in the existing popover as a secondary capability.

## Verified

Against demos:
- \`/api/health\` → 200
- \`/api/chatbot/status\` → 502 (GaChatbot.Api is the *actual* offline service — see separate issue)

Pre-fix screenshot: \`state/prime-radiant-demos-after.png\` (orange "API Offline")
Post-fix expected (after demos redeploy): "API Connected" with chatbot flagged in the popover

## Out of scope

GaChatbot.Api on demos.guitaralchemist.com is offline. Per the user's standing rule, the host operator must restart it — not this agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)