### PR TITLE
feat(skill): /council opt-in pre-merge gate for one-way-door PRs

### DIFF
--- a/.claude/skills/council/SKILL.md
+++ b/.claude/skills/council/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: council
+description: Opt-in pre-merge gate that convenes a virtual council of specialist sub-agents for one-way-door PRs (schema changes, public APIs, OPTIC-K dim changes, pricing). Adopts the claude-codex-forge council pattern. Use sparingly — only for high-stakes decisions the team would lose sleep about reverting. Invoked as `/council <PR#>` or `/council` for the current branch's open PR.
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
+last_verified: 2026-05-23
+harness_item: 6
+karpathy_rule: R-instrument-and-log-one-way-doors
+---
+
+# /council
+
+A **virtual council** of specialist sub-agents convened to review a PR that
+touches a known one-way door. Inspired by [claude-codex-forge](https://github.com/pablomarin/claude-codex-forge)'s
+`/council` pattern — five voices, one chair, one synthesized verdict, written
+to `state/quality/council/<head-sha>.json` and posted as a PR comment.
+
+This is **opt-in by design**. It does not auto-fire on every PR. The operator
+invokes it on PRs they would lose sleep about reverting. For routine review,
+use `/octo:review` or the existing `chatbot-iterate` tribunal gate.
+
+## When to run
+
+Invoke `/council` (or `/council <PR#>`) when the PR touches one of:
+
+- **`Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs`** — OPTIC-K
+  dimension changes. Locked field; ripples through every cached voicing
+  index and every cross-repo consumer.
+- **`docs/contracts/*.contract.md`** / **`docs/contracts/*.schema.json`** —
+  cross-repo contracts (qa-verdict, optick-sae-artifact, optick-weights-config,
+  ga-dsl-eval, ga-loop-driver, overseer-halt-marker, digest-schema). Once
+  shipped, both producer and consumer crates pin to the hash.
+- **`Apps/ga-server/GaApi/Controllers/*.cs`** — public HTTP API surface.
+  Renaming routes or changing response shapes breaks third-party callers
+  + the React SPAs.
+- **`ReactComponents/ga-react-components/src/main.tsx`** — route
+  definitions. URL changes break bookmarks, links, and embed iframes.
+- **`Scripts/install-ga-service.ps1`** (and other `install-*` /
+  `uninstall-*` scripts) — Windows-service installer changes that affect
+  already-deployed boxes.
+- Pricing / billing code — reserved pattern; nothing matches today.
+
+If no one-way-door path is touched, the skill exits early with
+`no council required`. The chair never convenes for ordinary code.
+
+## How to run
+
+### Step 1 — Resolve the PR
+
+```bash
+# If invoked as /council <num>, use that.
+# Otherwise, resolve from current branch.
+PR_NUM="${1:-$(gh pr view --json number --jq .number)}"
+if [ -z "$PR_NUM" ]; then
+  echo "No PR found for current branch and no PR number passed. Aborting."
+  exit 1
+fi
+
+gh pr view "$PR_NUM" --json title,body,baseRefName,headRefName,headRefOid,files,additions,deletions,url \
+  > /tmp/council-pr-$PR_NUM.json
+```
+
+### Step 2 — Detect one-way-door touches
+
+Read the `files[].path` array from the PR JSON and test each against the
+glob patterns below. Build the `one_way_door_paths` list.
+
+```text
+Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs
+docs/contracts/*.contract.md
+docs/contracts/*.schema.json
+Apps/ga-server/GaApi/Controllers/*.cs
+ReactComponents/ga-react-components/src/main.tsx
+Scripts/install-*.ps1
+Scripts/uninstall-*.ps1
+```
+
+If the list is empty:
+
+```text
+No one-way-door paths touched on PR #<N>. Council not required.
+Routine review path: /octo:review or chatbot-iterate.
+```
+
+…and **exit clean**. Do not write an artifact for skipped PRs.
+
+### Step 3 — Convene the council (only on door touches)
+
+Spawn five sub-agents in parallel via the `Agent` tool. Each receives the
+same brief plus a focus area.
+
+```text
+Brief sent to every advisor:
+
+  PR: #<N> — <title>
+  URL: <url>
+  Base → Head: <baseRefName> → <headRefName> @ <headRefOid>
+  Files: <N>, +<additions> / -<deletions>
+  One-way-door paths touched:
+    - <path1>
+    - <path2>
+
+  Body:
+  <pr body>
+
+  Diff (use `gh pr diff <N>` if you need the full patch):
+  <inline if short, or instruction to fetch>
+
+  Your focus: <per-role focus area>
+
+  Return JSON only:
+    {"verdict": "approve|request_changes|block", "reasoning": "<2-5 sentences>"}
+```
+
+Recommended slate (all live under `octo:personas:`):
+
+| Role | subagent_type | Focus area |
+|------|---------------|------------|
+| **Chair / synthesizer** | `octo:personas:backend-architect` | Architectural soundness; reconciles the other four into a final verdict |
+| Security | `octo:personas:security-auditor` | Authn/z, trust boundaries, secrets, supply chain implications of the one-way door |
+| Data | `octo:personas:database-architect` | Schema/index/migration implications; OPTIC-K dim ripple analysis when relevant |
+| Code quality | `octo:personas:code-reviewer` | Readability, naming, test coverage, error-path correctness |
+| UX | `octo:personas:ux-researcher` | User-visible impact: route changes, error messages, breaking API responses |
+
+Dispatch all five in a **single Agent tool call batch** (parallel) so the
+council convenes in one round-trip.
+
+#### Future: chair-by-PR-type
+
+The chair is `backend-architect` by default. A future revision can swap
+based on the dominant one-way-door type:
+
+- Public UX / route changes → chair = `octo:personas:ux-researcher`
+- Pure data schema (OPTIC-K, SAE artifact) → chair = `octo:personas:database-architect`
+- Pricing / billing → chair = `octo:personas:finance-analyst`
+
+We don't have a Codex CLI persona, so we can't mirror claude-codex-forge's
+"Codex as chairman" exactly. `backend-architect` is the closest analog.
+
+### Step 4 — Synthesize
+
+The chair (you, in chair mode) reads the four advisor JSONs and writes the
+**chair_synthesis**: 3–6 sentences naming each dissent, calling out the
+decisive concern, and stating the final verdict.
+
+**Aggregation rule** (deterministic, not a vibes call):
+
+- Any `block` from any advisor → `final_verdict = block`.
+- Else if any `request_changes` → `final_verdict = request_changes`.
+- Else → `final_verdict = approve`.
+
+The synthesis text explains *why*, not just *what*.
+
+### Step 5 — Persist the verdict
+
+Write to `state/quality/council/<head_sha>.json`. Schema is
+`state/quality/council/SCHEMA.json`. Required fields:
+
+```json
+{
+  "schema": "council-verdict-v1",
+  "pr_number": 123,
+  "head_sha": "abc1234567890...",
+  "one_way_door_paths": ["Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs"],
+  "convened_at": "2026-05-23T15:04:05Z",
+  "advisors": [
+    {"name": "octo:personas:security-auditor", "role": "security",
+     "verdict": "approve", "reasoning": "..."},
+    {"name": "octo:personas:database-architect", "role": "data",
+     "verdict": "request_changes", "reasoning": "..."},
+    {"name": "octo:personas:code-reviewer", "role": "code-quality",
+     "verdict": "approve", "reasoning": "..."},
+    {"name": "octo:personas:ux-researcher", "role": "ux",
+     "verdict": "approve", "reasoning": "..."}
+  ],
+  "chair": "octo:personas:backend-architect",
+  "chair_synthesis": "...",
+  "final_verdict": "request_changes",
+  "graded_by": "claude-opus-4-7"
+}
+```
+
+### Step 6 — Post the synthesis as a PR comment
+
+```bash
+gh pr comment "$PR_NUM" --body "$(cat <<EOF
+## Council verdict — $FINAL_VERDICT
+
+**One-way doors touched:** $(echo "$DOORS" | sed 's/^/- /')
+
+$CHAIR_SYNTHESIS
+
+<details>
+<summary>Advisor breakdown</summary>
+
+- security-auditor: $SEC_VERDICT
+- database-architect: $DB_VERDICT
+- code-reviewer: $CR_VERDICT
+- ux-researcher: $UX_VERDICT
+
+</details>
+
+Full verdict JSON: \`state/quality/council/$HEAD_SHA.json\`
+EOF
+)"
+```
+
+### Step 7 — Report
+
+One line back to the session:
+
+```text
+Council #<PR>: <final_verdict> · doors: <count> · advisors: 4 → 1 chair
+artifact: state/quality/council/<sha>.json
+```
+
+## Anti-patterns
+
+- **Auto-firing on every PR.** This skill is opt-in. If you find yourself
+  invoking it for routine changes, you're using the wrong gate — try
+  `/octo:review` or the chatbot-iterate tribunal instead.
+- **Skipping the door check.** If you convene the council on a PR that
+  doesn't touch a one-way door, you've spent four sub-agent budgets for
+  nothing. Always run Step 2 first.
+- **Ignoring a `block` verdict.** The aggregation rule is one-way-door
+  blast radius mirrored at the gate: a single advisor can halt the merge.
+  If you disagree, fix the concern or argue in PR comments and re-run
+  `/council` after the next commit (new `head_sha` → new artifact).
+- **Re-running on the same SHA.** Once the artifact for `<head_sha>.json`
+  exists, the council has spoken for that commit. Push a new commit to
+  re-convene.
+- **Treating advisor JSON as gospel.** Each advisor returns 2–5 sentences;
+  the chair must read them, not just count verdicts.
+
+## Why this exists
+
+Per the harness adoption plan (`docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md`,
+item M6): one-way-door PRs need a richer review than a single LLM pass.
+`/octo:review` is the standard daily gate. `/council` is the **escalated**
+gate — used when the cost of a wrong call is high and asymmetric (reverting
+an OPTIC-K dim change means re-indexing the corpus and coordinating with
+ix + every consumer crate).
+
+The forge pattern (multiple specialists + one chair + one verdict + persisted
+artifact) is the cheapest known protocol that reliably catches mistakes a
+single reviewer misses. We adopt it sparingly.
+
+## Related
+
+- `/octo:review` — daily review gate; runs on every PR.
+- `/chatbot-iterate` — chatbot-scoped tribunal gate; load-bearing on
+  `Common/GA.Business.ML/Agents/**` paths.
+- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` —
+  source plan; this skill is item M6.
+- `state/quality/council/README.md` — artifact format + retention.
+- `state/quality/council/SCHEMA.json` — verdict JSON Schema.
+- [claude-codex-forge](https://github.com/pablomarin/claude-codex-forge) —
+  upstream pattern this skill adopts.

--- a/state/quality/council/README.md
+++ b/state/quality/council/README.md
@@ -1,0 +1,57 @@
+# state/quality/council — Council verdict archive
+
+Produced by the `/council` skill (`.claude/skills/council/SKILL.md`). One
+JSON file per convened council, named by the PR head SHA at convocation
+time. Format is `council-verdict-v1` — see `SCHEMA.json` in this directory.
+
+## When a file gets written
+
+Only when `/council` is invoked **and** the PR touches a one-way-door path
+enumerated in the skill (OPTIC-K dim, contract schema, public controller,
+SPA route, installer script, pricing). PRs that don't touch a door produce
+no artifact and exit clean.
+
+This is the **opt-in escalated gate**, not the daily review gate. Routine
+review verdicts live elsewhere (see `state/chatbot-reviews/` for tribunal
+verdicts, and PR comments for `/octo:review` output).
+
+## File layout
+
+```
+state/quality/council/
+├── README.md                      # this file
+├── SCHEMA.json                    # JSON Schema for council-verdict-v1
+└── <head-sha>.json                # one verdict per convened council
+```
+
+`<head-sha>` is the 40-char Git SHA the council reviewed. A new push to
+the PR produces a new SHA and a new artifact; the old one stays for
+history. This is intentional — the verdict pins to the commit it judged.
+
+## Retention
+
+Verdicts are append-only history. Keep them indefinitely:
+
+- They are tiny (each file is a few KB).
+- They form the audit trail for one-way-door decisions, which is the whole
+  point of the gate. Deleting them defeats the purpose.
+- If the directory ever grows past ~1k files we'll revisit (unlikely —
+  one-way-door PRs are rare by construction).
+
+## Aggregation rule
+
+Mirrored in the skill and in `SCHEMA.json`'s `final_verdict` enum:
+
+- Any advisor returns `block` → final = `block`.
+- Else any returns `request_changes` → final = `request_changes`.
+- Else → final = `approve`.
+
+The chair's `chair_synthesis` field is prose, not a vote. It explains the
+reasoning behind the deterministic aggregation.
+
+## Related
+
+- `.claude/skills/council/SKILL.md` — the producer.
+- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` — the
+  source plan (item M6).
+- `state/quality/README.md` — overall quality-snapshot directory layout.

--- a/state/quality/council/SCHEMA.json
+++ b/state/quality/council/SCHEMA.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/GuitarAlchemist/ga/state/quality/council/SCHEMA.json",
+  "title": "Council Verdict v1",
+  "description": "Verdict produced by the /council skill for a one-way-door PR. One file per convened council, named state/quality/council/<head_sha>.json. Adopts the claude-codex-forge council pattern: five specialist sub-agents + one chair synthesizes + one deterministic final verdict.",
+  "type": "object",
+  "required": [
+    "schema",
+    "pr_number",
+    "head_sha",
+    "one_way_door_paths",
+    "convened_at",
+    "advisors",
+    "chair",
+    "chair_synthesis",
+    "final_verdict",
+    "graded_by"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "council-verdict-v1",
+      "description": "Schema discriminator. Locked at v1."
+    },
+    "pr_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "GitHub PR number the council reviewed."
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$",
+      "description": "Commit SHA the council reviewed. A new push produces a new artifact."
+    },
+    "one_way_door_paths": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" },
+      "description": "Paths from the PR diff that matched one-way-door patterns. Must be non-empty — the skill exits early without writing an artifact if no doors were touched."
+    },
+    "convened_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the council was convened."
+    },
+    "advisors": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Per-advisor verdicts. Default slate is 4 advisors (security, data, code-quality, ux) plus the chair which appears separately in the `chair` field.",
+      "items": {
+        "type": "object",
+        "required": ["name", "role", "verdict", "reasoning"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Sub-agent identifier, e.g. 'octo:personas:security-auditor'."
+          },
+          "role": {
+            "type": "string",
+            "enum": ["security", "data", "code-quality", "ux", "other"],
+            "description": "Focus area assigned to this advisor in the council brief."
+          },
+          "verdict": {
+            "type": "string",
+            "enum": ["approve", "request_changes", "block"],
+            "description": "This advisor's call. 'block' means the one-way door is unsafe to open as-is and the PR must not merge."
+          },
+          "reasoning": {
+            "type": "string",
+            "minLength": 1,
+            "description": "2-5 sentences. Free text. The chair reads these to write the synthesis."
+          }
+        }
+      }
+    },
+    "chair": {
+      "type": "string",
+      "description": "Sub-agent identifier of the chair, e.g. 'octo:personas:backend-architect'. Default chair is backend-architect; future rev can swap by PR type."
+    },
+    "chair_synthesis": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Chair's prose explanation of the final verdict. 3-6 sentences naming each dissent, the decisive concern, and the recommendation. This is what gets posted as the PR comment."
+    },
+    "final_verdict": {
+      "type": "string",
+      "enum": ["approve", "request_changes", "block"],
+      "description": "Deterministic aggregation: any 'block' from any advisor → 'block'; else any 'request_changes' → 'request_changes'; else 'approve'. Mirrored in README.md."
+    },
+    "graded_by": {
+      "type": "string",
+      "description": "Model identifier of the chair LLM, e.g. 'claude-opus-4-7'. Useful for tracking which model class signed off across the history."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Harness engineering adoption plan item M6 — adopts the [claude-codex-forge](https://github.com/pablomarin/claude-codex-forge) `/council` pattern as an **opt-in** pre-merge gate for one-way-door PRs (OPTIC-K dim changes, cross-repo contracts, public HTTP controllers, SPA route definitions, installer scripts, pricing).

- `.claude/skills/council/SKILL.md` — skill definition (~257 lines)
- `state/quality/council/README.md` — artifact format + retention policy
- `state/quality/council/SCHEMA.json` — `council-verdict-v1` JSON Schema
- `state/quality/council/.gitkeep` — keep dir tracked

## How it works

1. `/council <PR#>` (or just `/council` for current branch) resolves the PR.
2. Checks `files[].path` against the one-way-door glob list enumerated in `CLAUDE.md` + the skill.
3. **No door touched → exit clean.** Routine PRs are not the council's job — they go through `/octo:review` or the chatbot-iterate tribunal.
4. **Door touched → convene 5 sub-agents in parallel** via the `Agent` tool: `octo:personas:{security-auditor, database-architect, code-reviewer, ux-researcher}` plus `backend-architect` as chair.
5. Each advisor returns `{verdict: approve|request_changes|block, reasoning: "..."}`.
6. Chair synthesizes; final verdict aggregates deterministically (any `block` → block; any `request_changes` → request_changes; else approve).
7. Writes `state/quality/council/<head_sha>.json` + posts synthesis as a PR comment.

## Non-obvious design choices

- **Opt-in only.** The forge fires on every PR; we don't — one-way-door PRs are rare and the council costs four sub-agent budgets per convocation.
- **Chair = backend-architect** instead of Codex (claude-codex-forge's default) because we don't have a Codex CLI persona in `octo:personas:*`. The SKILL.md notes that future revisions can swap chairs by PR type (e.g., `ux-researcher` chairs SPA route changes).
- **Verdict pins to head SHA.** A new push → new artifact. The old verdict stays in the audit trail.

## What this PR does NOT touch

- `state/harness/items.json` — the orchestrator batches that dashboard update across all in-flight harness PRs.
- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` — same reason.
- `.github/workflows/` — Agent Blackbox blocks autonomous workflow edits.
- `CLAUDE.md` / `AGENTS.md` / `governance/` — same.
- Zero TypeScript files → zero new TS baseline errors.

## Test plan

- [ ] CI green (markdown-only + JSON-only diff; no test coverage to add)
- [ ] After merge, run `/council` on a clean branch with no open PR → expect `no council required` exit
- [ ] After merge, run `/council` on a future PR that touches `EmbeddingSchema.cs` → expect 5 advisors convened + artifact written + PR comment posted

Generated with [Claude Code](https://claude.com/claude-code).