### PR TITLE
ci(karpathy-discipline): accept Karpathy N Rules (N>=4) heading

### DIFF
--- a/.github/workflows/karpathy-cherny-discipline.yml
+++ b/.github/workflows/karpathy-cherny-discipline.yml
@@ -34,10 +34,13 @@ jobs:
       - name: Verify digest schema is well-formed JSON
         run: python -c "import json; json.load(open('docs/contracts/digest-schema.json'))"
 
-      - name: Verify CLAUDE.md contains Karpathy 4 Rules section
+      - name: Verify CLAUDE.md contains Karpathy Rules section
         run: |
-          if ! grep -q "Karpathy 4 Rules" CLAUDE.md; then
-            echo "::error file=CLAUDE.md::CLAUDE.md must contain a 'Karpathy 4 Rules' section."
+          # Match "Karpathy <N> Rules" — N was bumped from 4 → 6 (2026-05 added
+          # "Frame problem before solution" and "Instrument + log one-way doors").
+          # Stay tolerant of future additions; only require the heading family.
+          if ! grep -qE "Karpathy [0-9]+ Rules" CLAUDE.md; then
+            echo "::error file=CLAUDE.md::CLAUDE.md must contain a 'Karpathy N Rules' section (N=4..9)."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

6-line workflow tweak. The validator greps for the **literal** string \"Karpathy 4 Rules\" but \`CLAUDE.md\` has said **\"Karpathy 6 Rules\"** since rules 5 and 6 (\"Frame problem before solution\", \"Instrument + log one-way doors\") were added some weeks ago. Every PR that touches \`CLAUDE.md\` now fails this validator.

Relaxes the grep to a regex (\`Karpathy [0-9]+ Rules\`) so the heading family stays validated but future rule additions don't need a lockstep workflow update.

## Why split from PR #300

Agent Blackbox flagged PR #300 (which bundled this workflow tweak with the CLAUDE.md \"Where to find things\" addition) as a **critical** \`policy.blocked_path\` violation — workflow files are on the autonomous-blocked-paths list. Correct safety signal.

Splitting so the human-review override is a 6-line scan, not bundled with 70 lines of doc content.

## Why now

Blocks PR #300 (harness item #1) — that PR can't merge until this regex relaxation lands first.

## To merge

Needs the \`agent-blackbox-reviewed\` label (or admin merge by a human). After merge, PR #300's \`validate\` check will pass on the next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)