### PR TITLE
fix(deploy-demos): pass --force to npm install for Linux runner

### DIFF
--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -65,9 +65,17 @@ jobs:
       # missing patches). `npm ci` would require a committed
       # package-lock.json which this repo's .gitignore excludes — same
       # situation as the existing build-frontend job in ci.yml.
+      #
+      # `--force` is required because the package.json devDependencies
+      # include `@esbuild/win32-x64` (pinned for local Windows dev). On
+      # Linux runners npm refuses to install platform-locked packages
+      # with EBADPLATFORM. `--force` skips the OS check; the unusable
+      # win32 binary is harmless on Linux because the Linux esbuild
+      # picks up its own platform-matched native binary from
+      # `@esbuild/linux-x64` via Vite's optional-deps resolution.
       - name: Install dependencies
         working-directory: ReactComponents/ga-react-components
-        run: npm install --ignore-scripts --no-audit --no-fund
+        run: npm install --ignore-scripts --no-audit --no-fund --force
 
       # Run patches manually after install (the npm postinstall was
       # skipped above). Tolerate missing patch-package gracefully.


### PR DESCRIPTION
## Why

First post-merge run of \`deploy-demos.yml\` (commit \`6fe0196\`) failed at \`npm install\` with EBADPLATFORM: \`@esbuild/win32-x64@0.25.12\` is in devDependencies (pinned for local Windows dev) and refuses to install on Linux runners.

## Fix

Add \`--force\` to the install command. Vite picks up the correct Linux esbuild binary at runtime; the win32 binary sits unused.

Same pattern is implicitly used by the existing \`build-frontend\` job in \`ci.yml\` (which works only because it runs on \`windows-latest\`).

## Test plan

- [x] Local install with \`--force\` works
- [ ] CI green
- [ ] First post-merge \`deploy-demos\` run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)