### PR TITLE
feat(test-page): add Harness sub-tab to Development section

### DIFF
--- a/ReactComponents/ga-react-components/src/pages/DevelopmentSection.tsx
+++ b/ReactComponents/ga-react-components/src/pages/DevelopmentSection.tsx
@@ -43,6 +43,9 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import InventoryIcon from '@mui/icons-material/Inventory';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import LayersIcon from '@mui/icons-material/Layers';
+import ConstructionIcon from '@mui/icons-material/Construction';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 
 interface DevLink {
   title: string;
@@ -972,8 +975,332 @@ const LayerMapCard: React.FC = () => {
   );
 };
 
-type DevSubTab = 'summary' | 'architecture' | 'product' | 'project' | 'qa';
-const DEV_SUB_TABS: DevSubTab[] = ['summary', 'architecture', 'product', 'project', 'qa'];
+// Harness engineering adoption progress — surfaces the 8 prioritized items
+// from docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md.
+// Source of truth: state/harness/items.json (edit manually when an item ships).
+// Served via /dev-data/harness by vite.config.ts → devDataPlugin.
+
+type HarnessStatus = 'shipped' | 'in_flight' | 'todo';
+
+interface HarnessItem {
+  number: number;
+  title: string;
+  category: string;
+  effort: 'S' | 'M' | 'L';
+  impact: 'M' | 'H';
+  status: HarnessStatus;
+  pr_number: number | null;
+  pr_state: string | null;
+  evidence_url: string | null;
+  owner: string;
+  notes?: string;
+}
+
+interface HarnessRelatedPr {
+  number: number;
+  title: string;
+  state: string;
+  evidence_url: string;
+  note?: string;
+}
+
+interface HarnessPrinciple {
+  name: string;
+  techniques: string[];
+}
+
+interface HarnessBaseline {
+  value: number | string;
+  target?: number | string;
+  as_of?: string;
+  source?: string;
+  urls?: string[];
+  note?: string;
+}
+
+interface HarnessPayload {
+  generated_at: string;
+  schema_version?: string;
+  last_updated?: string;
+  items: HarnessItem[];
+  related_prs?: HarnessRelatedPr[];
+  principles?: HarnessPrinciple[];
+  baselines?: Record<string, HarnessBaseline>;
+}
+
+const statusMeta = (s: HarnessStatus): { label: string; color: 'success' | 'warning' | 'default'; icon: React.ReactNode } => {
+  switch (s) {
+    case 'shipped':
+      return { label: 'shipped', color: 'success', icon: <CheckCircleIcon sx={{ fontSize: 16 }} /> };
+    case 'in_flight':
+      return { label: 'in flight', color: 'warning', icon: <HourglassEmptyIcon sx={{ fontSize: 16 }} /> };
+    case 'todo':
+    default:
+      return { label: 'todo', color: 'default', icon: <RadioButtonUncheckedIcon sx={{ fontSize: 16 }} /> };
+  }
+};
+
+const HarnessCard: React.FC = () => {
+  const [data, setData] = useState<HarnessPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/dev-data/harness')
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<HarnessPayload>;
+      })
+      .then((p) => { if (!cancelled) setData(p); })
+      .catch((e) => { if (!cancelled) setError(String(e.message ?? e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const counts = React.useMemo(() => {
+    if (!data) return { shipped: 0, in_flight: 0, todo: 0, total: 0 };
+    const c = { shipped: 0, in_flight: 0, todo: 0, total: data.items.length };
+    for (const it of data.items) c[it.status] += 1;
+    return c;
+  }, [data]);
+
+  return (
+    <Stack spacing={2}>
+      <Paper sx={{ p: 2 }}>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+          <ConstructionIcon fontSize="small" sx={{ color: 'primary.main' }} />
+          <Typography variant="h6">Harness engineering adoption</Typography>
+          {data && (
+            <>
+              <Chip label={`${counts.shipped} shipped`} size="small" color="success" sx={{ fontSize: '0.7rem' }} />
+              <Chip label={`${counts.in_flight} in flight`} size="small" color="warning" sx={{ fontSize: '0.7rem' }} />
+              <Chip label={`${counts.todo} todo`} size="small" sx={{ fontSize: '0.7rem' }} />
+              <Box sx={{ flex: 1 }} />
+              <Typography variant="caption" color="text.secondary">
+                {counts.shipped}/{counts.total} done
+              </Typography>
+            </>
+          )}
+        </Stack>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Industry-canonical agent-harness techniques (Anthropic, OpenAI, LangChain, Fowler,
+          claude-codex-forge) graded against GA's multi-agent stack. Pick items by hand; each is
+          independent. Full plan:{' '}
+          <MuiLink
+            href="https://github.com/GuitarAlchemist/ga/blob/main/docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.3 }}
+          >
+            2026-05-23-arch-harness-engineering-adoption-plan.md <OpenInNewIcon fontSize="inherit" />
+          </MuiLink>
+          .
+        </Typography>
+        {data?.last_updated && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+            items.json last updated {data.last_updated} · schema v{data.schema_version ?? '?'}
+          </Typography>
+        )}
+        {error && <Alert severity="error" sx={{ mt: 1 }}>Failed to load /dev-data/harness: {error}</Alert>}
+        {!data && !error && <CircularProgress size={20} sx={{ mt: 1 }} />}
+      </Paper>
+
+      {data && (
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>Prioritized rollout</Typography>
+          <Box sx={{ overflow: 'auto' }}>
+            <Box component="table" sx={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+              <Box
+                component="thead"
+                sx={{ '& th': { textAlign: 'left', py: 0.75, color: 'text.secondary', fontWeight: 600, fontSize: '0.75rem', borderBottom: '1px solid', borderColor: 'divider' } }}
+              >
+                <tr>
+                  <th style={{ width: 32 }}>#</th>
+                  <th>Item</th>
+                  <th style={{ textAlign: 'center', width: 60 }}>Effort</th>
+                  <th style={{ textAlign: 'center', width: 60 }}>Impact</th>
+                  <th style={{ textAlign: 'center', width: 110 }}>Status</th>
+                  <th style={{ textAlign: 'center', width: 70 }}>PR</th>
+                  <th style={{ width: 130 }}>Owner</th>
+                </tr>
+              </Box>
+              <Box component="tbody" sx={{ '& td': { py: 1, borderBottom: '1px solid', borderColor: 'divider', verticalAlign: 'top' } }}>
+                {data.items.map((item) => {
+                  const meta = statusMeta(item.status);
+                  return (
+                    <tr key={item.number}>
+                      <td style={{ fontFamily: 'monospace', fontWeight: 600 }}>{item.number}</td>
+                      <td>
+                        <Typography variant="body2" sx={{ fontWeight: 500 }}>{item.title}</Typography>
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                          {item.category}
+                        </Typography>
+                        {item.notes && (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25, fontStyle: 'italic' }}>
+                            {item.notes}
+                          </Typography>
+                        )}
+                      </td>
+                      <td style={{ textAlign: 'center' }}>
+                        <Chip label={item.effort} size="small" variant="outlined" sx={{ fontSize: '0.7rem', height: 20, minWidth: 28 }} />
+                      </td>
+                      <td style={{ textAlign: 'center' }}>
+                        <Chip
+                          label={item.impact}
+                          size="small"
+                          color={item.impact === 'H' ? 'primary' : 'default'}
+                          sx={{ fontSize: '0.7rem', height: 20, minWidth: 28 }}
+                        />
+                      </td>
+                      <td style={{ textAlign: 'center' }}>
+                        <Chip
+                          icon={meta.icon as React.ReactElement}
+                          label={meta.label}
+                          size="small"
+                          color={meta.color}
+                          sx={{ fontSize: '0.7rem', height: 22 }}
+                        />
+                        {item.pr_state && item.pr_state !== 'merged' && (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem', mt: 0.25 }}>
+                            {item.pr_state}
+                          </Typography>
+                        )}
+                      </td>
+                      <td style={{ textAlign: 'center' }}>
+                        {item.pr_number ? (
+                          <MuiLink
+                            href={item.evidence_url ?? `https://github.com/GuitarAlchemist/ga/pull/${item.pr_number}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}
+                          >
+                            #{item.pr_number}
+                          </MuiLink>
+                        ) : (
+                          <Typography variant="caption" color="text.disabled">—</Typography>
+                        )}
+                      </td>
+                      <td>
+                        <Typography variant="caption" color="text.secondary">{item.owner}</Typography>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </Box>
+            </Box>
+          </Box>
+        </Paper>
+      )}
+
+      {data?.baselines && (
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>Baseline metrics</Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+            Concrete numbers from the plan. v1 is statically authored in <Box component="code" sx={{ px: 0.5, bgcolor: 'action.hover', borderRadius: 0.5, fontSize: '0.8rem' }}>state/harness/items.json</Box>; PR 2 will wire live measurements.
+          </Typography>
+          <Grid container spacing={1.5}>
+            {Object.entries(data.baselines).map(([key, b]) => {
+              const numericValue = typeof b.value === 'number' ? b.value : null;
+              const numericTarget = typeof b.target === 'number' ? b.target : null;
+              const onTrack =
+                numericValue != null && numericTarget != null
+                  ? key === 'frontend_typecheck_errors'
+                    ? numericValue <= numericTarget
+                    : numericValue >= numericTarget
+                  : null;
+              return (
+                <Grid item xs={12} sm={6} md={4} key={key}>
+                  <Box sx={{ p: 1.5, bgcolor: 'action.hover', borderRadius: 1, height: '100%', borderLeft: 3, borderColor: onTrack ? 'success.main' : onTrack === false ? 'warning.main' : 'divider' }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontFamily: 'monospace' }}>
+                      {key}
+                    </Typography>
+                    <Stack direction="row" spacing={1} alignItems="baseline" sx={{ mt: 0.5 }}>
+                      <Typography variant="h6" sx={{ fontWeight: 600 }}>{String(b.value)}</Typography>
+                      {b.target !== undefined && (
+                        <Typography variant="caption" color="text.secondary">
+                          / target: {String(b.target)}
+                        </Typography>
+                      )}
+                    </Stack>
+                    {b.note && (
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                        {b.note}
+                      </Typography>
+                    )}
+                    {b.urls && b.urls.length > 0 && (
+                      <Typography variant="caption" sx={{ display: 'block', mt: 0.5, fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                        {b.urls.join(' · ')}
+                      </Typography>
+                    )}
+                    {b.as_of && (
+                      <Typography variant="caption" color="text.disabled" sx={{ display: 'block', mt: 0.25, fontSize: '0.65rem' }}>
+                        as of {b.as_of}
+                      </Typography>
+                    )}
+                  </Box>
+                </Grid>
+              );
+            })}
+          </Grid>
+        </Paper>
+      )}
+
+      {data?.principles && data.principles.length > 0 && (
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>Principles refresher</Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+            The 4 rule families from the plan. Educates without forcing a full read of the 174-line source document.
+          </Typography>
+          <Grid container spacing={1.5}>
+            {data.principles.map((p) => (
+              <Grid item xs={12} sm={6} key={p.name}>
+                <Box sx={{ p: 1.5, bgcolor: 'action.hover', borderRadius: 1, height: '100%', borderLeft: 3, borderColor: 'primary.main' }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>{p.name}</Typography>
+                  <Box component="ul" sx={{ pl: 2.5, m: 0, '& li': { mb: 0.5 } }}>
+                    {p.techniques.map((t, i) => (
+                      <li key={i}>
+                        <Typography variant="caption" color="text.secondary">{t}</Typography>
+                      </li>
+                    ))}
+                  </Box>
+                </Box>
+              </Grid>
+            ))}
+          </Grid>
+        </Paper>
+      )}
+
+      {data?.related_prs && data.related_prs.length > 0 && (
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>Related PRs</Typography>
+          <Stack spacing={1}>
+            {data.related_prs.map((pr) => (
+              <Stack key={pr.number} direction="row" spacing={1} alignItems="center" sx={{ py: 0.5 }}>
+                <MuiLink
+                  href={pr.evidence_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{ fontFamily: 'monospace', fontSize: '0.8rem', flexShrink: 0 }}
+                >
+                  #{pr.number}
+                </MuiLink>
+                <Typography variant="body2" sx={{ flex: 1 }}>{pr.title}</Typography>
+                <Chip
+                  label={pr.state}
+                  size="small"
+                  color={pr.state === 'merged' ? 'success' : pr.state.includes('blocked') ? 'warning' : 'default'}
+                  sx={{ fontSize: '0.7rem', height: 20 }}
+                />
+              </Stack>
+            ))}
+          </Stack>
+        </Paper>
+      )}
+    </Stack>
+  );
+};
+
+type DevSubTab = 'summary' | 'architecture' | 'product' | 'project' | 'qa' | 'harness';
+const DEV_SUB_TABS: DevSubTab[] = ['summary', 'architecture', 'product', 'project', 'qa', 'harness'];
 
 const readSubTabFromHash = (): DevSubTab => {
   if (typeof window === 'undefined') return 'summary';
@@ -1025,6 +1352,7 @@ export const DevelopmentSection: React.FC = () => {
           <Tab value="product"      label="Product"      icon={<InventoryIcon fontSize="small" />}   iconPosition="start" sx={{ minHeight: 44 }} />
           <Tab value="project"      label="Project"      icon={<GroupsIcon fontSize="small" />}      iconPosition="start" sx={{ minHeight: 44 }} />
           <Tab value="qa"           label="QA"           icon={<VerifiedIcon fontSize="small" />}    iconPosition="start" sx={{ minHeight: 44 }} />
+          <Tab value="harness"      label="Harness"      icon={<ConstructionIcon fontSize="small" />} iconPosition="start" sx={{ minHeight: 44 }} />
         </Tabs>
       </Box>
 
@@ -1073,6 +1401,12 @@ export const DevelopmentSection: React.FC = () => {
         <Stack spacing={2}>
           <QualityCard />
           <ProcessHealthCard />
+        </Stack>
+      )}
+
+      {subTab === 'harness' && (
+        <Stack spacing={2}>
+          <HarnessCard />
         </Stack>
       )}
     </Stack>

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -376,6 +376,20 @@ function devDataPlugin(): Plugin {
         return parseBacklog(readFileSync(p, 'utf-8'));
     }
 
+    // Harness engineering adoption progress, sourced from state/harness/items.json.
+    // Manually authored — edit that file when an item ships or a PR opens.
+    // Schema documented inline in items.json. Returns null if the file is missing
+    // so the dashboard renders an empty-state hint instead of throwing.
+    function gatherHarness(): unknown | null {
+        const p = path.join(repoRoot, 'state/harness/items.json');
+        if (!existsSync(p)) return null;
+        try {
+            return JSON.parse(readFileSync(p, 'utf-8'));
+        } catch {
+            return null;
+        }
+    }
+
     interface AgentFileEntry {
         path: string;
         exists: boolean;
@@ -503,6 +517,18 @@ function devDataPlugin(): Plugin {
                 res.end(JSON.stringify(gatherAgentActivity()));
             });
 
+            server.middlewares.use('/dev-data/harness', (req, res, next) => {
+                if (req.method !== 'GET') { next(); return; }
+                const payload = gatherHarness();
+                if (payload == null) {
+                    res.writeHead(404, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'state/harness/items.json not found' }));
+                    return;
+                }
+                res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+                res.end(JSON.stringify({ generated_at: new Date().toISOString(), ...(payload as Record<string, unknown>) }));
+            });
+
             server.middlewares.use('/dev-data/manifest', (req, res, next) => {
                 if (req.method !== 'GET') { next(); return; }
                 const manifest = {
@@ -517,6 +543,7 @@ function devDataPlugin(): Plugin {
                         architecture: '/dev-data/architecture',
                         agents: '/dev-data/agents',
                         agent_activity: '/dev-data/agent-activity',
+                        harness: '/dev-data/harness',
                         manifest: '/dev-data/manifest',
                     },
                     services: serviceTopology,
@@ -528,6 +555,7 @@ function devDataPlugin(): Plugin {
                     agent_files: gatherAgentFiles(),
                     mcp_servers: gatherMcpServers(),
                     agent_activity: gatherAgentActivity(),
+                    harness: gatherHarness(),
                 };
                 res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
                 res.end(JSON.stringify(manifest, null, 2));

--- a/state/harness/items.json
+++ b/state/harness/items.json
@@ -1,0 +1,191 @@
+{
+  "_comment": "Source of truth for the 8 prioritized items in the harness engineering adoption plan. Edit this file manually when an item ships (or a PR opens). The /test#dev/harness tab reads /dev-data/harness which is served from this file.",
+  "_plan": "docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-05-23",
+  "items": [
+    {
+      "number": 1,
+      "title": "\"Where to find things\" map in CLAUDE.md",
+      "category": "Context & memory",
+      "effort": "S",
+      "impact": "M",
+      "status": "in_flight",
+      "pr_number": 300,
+      "pr_state": "blocked-on-agent-blackbox",
+      "evidence_url": "https://github.com/GuitarAlchemist/ga/pull/300",
+      "owner": "next session",
+      "notes": "PR open; currently blocked on Agent Blackbox policy review."
+    },
+    {
+      "number": 2,
+      "title": "Add `npm run typecheck` to pre-commit hook (warning-only)",
+      "category": "Verification & feedback loops",
+      "effort": "S",
+      "impact": "M",
+      "status": "in_flight",
+      "pr_number": 301,
+      "pr_state": "ci-running",
+      "evidence_url": "https://github.com/GuitarAlchemist/ga/pull/301",
+      "owner": "next session",
+      "notes": "Warning-only mode so the ~185 existing errors do not break commits while the baseline is paid down."
+    },
+    {
+      "number": 3,
+      "title": "Per-session `.claude/local/state.md`",
+      "category": "Context & memory",
+      "effort": "S",
+      "impact": "M",
+      "status": "todo",
+      "pr_number": null,
+      "pr_state": null,
+      "evidence_url": null,
+      "owner": "next session",
+      "notes": "Adopt the forge's `.claude/local/state.md` pattern for cross-session same-agent continuity."
+    },
+    {
+      "number": 4,
+      "title": "Post-merge smoke (curl + screenshot the 3 demo URLs) via GitHub Action",
+      "category": "Verification & feedback loops",
+      "effort": "M",
+      "impact": "H",
+      "status": "todo",
+      "pr_number": null,
+      "pr_state": null,
+      "evidence_url": null,
+      "owner": "week of",
+      "notes": "Closes the 25-min-outage class. Curls /test, /api/chatbot/status, /dev-data/manifest after each push to main."
+    },
+    {
+      "number": 5,
+      "title": "`/grade-last-pr` skill: re-run octo:review against the merged diff",
+      "category": "Verification & feedback loops",
+      "effort": "M",
+      "impact": "M",
+      "status": "todo",
+      "pr_number": null,
+      "pr_state": null,
+      "evidence_url": null,
+      "owner": "week of",
+      "notes": "Closes the intent-vs-delivery loop. Writes score to state/quality/pr-grades/<sha>.json."
+    },
+    {
+      "number": 6,
+      "title": "Adopt `/council` from claude-codex-forge for one-way-door PRs",
+      "category": "Architecture-aligned techniques",
+      "effort": "M",
+      "impact": "M",
+      "status": "todo",
+      "pr_number": null,
+      "pr_state": null,
+      "evidence_url": null,
+      "owner": "sprint of",
+      "notes": "Opt-in pre-merge gate for schema changes, public API surfaces, OPTIC-K dims, pricing — the one-way doors already enumerated in CLAUDE.md."
+    },
+    {
+      "number": 7,
+      "title": "Playwright E2E job on demos dashboard + chatbot showcase",
+      "category": "Workflow & environment security",
+      "effort": "M",
+      "impact": "H",
+      "status": "todo",
+      "pr_number": null,
+      "pr_state": null,
+      "evidence_url": null,
+      "owner": "sprint of",
+      "notes": "Outside-in browser verification. Asserts heartbeat banner color, manifest schema_version, and chatbot showcase response time < 5s."
+    },
+    {
+      "number": 8,
+      "title": "Run Vite + GaApi as a non-admin Windows service",
+      "category": "Workflow & environment security",
+      "effort": "L",
+      "impact": "H",
+      "status": "todo",
+      "pr_number": null,
+      "pr_state": null,
+      "evidence_url": null,
+      "owner": "when the same outage recurs",
+      "notes": "Eliminates the elevated-process kill problem (GaApi PID 21036 today). Or install the GuitarAlchemist Windows service via Scripts/install-ga-service.ps1."
+    }
+  ],
+  "related_prs": [
+    {
+      "number": 295,
+      "title": "Harness engineering adoption plan",
+      "state": "merged",
+      "evidence_url": "https://github.com/GuitarAlchemist/ga/pull/295",
+      "note": "Source document for this rollout — landed the plan itself."
+    },
+    {
+      "number": 302,
+      "title": "karpathy-rules workflow regex fix (split from #300)",
+      "state": "blocked-on-agent-blackbox",
+      "evidence_url": "https://github.com/GuitarAlchemist/ga/pull/302",
+      "note": "Workflow tweak split out of item #1 so the CLAUDE.md change can land independently."
+    }
+  ],
+  "principles": [
+    {
+      "name": "Context & memory management",
+      "techniques": [
+        "Progressive disclosure navigation — small map + on-demand drill-down, not a 5000-line CLAUDE.md.",
+        "Disk-persistent state — decisions go to state/, docs/solutions/, docs/plans/ on the same beat as the conversation.",
+        "Cross-session memory compaction — auto-compact at 40%; durable knowledge off-loaded via the digest skill + precompact hook."
+      ]
+    },
+    {
+      "name": "Verification & feedback loops",
+      "techniques": [
+        "Cybernetic governance loops — feed-forward skills + post-action evaluators against architecture boundaries.",
+        "Generator-evaluator separation — the agent that wrote the code is never the one to grade it.",
+        "Pre-completion interceptors — block 'done' until lint, type-check, build, and E2E suites are green."
+      ]
+    },
+    {
+      "name": "Workflow & environment security",
+      "techniques": [
+        "User-experience E2E verification — outside-in browser checks so the agent sees what the user sees.",
+        "Mechanical invariant enforcement — encode rules into tooling (pre-commit, hooks, OS sandboxes), not prompts."
+      ]
+    },
+    {
+      "name": "Architecture-aligned techniques",
+      "techniques": [
+        "claude-codex-forge 7-phase workflow — PRD → Research → Design → Review → Build → Verify → Ship.",
+        "`state.md` Workflow / Done / Now / Next — gitignored, read by hooks, kept out of auto-loaded context.",
+        "ADR / CHANGELOG / solutions/ as compounded knowledge — every session builds on the previous."
+      ]
+    }
+  ],
+  "baselines": {
+    "frontend_typecheck_errors": {
+      "value": 185,
+      "as_of": "2026-05-23",
+      "source": "cd ReactComponents/ga-react-components && npx tsc -b 2>&1 | grep -c 'error TS'",
+      "target": 0,
+      "note": "Treat as a debt ledger. Number should never go up between PRs once item #2 lands."
+    },
+    "post_merge_smoke_urls": {
+      "value": 0,
+      "target": 3,
+      "urls": ["/test", "/api/chatbot/status", "/dev-data/manifest"],
+      "note": "Item #4 ships these as automated post-merge curls."
+    },
+    "one_way_door_prs_gated_by_council": {
+      "value": 0,
+      "target": "all schema/API/pricing PRs",
+      "note": "Item #6 ships the `/council` opt-in pre-merge gate."
+    },
+    "e2e_dashboard_coverage_tests": {
+      "value": 0,
+      "target": 3,
+      "note": "Item #7 ships Playwright tests for /test, /test/manifest, /chatbot/#showcase."
+    },
+    "auto_compact_threshold_pct": {
+      "value": 40,
+      "as_of": "2026-05-23",
+      "note": "Set globally in ~/.claude/settings.json across all 6 repos. Status: have."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a 6th sub-tab **Harness** to the Development section at `/test#dev/harness`
that surfaces the 8 prioritized items from the harness engineering adoption
plan ([docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md](https://github.com/GuitarAlchemist/ga/blob/main/docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md))
at a glance — status, effort/impact, linked PRs, baseline metrics, and a
principles refresher — so progress is visible without re-reading the 174-line
plan.

- New static-truth file `state/harness/items.json` (keyed by item number).
- New `/dev-data/harness` middleware in `vite.config.ts` (mirrors the
  `gatherBacklog` / `gatherQuality` pattern; also added to `/dev-data/manifest`).
- New `HarnessCard` in `DevelopmentSection.tsx` with header, rollout table,
  baseline-metrics grid, principles cards, and related-PRs strip.
- Hash routing extended: `harness` added to the `DevSubTab` enum.

## What the user sees on `/test#dev/harness`

- Header counts chips (shipped / in flight / todo) + link to the plan
- 8-row prioritized table with status icons, effort/impact chips, PR links
  (#300 in flight on item 1, #301 in flight on item 2, others todo)
- Baseline metrics: typecheck errors 185 → target 0; smoke URLs 0/3;
  council gates 0; E2E coverage 0; auto-compact 40%
- Principles refresher: 4 cards (Context & memory / Verification & feedback
  loops / Workflow & env security / Architecture-aligned)
- Related PRs strip: #295 merged (the plan itself), #302 blocked on Agent
  Blackbox

## v1 vs follow-ups

Item statuses are **manually authored** in `state/harness/items.json` — edit
that file when a PR opens or merges. Live baseline measurements (running tsc
and counting errors at request time, curling the smoke URLs) are deferred to
**PR 2**. Pattern-match autodetect of item status is deferred to a possible
**PR 3**.

## Files touched

- `state/harness/items.json` (new)
- `ReactComponents/ga-react-components/vite.config.ts` (+28 lines:
  `gatherHarness()` helper, `/dev-data/harness` middleware, `harness` key in
  manifest endpoints map + body)
- `ReactComponents/ga-react-components/src/pages/DevelopmentSection.tsx`
  (+338 lines: types, `HarnessCard` component, `'harness'` added to
  `DevSubTab` enum, `<Tab>` + conditional render)

## Test plan

- [x] Frontend type-error count unchanged: 185 before, 185 after.
- [x] No errors in `DevelopmentSection.tsx` per `tsc -b` (the 185 are
      pre-existing baseline).
- [x] `curl http://127.0.0.1:5187/dev-data/harness` returns the JSON payload.
- [ ] Visual confirmation on `https://demos.guitaralchemist.com/test#dev/harness`
      once merged + deployed.

## Hard-rule compliance

- No `.github/workflows/` edits (Agent Blackbox block respected).
- No `CLAUDE.md` / `AGENTS.md` / governance file edits.
- Typecheck baseline unchanged (185).
- Worktree off `origin/main` (`feat/dashboard-harness-tab`), not the dirty
  local tree.
- No overlap with the Modal Meadow visual agent's lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)