### PR TITLE
feat(demos): Modal Meadow v1.4 — mobile fallback (don't mount Three.js on touch devices)

### DIFF
--- a/ReactComponents/ga-react-components/src/components/ModalMeadow/MobileFallback.tsx
+++ b/ReactComponents/ga-react-components/src/components/ModalMeadow/MobileFallback.tsx
@@ -1,0 +1,153 @@
+/**
+ * Modal Meadow — mobile fallback (v1.4).
+ *
+ * The desktop demo at `/test/modal-meadow` is a first-person, keyboard +
+ * mouse + pointer-lock experience driving a 240k-instance grass scene
+ * with PCF-soft shadows, UnrealBloomPass, and god rays. None of those
+ * primitives port cleanly to mobile:
+ *
+ *   1. Pointer-lock API is desktop-only (no spec on iOS/Android Safari).
+ *   2. WASD/keyboard movement assumes a physical keyboard.
+ *   3. The grass instance count alone tanks integrated mobile GPUs;
+ *      even at perf=low the post-pipeline still costs real ms/frame.
+ *
+ * Until full mobile support lands (touch joystick + perf=low + reduced
+ * blade count — tracked in a separate plan), the polite shape is to NOT
+ * mount the Three.js scene on small viewports and instead show a clean
+ * "use a desktop" card with a screenshot preview and a back-link.
+ *
+ * This is purely additive: the existing desktop component is unchanged,
+ * and the branch happens at the test-page level (`ModalMeadowTest.tsx`)
+ * via `useIsMobile()`.
+ */
+
+import React from 'react';
+import { Box, Paper, Typography, Button } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+interface MobileFallbackProps {
+  /** Optional screenshot URL to show as preview. */
+  previewImage?: string;
+}
+
+export const MobileFallback: React.FC<MobileFallbackProps> = ({
+  previewImage,
+}) => {
+  return (
+    <Box
+      sx={{
+        height: '100vh',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background:
+          'linear-gradient(180deg, #1a2a18 0%, #2a3a1a 45%, #d9a86a 100%)',
+        color: '#cdeac0',
+        fontFamily: 'monospace',
+        px: 3,
+        py: 4,
+        textAlign: 'center',
+        overflowY: 'auto',
+      }}
+    >
+      <Paper
+        elevation={6}
+        sx={{
+          maxWidth: 540,
+          width: '100%',
+          backgroundColor: 'rgba(8, 14, 8, 0.85)',
+          color: '#cdeac0',
+          borderLeft: '3px solid #9be38a',
+          px: { xs: 2.5, sm: 4 },
+          py: { xs: 3, sm: 4 },
+        }}
+      >
+        <Typography
+          variant="caption"
+          sx={{ color: '#7da876', letterSpacing: 2, display: 'block', mb: 1 }}
+        >
+          MODAL MEADOW
+        </Typography>
+        <Typography
+          variant="h5"
+          sx={{
+            color: '#9be38a',
+            fontFamily: 'monospace',
+            mb: 2,
+            fontWeight: 'normal',
+          }}
+        >
+          Desktop only — for now
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={{ color: '#cdeac0', mb: 2, lineHeight: 1.6 }}
+        >
+          This demo is a first-person walk through seven musical mode-regions.
+          It needs a physical keyboard for WASD movement and a mouse for
+          pointer-lock camera control — neither of which mobile browsers
+          expose.
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{ color: '#7da876', mb: 3, lineHeight: 1.5 }}
+        >
+          Open this page on a laptop or desktop to walk from Lydian through
+          Locrian and hear the modes shift around you.
+        </Typography>
+
+        {previewImage && (
+          <Box
+            component="img"
+            src={previewImage}
+            alt="Modal Meadow desktop preview"
+            sx={{
+              width: '100%',
+              maxWidth: 480,
+              height: 'auto',
+              borderRadius: 1,
+              border: '1px solid rgba(155, 227, 138, 0.3)',
+              mb: 3,
+              display: 'block',
+              marginLeft: 'auto',
+              marginRight: 'auto',
+            }}
+          />
+        )}
+
+        <Button
+          component={Link}
+          to="/test"
+          variant="outlined"
+          sx={{
+            color: '#9be38a',
+            borderColor: '#9be38a',
+            fontFamily: 'monospace',
+            '&:hover': {
+              borderColor: '#cdeac0',
+              backgroundColor: 'rgba(155, 227, 138, 0.1)',
+            },
+          }}
+        >
+          ← Back to demos
+        </Button>
+      </Paper>
+
+      <Typography
+        variant="caption"
+        sx={{
+          color: 'rgba(205, 234, 192, 0.5)',
+          mt: 3,
+          letterSpacing: 1,
+          fontSize: 10,
+        }}
+      >
+        Touch + reduced-detail mobile build is planned. Track at GitHub.
+      </Typography>
+    </Box>
+  );
+};
+
+export default MobileFallback;

--- a/ReactComponents/ga-react-components/src/components/ModalMeadow/index.ts
+++ b/ReactComponents/ga-react-components/src/components/ModalMeadow/index.ts
@@ -1,4 +1,5 @@
 export { ModalMeadow, default } from './ModalMeadow';
