### PR TITLE
feat(deploy): auto-deploy demos SPA to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -1,0 +1,126 @@
+name: Deploy Demos to GitHub Pages
+
+# Ships ReactComponents/ga-react-components as a static SPA to
+# GitHub Pages whenever main changes the demo surface.
+#
+# Why this exists: demos.guitaralchemist.com today is the local Vite
+# dev process on port 5176, exposed via Cloudflare Tunnel. New routes
+# added to ReactComponents/ga-react-components/src/main.tsx silently
+# 404 on the public host until someone restarts the local Vite. This
+# workflow gives the demos a durable, hands-off serve path. The
+# operator can flip cloudflared (or DNS) over to the GH Pages URL
+# when they want to retire the localhost-tunnel path.
+#
+# Behaviour notes:
+# - DOES NOT touch DNS or cloudflared config. The PR body documents
+#   the one-time operator step to flip the serve target.
+# - DOES NOT break the current setup: this workflow only adds a new
+#   serve URL (https://guitaralchemist.github.io/ga/). The existing
+#   tunnel keeps working until the operator chooses to retire it.
+# - DOES NOT deploy the .NET API. /api/* fetches inside test pages
+#   will only resolve when a reverse proxy (current Cloudflare Tunnel
+#   or its successor) routes /api/* to a live GaApi host.
+
+on:
+  push:
+    branches: [main]
+    # Trigger only on changes to the demo surface or this workflow
+    # itself. Most main pushes (C# work, docs, state snapshots) don't
+    # need a redeploy.
+    paths:
+      - 'ReactComponents/ga-react-components/**'
+      - '.github/workflows/deploy-demos.yml'
+  workflow_dispatch: {}
+
+# Required by actions/deploy-pages — it uses OIDC to authenticate
+# the deployment to the Pages environment.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Don't ship two builds simultaneously; if a new push lands while a
+# deploy is in flight, queue it.
+concurrency:
+  group: deploy-demos
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build demos SPA
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      # `npm install --ignore-scripts` to skip the patch-package
+      # postinstall hook (it needs the patches/ dir but also tolerates
+      # missing patches). `npm ci` would require a committed
+      # package-lock.json which this repo's .gitignore excludes — same
+      # situation as the existing build-frontend job in ci.yml.
+      - name: Install dependencies
+        working-directory: ReactComponents/ga-react-components
+        run: npm install --ignore-scripts --no-audit --no-fund
+
+      # Run patches manually after install (the npm postinstall was
+      # skipped above). Tolerate missing patch-package gracefully.
+      - name: Apply patches (best-effort)
+        working-directory: ReactComponents/ga-react-components
+        run: |
+          if [ -d patches ]; then
+            npx -y patch-package || echo "patch-package skipped"
+          else
+            echo "No patches/ dir — skipping"
+          fi
+
+      # Build with DEMOS_BASE_PATH=/ga/ so the bundle is correctly
+      # prefixed for https://guitaralchemist.github.io/ga/. If the
+      # operator later moves to a custom domain at the root, change
+      # this to '/' and remove CNAME special-casing below.
+      - name: Build SPA
+        working-directory: ReactComponents/ga-react-components
+        env:
+          DEMOS_BASE_PATH: /ga/
+        run: npm run build:demos
+
+      # GitHub Pages serves an SPA via the 404.html fallback trick:
+      # any path that doesn't resolve to a static file gets 404.html,
+      # which we set to a copy of index.html. React Router then takes
+      # over client-side. Without this, https://.../ga/test/fleet
+      # 404s on first hit.
+      - name: Add SPA 404 fallback
+        run: cp ReactComponents/ga-react-components/dist-demos/index.html \
+              ReactComponents/ga-react-components/dist-demos/404.html
+
+      # Bypass Jekyll: GH Pages defaults to running Jekyll on the
+      # uploaded site, which strips files starting with `_` (like
+      # _astro, _redirects, etc). Vite's hashed asset filenames
+      # don't start with `_`, but adding `.nojekyll` is the standard
+      # belt-and-braces step and protects future tooling changes.
+      - name: Disable Jekyll
+        run: touch ReactComponents/ga-react-components/dist-demos/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ReactComponents/ga-react-components/dist-demos
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/ReactComponents/ga-react-components/.gitignore
+++ b/ReactComponents/ga-react-components/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-demos
 dist-ssr
 *.local
 

