### PR TITLE
chore(modal-meadow): bump banner v1.2 → v1.4 (catches up #304 + #305)

### DIFF
--- a/ReactComponents/ga-react-components/src/pages/ModalMeadowTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/ModalMeadowTest.tsx
@@ -174,7 +174,7 @@ const ModalMeadowTest: React.FC = () => {
             letterSpacing: 1,
           }}
         >
-          MODAL MEADOW · v1.2 · 7 modes · ADSR Spread Voicings · Reverb · Hills + Ponds · Descent · Ground Clamp
+          MODAL MEADOW · v1.4 · 7 modes · ADSR · Reverb · Hills · Ponds · Descent · Ground Clamp · Sky · Sun · PCF Shadows · God Rays · Mobile Fallback
         </Box>
       </Container>
     </DemoErrorBoundary>


### PR DESCRIPTION
## Summary

\`v1.3\` cinematic (#304: sky / sun / PCF shadows / god rays / perf toggle) and \`v1.4\` mobile fallback (#305) shipped — but neither updated the on-screen banner. Banner has been reading \`v1.2 · ... · Ground Clamp\` while users actually see the cinematic pass + the mobile fallback.

One-line fix to bring the banner to reality:
\`MODAL MEADOW · v1.4 · 7 modes · ADSR · Reverb · Hills · Ponds · Descent · Ground Clamp · Sky · Sun · PCF Shadows · God Rays · Mobile Fallback\`

## Why this keeps happening

Third instance this session (PR #296: v0.8 metadata, PR #299: v1.2 bump, this one: v1.4 bump). Feature PRs don't include the banner update in their scope. The standing reminder for future agents working on Modal Meadow visible features: **\"update the banner string in ModalMeadowTest.tsx when shipping a visible feature\"**. Will add this to the next Modal Meadow agent brief.

## Test plan

- [x] String-only change
- [x] Local Vite already showing the new banner (worked around in the local working tree before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)