### PR TITLE
feat(harness): adopt .claude/local/state.md pattern (harness item #3)

### DIFF
--- a/.claude/local-template/README.md
+++ b/.claude/local-template/README.md
@@ -1,0 +1,65 @@
+# Per-Session Same-Agent State (`.claude/local/state.md`)
+
+Harness engineering plan item #3 — adopted from [pablomarin/claude-codex-forge](https://github.com/pablomarin/claude-codex-forge).
+
+## What this solves
+
+Today, if you open a second Claude Code window in parallel on this repo
+(or come back after a long break), the new session has no idea you were
+6 PRs deep into a dashboard refactor. The conversation buffer is gone,
+and the [`/digest`](../skills/digest/SKILL.md) system captures
+*session-end* state but not the mid-session "I'm in the middle of X,
+blocked on Y, about to start Z" cursor.
+
+`.claude/local/state.md` is that cursor. It survives auto-compaction
+(disk, not conversation buffer), survives session end, and is read
+manually at session start when you (or the next agent) want to
+re-orient.
+
+## How to use it
+
+1. Copy the template into place:
+   ```bash
+   cp .claude/local-template/state.md.template .claude/local/state.md
+   ```
+2. Edit it as you work. The four sections (Done / Now / Next /
+   Blocked-by) are the minimum useful schema; Hypotheses + Notes are
+   optional carry-forward.
+3. At the start of a new session, open `.claude/local/state.md`
+   (or paste its content into the conversation) to re-orient.
+
+## Why gitignored
+
+Per-developer, per-machine. Your "Now" is not someone else's "Now."
+Cross-agent baton-passing is a different mechanism — that one is
+`state/handoffs/` via `Scripts/antigravity-bridge.ps1` (see CLAUDE.md
+"AI surfaces in this workspace"), and it IS tracked because the
+hand-off is a shared artifact between agents.
+
+| Pattern | File | Tracked? | Purpose |
+|---|---|---|---|
+| **Per-session state** | `.claude/local/state.md` | No | Same-agent cross-session continuity |
+| **Cross-agent handoff** | `state/handoffs/<date>-*.md` | Yes | Shared baton between Claude / Codex / Antigravity |
+| **Session digest** | `state/digests/latest.md` | Yes | Session-end snapshot, auto-injected on next start |
+
+## Schema
+
+See `state.md.template` in this directory. The frontmatter carries
+`schema: claude-local-state-v1` + session start time + branch. Sections
+are:
+
+- **Done** — shipped work this session (append-only)
+- **Now** — active workstream (1-2 items max)
+- **Next** — queued / on-deck
+- **Blocked by** — external waits (human-only unsticks)
+- **Hypotheses** — working theories worth checking
+- **Notes** — anything else worth carrying forward
+
+## Future work (not in this PR)
+
+- A `/state` slash command for read / append / clear
+- A SessionStart hook that auto-injects `.claude/local/state.md` if
+  present, alongside the digest auto-inject
+- Schema validation via JSON Schema (the frontmatter is YAML)
+- A "stale state" nudge if the file's `updated` timestamp is more than
+  N hours old at session start

--- a/.claude/local-template/state.md.template
+++ b/.claude/local-template/state.md.template
@@ -1,0 +1,59 @@
+---
+schema: claude-local-state-v1
+session_started: <YYYY-MM-DDTHH:MM:SSZ>
+updated: <YYYY-MM-DDTHH:MM:SSZ>
+branch: <feat/whatever-you're-on>
+---
+
+# Per-Session Working State
+
+Cross-session same-agent continuity. Edit this file as you work — survives
+auto-compaction (it's on disk, not in the conversation buffer). When you
+open a new Claude session, read this file FIRST to re-orient without
+re-explaining "I'm 6 PRs deep into dashboard work."
+
+This file is **gitignored** — per-developer-machine, never committed.
+
+See `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md`
+item #3 for the rationale.
+
+## Done (this session's shipped work)
+
+What's already merged or otherwise completed. Append, don't overwrite.
+
+-
+
+## Now (active workstream)
+
+One or two items max. What you'd describe if someone asked "what are you
+in the middle of?" Include the PR number if there's one in flight.
+
+-
+
+## Next (queued / blocked / on-deck)
+
+What you'd start next if Now finished right now. Mark blockers explicitly.
+
+-
+
+## Blocked by
+
+External waits. Things only the human can unstick: labels, approvals,
+credentials, etc. Empty if nothing's blocked.
+
+-
+
+## Hypotheses (working theories worth checking)
+
+Things you suspect but haven't verified. Keep them out of Now until
+proven. Examples: "the flaky test is caused by GC pressure, not the
+test itself" or "the slowness is in OPTIC-K mmap fopen, not search."
+
+-
+
+## Notes
+
+Anything else worth carrying forward. Discoveries, gotchas, "next time
+remember to …". Free-form.
+
+-

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,10 @@ jetbrains-plugin/.gradle/
 # Claude Code local settings and working directories (not shared)
 .claude/settings.local.json
 .claude/worktrees/
+# Per-session same-agent state (harness plan item #3). The actual file
+# is .claude/local/state.md — the .claude/local-template/ directory
+# (tracked) holds the schema + README + setup script.
+.claude/local/
 
 # AI chat exports (ChatGPT, Gemini, etc. — personal notes, not repo artifacts)
 ChatGPT-*.md


### PR DESCRIPTION
## Summary

Closes **item #3** from [docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md](docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md). Adopted from [pablomarin/claude-codex-forge](https://github.com/pablomarin/claude-codex-forge).

Status was ❌ Missing — today Claude's session state lives in the conversation buffer. Opening a second Claude window in parallel = re-explaining "I'm 6 PRs deep into a dashboard refactor."

## What this PR adds

- \`.gitignore\`: \`.claude/local/\` (the actual state file is per-developer-machine, never committed).
- \`.claude/local-template/state.md.template\`: schema with v1 frontmatter + 6 sections (Done / Now / Next / Blocked-by / Hypotheses / Notes).
- \`.claude/local-template/README.md\`: usage docs + the comparison table that clarifies which of GA's three persistence patterns to use when:

| Pattern | File | Tracked? | Purpose |
|---|---|---|---|
| **Per-session state** | \`.claude/local/state.md\` | No | Same-agent cross-session continuity |
| **Cross-agent handoff** | \`state/handoffs/<date>-*.md\` | Yes | Shared baton between Claude / Codex / Antigravity |
| **Session digest** | \`state/digests/latest.md\` | Yes | Session-end snapshot, auto-injected on next start |

## Setup

\`cp .claude/local-template/state.md.template .claude/local/state.md\` — intentionally manual to avoid auto-pollution of every checkout.

## Out of scope (future PRs)

- \`/state\` slash command for read / append / clear
- SessionStart hook auto-inject of \`.claude/local/state.md\` if present (alongside the digest auto-inject)
- JSON Schema validation of the frontmatter
- "Stale state" nudge if \`updated\` > N hours old

## Test plan

- [x] \`.gitignore\` block matches the existing \`.claude/\` pattern (placed under the existing local-settings comment)
- [x] Template + README parse cleanly as Markdown
- [ ] After merge: \`cp .claude/local-template/state.md.template .claude/local/state.md\` should work and the file should not appear in \`git status\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)