### PR TITLE
fix(modal-meadow): clamp camera to highest near terrain (v1.2)

### DIFF
--- a/ReactComponents/ga-react-components/src/components/ModalMeadow/ModalMeadow.tsx
+++ b/ReactComponents/ga-react-components/src/components/ModalMeadow/ModalMeadow.tsx
@@ -260,6 +260,8 @@ export const ModalMeadow: React.FC<ModalMeadowProps> = ({
     // Scratch objects we reuse each frame to avoid GC pressure.
     const sunDirScratch = new THREE.Vector3();
     const sunColorScratch = new THREE.Color();
+    // Scratch for the ground-clamp sample-ahead vector (see tick()).
+    const groundClampDirScratch = new THREE.Vector3();
 
     // ─── Ground plane — heightmap-displaced rolling hills ──────────────────
     // 7-region tinted ground. Lambert from the interpolated sun direction.
@@ -950,7 +952,40 @@ export const ModalMeadow: React.FC<ModalMeadowProps> = ({
 
       // Camera Y follows the terrain at eye height — every frame so the
       // descent effect always reads a real slope, even when looking around.
-      const groundY = sampleTerrainY(camera.position.x, camera.position.z);
+      //
+      // Ground clamp (v1.2): sample terrain at camera XZ AND at three points
+      // ahead along the camera's facing direction, and ride the MAX. With
+      // 8m amplitude hills, sampling only at the camera's centre lets the
+      // near-frustum clip through approaching hillsides — the geometric
+      // centre is above its local terrain Y, but the upcoming hill face is
+      // higher. Riding the max of (here, +1m, +2.5m, +4m ahead) lifts the
+      // camera onto the approaching slope before its near plane reaches it.
+      // Facing direction is a reasonable proxy for movement direction:
+      // auto-walk eases yaw toward velocity each frame, and pure-rotation
+      // browsing still wants "ahead = where you're looking" so the camera
+      // never tilts to reveal sub-terrain.
+      camera.getWorldDirection(groundClampDirScratch);
+      groundClampDirScratch.y = 0;
+      const horizLen2 =
+        groundClampDirScratch.x * groundClampDirScratch.x +
+        groundClampDirScratch.z * groundClampDirScratch.z;
+      let groundY = sampleTerrainY(camera.position.x, camera.position.z);
+      if (horizLen2 > 1e-6) {
+        const invLen = 1 / Math.sqrt(horizLen2);
+        const dirX = groundClampDirScratch.x * invLen;
+        const dirZ = groundClampDirScratch.z * invLen;
+        // 1.0 / 2.5 / 4.0 m — covers the near-plane (0.1m) plus reasonable
+        // step-ahead at WALK_SPEED 5 m/s. Tight enough to avoid the
+        // "invisible wall" feel of clamping to a distant peak.
+        const camX = camera.position.x;
+        const camZ = camera.position.z;
+        const a1 = sampleTerrainY(camX + dirX * 1.0, camZ + dirZ * 1.0);
+        if (a1 > groundY) groundY = a1;
+        const a2 = sampleTerrainY(camX + dirX * 2.5, camZ + dirZ * 2.5);
+        if (a2 > groundY) groundY = a2;
+        const a3 = sampleTerrainY(camX + dirX * 4.0, camZ + dirZ * 4.0);
+        if (a3 > groundY) groundY = a3;
+      }
       const targetY = groundY + EYE_HEIGHT;
       camera.position.y = targetY;
 


### PR DESCRIPTION
## Summary

- Cherry-picks the camera-Y clamp fix from `feat/modal-meadow-ground-clamp` (`1eedc2b5`) onto current main.
- The original branch was contaminated with 50+ unrelated files from parallel-agent WIP, so I cherry-picked only the `ModalMeadow.tsx` portion.
- Original commit was authored against the v0.6 base (no seven-mode rework, no descent-effect block). The descent-effect block from current main (v0.9) is preserved; only the camera-Y assignment was rewritten in place.

## Why now

This unblocks the showcase entry update to reflect actual deployed state. v0.9 (#284) just landed; v1.0 (#285) is sitting on a v0.6 base and needs a fresh visual-cinematic patch; v1.2 (this PR) is a small, self-contained fix that should land independently.

## Behaviour

Before: per-frame Y-clamp samples only at camera XZ — near-frustum can clip through approaching hillsides.

After: samples at camera XZ + three points ahead (1.0/2.5/4.0m) along horizontal facing direction; rides the max. Single scratch `Vector3`, no per-frame allocation.

## Test plan

- [x] Build passes (Vite SPA — see CI)
- [x] Diff is +36/-1 in `ModalMeadow.tsx` only
- [ ] Manual: walk into a steep hill at `/test/modal-meadow` — camera should ride up the slope, not clip through

🤖 Generated with [Claude Code](https://claude.com/claude-code)