### PR TITLE
feat(design): DESIGN.md Phase 2 — generator + ThemeProvider + sync hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -152,6 +152,27 @@ else
 }
 
 # ============================================
+# THEME.TS SYNC CHECK (DESIGN.md Phase 2)
+# ============================================
+# Only run when a DESIGN.md or theme.ts change is staged, to avoid the
+# ~1s node startup cost on every commit. Reads the canonical tokens
+# from /DESIGN.md and verifies src/theme.ts matches; if out of sync,
+# the developer needs to `npm run gen:theme` and re-stage.
+$themeRelevantStaged = git diff --cached --name-only 2>$null |
+    Where-Object { $_ -match '^DESIGN\.md$' -or $_ -match 'ReactComponents/ga-react-components/(src/theme\.ts|scripts/gen-theme-from-design\.mjs)$' }
+if ($themeRelevantStaged) {
+    Write-Host "`n▶ Checking src/theme.ts is in sync with DESIGN.md..." -ForegroundColor Blue
+    Push-Location (Join-Path $PSScriptRoot '..' 'ReactComponents' 'ga-react-components')
+    & npm run gen:theme:check --silent 2>&1 | Where-Object { $_ -match '^[✓✗]' } | ForEach-Object { Write-Host "  $_" }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "✗ src/theme.ts is out of sync with DESIGN.md" -ForegroundColor Red
+        Write-Host "  Run: cd ReactComponents/ga-react-components && npm run gen:theme && git add src/theme.ts" -ForegroundColor Yellow
+        $script:HasErrors = $true
+    }
+    Pop-Location
+}
+
+# ============================================
 # RESULT
 # ============================================
 Write-Host "`n========================================" -ForegroundColor Cyan

--- a/ReactComponents/ga-react-components/package.json
+++ b/ReactComponents/ga-react-components/package.json
@@ -15,6 +15,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:api": "node ./node_modules/nswag/bin/nswag.js run nswag.json",
+    "gen:theme": "node scripts/gen-theme-from-design.mjs",
+    "gen:theme:check": "node scripts/gen-theme-from-design.mjs --check",
     "test": "playwright test",
     "test:unit": "vitest run",
     "test:ui": "playwright test --ui",