--- a/ReactComponents/ga-react-components/index.html
+++ b/ReactComponents/ga-react-components/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Vite + React + TS</title>
+    <title>Guitar Alchemist — Demos</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ReactComponents/ga-react-components/package.json
+++ b/ReactComponents/ga-react-components/package.json
@@ -10,6 +10,7 @@
     "postinstall": "npx -y patch-package || echo patch-package skipped (deps hoisted to parent)",
     "dev": "vite",
     "build": "vite build",
+    "build:demos": "vite build --config vite.config.demos.ts",
     "build:with-types": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/ReactComponents/ga-react-components/src/components/FleetStatus/FleetStatus.tsx
+++ b/ReactComponents/ga-react-components/src/components/FleetStatus/FleetStatus.tsx
@@ -115,8 +115,10 @@ const FleetStatus: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Public assets are served from the Vite root; bust cache on first paint.
-    fetch('/fleet-status.json', { cache: 'no-cache' })
+    // Public assets are served from Vite's BASE_URL (root in dev,
+    // /ga/ on GitHub Pages); bust cache on first paint.
+    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+    fetch(`${base}/fleet-status.json`, { cache: 'no-cache' })
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();

--- a/ReactComponents/ga-react-components/src/main.tsx
+++ b/ReactComponents/ga-react-components/src/main.tsx
@@ -408,7 +408,18 @@ const DiatonicPanel: React.FC = () => {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+    {/*
+      basename uses Vite's BASE_URL. For the lib-mode dev server (current
+      cloudflared origin) BASE_URL is "/" and the router behaves exactly
+      as before. For the GitHub Pages SPA build (vite.config.demos.ts with
+      DEMOS_BASE_PATH=/ga/) BASE_URL is "/ga/", which makes routes resolve
+      under that sub-path. Trailing slash is stripped because react-router
+      expects the basename without it.
+    */}
+    <BrowserRouter
+      basename={(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
       <Routes>
         {/* Test pages */}
         <Route path="/test" element={<App><TestIndex /></App>} />

--- a/ReactComponents/ga-react-components/vite.config.demos.ts
+++ b/ReactComponents/ga-react-components/vite.config.demos.ts
@@ -1,0 +1,63 @@
+// vite.config.demos.ts — SPA build configuration for the demos site.
+//
+// The default `vite.config.ts` builds this package as a *library* (lib mode)
+// for consumption by Apps/ga-client. Library mode does not produce an
+// index.html + asset bundle the way GitHub Pages needs.
+//
+// This config is loaded by `npm run build:demos` (see package.json) and
+// emits a standard SPA bundle into `dist-demos/`. It is invoked from the
+// GitHub Actions `deploy-demos.yml` workflow on push-to-main.
+//
+// Base path notes:
+// - We use `base: './'` so the generated bundle works at any sub-path
+//   (e.g. https://guitaralchemist.github.io/ga/ or a future custom domain
+//   served at the root). Relative URLs in index.html and bundled assets
+//   are the safest choice when the eventual serve path may change.
+// - For React Router we rely on `BrowserRouter` with `basename` injected
+//   at runtime by `main.tsx` via `import.meta.env.BASE_URL`. The router
+//   already lives in main.tsx; the env var is wired in deploy-demos.yml.
+//
+// What this config does NOT do:
+// - It does not run on every CI build — only the deploy-demos workflow
+//   calls it. Library publishes still use the default `vite.config.ts`.
+// - It does not bundle the .NET API. `/api/*` fetches from inside test
+//   pages will only succeed when an operator-controlled reverse proxy
+//   (current Cloudflare Tunnel, or a future replacement) sits in front
+//   of the static site and routes `/api/*` to a live GaApi instance.
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import * as path from 'path';
+
+// BASE_PATH lets the deploy workflow point at either the GitHub Pages
+// project sub-path (`/ga/`) or a custom-domain root (`/`). Default to
+// `./` so a developer running `npm run build:demos` locally gets a
+// portable bundle without committing to a single serve path.
+const basePath = process.env.DEMOS_BASE_PATH ?? './';
+
+export default defineConfig({
+    base: basePath,
+    plugins: [react()],
+    // Build the SPA, not the library. Entry is the standard index.html
+    // at the package root, which already mounts /src/main.tsx — the same
+    // file the Vite dev server uses today behind cloudflared.
+    build: {
+        outDir: 'dist-demos',
+        emptyOutDir: true,
+        // GitHub Pages caps individual files at 100 MB; warn at 5 MB so
+        // we notice if a planet texture or splat sneaks past `public/`
+        // size budget.
+        chunkSizeWarningLimit: 5000,
+        rollupOptions: {
+            // No `external` here — unlike lib mode we WANT react/react-dom
+            // bundled so the static site is self-contained.
+            input: path.resolve(__dirname, 'index.html'),
+        },
+    },
+    resolve: {
+        alias: {
+            // Match the runtime alias from the library config so dev and
+            // demos bundles resolve `prop-types` identically.
+            'prop-types': 'prop-types/prop-types.js',
+        },
+    },
+});

--- a/docs/operations/demos-deploy.md
+++ b/docs/operations/demos-deploy.md
@@ -1,0 +1,150 @@
+# Demos deploy — `demos.guitaralchemist.com`
+
+Operator-facing reference for the demos serving path. Read this first
+when `demos.guitaralchemist.com` is showing stale or 404-ing routes.
+
+## Current state (after this PR)
+
+Two serve paths exist in parallel. **The PR does NOT change which one
+the public domain points at.** That flip is an operator action,
+documented below.
+
+| Path | URL | Source | Trigger |
+| --- | --- | --- | --- |
+| **Legacy (live)** | `https://demos.guitaralchemist.com` | Local Vite dev server on `localhost:5176` via Cloudflare Tunnel `ga-demos` | Operator runs `pwsh Scripts/start-dev.ps1` on their workstation |
+| **New (auto-deploy)** | `https://guitaralchemist.github.io/ga/` | GitHub Pages, built by `.github/workflows/deploy-demos.yml` | Push to `main` that touches `ReactComponents/ga-react-components/**` |
+
+The legacy path is what's broken — every new route in
+`ReactComponents/ga-react-components/src/main.tsx` silently 404s
+until the local Vite process is restarted. The new path is
+auto-rebuilt and auto-deployed on every relevant push to main.
+
+## What gets deployed
+
+`vite.config.demos.ts` builds the contents of
+`ReactComponents/ga-react-components/index.html` and `src/main.tsx`
+as a standard SPA (not a library). All test routes
+(`/test/fleet`, `/test/modal-meadow`, etc.) ship as a single static
+bundle plus `404.html` fallback so React Router's `BrowserRouter`
+handles deep links.
+
+The router uses `import.meta.env.BASE_URL` so the same `main.tsx`
+serves both:
+
+- The lib-mode dev server at `/` (current cloudflared origin)
+- The GH Pages build at `/ga/` (new deploy path)
+
+`public/fleet-status.json` and similar static assets are served
+relative to `BASE_URL` (see `FleetStatus.tsx`).
+
+## Verifying the deploy
+
+After a push to `main` touching the demos surface:
+
+```bash
+gh run list --repo GuitarAlchemist/ga \
+    --workflow deploy-demos --limit 5
+# Pick the latest run — it should say `completed` and `success`.
+
+# Then hit the live URL:
+curl -sI https://guitaralchemist.github.io/ga/ | head -5
+# Expect HTTP/2 200.
+
+# And a deep-linked test route:
+curl -sI https://guitaralchemist.github.io/ga/test/fleet | head -5
+# Expect HTTP/2 200 (404.html fallback serves index.html).
+```
+
+If the workflow is red, check the build logs — the most common
+breakage is a new dependency that doesn't survive `npm install`
+without `patch-package`.
+
+## Operator flip — point `demos.guitaralchemist.com` at GH Pages
+
+**This step is owned by the operator.** Pick one of two options.
+
+### Option 1 — Update the Cloudflare Tunnel config (recommended)
+
+Edit `~/.cloudflared/config.yml` and change the **catch-all** ingress
+rule from `service: http://localhost:5176` to a GH Pages origin via
+`service: https://guitaralchemist.github.io` plus `originRequest`
+host header override:
+
+```yaml
+# Keep these three rules at the top — backend stays local:
+- hostname: demos.guitaralchemist.com
+  path: ^/chatbot(/.*)?$
+  service: http://localhost:5252
+- hostname: demos.guitaralchemist.com
+  path: ^/api/.*$
+  service: http://localhost:5232
+- hostname: demos.guitaralchemist.com
+  path: ^/hubs/.*$
+  service: http://localhost:5232
+
+# CHANGED — was http://localhost:5176, now GH Pages:
+- hostname: demos.guitaralchemist.com
+  service: https://guitaralchemist.github.io
+  originRequest:
+    httpHostHeader: guitaralchemist.github.io
+    # GH Pages serves the site at /ga/, so rewrite the path:
+    originServerName: guitaralchemist.github.io
+- service: http_status:404
+```
+
+Then `Restart-Service cloudflared`. After that:
+
+- `demos.guitaralchemist.com/test/fleet` is served by GH Pages
+- `demos.guitaralchemist.com/api/*` still routes to the local GaApi
+- `demos.guitaralchemist.com/chatbot/*` still routes to GaChatbot.Api
+
+Caveat: cloudflared's URL-rewriting to inject the `/ga/` base path is
+fiddly. The cleanest variant is **Option 2** below.
+
+### Option 2 — Custom domain on GitHub Pages (cleaner, requires DNS edit)
+
+This retires the Cloudflare Tunnel for the demos host entirely.
+
+1. In `https://github.com/GuitarAlchemist/ga/settings/pages`, set
+   the **Custom domain** to `demos.guitaralchemist.com`. GitHub will
+   add a `CNAME` file to the repo (or fail with a DNS warning).
+2. In Cloudflare DNS for `guitaralchemist.com`, change the `demos`
+   record:
+   - **From** CNAME → `6a7697f8-9178-4c0e-91f4-b0b56e550813.cfargotunnel.com`
+   - **To**   CNAME → `guitaralchemist.github.io`
+   - Disable Cloudflare's orange-cloud proxy (gray cloud) for this
+     record. GH Pages provisions its own TLS cert and the
+     Cloudflare proxy interferes with that handshake.
+3. In `vite.config.demos.ts` (or via the workflow env), change
+   `DEMOS_BASE_PATH` from `/ga/` to `/`. Next push to main triggers
+   a fresh deploy serving from the domain root.
+4. After GH Pages reports the cert as issued (≈30 min), the
+   Cloudflare Tunnel for this host can be retired.
+
+DNS change is a one-way door — revert is a DNS edit back to the
+tunnel CNAME, but propagation can take up to 5 min for Cloudflare
+TTL defaults.
+
+## Rolling back
+
+If the new deploy breaks something:
+
+1. **Don't change DNS.** The legacy path
+   (`localhost:5176` via cloudflared) is still live and serving — the
+   GH Pages deploy is additive.
+2. Revert the offending commit on `main`, or `workflow_dispatch` an
+   earlier good commit via the Actions UI:
+   `gh workflow run deploy-demos.yml --ref <good-sha>`.
+3. To stop further deploys while diagnosing:
+   `gh workflow disable deploy-demos.yml`.
+
+## What this fix does NOT cover
+
+- **The .NET API.** `/api/*` and `/hubs/*` still come from the
+  operator's local GaApi instance through Cloudflare Tunnel. Test
+  pages that fetch from `/api/*` only work behind a proxy that
+  routes those paths to a live GaApi.
+- **The chatbot service.** `GaChatbot.Api` on `:5252` is still
+  local-tunnel only.
+- **Custom domain.** `demos.guitaralchemist.com` continues to point
+  at the tunnel until the operator does Option 1 or Option 2 above.


### PR DESCRIPTION
## Why

Every new route added to `ReactComponents/ga-react-components/src/main.tsx` (e.g., `/test/fleet`, `/test/modal-meadow`, `/test/cheese-avalanche`) silently 404s on `https://demos.guitaralchemist.com/test/*` until someone manually restarts the local Vite process the Cloudflare Tunnel routes to. The tunnel works; the served process is stale. No auto-deploy existed.

Observed three times this session alone.

## What this PR does

Adds an **additive** durable serve path. Every push to `main` that touches `ReactComponents/ga-react-components/**` builds the SPA and ships it to **https://guitaralchemist.github.io/ga/** via `actions/deploy-pages`. The current `cloudflared -> localhost:5176` path keeps working — this PR does not change DNS, cloudflared config, or break the existing flow.

### Path chosen: A (build + GH Pages)

Path A from the spec, picked over B (custom-domain GH Pages requires DNS edit — one-way door deferred to operator) and C (poll-and-rebuild service still requires the user's machine to be on). Path A:
- Removes the user's machine from the **future** serving path
- Requires only the operator's one-time tunnel/DNS flip (documented in `docs/operations/demos-deploy.md`)
- Reuses existing repo infrastructure (Pages is already enabled at `build_type: workflow`)
- Survives the user's laptop being off

## Files

- `.github/workflows/deploy-demos.yml` — push-to-main + workflow_dispatch, paths-scoped to demos surface
- `ReactComponents/ga-react-components/vite.config.demos.ts` — SPA build config (alongside the existing lib-mode `vite.config.ts`)
- `ReactComponents/ga-react-components/package.json` — adds `build:demos` script
- `ReactComponents/ga-react-components/src/main.tsx` — `BrowserRouter` `basename` from `import.meta.env.BASE_URL` so the same `main.tsx` works at `/` (dev) and `/ga/` (Pages)
- `ReactComponents/ga-react-components/src/components/FleetStatus/FleetStatus.tsx` — `fetch` rewritten through `BASE_URL` prefix
- `ReactComponents/ga-react-components/index.html` — title updated from `Vite + React + TS`
- `ReactComponents/ga-react-components/.gitignore` — ignore `dist-demos/`
- `docs/operations/demos-deploy.md` — operator flip + rollback instructions

## Verification

Local build (Ubuntu CI mirrors this path):
```
cd ReactComponents/ga-react-components
DEMOS_BASE_PATH=/ga/ npm run build:demos
# built in 15.84s; dist-demos/index.html references /ga/assets/... correctly
```

After merge, verify:
```bash
gh run list --repo GuitarAlchemist/ga --workflow deploy-demos --limit 1
curl -sI https://guitaralchemist.github.io/ga/ | head -3
curl -sI https://guitaralchemist.github.io/ga/test/fleet | head -3   # 404.html fallback -> 200
```

## Operator action (pick ONE) — do this after merge, NOT before

**Both options keep `/api/*` and `/hubs/*` on local GaApi via tunnel.**

### Option 1 — Edit `~/.cloudflared/config.yml`

Change the catch-all ingress from `http://localhost:5176` to `https://guitaralchemist.github.io` (full snippet in `docs/operations/demos-deploy.md`). Then `Restart-Service cloudflared`. No DNS edit needed. Caveat: cloudflared sub-path rewriting for `/ga/` is fiddly; if it misbehaves, fall back to Option 2.

### Option 2 — Custom domain on GH Pages (cleaner)

1. `https://github.com/GuitarAlchemist/ga/settings/pages` -> Custom domain = `demos.guitaralchemist.com`
2. Cloudflare DNS: change `demos` CNAME from `6a7697f8-9178-4c0e-91f4-b0b56e550813.cfargotunnel.com` -> `guitaralchemist.github.io`, gray-cloud (disable proxy) so GH Pages can issue TLS
3. Change `DEMOS_BASE_PATH` in `deploy-demos.yml` env from `/ga/` to `/` and trigger a rebuild
4. After GH Pages issues the cert (~30 min), the Cloudflare Tunnel for this host can be retired

Full detail (incl. rollback) in `docs/operations/demos-deploy.md`.

## Constraints respected

- No cloudflared/Vite restart from the agent
- No DNS change from the agent
- No tunnel config modification
- Worktree-isolated (`C:/tmp/ga-demos-autodeploy`)
- No `--admin` merge; CI-gated
- No `agent-blackbox-reviewed` label
- Did not touch `Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml`
- Did not touch `docs/runbooks/chatbot-improvement-loop.md`

## Test plan

- [x] Local SPA build succeeds; `dist-demos/index.html` correctly prefixes assets with `/ga/`
- [x] Lint passes on modified files (no new errors)
- [x] `dist-demos/` is gitignored
- [x] GH Pages is already enabled on the repo (`build_type: workflow`, confirmed via `gh api`)
- [ ] CI green on this PR
- [ ] First `deploy-demos` run on merged main commit completes successfully
- [ ] `https://guitaralchemist.github.io/ga/` serves the demos
- [ ] `https://guitaralchemist.github.io/ga/test/fleet` resolves (404.html SPA fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)