### PR TITLE
fix(ga-client): guard against accidental Vite start that steals port 5176

### DIFF
--- a/Apps/ga-client/package.json
+++ b/Apps/ga-client/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "postinstall": "npx -y patch-package",
-    "dev": "vite",
+    "dev": "node -e \"console.error('\\n  Apps/ga-client is the LEGACY demo client.\\n  The canonical dev server is ReactComponents/ga-react-components (port 5176, tunneled at demos.guitaralchemist.com).\\n  Starting Vite here would compete for that port and break the public site.\\n\\n  To run the dashboard:    cd ../../ReactComponents/ga-react-components && npm run dev\\n  To intentionally run ga-client (rare): npm run dev:legacy\\n'); process.exit(1)\"",
+    "dev:legacy": "vite --port 5173 --strictPort",
     "build": "vite build",
     "build:with-types": "tsc -b && vite build",
     "lint": "eslint .",


### PR DESCRIPTION
## Why

Apps/ga-client's `dev` script was a bare `vite` with no port pin. Any agent running `npm run dev -- --port 5176` from this directory would silently bind the port that belongs to the canonical ga-react-components dashboard at `demos.guitaralchemist.com/test`.

This happened today — codex spawned `pwsh -c "npm run dev -- --host 0.0.0.0 --port 5176"` from `Apps/ga-client/`, displaced the real Vite, and the public test page served a 634-byte "Vite + React + TS" boilerplate for ~25 minutes.

## Fix

- `"dev"` now runs a `node -e` that prints a clear message naming the canonical dev location (`ReactComponents/ga-react-components`) and exits 1 — so Vite never boots and the port stays free.
- The original behavior moves to `"dev:legacy"` with `--port 5173 --strictPort` so it can never accidentally take 5176 even if invoked.

Verified locally: `npm run dev` exits non-zero with the warning; site at `demos.guitaralchemist.com/test` confirms 1391-byte dashboard response with title "Guitar Alchemist — Demos".

🤖 Generated with [Claude Code](https://claude.com/claude-code)