### PR TITLE
feat(harness): add /grade-last-pr skill for intent-vs-delivery loop (item #5)

### DIFF
--- a/.claude/skills/grade-last-pr/SKILL.md
+++ b/.claude/skills/grade-last-pr/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: grade-last-pr
+description: Post-merge intent-vs-delivery evaluator. Resolves the most recent squash-merged PR, captures its stated intent (title + Summary), diffs it against what actually landed, runs /octo:review for specialist commentary, computes a high/medium/low alignment score, and writes a structured grade to state/quality/pr-grades/<merge-sha>.json. Closes the "agent declared done, nobody checked the goal" loop.
+allowed-tools: Bash, Read, Write, Skill
+last_verified: 2026-05-23
+karpathy_rule: R4-goal-driven-execution (task complete != goal achieved)
+---
+
+# /grade-last-pr
+
+Grades the last merged PR on the current branch's upstream against the goal the author stated. Outputs a JSON grade card + a terminal summary.
+
+Part of item #5 in `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` — "Cybernetic governance loops". Today, an agent declares "done" and that's the end of the loop. This skill closes the loop by re-reading the intent after merge and comparing it to the diff.
+
+## When to run
+
+- **Immediately after a PR merges to main** — fresh memory, clean diff.
+- **Inside the post-merge smoke action** (once item #4 lands, this skill can be invoked from CI as a follow-up step — but works standalone today).
+- **Spot-checking an agent's work** — pick any merge SHA and grade it.
+
+**Do NOT** invoke for unmerged PRs (the diff isn't stable yet — use `/octo:review` instead) or for revert commits (use `/learnings` to capture the regression).
+
+## How to run
+
+### 1. Resolve the last merged PR
+
+```bash
+# Latest merge on this branch
+git log -1 --format='%H %s'
+# Cross-check against gh's view of merged PRs
+gh pr list --state merged --limit 1 --json number,title,mergeCommit,mergedAt,headRefName
+```
+
+The merge SHA from `git log` should equal `mergeCommit.oid` from `gh`. If they disagree, the local branch is ahead of what gh sees — `git fetch origin` and retry, or pass an explicit PR number as the argument (`/grade-last-pr 308`).
+
+Squash-merge convention means `HEAD` is the merged commit itself (one commit per PR). For merge-commit PRs the same logic still works; `git show HEAD --stat` reports the merge.
+
+### 2. Capture the stated intent
+
+```bash
+gh pr view <num> --json title,body,number,mergedAt,mergeCommit,headRefName,author
+```
+
+The **stated intent** is `title` plus the `## Summary` section of `body` (the first `##` block, up to the next `##`). If the body has no `## Summary`, fall back to the title and flag `intent_section_missing` in `reasons`.
+
+Skip everything below `## Test plan` — that's how the PR was verified, not what it was for.
+
+### 3. Capture the actual diff
+
+```bash
+git show HEAD --stat       # files changed + line counts
+git show HEAD --name-only  # just the file list (cleaner for the JSON field)
+```
+
+For the specialist review (step 4) pipe the full unified diff:
+
+```bash
+git show HEAD
+```
+
+If the PR is huge (> 500 changed lines or > 50 files), summarize per-directory line counts instead — the specialist review tools have token caps.
+
+### 4. Run /octo:review against the merged diff
+
+Invoke the existing `/octo:review` skill (`plugin:octo:review`) with the PR title + Summary as the "intent" frame and the unified diff as the target. Set `target=specific path` with the merge SHA, `focus=all`, `autonomy=autonomous`, `publish=skip` (this is a grading pass, not an inline-comment pass).
+
+Capture the specialists' verdicts — at minimum `code-reviewer` and `security-sentinel` if present in the output — for the `specialist_notes` field. If `/octo:review` returns its multi-AI fleet output, take the synthesis section verbatim (one paragraph) for each named specialist.
+
+If `/octo:review` is unavailable in the current session (no `plugin:octo:review` in the skill list), record `"specialist_notes": {"unavailable": "octo:review skill not loaded; grade based on diff inspection only"}` and proceed with a Claude-only review pass.
+
+### 5. Compute the alignment score
+
+Three buckets — no in-between. Be honest, not generous.
+
+| Score | When |
+|---|---|
+| **high** | Diff matches stated intent. No surprise files. Tests/types are green (no new failures introduced). Scope is what the title says. |
+| **medium** | Diff matches the intent's spirit but introduces something not called out in the Summary — e.g., a helper function, a tangential rename, a config tweak. The work isn't *wrong*, but the PR description undersold it. |
+| **low** | Diff drifts from intent. E.g., title says "fix typo" but the diff refactors 3 files; or Summary promises a feature and the diff only adds tests; or the PR title and the changed file list have no overlap. |
+
+Tie-breaker examples — these are the calls that matter most:
+
+- **Refactor smuggled into a fix.** Title: "fix: handle null in X". Diff: fixes X + renames 4 unrelated symbols. → **medium** (renames weren't promised). Use **low** if the rename touches > 50% of changed lines.
+- **Test-only PR with a "fix:" prefix.** Title says fix, diff is `*.test.ts` only. → **medium** (consider tests as evidence of a fix; flag if no production-code change accompanies a "fix:").
+- **Doc PR that touches code.** Title: "docs: update README". Diff: README + one config change. → **low** (config change is a one-way door; should be a separate PR).
+- **Multi-feature PR with a single-feature title.** → **low**.
+- **Stated feature ships + a Karpathy-rule self-improvement gets bundled.** → **medium** (legitimate compound work, but the title hid the rule change).
+
+### 6. Write the grade card
+
+To `state/quality/pr-grades/<merge-sha>.json` — the **full** SHA, no truncation, so it sorts alphabetically and never collides with a short-SHA prefix.
+
+```json
+{
+  "schema": "pr-grade-v1",
+  "pr_number": 308,
+  "merge_sha": "abc123def456...",
+  "merged_at": "2026-05-23T23:35:20Z",
+  "title": "feat(harness): /grade-last-pr skill",
+  "stated_intent": "Adds a /grade-last-pr skill that grades merged PRs against stated intent and writes the result to state/quality/pr-grades/. Closes item #5 of the harness plan.",
+  "actual_files_changed": [
+    ".claude/skills/grade-last-pr/SKILL.md",
+    "state/quality/pr-grades/README.md",
+    "state/quality/pr-grades/SCHEMA.json",
+    "state/harness/items.json",
+    "docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md"
+  ],
+  "alignment": "high",
+  "reasons": [
+    "Diff matches stated intent: skill file + artifact dir + harness state update.",
+    "No surprise files outside the plan's PR shape.",
+    "Frontmatter declares allowed-tools and karpathy_rule per skill convention."
+  ],
+  "specialist_notes": {
+    "code-reviewer": "Markdown-only addition; no executable changes; zero TS regression risk.",
+    "security-sentinel": "Skill reads gh CLI + git output, no network egress, no eval."
+  },
+  "graded_at": "2026-05-23T23:50:00Z",
+  "grader": "claude-opus-4-7"
+}
+```
+
+Validate against `state/quality/pr-grades/SCHEMA.json` before writing — if you have `npx ajv` or `jq` available, lint the JSON. Otherwise, eyeball the required fields list.
+
+Schema notes:
+- `schema` is the literal string `pr-grade-v1`. Bump to `pr-grade-v2` only when fields are removed or renamed (additive changes don't need a bump — readers must tolerate unknown fields).
+- `merge_sha` is the **full 40-char** SHA so file sorts are chronological and unambiguous.
+- `merged_at` and `graded_at` are RFC3339 UTC.
+- `alignment` is one of `"high"`, `"medium"`, `"low"` — no other values.
+- `reasons` is 1–5 short sentences. If you can't articulate a reason, the grade isn't ready.
+- `grader` is the model name (free-form string; example: `"claude-opus-4-7"`).
+
+### 7. Print the terminal summary
+
+One concise block. Keep it under 10 lines.
+
+```
+PR #308 graded · alignment: high
+  merge:   5bb745b0  (2026-05-23T23:35:20Z)
+  title:   feat(harness): /grade-last-pr skill
+  changed: 5 files, +312/-2
+
+  reasons:
+  • Diff matches stated intent: skill + artifact dir + state bump.
+  • No surprise files outside the plan's PR shape.
+  • specialist_notes/code-reviewer: no TS regression risk.
+
+  grade card: state/quality/pr-grades/5bb745b0bb2d643dbabce06dd56bdaedcc887542.json
+```
+
+Surface the absolute path to the JSON in the last line so the user can `cat` it without rebuilding it.
+
+## Edge cases
+
+- **Detached HEAD or non-main branch.** Use `gh pr list --state merged --base main` to filter, or accept the argument override (`/grade-last-pr 308`).
+- **PR with no `## Summary` section.** Fall back to title; add `intent_section_missing` to `reasons` so the human knows the grade is title-only.
+- **Bot-merged PR (dependabot, renovate).** Treat as a separate class — grade still applies but `grader_notes` should call out the bot author. Auto-bumps usually score `high`.
+- **Squash with edited commit message.** GitHub sometimes rewrites the merge subject. Use the PR title from `gh pr view`, not the commit subject.
+- **Multiple PRs merged in the same minute.** `git log -1` and `gh pr list --limit 1` may disagree. Cross-check the SHA. If still ambiguous, accept the merge SHA as an argument.
+
+## Anti-patterns
+
+- **Grade inflation.** Don't default to `high` when the diff "kind of" matches. The whole point of this skill is to surface drift — graded everything `high` and the loop tells you nothing.
+- **Grading without reading the diff.** The skill must actually `git show HEAD`. A grade based on the PR description alone is theatre.
+- **Grading agent-authored PRs more leniently than human-authored ones.** Same bar. The agent gets the same `low` you'd give a human who shipped scope creep.
+- **Re-writing existing grade cards on re-invocation.** If `<sha>.json` already exists, append a `regraded_at` timestamp and an entry in `prior_grades[]` rather than overwriting silently — drift in grading itself is signal.
+- **Editing the PR after grading.** The grade is a snapshot of the merged state. If the PR gets reverted, that's a *new* event for a *new* grade card (on the revert SHA).
+
+## Why this exists
+
+Karpathy R4: "Task completed != goal achieved." Today, when an agent finishes a PR, no automated system asks "did the diff actually deliver what the title promised?" Humans skim the title and the green CI checkmark and merge. Drift accumulates silently — a "fix typo" PR refactored three modules; a "feat: add X" PR added X but also broke Y in a way the tests didn't catch.
+
+`/grade-last-pr` is the cheapest possible closing of that loop:
+- **Generator-evaluator separation** — Cherny's pattern: the agent that wrote the PR is not the agent that grades it. The grader reads only the diff + the stated intent, not the conversation that produced them.
+- **Append-only ledger** — `state/quality/pr-grades/` becomes the audit trail. Over weeks, a histogram of `high/medium/low` reveals whether the team's intent-articulation is tightening (more `high`) or eroding (more `medium`).
+- **Cheap enough to run on every merge** — markdown skill + 2 git commands + 1 gh CLI call + 1 skill dispatch. Sub-second on a normal PR, < 30 s with `/octo:review` engaged.
+
+## Related
+
+- `/octo:review` — the multi-LLM review skill this skill dispatches.
+- `/digest` — captures session state; complementary (digest is forward-looking, grade is backward-looking).
+- `/learnings` — captures surprises into `docs/solutions/`; if a grade comes in `low`, the *next* step is often a `/learnings` entry.
+- `state/quality/pr-grades/README.md` — explains the artifact directory + retention policy.
+- `state/quality/pr-grades/SCHEMA.json` — JSON Schema for the grade card.
+- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` — item #5; the parent plan.
+- `state/harness/items.json` — item #5 status; bump from `todo` → `in_flight` → `shipped` as this skill lands.

--- a/docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md
+++ b/docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md
@@ -73,8 +73,8 @@ Auto-summarize the volatile conversation; off-load durable knowledge to external
 
 Pre-defined skills + automated post-action evaluation against architecture boundaries.
 
-- **Status: 🟡 Partial.** We have feed-forward via skills (`/digest`, `/learnings`, `/correct`, `/feature`) and feedback via the `karpathy-cherny-discipline.yml` workflow + the ROP-naked-throws check in `.githooks/pre-commit`. Missing: a structured **post-merge** evaluator that grades the merged PR against the original goal. Today an agent declares "done" and that's the end of the loop.
-- **Action (M):** Add a `/grade-last-pr` skill that runs `octo:review` against `git diff HEAD~1` and writes the score to `state/quality/pr-grades/<sha>.json`. Surfaces drift between intent and delivery without humans manually reviewing.
+- **Status: 🟡 In flight.** We have feed-forward via skills (`/digest`, `/learnings`, `/correct`, `/feature`) and feedback via the `karpathy-cherny-discipline.yml` workflow + the ROP-naked-throws check in `.githooks/pre-commit`. The post-merge evaluator is now scaffolded: `/grade-last-pr` ships in this PR (`.claude/skills/grade-last-pr/SKILL.md`) with the artifact directory at `state/quality/pr-grades/` and `pr-grade-v1` JSON Schema. Mark ✅ once the skill has been invoked on its own merge SHA and the grade card is committed.
+- **Action (M):** Add a `/grade-last-pr` skill that runs `octo:review` against `git diff HEAD~1` and writes the score to `state/quality/pr-grades/<sha>.json`. Surfaces drift between intent and delivery without humans manually reviewing. **(skill landed; first dogfood grade card pending)**
 
 ### Generator-evaluator separation
 

--- a/state/harness/items.json
+++ b/state/harness/items.json
@@ -2,7 +2,7 @@
   "_comment": "Source of truth for the 8 prioritized items in the harness engineering adoption plan. Edit this file manually when an item ships (or a PR opens). The /test#dev/harness tab reads /dev-data/harness which is served from this file.",
   "_plan": "docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md",
   "schema_version": "1.0.0",
-  "last_updated": "2026-05-23",
+  "last_updated": "2026-05-23T23:55:00Z",
   "items": [
     {
       "number": 1,
@@ -62,12 +62,12 @@
       "category": "Verification & feedback loops",
       "effort": "M",
       "impact": "M",
-      "status": "todo",
+      "status": "in_flight",
       "pr_number": null,
-      "pr_state": null,
+      "pr_state": "open",
       "evidence_url": null,
-      "owner": "week of",
-      "notes": "Closes the intent-vs-delivery loop. Writes score to state/quality/pr-grades/<sha>.json."
+      "owner": "next session",
+      "notes": "Closes the intent-vs-delivery loop. Writes score to state/quality/pr-grades/<sha>.json. Skill at .claude/skills/grade-last-pr/SKILL.md; artifact dir with SCHEMA.json + README.md at state/quality/pr-grades/. PR shipping; bump status to 'shipped' on merge and populate pr_number + evidence_url."
     },
     {
       "number": 6,

--- a/state/quality/pr-grades/README.md
+++ b/state/quality/pr-grades/README.md
@@ -1,0 +1,112 @@
+# state/quality/pr-grades — PR Grade Cards
+
+Append-only ledger of **intent-vs-delivery grades** for merged PRs, produced
+by the `/grade-last-pr` skill (see `.claude/skills/grade-last-pr/SKILL.md`).
+
+Each file is one merged PR's grade card:
+
+```
+state/quality/pr-grades/
+├── README.md          ← this file
+├── SCHEMA.json        ← JSON Schema (pr-grade-v1)
+└── <merge-sha>.json   ← one per merged PR; full 40-char SHA
+```
+
+## Why this exists
+
+Closes item #5 of `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md`:
+"Cybernetic governance loops". Without a post-merge evaluator, "an agent
+declares done and that's the end of the loop." This directory is that
+evaluator's output.
+
+Karpathy R4 in one sentence: **task completed != goal achieved**. The grade
+card asks, after the fact, whether the diff that landed actually delivers
+what the PR title and Summary promised.
+
+## Schema (pr-grade-v1)
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema` | string | Literal `"pr-grade-v1"`. |
+| `pr_number` | integer | The PR number (e.g. `308`). |
+| `merge_sha` | string | **Full 40-char** merge SHA. |
+| `merged_at` | string | RFC3339 UTC. |
+| `title` | string | The PR title from `gh pr view`. |
+| `stated_intent` | string | PR title + the `## Summary` section of the body. |
+| `actual_files_changed` | string[] | Output of `git show --name-only <sha>`. |
+| `alignment` | enum | One of `"high"`, `"medium"`, `"low"`. See the SKILL for tie-breakers. |
+| `reasons` | string[] | 1–5 short sentences explaining the alignment call. |
+| `specialist_notes` | object | Map of specialist name → one-paragraph verdict (from `/octo:review`). |
+| `graded_at` | string | RFC3339 UTC. When the grade was written. |
+| `grader` | string | Model name (e.g. `"claude-opus-4-7"`). |
+| `prior_grades` | object[] | Optional. Populated only on re-grades — see "Re-grading" below. |
+
+Validate any grade card against `SCHEMA.json` before writing:
+
+```bash
+# If npx ajv is available:
+npx -y ajv-cli@5 validate -s state/quality/pr-grades/SCHEMA.json \
+  -d state/quality/pr-grades/<merge-sha>.json
+```
+
+## Alignment buckets at a glance
+
+- **high** — diff matches stated intent; no surprises.
+- **medium** — diff matches intent but introduces something not called out.
+- **low** — diff drifts from intent (e.g., "fix typo" PR refactors 3 files).
+
+The SKILL has worked examples for the tricky calls.
+
+## Re-grading
+
+Grade cards are append-mostly. If the same `<merge-sha>.json` is graded a
+second time (e.g. by a different model, or after a follow-up `/octo:review`
+shows something the first pass missed), the skill **must** preserve the
+prior grade by moving it into `prior_grades[]`:
+
+```json
+{
+  "schema": "pr-grade-v1",
+  "pr_number": 308,
+  "merge_sha": "abc123...",
+  "alignment": "medium",
+  "reasons": ["…revised reason…"],
+  "graded_at": "2026-05-24T10:00:00Z",
+  "grader": "claude-opus-4-7",
+  "prior_grades": [
+    {
+      "alignment": "high",
+      "reasons": ["…original reason…"],
+      "graded_at": "2026-05-23T23:50:00Z",
+      "grader": "claude-opus-4-7"
+    }
+  ]
+}
+```
+
+Drift in grading itself is signal — if a PR moves from `high` to `low` two
+weeks later because downstream regressions surfaced, that's exactly the
+kind of trend this ledger exists to expose.
+
+## What goes here vs elsewhere
+
+| Question | File |
+|---|---|
+| "Did this merged PR deliver what its title said?" | `state/quality/pr-grades/<sha>.json` |
+| "What's the trend of frontend type errors over time?" | `state/quality/embeddings/` and the parent `state/quality/` snapshots |
+| "What surprised the agent this week?" | `docs/solutions/<category>/<date>-<topic>.md` (via `/learnings`) |
+| "What's the agent's cursor right now?" | `state/digests/latest.md` (via `/digest`) |
+
+## Retention policy
+
+Keep all grade cards. Each is < 5 KB; even 10,000 merged PRs would be < 50 MB.
+Do **not** prune. The histogram of `alignment` over time is a long-arc
+quality signal.
+
+## Related
+
+- `.claude/skills/grade-last-pr/SKILL.md` — the producer.
+- `SCHEMA.json` — JSON Schema for `pr-grade-v1`.
+- `../README.md` — parent `state/quality/` directory contract.
+- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` — plan item #5.
+- `state/harness/items.json` — harness rollout tracker.

--- a/state/quality/pr-grades/SCHEMA.json
+++ b/state/quality/pr-grades/SCHEMA.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/ga/state/quality/pr-grades/SCHEMA.json",
+  "title": "PR Grade Card",
+  "description": "Schema for post-merge intent-vs-delivery grades produced by the /grade-last-pr skill.",
+  "type": "object",
+  "required": [
+    "schema",
+    "pr_number",
+    "merge_sha",
+    "merged_at",
+    "title",
+    "stated_intent",
+    "actual_files_changed",
+    "alignment",
+    "reasons",
+    "graded_at",
+    "grader"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "pr-grade-v1",
+      "description": "Schema version literal. Bump only on field removal/rename; additive changes do not need a bump."
+    },
+    "pr_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "GitHub PR number."
+    },
+    "merge_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Full 40-char merge commit SHA. No truncation — files sort chronologically and never collide on a short-SHA prefix."
+    },
+    "merged_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 UTC timestamp when the PR was merged."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "PR title from `gh pr view`."
+    },
+    "stated_intent": {
+      "type": "string",
+      "minLength": 1,
+      "description": "PR title plus the `## Summary` section of the body. If no Summary, the title only — and `intent_section_missing` should appear in `reasons`."
+    },
+    "actual_files_changed": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "description": "File paths from `git show --name-only <sha>`."
+    },
+    "alignment": {
+      "type": "string",
+      "enum": ["high", "medium", "low"],
+      "description": "high = diff matches intent; medium = matches but introduces something not called out; low = drifts from intent."
+    },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "maxItems": 5,
+      "description": "1–5 short sentences explaining the alignment call."
+    },
+    "specialist_notes": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Map of specialist name → one-paragraph verdict (typically from `/octo:review`). Common keys: code-reviewer, security-sentinel, architecture-architect."
+    },
+    "graded_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 UTC timestamp when this grade was written."
+    },
+    "grader": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Model name that performed the grading (e.g. claude-opus-4-7)."
+    },
+    "prior_grades": {
+      "type": "array",
+      "description": "Populated only on re-grades. The original card's content (minus pr_number / merge_sha / title / stated_intent / actual_files_changed, which are immutable for a given SHA) is moved here.",
+      "items": {
+        "type": "object",
+        "required": ["alignment", "reasons", "graded_at", "grader"],
+        "properties": {
+          "alignment": { "type": "string", "enum": ["high", "medium", "low"] },
+          "reasons": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "minItems": 1
+          },
+          "specialist_notes": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "graded_at": { "type": "string", "format": "date-time" },
+          "grader": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes item #5 of [docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md](docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md) — "Cybernetic governance loops".

- **New skill** at `.claude/skills/grade-last-pr/SKILL.md`. When invoked (`/grade-last-pr`), it:
  1. Resolves the last squash-merged PR (`git log -1` cross-checked against `gh pr list --state merged --limit 1`).
  2. Captures the **stated intent** — PR title + `## Summary` section of the body.
  3. Captures the **actual diff** via `git show HEAD`.
  4. Dispatches the existing `plugin:octo:review` skill for multi-LLM specialist commentary.
  5. Computes a **high / medium / low** alignment score with documented tie-breakers.
  6. Writes a `pr-grade-v1` JSON card to `state/quality/pr-grades/<full-merge-sha>.json`.
  7. Prints a concise terminal summary with the absolute path to the grade card.
- **New artifact directory** `state/quality/pr-grades/`:
  - `README.md` — schema reference, alignment buckets, re-grading policy, what-goes-here-vs-elsewhere matrix.
  - `SCHEMA.json` — JSON Schema 2020-12 for `pr-grade-v1`, all required + optional fields enumerated, includes `prior_grades[]` for the append-mostly re-grade case.
- **Harness state bumped** — `state/harness/items.json` item #5 status: `todo` → `in_flight`. The `/test#dev/harness` sub-tab reads this and the dashboard refreshes immediately. Will flip to `shipped` once merged.
- **Plan updated** — the "Cybernetic governance loops" subsection's status is `Partial` → `In flight` with a note about first dogfood grade card pending.

## Why

Today an agent declares "done" and that's the end of the loop. There's no structured post-merge evaluator. Karpathy R4: *task completed != goal achieved*. This skill closes the loop with:

- **Generator-evaluator separation** — the agent that wrote the PR is not the agent that grades it (Cherny's pattern).
- **Append-only ledger** — `state/quality/pr-grades/` becomes the audit trail. Over weeks, the histogram of `high / medium / low` exposes whether intent-articulation is tightening or eroding.
- **Cheap to run** — markdown skill + 2 git commands + 1 gh CLI call + 1 skill dispatch. Sub-second baseline, < 30 s with `/octo:review` engaged.

## What this does NOT do

- No `.github/workflows/` touches (Agent Blackbox blocks autonomous workflow edits).
- No `CLAUDE.md` / `AGENTS.md` edits (same).
- No TypeScript code (zero new TS errors against the ~185 pre-existing baseline).
- No `/octo:review` skill modifications — this skill *dispatches* it, doesn't fork it.

## Test plan

- [ ] CI green on this PR (no workflow edits → no new failure modes).
- [ ] `SCHEMA.json` parses as valid JSON Schema 2020-12 (verified locally — `python -c "import json; json.load(open(...))"` passes).
- [ ] After merge, `/test#dev/harness` shows item #5 as `in_flight` (then `shipped` after the post-merge items.json bump).
- [ ] **Dogfood**: invoke `/grade-last-pr` against this PR's own merge SHA, commit the resulting grade card as the first entry in `state/quality/pr-grades/`. That grade card is the proof the skill works end-to-end.

## PR shape (per plan)

5 files, all additive or schema-frozen-additive:
- `.claude/skills/grade-last-pr/SKILL.md` (new, 186 lines)
- `state/quality/pr-grades/README.md` (new, 112 lines)
- `state/quality/pr-grades/SCHEMA.json` (new, 109 lines)
- `state/harness/items.json` (modified, +5/-5: item #5 status + last_updated)
- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` (modified, +2/-2: subsection status note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)