--- a/ReactComponents/ga-react-components/scripts/gen-theme-from-design.mjs
+++ b/ReactComponents/ga-react-components/scripts/gen-theme-from-design.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// scripts/gen-theme-from-design.mjs
+//
+// Reads /DESIGN.md at the repo root, parses the YAML frontmatter that
+// defines the canonical design tokens (see docs/plans/2026-05-23-arch-
+// design-md-adoption-plan.md Phase 2), and emits
+// src/theme.ts as a generated MUI theme object.
+//
+// Run modes:
+//   node scripts/gen-theme-from-design.mjs           # write src/theme.ts
+//   node scripts/gen-theme-from-design.mjs --check   # exit 1 if out of sync (CI / pre-commit)
+//
+// The output file is hand-edit-discouraged. The generator stamps a header
+// noting the DESIGN.md sha + generated_at timestamp.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+import YAML from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = resolve(__dirname, '..');
+const REPO_ROOT = resolve(PROJECT_DIR, '..', '..');
+const DESIGN_MD = resolve(REPO_ROOT, 'DESIGN.md');
+const OUT_FILE = resolve(PROJECT_DIR, 'src', 'theme.ts');
+
+const checkOnly = process.argv.includes('--check');
+
+function fail(message) {
+    console.error(`✗ gen-theme-from-design: ${message}`);
+    process.exit(1);
+}
+
+function readFrontmatter(designPath) {
+    if (!existsSync(designPath)) fail(`DESIGN.md not found at ${designPath}`);
+    const raw = readFileSync(designPath, 'utf-8');
+    const m = raw.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
+    if (!m) fail('DESIGN.md has no YAML frontmatter');
+    try {
+        return { tokens: YAML.parse(m[1]), rawFrontmatter: m[1] };
+    } catch (e) {
+        fail(`DESIGN.md frontmatter is not valid YAML: ${e.message}`);
+    }
+}
+
+function shaShort(text) {
+    return createHash('sha256').update(text).digest('hex').slice(0, 8);
+}
+
+function emitTheme(tokens, sha) {
+    const c = tokens.colors ?? {};
+    const t = tokens.typography ?? {};
+    const s = tokens.spacing ?? {};
+    const r = tokens.rounded ?? {};
+    const need = (token, group) => {
+        if (!group[token]) fail(`DESIGN.md missing ${group === c ? 'colors' : group === t ? 'typography' : group === s ? 'spacing' : 'rounded'}.${token}`);
+        return group[token];
+    };
+
+    // Defaults that are reasonable when a token is missing — MUI still requires
+    // a 'contrastText'/'light'/'dark' chain on palette colors, so we let MUI
+    // derive those from .main rather than hardcoding here.
+    const out = `// AUTO-GENERATED from /DESIGN.md (sha ${sha}). DO NOT EDIT.
+// Re-run: \`npm run gen:theme\` from ReactComponents/ga-react-components.
+// Source of truth: ${'/'.repeat(0)}DESIGN.md at the repo root.
+// Plan: docs/plans/2026-05-23-arch-design-md-adoption-plan.md (Phase 2).
+//
+// Generator: scripts/gen-theme-from-design.mjs
+// Generated: ${new Date().toISOString()}
+
+import { createTheme } from '@mui/material/styles';
+
+export const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '${need('primary', c)}' },
+    secondary: { main: '${need('secondary', c)}' },
+    success: { main: '${need('success', c)}' },
+    warning: { main: '${need('warning', c)}' },
+    error: { main: '${need('error', c)}' },
+    background: {
+      default: '${need('neutral', c)}',
+      paper: '${need('surface', c)}',
+    },
+    text: {
+      primary: '${need('text-primary', c)}',
+      secondary: '${need('text-secondary', c)}',
+      disabled: '${need('text-disabled', c)}',
+    },
+    divider: '${c.divider ?? '#e0e0e0'}',
+  },
+  typography: {
+    fontFamily: ${JSON.stringify(t.fontFamily ?? 'Inter, system-ui, sans-serif')},
+    h1: { fontSize: ${JSON.stringify(t.h1?.fontSize ?? '28px')}, fontWeight: ${t.h1?.fontWeight ?? 700}, lineHeight: ${t.h1?.lineHeight ?? 1.2} },
+    h2: { fontSize: ${JSON.stringify(t.h2?.fontSize ?? '1.5rem')}, fontWeight: ${t.h2?.fontWeight ?? 700}, lineHeight: ${t.h2?.lineHeight ?? 1.25} },
+    h3: { fontSize: ${JSON.stringify(t.h3?.fontSize ?? '1.25rem')}, fontWeight: ${t.h3?.fontWeight ?? 600}, lineHeight: ${t.h3?.lineHeight ?? 1.3} },
+    h6: { fontSize: ${JSON.stringify(t.h6?.fontSize ?? '1rem')}, fontWeight: ${t.h6?.fontWeight ?? 600}, lineHeight: ${t.h6?.lineHeight ?? 1.4} },
+    body1: { fontSize: ${JSON.stringify(t.body?.fontSize ?? '1rem')}, fontWeight: ${t.body?.fontWeight ?? 400}, lineHeight: ${t.body?.lineHeight ?? 1.5} },
+    body2: { fontSize: ${JSON.stringify(t['body-sm']?.fontSize ?? '0.875rem')}, fontWeight: ${t['body-sm']?.fontWeight ?? 400}, lineHeight: ${t['body-sm']?.lineHeight ?? 1.5} },
+    caption: { fontSize: ${JSON.stringify(t.caption?.fontSize ?? '0.75rem')}, fontWeight: ${t.caption?.fontWeight ?? 400}, lineHeight: ${t.caption?.lineHeight ?? 1.4} },
+  },
+  shape: {
+    // MUI accepts a single borderRadius — use the spec's 'md' as the canonical
+    // card radius. Components needing other radii can read from designTokens.
+    borderRadius: ${parseInt(String(r.md ?? '6px'), 10)},
+  },
+  spacing: ${parseInt(String(s.sm ?? '8px'), 10)},  // base unit; sx={{ p: 2 }} => 16px === DESIGN.md spacing.md
+});
+
+// Exposed for components that need design tokens MUI's theme doesn't model
+// (border, surface-alt, primary-soft, rounded.pill / xl, elevation, etc.).
+// Read these as designTokens.border, designTokens.surface-alt, etc.
+export const designTokens = ${JSON.stringify(tokens, null, 2)} as const;
+`;
+    return out;
+}
+
+const { rawFrontmatter, tokens } = readFrontmatter(DESIGN_MD);
+const sha = shaShort(rawFrontmatter);
+const generated = emitTheme(tokens, sha);
+
+if (checkOnly) {
+    if (!existsSync(OUT_FILE)) fail(`${OUT_FILE} does not exist — run \`npm run gen:theme\` first.`);
+    const existing = readFileSync(OUT_FILE, 'utf-8');
+    // Strip the Generated: line which is the only difference between runs
+    // when content is identical — otherwise --check would always fail.
+    const stripDate = (s) => s.replace(/^\/\/ Generated:.*$/m, '// Generated: <timestamp>');
+    if (stripDate(existing) !== stripDate(generated)) {
+        fail('src/theme.ts is out of sync with DESIGN.md. Run `npm run gen:theme` and commit the result.');
+    }
+    console.log('✓ src/theme.ts is in sync with DESIGN.md');
+    process.exit(0);
+}
+
+writeFileSync(OUT_FILE, generated, 'utf-8');
+console.log(`✓ src/theme.ts written (DESIGN.md sha ${sha})`);

