### PR TITLE
fix(tests): realign ChatAsync_BoundsDirectFallback assertion with producer

### DIFF
--- a/Tests/Apps/GaChatbot.Api.Tests/Services/OrchestratedChatApplicationServiceTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Services/OrchestratedChatApplicationServiceTests.cs
@@ -54,7 +54,12 @@ public sealed class OrchestratedChatApplicationServiceTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(result.NaturalLanguageAnswer, Does.Contain("fallback timeout"));
+            // Producer message was rewritten in #221 to surface the actual
+            // timeout duration and avoid blaming the user's prompt. Match
+            // the substring that's stable across timeout values: "exceeded
+            // the {N}s timeout". Test config sets FallbackTimeoutSeconds=1
+            // above, so the rendered string contains "exceeded the 1s timeout".
+            Assert.That(result.NaturalLanguageAnswer, Does.Contain("exceeded the 1s timeout"));
             Assert.That(result.Routing.AgentId, Is.EqualTo("fallback-direct"));
             Assert.That(result.Routing.Confidence, Is.EqualTo(0f));
             Assert.That(result.Routing.RoutingMethod, Is.EqualTo("error-fallback-timeout"));


### PR DESCRIPTION
## Summary

Realigns the `ChatAsync_BoundsDirectFallbackWhenFallbackChatTimesOut` test assertion with the producer message rewrite that landed in #221. The test had drifted from the producer and is currently red on `main`, blocking #268, #211, #209 from clean CI.

## Root cause

PR #221 (`fix(chatbot): honest user-facing message when LLM backend times out`) rewrote the fallback-timeout user-facing message from the old wording (which implied user error: "try a narrower prompt") to a new wording that:

- Surfaces the actual timeout duration: `"exceeded the {N}s timeout"`
- Explicitly says `"This is on our side, not your prompt"`
- Points users at deterministic skills that don't depend on the LLM

But that PR didn't update `Tests/Apps/GaChatbot.Api.Tests/Services/OrchestratedChatApplicationServiceTests.cs`, which still asserts `Does.Contain("fallback timeout")`. The substring `"fallback timeout"` doesn't appear anywhere in the new message — pure assertion drift.

## Decision

Update the test to match the producer. The new producer message is genuinely better engineering (it surfaces the timeout duration and gives the user actionable next steps without blaming them), and reverting it for a stale test would be regressive. The new assertion uses the substring `"exceeded the 1s timeout"`, which is stable because the test sets `FallbackTimeoutSeconds=1` via `configurationOverrides`.

## Test plan

- [x] `dotnet test --filter "ChatAsync_BoundsDirectFallbackWhenFallbackChatTimesOut"` -> Passed: 1
- [x] `dotnet test --filter "FullyQualifiedName~ChatAsync"` -> Passed: 13 (no sibling tests broken)
- [ ] CI green on this PR
- [ ] After merge: ga `main` CI runs no longer fail with the "fallback timeout" assertion

## Out of scope

The CI run for #267 (commit `98f0e025`) also shows ~45 unrelated `Setup failed for test fixture GaChatbot.Api.Tests.Controllers.ChatbotControllerAlgebraTests` failures due to a `DirectoryNotFoundException` on `Apps/GaChatbot.Api/obj/Release/net10.0/compressed/`. That's a separate CI infrastructure issue (static-web-assets build artifact mismatch in Release config) and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)