### PR TITLE
fix(tests): repair SearchAsync_WithFilters_ShouldStillBeFast — 3rd chronic main flake

### DIFF
--- a/Tests/Common/GA.Business.Core.Tests/Fretboard/Voicings/GpuVoicingSearchPerformanceTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Fretboard/Voicings/GpuVoicingSearchPerformanceTests.cs
@@ -140,9 +140,15 @@ public class GpuVoicingSearchPerformanceTests
         // Assert
         Assert.That(results, Is.Not.Null);
         Assert.That(results.Count, Is.LessThanOrEqualTo(10));
-        // Note: Allow a wider threshold to accommodate CI and hardware variance while still ensuring GPU speed.
-        Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(1500),
-            $"Filtered search should complete within 1500ms (actual: {stopwatch.ElapsedMilliseconds}ms)");
+        // CI GitHub-hosted runners hit ~800-1500ms on this path vs ~50-200ms locally with a real GPU.
+        // The 1500ms guard was already a runner-class concession but still flakes (1507ms observed
+        // 2026-05-18 in run 26010838922; ditto ~1000ms baseline across the past day). Loosen the CI
+        // budget to 3000ms — still catches a true regression (full first-search uncached path is
+        // sub-2s even on the cheapest runners) without paying for shared-CPU/GPU jitter. Keep the
+        // tight 1500ms guard locally so the test still flags real perf regressions on dev boxes.
+        var threshold = Environment.GetEnvironmentVariable("CI") == "true" ? 3000 : 1500;
+        Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(threshold),
+            $"Filtered search should complete within {threshold}ms (actual: {stopwatch.ElapsedMilliseconds}ms)");
         Console.WriteLine($"Filtered search time (2000/10000 voicings): {stopwatch.ElapsedMilliseconds}ms");
     }
 


### PR DESCRIPTION
## Summary

This is the 3rd of 3 chronic main flakes (1st + 2nd shipped via #273, now merged). The task asked to fix `Detect_AndalusianCadence_FromTab` but that test was already `[Ignore]`-marked on 2026-05-03 and is not running in CI. The actual chronic third flake on ga main is **`SearchAsync_WithFilters_ShouldStillBeFast`** — the GPU performance test that was keeping #273's `build` check red.

## What was broken

Existing CI guard of 1500ms in `GpuVoicingSearchPerformanceTests.SearchAsync_WithFilters_ShouldStillBeFast` was already a hardware-variance concession ("Allow a wider threshold to accommodate CI and hardware variance"), but still flakes on GitHub-hosted runners. Observed timings on main / #273 over the past 24h:

| Run | Time |
|-----|------|
| 26010838922 (last #273 build before merge) | 1507ms (Failed) |
| 25983114051 | 958ms |
| 25981038655 | 787ms |
| 25980892146 | ~1000ms |

7ms-over-threshold and ratchet behavior — classic shared-runner GPU/CPU jitter.

## Fix

Mirror the existing CI-aware threshold pattern already used in `SearchAsync_MultipleQueries_ShouldMaintainPerformance` (lines 119-121, same file):

```csharp
var threshold = Environment.GetEnvironmentVariable("CI") == "true" ? 3000 : 1500;
```

- **CI budget: 3000ms** — covers observed jitter on shared GitHub-hosted runners
- **Local budget: 1500ms unchanged** — dev workstation with a real GPU still catches a true regression (a real breakage would push multi-seconds over)

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~SearchAsync_WithFilters_ShouldStillBeFast"` — passes locally in 571ms
- [x] Full `GpuVoicingSearchPerformanceTests` suite — 8 passed
- [x] Andalusian sweep — still correctly Skipped (no false re-enable)
- [ ] CI green on this branch

## Note on the task framing

The third chronic flake was reported as `Detect_AndalusianCadence_FromTab`. That test is `[Ignore]`-marked (see `Tests/Common/GA.Business.ML.Tests/TabCadenceIntegrationTests.cs:44`) and reports "Skipped" in test output — not the actual blocker. #273's PR body itself called this out: *"A third reported as chronic — `Detect_AndalusianCadence_FromTab` — was already `[Ignore]`-marked on 2026-05-03 and isn't actually running in CI."* The real third blocker on ga main is the GPU perf flake fixed here. Surfacing rather than papering over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)