### PR TITLE
chore(test-page): refresh Modal Meadow showcase to v0.9 + v1.2 reality

### DIFF
--- a/ReactComponents/ga-react-components/src/pages/TestIndex.tsx
+++ b/ReactComponents/ga-react-components/src/pages/TestIndex.tsx
@@ -180,10 +180,10 @@ const testPages: TestPageInfo[] = [
   {
     id: 'modal-meadow',
     title: 'Modal Meadow',
-    description: 'Walk through a meadow split into seven musical mode-regions (Ionian → Locrian); ambient chord progression, grass color, and wind shift as you cross between modes. v0.8 adds rolling hills, ponds, and a descent effect.',
+    description: 'Walk through a meadow split into seven musical mode-regions (Lydian → Locrian, modal-brightness order); ambient chord progression, grass color, sun, and wind shift as you cross between modes. v0.9 rewrites the synth (ADSR pad voices, spread voicings root −24/root/top +12, fake-reverb send) so the bII half-step in Phrygian reads as a 10th not a m2. v0.8 keeps the slope-driven pitch glide + FOV bump on descents. v1.2 ground-clamp samples terrain ahead so the camera rides approaching hills.',
     technology: 'Three.js + Web Audio + FPS Controls',
     path: '/test/modal-meadow',
-    features: ['First-Person', 'WASD Walker', 'Pointer Lock', 'Seven Modes', 'Auto-Walk Default', 'Hills + Ponds', 'Web Audio Pad', 'Crossfade'],
+    features: ['First-Person', 'WASD Walker', 'Pointer Lock', 'Seven Modes', 'Auto-Walk Default', 'Hills + Ponds', 'ADSR Spread Voicings', 'Fake-Reverb Send', 'Descent Pitch Glide', 'Ground Clamp'],
     status: 'complete',
   },
   {


### PR DESCRIPTION
## Summary

- Previous showcase entry stopped at v0.8 (\"Web Audio Pad / Crossfade\"). Main has since shipped **v0.9** (#284) — synth rewrite with ADSR + spread voicings + fake-reverb send.
- PR #297 adds the **v1.2** ground-clamp (\"don't clip through approaching hillsides\").
- Description and feature chips refreshed to reflect both.

## Why now

User asked: \"We progress a lot more in the version for modal meadows, no?\" — the showcase was lying. This PR closes the gap.

Modal Meadow status across the parallel branches:
- v0.9 (#284) — **merged** (5291271f)
- v1.0 (#285) — **parked**, needs cinematic port onto v0.8 base ([comment](https://github.com/GuitarAlchemist/ga/pull/285#issuecomment-4526478631))
- v1.2 (#297) — **in flight**, CI running

## Test plan

- [x] String-only change in TestIndex.tsx
- [ ] Verify rendered entry at https://demos.guitaralchemist.com/test once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)