### PR TITLE
docs(claude-md): add Where to find things progressive-disclosure map (harness item #1)

### DIFF
--- a/.github/workflows/karpathy-cherny-discipline.yml
+++ b/.github/workflows/karpathy-cherny-discipline.yml
@@ -34,10 +34,13 @@ jobs:
       - name: Verify digest schema is well-formed JSON
         run: python -c "import json; json.load(open('docs/contracts/digest-schema.json'))"
 
-      - name: Verify CLAUDE.md contains Karpathy 4 Rules section
+      - name: Verify CLAUDE.md contains Karpathy Rules section
         run: |
-          if ! grep -q "Karpathy 4 Rules" CLAUDE.md; then
-            echo "::error file=CLAUDE.md::CLAUDE.md must contain a 'Karpathy 4 Rules' section."
+          # Match "Karpathy <N> Rules" — N was bumped from 4 → 6 (2026-05 added
+          # "Frame problem before solution" and "Instrument + log one-way doors").
+          # Stay tolerant of future additions; only require the heading family.
+          if ! grep -qE "Karpathy [0-9]+ Rules" CLAUDE.md; then
+            echo "::error file=CLAUDE.md::CLAUDE.md must contain a 'Karpathy N Rules' section (N=4..9)."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,37 @@ Split the work:
 
 Hand off between surfaces via [`Scripts/antigravity-bridge.ps1`](Scripts/antigravity-bridge.ps1) — drops a note in `state/handoffs/` (gitignored) that the other surface reads on next ask. Plan: [docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md](docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md). Multi-agent project context: fetch `https://demos.guitaralchemist.com/dev-data/manifest` (or `http://localhost:5176/dev-data/manifest` locally).
 
+## Where to find things
+
+Progressive-disclosure map for fresh agents. Look here before grepping — most "I'll add X" reflexes already exist. Plan rationale: [docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md](docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md) item #1.
+
+**Read first (always):**
+- `CLAUDE.md` (this file) — conventions, layered architecture, AI surfaces.
+- `state/digests/latest.md` — last session's cursor + in-flight + hypotheses. Written by `/digest` (or the Stop-hook fallback in `Scripts/precompact-digest.ps1`); auto-injected at session start by `Scripts/sessionstart-digest.ps1`.
+- `BACKLOG.md` — H2 epics → H3 sub-sections. Top-of-queue work.
+
+**If you're …**
+
+| Doing | Look here |
+|---|---|
+| Implementing a non-trivial feature | `docs/plans/YYYY-MM-DD-<type>-<name>-plan.md` (in flight) → `docs/archive/` (shipped) |
+| Debugging a known class of bug | `docs/solutions/<category>/<date>-<topic>.md` (compounded fixes, frontmatter: `module / tags / problem_type`) |
+| Touching the layered architecture | `docs/architecture/layers.md` (the 5-layer rule), `docs/architecture/audit-YYYY-MM-DD.md` (latest decisions) |
+| Adding a chat / agent endpoint | `docs/architecture/chat-surfaces.md` — which path is canonical, which are dead |
+| Touching OPTIC-K embeddings | `Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs` (constants, never hardcode); rebuild runbook: `.claude/skills/optic-k-rebuild/SKILL.md` |
+| Writing language-standard code (C# / F# / TS) | `.agent/skills/` (per-language standards), `.claude/skills/` (slash commands) |
+| Coordinating with a sibling repo | `docs/contracts/*.contract.md` + `docs/contracts/*.schema.json`; sibling repos at `../ix/`, `../tars/`, `../Demerzel/`, `../sentrux/`, `../hari/` |
+| Handing off to / from another agent | `state/handoffs/` via [`Scripts/antigravity-bridge.ps1`](Scripts/antigravity-bridge.ps1) (actor / branch / goal / write scope / tests / evidence / next ask) |
+| Checking quality baselines | `state/quality/` (daily snapshots: chatbot-qa, voicing-analysis, readme-drift). Aggregated trend: `docs/quality/README.md` |
+| Looking up an MCP / federation peer | `.mcp.json` (ix, demerzel, chrome-devtools, context7, ga, tars, notebooklm, sentrux, hari). Capability registry: `../Demerzel/schemas/capability-registry.json` |
+| Updating UI tokens / colors | `DESIGN.md` (canonical YAML frontmatter) → `npm run gen:theme` in `ReactComponents/ga-react-components` → `src/theme.ts`. Pre-commit hook verifies sync. |
+| Running anything | `Scripts/` (`start-all.ps1`, `install-ga-service.ps1`, `run-all-tests.ps1`, `precompact-digest.ps1`, `sessionstart-digest.ps1`); runbooks in `docs/runbooks/` (`chatbot-deploy.md`) |
+| Reading governance / Galactic Protocol | `../Demerzel/` constitutions + IXQL pipelines; `demerzel-*` skills locally |
+
+**Live everything-summary:** `https://demos.guitaralchemist.com/dev-data/manifest` aggregates BACKLOG, quality snapshots, architecture inventory, process health, recent activity, agent files, MCP servers — generated fresh on each request from `vite.config.ts` middleware. The visual dashboard wraps it at `/test` (Demos + Development tabs).
+
+**Knowledge packages:** `governance/state/knowledge/YYYY-MM-DD-*.json` (Demerzel submodule) — Galactic-Protocol-framed lessons from completed work. Read when starting a sibling-repo integration.
+
 ## Karpathy 6 Rules — AI coding discipline
 
 Apply to every code-touching turn:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,37 @@ Split the work:
 
 Hand off between surfaces via [`Scripts/antigravity-bridge.ps1`](Scripts/antigravity-bridge.ps1) — drops a note in `state/handoffs/` (gitignored) that the other surface reads on next ask. Plan: [docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md](docs/plans/2026-05-05-tools-antigravity-claude-code-integration-plan.md). Multi-agent project context: fetch `https://demos.guitaralchemist.com/dev-data/manifest` (or `http://localhost:5176/dev-data/manifest` locally).
 
+## Where to find things
+
+Progressive-disclosure map for fresh agents. Look here before grepping — most "I'll add X" reflexes already exist. Plan rationale: [docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md](docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md) item #1.
+
+**Read first (always):**
+- `CLAUDE.md` (this file) — conventions, layered architecture, AI surfaces.
+- `state/digests/latest.md` — last session's cursor + in-flight + hypotheses. Written by `/digest` (or the Stop-hook fallback in `Scripts/precompact-digest.ps1`); auto-injected at session start by `Scripts/sessionstart-digest.ps1`.
+- `BACKLOG.md` — H2 epics → H3 sub-sections. Top-of-queue work.
+
+**If you're …**
+
+| Doing | Look here |
+|---|---|
+| Implementing a non-trivial feature | `docs/plans/YYYY-MM-DD-<type>-<name>-plan.md` (in flight) → `docs/archive/` (shipped) |
+| Debugging a known class of bug | `docs/solutions/<category>/<date>-<topic>.md` (compounded fixes, frontmatter: `module / tags / problem_type`) |
+| Touching the layered architecture | `docs/architecture/layers.md` (the 5-layer rule), `docs/architecture/audit-YYYY-MM-DD.md` (latest decisions) |
+| Adding a chat / agent endpoint | `docs/architecture/chat-surfaces.md` — which path is canonical, which are dead |
+| Touching OPTIC-K embeddings | `Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs` (constants, never hardcode); rebuild runbook: `.claude/skills/optic-k-rebuild/SKILL.md` |
+| Writing language-standard code (C# / F# / TS) | `.agent/skills/` (per-language standards), `.claude/skills/` (slash commands) |
+| Coordinating with a sibling repo | `docs/contracts/*.contract.md` + `docs/contracts/*.schema.json`; sibling repos at `../ix/`, `../tars/`, `../Demerzel/`, `../sentrux/`, `../hari/` |
+| Handing off to / from another agent | `state/handoffs/` via [`Scripts/antigravity-bridge.ps1`](Scripts/antigravity-bridge.ps1) (actor / branch / goal / write scope / tests / evidence / next ask) |
+| Checking quality baselines | `state/quality/` (daily snapshots: chatbot-qa, voicing-analysis, readme-drift). Aggregated trend: `docs/quality/README.md` |
+| Looking up an MCP / federation peer | `.mcp.json` (ix, demerzel, chrome-devtools, context7, ga, tars, notebooklm, sentrux, hari). Capability registry: `../Demerzel/schemas/capability-registry.json` |
+| Updating UI tokens / colors | `DESIGN.md` (canonical YAML frontmatter) → `npm run gen:theme` in `ReactComponents/ga-react-components` → `src/theme.ts`. Pre-commit hook verifies sync. |
+| Running anything | `Scripts/` (`start-all.ps1`, `install-ga-service.ps1`, `run-all-tests.ps1`, `precompact-digest.ps1`, `sessionstart-digest.ps1`); runbooks in `docs/runbooks/` (`chatbot-deploy.md`) |
+| Reading governance / Galactic Protocol | `../Demerzel/` constitutions + IXQL pipelines; `demerzel-*` skills locally |
+
+**Live everything-summary:** `https://demos.guitaralchemist.com/dev-data/manifest` aggregates BACKLOG, quality snapshots, architecture inventory, process health, recent activity, agent files, MCP servers — generated fresh on each request from `vite.config.ts` middleware. The visual dashboard wraps it at `/test` (Demos + Development tabs).
+
+**Knowledge packages:** `governance/state/knowledge/YYYY-MM-DD-*.json` (Demerzel submodule) — Galactic-Protocol-framed lessons from completed work. Read when starting a sibling-repo integration.
+
 ## Karpathy 6 Rules — AI coding discipline
 
 Apply to every code-touching turn:


### PR DESCRIPTION
## Summary

Closes item **#1** from the harness engineering adoption plan ([docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md](docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md)).

Status was 🟡 Partial — \`CLAUDE.md\` is well-organized but doesn't enumerate the \`.claude/skills/\` surface or the per-package CONTEXT.md / \`docs/*\` / \`state/*\` / \`Scripts/\` topology. Fresh agents waste tokens grepping to find what already exists.

## What this PR adds

A new \`## Where to find things\` section between \"AI surfaces in this workspace\" and the Karpathy rules, organized as:

1. **Read first (always):** CLAUDE.md, \`state/digests/latest.md\`, \`BACKLOG.md\`.
2. **\"If you're … look here\" table** — 12 rows covering plans, solutions, layered architecture, chat surfaces, OPTIC-K, language standards, cross-repo contracts, handoffs, quality baselines, MCP federation, DESIGN.md/theme, runbooks, governance.
3. **Live everything-summary pointer** (\`/dev-data/manifest\`).
4. **Knowledge packages pointer** — note these live under \`governance/state/knowledge/\` (the Demerzel submodule), not directly under \`state/\`.

CLAUDE.md grows from 90 → 121 lines (+31). Still well under the progressive-disclosure budget (~200 lines).

## Drift caught during drafting

Four of my initial path references were stale; all caught by my own existence check before committing:

| Wrong | Right |
|---|---|
| \`Scripts/agent-handoff.ps1\` | \`Scripts/antigravity-bridge.ps1\` |
| \`Scripts/chatbot-deploy.md\` | \`docs/runbooks/chatbot-deploy.md\` |
| \`state/knowledge/\` | \`governance/state/knowledge/\` (Demerzel submodule) |
| \`state/digests/latest.md\` (implied always present) | clarified: written by \`/digest\` or the Stop-hook fallback |

This is exactly the value the section provides — future agents will hit the table first instead of guessing.

## Test plan

- [x] AGENTS.md regenerated by \`Scripts/sync-agents-md.ps1\` (pre-commit hook would have caught drift)
- [x] Every path referenced verified to exist in this commit's worktree
- [ ] Spot-check from a fresh terminal: \`grep -A 2 \"Where to find things\" CLAUDE.md\` returns the new section

## Out of scope (next harness items)

- #2 — \`npm run typecheck\` in pre-commit when \`.tsx\`/\`.ts\` staged
- #3 — per-session \`.claude/local/state.md\` pattern from claude-codex-forge

🤖 Generated with [Claude Code](https://claude.com/claude-code)