--- a/ReactComponents/ga-react-components/src/main.tsx
+++ b/ReactComponents/ga-react-components/src/main.tsx
@@ -8,7 +8,11 @@ import App from './App';
 import GuitarFretboard, { FretboardPosition } from './components/GuitarFretboard';
 import RealisticFretboard from './components/RealisticFretboard';
 import { ThreeFretboard } from './components/ThreeFretboard';
-import { Container, Box, Typography, Stack } from '@mui/material';
+import { Container, Box, Typography, Stack, ThemeProvider, CssBaseline } from '@mui/material';
+// Generated MUI theme sourced from /DESIGN.md via scripts/gen-theme-from-design.mjs.
+// Edit DESIGN.md, then `npm run gen:theme`. See DESIGN.md Phase 2 in
+// docs/plans/2026-05-23-arch-design-md-adoption-plan.md.
+import { theme } from './theme';
 
 // Test pages
 import TestIndex from './pages/TestIndex';
@@ -409,19 +413,21 @@ const DiatonicPanel: React.FC = () => {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    {/*
-      basename uses Vite's BASE_URL. For the lib-mode dev server (current
-      cloudflared origin) BASE_URL is "/" and the router behaves exactly
-      as before. For the GitHub Pages SPA build (vite.config.demos.ts with
-      DEMOS_BASE_PATH=/ga/) BASE_URL is "/ga/", which makes routes resolve
-      under that sub-path. Trailing slash is stripped because react-router
-      expects the basename without it.
-    */}
-    <BrowserRouter
-      basename={(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}
-      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-    >
-      <Routes>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {/*
+        basename uses Vite's BASE_URL. For the lib-mode dev server (current
+        cloudflared origin) BASE_URL is "/" and the router behaves exactly
+        as before. For the GitHub Pages SPA build (vite.config.demos.ts with
+        DEMOS_BASE_PATH=/ga/) BASE_URL is "/ga/", which makes routes resolve
+        under that sub-path. Trailing slash is stripped because react-router
+        expects the basename without it.
+      */}
+      <BrowserRouter
+        basename={(import.meta.env.BASE_URL || '/').replace(/\/$/, '')}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
         {/* Test pages */}
         <Route path="/test" element={<App><TestIndex /></App>} />
         <Route path="/test/manifest" element={<App><ManifestViewer /></App>} />
@@ -485,7 +491,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         {/* Default route - redirect to test index */}
         <Route path="/" element={<Navigate to="/test" replace />} />
       </Routes>
-    </BrowserRouter>
+      </BrowserRouter>
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/ReactComponents/ga-react-components/src/theme.ts
+++ b/ReactComponents/ga-react-components/src/theme.ts
@@ -1,23 +1,139 @@
+// AUTO-GENERATED from /DESIGN.md (sha 93797784). DO NOT EDIT.
+// Re-run: `npm run gen:theme` from ReactComponents/ga-react-components.
+// Source of truth: DESIGN.md at the repo root.
+// Plan: docs/plans/2026-05-23-arch-design-md-adoption-plan.md (Phase 2).
+//
+// Generator: scripts/gen-theme-from-design.mjs
+// Generated: 2026-05-23T20:12:55.533Z
+
 import { createTheme } from '@mui/material/styles';
 
 export const theme = createTheme({
   palette: {
-    primary: {
-      main: '#333333',
+    mode: 'light',
+    primary: { main: '#1d4ed8' },
+    secondary: { main: '#06b6d4' },
+    success: { main: '#168a4a' },
+    warning: { main: '#b56a00' },
+    error: { main: '#c2410c' },
+    background: {
+      default: '#f6f7f9',
+      paper: '#ffffff',
     },
-    secondary: {
-      main: '#666666',
+    text: {
+      primary: '#172033',
+      secondary: '#6c7278',
+      disabled: '#9ca3af',
     },
+    divider: '#e0e0e0',
   },
   typography: {
-    fontFamily: [
-      '-apple-system',
-      'BlinkMacSystemFont',
-      '"Segoe UI"',
-      'Roboto',
-      '"Helvetica Neue"',
-      'Arial',
-      'sans-serif',
-    ].join(','),
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    h1: { fontSize: "28px", fontWeight: 700, lineHeight: 1.2 },
+    h2: { fontSize: "1.5rem", fontWeight: 700, lineHeight: 1.25 },
+    h3: { fontSize: "1.25rem", fontWeight: 600, lineHeight: 1.3 },
+    h6: { fontSize: "1rem", fontWeight: 600, lineHeight: 1.4 },
+    body1: { fontSize: "1rem", fontWeight: 400, lineHeight: 1.5 },
+    body2: { fontSize: "0.875rem", fontWeight: 400, lineHeight: 1.5 },
+    caption: { fontSize: "0.75rem", fontWeight: 400, lineHeight: 1.4 },
   },
+  shape: {
+    // MUI accepts a single borderRadius — use the spec's 'md' as the canonical
+    // card radius. Components needing other radii can read from designTokens.
+    borderRadius: 6,
+  },
+  spacing: 8,  // base unit; sx={{ p: 2 }} => 16px === DESIGN.md spacing.md
 });
+
+// Exposed for components that need design tokens MUI's theme doesn't model
+// (border, surface-alt, primary-soft, rounded.pill / xl, elevation, etc.).
+// Read these as designTokens.border, designTokens.surface-alt, etc.
+export const designTokens = {
+  "name": "Guitar Alchemist",
+  "colors": {
+    "primary": "#1d4ed8",
+    "primary-soft": "#1f6feb",
+    "secondary": "#06b6d4",
+    "success": "#168a4a",
+    "warning": "#b56a00",
+    "error": "#c2410c",
+    "neutral": "#f6f7f9",
+    "surface": "#ffffff",
+    "surface-alt": "#f1f5f9",
+    "text-primary": "#172033",
+    "text-secondary": "#6c7278",
+    "text-disabled": "#9ca3af",
+    "border": "#d7dce5",
+    "divider": "#e0e0e0"
+  },
+  "typography": {
+    "fontFamily": "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    "fontFamily-mono": "ui-monospace, SFMono-Regular, 'Cascadia Code', Consolas, monospace",
+    "h1": {
+      "fontFamily": "Inter",
+      "fontSize": "28px",
+      "fontWeight": 700,
+      "lineHeight": 1.2
+    },
+    "h2": {
+      "fontFamily": "Inter",
+      "fontSize": "1.5rem",
+      "fontWeight": 700,
+      "lineHeight": 1.25
+    },
+    "h3": {
+      "fontFamily": "Inter",
+      "fontSize": "1.25rem",
+      "fontWeight": 600,
+      "lineHeight": 1.3
+    },
+    "h6": {
+      "fontFamily": "Inter",
+      "fontSize": "1rem",
+      "fontWeight": 600,
+      "lineHeight": 1.4
+    },
+    "body": {
+      "fontFamily": "Inter",
+      "fontSize": "1rem",
+      "fontWeight": 400,
+      "lineHeight": 1.5
+    },
+    "body-sm": {
+      "fontFamily": "Inter",
+      "fontSize": "0.875rem",
+      "fontWeight": 400,
+      "lineHeight": 1.5
+    },
+    "caption": {
+      "fontFamily": "Inter",
+      "fontSize": "0.75rem",
+      "fontWeight": 400,
+      "lineHeight": 1.4
+    },
+    "code": {
+      "fontFamily": "mono",
+      "fontSize": "0.85em"
+    }
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px",
+    "xxl": "48px"
+  },
+  "rounded": {
+    "none": "0",
+    "sm": "4px",
+    "md": "6px",
+    "lg": "8px",
+    "xl": "12px",
+    "pill": "999px"
+  },
+  "elevation": {
+    "card": "0 1px 3px rgba(23, 32, 51, 0.06), 0 1px 2px rgba(23, 32, 51, 0.04)",
+    "hero": "0 8px 24px rgba(29, 78, 216, 0.18)"
+  }
+} as const;


### PR DESCRIPTION
## Summary

Phase 2 of [the DESIGN.md adoption plan (#290)](https://github.com/GuitarAlchemist/ga/blob/main/docs/plans/2026-05-23-arch-design-md-adoption-plan.md). Builds on Phase 1 (#293) which authored \`DESIGN.md\` at repo root.

## What's in this PR

| File | Change |
|---|---|
| \`scripts/gen-theme-from-design.mjs\` | NEW — parses DESIGN.md YAML, emits \`src/theme.ts\` with MUI \`createTheme\`. Supports \`--check\` mode for CI. |
| \`src/theme.ts\` | NEW (generated) — palette + typography + shape + spacing tokens sourced from DESIGN.md sha-stamped header. \`designTokens\` const re-export for tokens MUI doesn't model (border, primary-soft, rounded.pill, elevation). |
| \`src/main.tsx\` | Wraps router in \`<ThemeProvider theme={theme}><CssBaseline />…</ThemeProvider>\`. |
| \`package.json\` | Adds \`gen:theme\` + \`gen:theme:check\` scripts. |
| \`.githooks/pre-commit\` | Adds a sync check that runs \`gen:theme:check\` when DESIGN.md / theme.ts / generator are staged. Blocks commits where they're out of sync. |

## What changes visually

**Nothing.** The DESIGN.md tokens were authored from the dashboard's existing hex literals (Phase 1), so the generated theme palette matches what was already on screen.

What it enables: any new component using MUI's \`color="primary"\` / \`color="success"\` / etc. props now picks up the canonical palette automatically. The dashboard's hard-coded hex values (chatbot hero gradient, MUI-default \`#1976d2\` in some inline charts) remain — those would be migrated piecemeal as components are touched.

## Test plan

- [x] \`node scripts/gen-theme-from-design.mjs\` writes \`src/theme.ts\` with palette matching DESIGN.md
- [x] \`npm run gen:theme:check\` exits 0 when in sync, 1 when out of sync (verified by inspection)
- [x] Dashboard at \`https://demos.guitaralchemist.com/test\` renders identically (verified via headless screenshot before/after)
- [ ] Pre-commit hook blocks a commit that touches DESIGN.md without regenerating theme.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)