### PR TITLE
chore(test-page): update Modal Meadow showcase entry to v0.8

### DIFF
--- a/ReactComponents/ga-react-components/src/pages/TestIndex.tsx
+++ b/ReactComponents/ga-react-components/src/pages/TestIndex.tsx
@@ -180,11 +180,11 @@ const testPages: TestPageInfo[] = [
   {
     id: 'modal-meadow',
     title: 'Modal Meadow',
-    description: 'Walk a 220m meadow split into musical mode-regions; ambient chord progression and grass colour shift as you cross from Ionian to Phrygian',
+    description: 'Walk through a meadow split into seven musical mode-regions (Ionian → Locrian); ambient chord progression, grass color, and wind shift as you cross between modes. v0.8 adds rolling hills, ponds, and a descent effect.',
     technology: 'Three.js + Web Audio + FPS Controls',
     path: '/test/modal-meadow',
-    features: ['First-Person', 'WASD Walker', 'Pointer Lock', 'Two Mode Regions', 'Per-Region Wind', 'Web Audio Pad', 'Crossfade'],
-    status: 'partial',
+    features: ['First-Person', 'WASD Walker', 'Pointer Lock', 'Seven Modes', 'Auto-Walk Default', 'Hills + Ponds', 'Web Audio Pad', 'Crossfade'],
+    status: 'complete',
   },
   {
     id: 'ocean',


### PR DESCRIPTION
## Why

PR #280 shipped Modal Meadow v0.8 (seven modes, descent effect, hills + ponds, auto-walk default) but \`TestIndex.tsx\`'s showcase entry was never updated. The row still described v0.6 ("Two Mode Regions", "Per-Region Wind") with status \`partial\`. Users browsing the demos table see the v0.6 description even though the live demo is v0.8.

## Change

\`\`\`diff
-  description: 'Walk a 220m meadow split into musical mode-regions; ambient chord progression and grass colour shift as you cross from Ionian to Phrygian',
+  description: 'Walk through a meadow split into seven musical mode-regions (Ionian → Locrian); ambient chord progression, grass color, and wind shift as you cross between modes. v0.8 adds rolling hills, ponds, and a descent effect.',
   ...
-  features: ['First-Person', 'WASD Walker', 'Pointer Lock', 'Two Mode Regions', 'Per-Region Wind', 'Web Audio Pad', 'Crossfade'],
+  features: ['First-Person', 'WASD Walker', 'Pointer Lock', 'Seven Modes', 'Auto-Walk Default', 'Hills + Ponds', 'Web Audio Pad', 'Crossfade'],
-  status: 'partial',
+  status: 'complete',
\`\`\`

Pure metadata. The route \`/test/modal-meadow\` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)