### PR TITLE
chore(modal-meadow): bump on-screen banner v0.8 → v1.2

### DIFF
--- a/ReactComponents/ga-react-components/src/components/ModalMeadow/ModalMeadow.tsx
+++ b/ReactComponents/ga-react-components/src/components/ModalMeadow/ModalMeadow.tsx
@@ -1,7 +1,15 @@
 /**
- * Modal Meadow — interactive mode-region 3D demo (v0.8).
+ * Modal Meadow — interactive mode-region 3D demo (v1.2).
  *
- * v0.8 ships:
+ * v1.2 (PR #297): ground-clamp samples terrain at camera XZ plus three
+ * points ahead along facing direction, riding the max so the camera rides
+ * up approaching hillsides instead of clipping through them.
+ *
+ * v0.9 (PR #284, in audio.ts): synth rewrite — ADSR pad voices, spread
+ * voicings (bass −24 / root / top +12), fake-reverb send. ModalMeadow.tsx
+ * is unchanged; the public API surface of audio.ts is preserved.
+ *
+ * v0.8 shipped:
  *   1. All SEVEN diatonic modes (Lydian, Ionian, Mixolydian, Dorian, Aeolian,
  *      Phrygian, Locrian) laid out left-to-right in modal-brightness order.
  *      x = -210, -140, -70, 0, +70, +140, +210. Field half-width ±245m.

--- a/ReactComponents/ga-react-components/src/pages/ModalMeadowTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/ModalMeadowTest.tsx
@@ -1,5 +1,5 @@
 /**
- * Modal Meadow Test Page (v0.8).
+ * Modal Meadow Test Page (v1.2).
  *
  * Mounts the ModalMeadow component full-screen with two HUDs:
  *   - bottom-left: current mode name + descriptor + position along the
@@ -153,7 +153,7 @@ const ModalMeadowTest: React.FC = () => {
             letterSpacing: 1,
           }}
         >
-          MODAL MEADOW · v0.8 · 7 modes · Hills + Ponds + Descent · Brightness walk
+          MODAL MEADOW · v1.2 · 7 modes · ADSR Spread Voicings · Reverb · Hills + Ponds · Descent · Ground Clamp
         </Box>
       </Container>
     </DemoErrorBoundary>


### PR DESCRIPTION
## Summary

User report: `/test/modal-meadow` corner banner still says **v0.8** even though v0.9 (PR #284) and v1.2 (PR #297) have landed on main.

This PR updates:

- The on-screen banner string (the only thing actually visible to a visitor) from `MODAL MEADOW · v0.8 · 7 modes · Hills + Ponds + Descent · Brightness walk` to `MODAL MEADOW · v1.2 · 7 modes · ADSR Spread Voicings · Reverb · Hills + Ponds · Descent · Ground Clamp`.
- The file-header version comment in `ModalMeadow.tsx` (so a reader of the file gets accurate version info).

## Out of scope

- `modes.ts` and `terrain.ts` still say "v0.8" in their headers because their *content* hasn't changed since v0.8 — the v0.9/v1.2 work landed in `audio.ts` and `ModalMeadow.tsx`. Updating those headers would be misleading-by-rounding-up.

## Test plan

- [x] String-only change — Vite hot-reload will pick it up
- [ ] Verify after deploy that the banner reads "v1.2 · …" on https://demos.guitaralchemist.com/test/modal-meadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)