### PR TITLE
chore(pre-commit): add warning-only frontend typecheck (harness item #2)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -89,6 +89,46 @@ if ($ropViolations.Count -gt 0) {
 }
 
 # ============================================
+# FRONTEND TYPECHECK (warning-only, harness plan item #2)
+# ============================================
+# Reports TypeScript errors when any .tsx/.ts file under
+# ReactComponents/ga-react-components/ is staged. Currently warning-only:
+# baseline at the time this hook was added carried ~185 pre-existing errors
+# (BSPDoomExplorer, ForceRadiant, StringedInstrumentFretboard, etc.), so
+# making this fatal would gate every commit. Promote to fatal once the
+# baseline reaches zero — see docs/plans/2026-05-23-arch-harness-engineering-
+# adoption-plan.md item #2.
+$stagedTsFiles = git diff --cached --name-only 2>/dev/null |
+    Where-Object { $_ -match "^ReactComponents/ga-react-components/.*\.(ts|tsx)$" }
+if ($stagedTsFiles.Count -gt 0) {
+    Write-Host "`n▶ Running frontend typecheck (warning-only)..." -ForegroundColor Blue
+    Push-Location ReactComponents/ga-react-components
+    try {
+        $typecheckOutput = npm run --silent typecheck 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "✓ Frontend typecheck clean" -ForegroundColor Green
+        } else {
+            $errorLines = $typecheckOutput | Select-String -Pattern 'error TS'
+            $errorCount = $errorLines.Count
+            $topOffenders = $errorLines |
+                ForEach-Object { ($_.Line -split '\(')[0] } |
+                Group-Object | Sort-Object Count -Descending |
+                Select-Object -First 3 |
+                ForEach-Object { "$($_.Name) ($($_.Count))" }
+            $topStr = $topOffenders -join ', '
+            Write-Host "⚠ Frontend typecheck reports $errorCount type errors (baseline ~185 — see plan item #2)" -ForegroundColor Yellow
+            Write-Host "  Top offenders: $topStr" -ForegroundColor Yellow
+            Write-Host "  Run: cd ReactComponents/ga-react-components; npm run typecheck" -ForegroundColor Yellow
+            # Warning only — does not block the commit
+        }
+    } finally {
+        Pop-Location
+    }
+} else {
+    # No frontend files staged; skip silently to keep hook fast on backend commits.
+}
+
+# ============================================
 # SYNC AGENTS.md FROM CLAUDE.md
 # ============================================
 Write-Host "`n▶ Syncing AGENTS.md from CLAUDE.md..." -ForegroundColor Blue

--- a/ReactComponents/ga-react-components/package.json
+++ b/ReactComponents/ga-react-components/package.json
@@ -12,6 +12,7 @@
     "build": "vite build",
     "build:demos": "vite build --config vite.config.demos.ts",
     "build:with-types": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:api": "node ./node_modules/nswag/bin/nswag.js run nswag.json",

--- a/ReactComponents/ga-react-components/tsconfig.node.json
+++ b/ReactComponents/ga-react-components/tsconfig.node.json
@@ -12,6 +12,10 @@
     "moduleDetection": "force",
     "noEmit": true,
 
+    /* Node globals needed by vite.config.ts (process, Buffer, __dirname,
+       URL, IncomingMessage). @types/node is already in devDependencies. */
+    "types": ["node"],
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary

Implements **item #2** from [docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md](docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md). Goal: surface TypeScript regressions before commit so the class-of-bug that produced the 25-min Vite outage (PR #289) gets caught earlier.

## What this PR adds

1. **`typecheck` npm script** in \`ReactComponents/ga-react-components\` — exposes \`tsc -b\` standalone (previously only via \`build:with-types\` which bundles a Vite build).

2. **\`tsconfig.node.json\` fix** — \`vite.config.ts\` uses Node globals (\`process\`, \`Buffer\`, \`__dirname\`, \`URL\`, \`IncomingMessage\`) but the tsconfig was missing \`\"types\": [\"node\"]\`. With this fix, \`vite.config.ts\` drops from 21 errors → 6 (only unused-import warnings remain).

3. **\`.githooks/pre-commit\` section** — when any \`.ts(x)\` file under \`ReactComponents/ga-react-components/\` is staged, runs \`npm run typecheck\` and reports counts + top offending files. **Warning-only** (matches ROP-naked-throws pattern).

## Why warning-only

Baseline at this commit: **~185 pre-existing type errors** concentrated in:

| File | Count |
|---|---|
| \`src/components/BSP/BSPDoomExplorer.tsx\` | 45 |
| \`src/components/PrimeRadiant/ForceRadiant.tsx\` | 19 |
| \`src/components/StringedInstrumentFretboard.tsx\` | 12 |
| \`src/components/PrimeRadiant/shaders/PlanetSurfaceTSL.ts\` | 8 |
| \`src/components/PrimeRadiant/QAPanel.tsx\` | 7 |
| \`src/components/DSL/FretboardNavigationDSLDemo.tsx\` | 7 |
| …and ~30 other files | |

Promoting this check to fatal today would gate every commit. **Phase 2** of this plan item: drive the baseline to zero, then flip the warning to a fail-on-non-zero gate. Until then this PR closes the \"no signal\" part of the harness gap without blocking momentum.

## Testing

- [x] Pre-commit hook parses cleanly via \`[scriptblock]::Create\`
- [x] \`npm run typecheck\` exists and runs \`tsc -b\`
- [x] \`tsc -b\` in \`vite.config.ts\` now resolves Node globals — TS2591 (\`process\`, \`Buffer\`) and TS2304 (\`__dirname\`) gone
- [ ] Live test: stage a \`.tsx\` file and verify hook warns (will happen on the next frontend commit)

## Out of scope

- Fixing the 185 baseline errors (Phase 2 work — separate cleanup PRs)
- Promoting to fatal (Phase 2 once baseline is zero)
- Backend type-check parity (\`dotnet build\` already gates this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)