### PR TITLE
fix(tests): repair 2 chronic main flakes (Registry + Algebra)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
@@ -353,6 +353,22 @@ public class ProductionOrchestrator(
                 activity, sw, ct);
         }
 
+        // ── Deterministic algebra fast-path runs BEFORE semantic intent routing ──
+        // Algebra prompts (prime form, ICV, Forte label, Z-relation, set class) are
+        // pure finite math handled by IxAlgebraService — no LLM, no embeddings. The
+        // unified semantic dispatch otherwise routes algebra via embeddings, which
+        // means an environment without an embedding endpoint (CI runners without
+        // Ollama) fails through to the LLM agent path and 500s when the LLM is
+        // ALSO unreachable. The classifier is high-precision: keyword hit OR
+        // bracketed/compact pitch-class set pattern. When it fires we already know
+        // the prompt is algebra-shaped, so there is no value in paying the
+        // embedding round-trip. Mirrors the deterministic voicing guard above.
+        var algebraFastPath = await TryAnswerWithAlgebraFastPathAsync(req, message, sessionId, correlationId, activity, sw, ct);
+        if (algebraFastPath is not null)
+        {
+            return algebraFastPath;
+        }
+
         // ── Follow-up context enrichment for the routing pass ────────────────
         // A short prompt like "Show me a practical example on guitar" right
         // after a substantive turn ("How do I make this progression sound
