### PR TITLE
fix(deploy-demos): collapse cp onto single line

### DIFF
--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -104,8 +104,7 @@ jobs:
       # over client-side. Without this, https://.../ga/test/fleet
       # 404s on first hit.
       - name: Add SPA 404 fallback
-        run: cp ReactComponents/ga-react-components/dist-demos/index.html \
-              ReactComponents/ga-react-components/dist-demos/404.html
+        run: cp ReactComponents/ga-react-components/dist-demos/index.html ReactComponents/ga-react-components/dist-demos/404.html
 
       # Bypass Jekyll: GH Pages defaults to running Jekyll on the
       # uploaded site, which strips files starting with `_` (like


### PR DESCRIPTION
Fix second post-merge failure (run 26014311910) of `deploy-demos.yml`. The backslash-newline in 'Add SPA 404 fallback' was passed as a literal arg to cp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)