+export { MobileFallback } from './MobileFallback';
 export type { ModeConfig } from './modes';
 export {
   LYDIAN,

--- a/ReactComponents/ga-react-components/src/pages/ModalMeadowTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/ModalMeadowTest.tsx
@@ -1,5 +1,5 @@
 /**
- * Modal Meadow Test Page (v1.2).
+ * Modal Meadow Test Page (v1.4).
  *
  * Mounts the ModalMeadow component full-screen with two HUDs:
  *   - bottom-left: current mode name + descriptor + position along the
@@ -10,6 +10,11 @@
  *     the hint reads "Auto-walking · Click to take control"; afterward it
  *     becomes "Click to enter · WASD to walk · ESC to release".
  *
+ * v1.4 (mobile fallback): if `useIsMobile()` reports coarse pointer or a
+ * narrow viewport, render <MobileFallback> instead of mounting the heavy
+ * Three.js scene. Saves the 240k-blade GPU cost on devices where the
+ * controls (WASD + pointer-lock) wouldn't work anyway.
+ *
  * The mode state lives here so the HUD can be plain React; the canvas
  * notifies us via the onModeChange / onUserTakeover callbacks.
  */
@@ -17,14 +22,17 @@
 import React, { useState, useCallback } from 'react';
 import { Container, Box, Typography, Paper } from '@mui/material';
 import { DemoErrorBoundary } from '../components/Common/DemoErrorBoundary';
+import { useIsMobile } from '../components/Common/ResponsiveDemoShell';
 import {
   ModalMeadow,
+  MobileFallback,
   LYDIAN,
   MODES,
   type ModeConfig,
 } from '../components/ModalMeadow';
 
 const ModalMeadowTest: React.FC = () => {
+  const isMobile = useIsMobile();
   const [mode, setMode] = useState<ModeConfig>(LYDIAN);
   const [locked, setLocked] = useState<boolean>(false);
   // v0.6 pattern (kept): auto-walk is on until this flips true via
@@ -33,9 +41,22 @@ const ModalMeadowTest: React.FC = () => {
 
   // Callbacks are useCallback'd because ModalMeadow's effect depends on them;
   // a fresh function each render would re-tear-down the whole scene.
+  // Hooks must always run unconditionally — even on mobile, where we'll
+  // skip rendering ModalMeadow — so they live above the early return.
   const handleModeChange = useCallback((m: ModeConfig) => setMode(m), []);
   const handleLockChange = useCallback((l: boolean) => setLocked(l), []);
   const handleUserTakeover = useCallback(() => setTookOver(true), []);
+
+  // v1.4: short-circuit before instantiating the Three.js scene on mobile.
+  // Saves the 240k-blade GPU spin-up and avoids the pointer-lock /
+  // keyboard / mouse controls that don't exist on touch devices.
+  if (isMobile) {
+    return (
+      <DemoErrorBoundary demoName="Modal Meadow (mobile)">
+        <MobileFallback />
+      </DemoErrorBoundary>
+    );
+  }
 
   // Index of the current mode (0..6, Lydian..Locrian). Used to draw the
   // "you are here" pip in the brightness curve below the HUD.


### PR DESCRIPTION
## Summary

Reported on mobile: Modal Meadow is unusable — no controls. The desktop demo at `/test/modal-meadow` needs WASD + pointer-lock + mouse, none of which exist on touch devices, and the 240k-blade scene tanks integrated mobile GPUs even at `?perf=low`.

This PR adds the polite fallback: don't mount the Three.js scene on mobile at all. Show a clean "Desktop only — for now" card with a back-link instead.

### What lands

- **New `<MobileFallback />`** component (`components/ModalMeadow/MobileFallback.tsx`). Mode-region palette (green → ochre gradient + leaf-green accents) so it visually belongs to the demo. Title + brief explanation + "← Back to demos" button. Optional `previewImage` prop for future screenshot use.
- **`ModalMeadowTest.tsx`** branches via the existing `useIsMobile()` hook (from `Common/ResponsiveDemoShell` — coarse pointer OR viewport ≤900px). Branch happens **before** the Three.js scene mounts, so we never pay the 240k-blade GPU spin-up on devices that can't use it anyway.
- **`components/ModalMeadow/index.ts`** exports `MobileFallback` alongside the existing surface.

### What's preserved

- v1.3 cinematic pipeline (bloom + shadows + god rays) — desktop path is unchanged.
- v0.9 audio rewrite, v1.2 ground-clamp, seven-mode region split.
- React Hook rules: `useCallback` handlers stay above the early return so hook order is constant across renders.

### Out of scope (separate plan)

Full touch support — left/right thumb joysticks for movement + look, force `?perf=low`, drop blade count to ~60k, disable god rays + shadows. Tracked as a separate multi-PR series. This PR is the bare-minimum "stop confusing mobile users" step.

### Live site

Vite serves the live demo from the local working tree on port 5176 (tunneled). After this PR merges to main, the local tree needs a `git pull` for demos.guitaralchemist.com/test/modal-meadow to reflect v1.4.

## Test plan

- [ ] CI green (build, Build Solution, Build Frontend, Code Quality, Security Scan, Backend Tests, Playwright Tests, CI Summary, claude-review, benchmark, risk-report)
- [ ] After merge + local-tree pull: open `/test/modal-meadow` on a desktop — unchanged behaviour, cinematic demo as before
- [ ] Open `/test/modal-meadow` on a mobile / narrow window (≤900px) — see "Desktop only" card with back-link, no canvas
- [ ] Resize between desktop and mobile widths — graceful swap, no hook-order errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)