@@ -630,6 +646,93 @@ public class ProductionOrchestrator(
             await hook.OnResponseSent(sentCtx, ct);
 
         return deterministicResponse;
+    }
+
+    /// <summary>
+    /// Deterministic algebra fast-path. Detects set-class-algebra prompts via
+    /// <see cref="IAlgebraPromptClassifier"/> (regex over keywords + bracketed/
+    /// compact pitch-class sets) and dispatches to <see cref="IIxAlgebraService"/>
+    /// directly. Bypasses <see cref="SemanticIntentRouter"/> so the dispatch
+    /// works in environments without an embedding endpoint (CI without Ollama,
+    /// offline dev). Returns <c>null</c> when the classifier rejects the prompt
+    /// or when the service can't extract a usable pitch-class set — caller falls
+    /// through to the unified semantic-intent dispatch as before.
+    /// </summary>
+    /// <remarks>
+    /// Why this isn't the only algebra path: the semantic router's example-prompt
+    /// matching still beats the classifier on edge cases where the user phrases an
+    /// algebra question without keyword hits ("are these two collections related?").
+    /// The fast-path is a STRICTLY HIGH-PRECISION subset — if it fires we short-
+    /// circuit; if it doesn't, semantic dispatch still owns the prompt. Mirrors
+    /// the deterministic voicing guard's relationship to VoicingIntent.
+    ///
+    /// The routing method <c>"ix-algebra"</c> matches <see cref="AlgebraIntent.ExecuteAsync"/>
+    /// so downstream consumers (FallbackChatApplicationService deterministic-failure
+    /// protection, trace dashboards) can't tell whether the fast-path or the
+    /// semantic-routed AlgebraIntent answered.
+    /// </remarks>
+    private async Task<ChatResponse?> TryAnswerWithAlgebraFastPathAsync(
+        ChatRequest req,
+        string message,
+        string sessionId,
+        Guid correlationId,
+        Activity? activity,
+        Stopwatch sw,
+        CancellationToken ct)
+    {
+        if (!algebraPromptClassifier.IsAlgebraPrompt(message))
+        {
+            return null;
+        }
+
+        var answer = await ixAlgebraService.TryAnswerAsync(message, ct);
+        if (answer is null)
+        {
+            // Classifier said algebra-shaped but service couldn't extract a set.
+            // Fall through to semantic dispatch so AlgebraIntent can emit its
+            // "I couldn't extract a pitch-class set" guidance with proper trace
+            // attribution. Returning the same message inline would short-circuit
+            // observability for the failure mode.
+            return null;
+        }
+
+        sw.Stop();
+        activity?.SetTag("orchestration.branch", "algebra.fast_path");
+        activity?.SetTag("orchestration.elapsed_ms", sw.ElapsedMilliseconds);
+
+        var algebraResponse = new ChatResponse(
+            NaturalLanguageAnswer: answer.NaturalLanguageAnswer,
+            Candidates: [],
+            Routing: new AgentRoutingMetadata(
+                AgentId: "algebra",
+                Confidence: 1.0f,
+                RoutingMethod: "ix-algebra"),
+            Grounding: answer.Grounding);
+
+        historyStore.AddTurn(sessionId, "assistant", algebraResponse.NaturalLanguageAnswer);
+
+        // OnResponseSent for parity with every other dispatch path. Wrap the
+        // facts dictionary as evidence strings so MemoryHook / analytics see a
+        // shape consistent with skill responses.
+        var sentCtx = new ChatHookContext
+        {
+            OriginalMessage = req.Message,
+            CurrentMessage  = message,
+            CorrelationId   = correlationId,
+            SessionId       = sessionId,
+            Response        = new AgentResponse
+            {
+                AgentId    = "algebra",
+                Result     = answer.NaturalLanguageAnswer,
+                Confidence = 1.0f,
+                Evidence   = answer.Facts.Select(kv => $"{kv.Key}: {kv.Value}").ToList(),
+                Assumptions = [],
+            },
+        };
+        foreach (var hook in _hooks)
+            await hook.OnResponseSent(sentCtx, ct);
+
+        return algebraResponse;
     }
 
     private bool TrySelectDeterministicAgent(

--- a/Tests/Common/GA.Business.ML.Tests/Eval/RoutingEvalHarness.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Eval/RoutingEvalHarness.cs
@@ -7,8 +7,11 @@ using GA.Business.ML.Agents.Intents;
 using GA.Business.ML.Agents.Plugins;
 using GA.Business.ML.Agents.Skills;
 using GA.Business.ML.Extensions;
+using GA.Business.ML.Search;
 using GA.Domain.Services.Atonal.Grothendieck;
+using Domain.Services.Fretboard.Voicings.Filtering;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -402,6 +405,27 @@ public class RoutingEvalHarness
         sc.TryAddSingleton<IMcpToolsProvider>(_ => new StubMcpToolsProvider());
         sc.TryAddSingleton<IChatClientFactory>(_ => new StubChatClientFactory());
         sc.TryAddSingleton<IChatClient>(_ => new StubChatClient());
+
+        // Voicing-search stack — required by ChordVoicingsSkill (PR #251).
+        // Mirrors the OrchestratorTestHarness wiring; the router never
+        // exercises these, but the skill ctor demands them.
+        sc.AddMemoryCache();
+        sc.TryAddSingleton<VoicingIndexingService>();
+        sc.TryAddSingleton<IVoicingSearchStrategy, CpuVoicingSearchStrategy>();
+        sc.TryAddSingleton<EnhancedVoicingSearchService>();
+
+        // Musical-query extractor stack — required by ChordVoicingsSkill
+        // and ImprovisationSkill (PR #253). CompositeMusicalQueryExtractor
+        // sits on top of Typed + Llm; both must be registered.
+        // MusicalQueryEncoder depends on the four partition vector services
+        // — AddMusicalEmbeddings wires them up alongside the rest of the
+        // OPTIC-K embedding stack so future additions stay in lockstep with
+        // production.
+        sc.AddMusicalEmbeddings();
+        sc.TryAddSingleton<MusicalQueryEncoder>();
+        sc.TryAddSingleton<TypedMusicalQueryExtractor>();
+        sc.TryAddSingleton<LlmMusicalQueryExtractor>();
+        sc.TryAddSingleton<IMusicalQueryExtractor, CompositeMusicalQueryExtractor>();
 
         // Reflect-discover every concrete IOrchestratorSkill in the
         // GA.Business.ML assembly. (Skills implemented in host apps —


### PR DESCRIPTION
## Summary

Two tests have been red on `origin/main` consistently since at least 2026-05-13. Both reproduce locally, both fixed surgically. (A third reported as chronic — `Detect_AndalusianCadence_FromTab` — was already `[Ignore]`-marked on 2026-05-03 and isn't actually running in CI. See report.)

### `ProductionLikeRegistry_LoadsAllSkillIntents`

The reflection-loaded registry in `RoutingEvalHarness` could not construct `ChordVoicingsSkill` or `ImprovisationSkill`. Those skills landed in PR #251 / #253 with new ctor deps (`EnhancedVoicingSearchService`, `IMusicalQueryExtractor`, `MusicalQueryEncoder`) and the test stubs weren't extended to match. Fixed by adding the voicing-search and musical-query-extractor stacks to `BuildProductionLikeIntentRegistry`, mirroring `OrchestratorTestHarness`. `MusicalQueryEncoder` transitively needs four partition vector services, registered via the existing `AddMusicalEmbeddings` extension so future additions stay in lockstep with production.

### `Chat_AlgebraPrompt_UsesIxAlgebraRoute_AndReturnsGrounding`

The unified semantic-intent dispatch routes algebra prompts via `SemanticIntentRouter`, which needs an embedding endpoint. CI has no Ollama, so the embedding call fails, dispatch falls through to the LLM agent path, which also fails on missing Ollama, and `OrchestratedChatApplicationService` only catches `OperationCanceledException` in its fallback — the connection-refused `HttpRequestException` returned 500 instead of the expected `ix-algebra` grounded answer.

`ProductionOrchestrator` already had `IAlgebraPromptClassifier` + `IIxAlgebraService` injected as ctor params (build warning CS9113 said `ixAlgebraService` is unread). They were leftovers from the legacy deterministic algebra dispatcher that PR #29 collapsed into the semantic router. Fixed by reinstating a deterministic algebra fast-path that runs BEFORE `intentRouter.RouteAsync` — mirrors the existing deterministic voicing guard's relationship to `VoicingIntent`. High-precision: classifier hit + service-extractable pitch-class set required; otherwise falls through unchanged. Emits `routingMethod="ix-algebra"`, `agentId="algebra"` so `FallbackChatApplicationService`'s deterministic-failure protection and trace dashboards can't tell whether the fast-path or the semantic-routed `AlgebraIntent` answered.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~ProductionLikeRegistry_LoadsAllSkillIntents"` — passes (was Failed)
- [x] `dotnet test ... --filter "FullyQualifiedName~Chat_AlgebraPrompt_UsesIxAlgebraRoute"` — passes locally in 333 ms (was 42s before relying on Ollama; was Failed in CI)
- [x] Broader sweep `--filter "FullyQualifiedName~Algebra|Registry|Cadence|IxAlgebra"` — all 19 tests pass
- [x] Full `GA.Business.Core.Tests` suite — 821 passed / 5 skipped (no regressions)
- [x] Full `GaChatbot.Api.Tests` suite — 106 passed / 1 skipped (no regressions)
- [x] Orchestration-focused tests — 48 passed
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)