### PR TITLE
feat(harness): non-admin Windows service install scaffold (item #8)

### DIFF
--- a/Scripts/install-ga-service.ps1
+++ b/Scripts/install-ga-service.ps1
@@ -1,199 +1,318 @@
 <#
 .SYNOPSIS
-    Install Guitar Alchemist as a Windows Service
+    Install Guitar Alchemist platform processes as non-admin Windows services.
+
 .DESCRIPTION
-    Creates a Windows service that manages:
-    1. GaApi backend (ASP.NET Core on port 7001)
-    2. Cloudflare tunnel (demos.guitaralchemist.com)
-    3. Frontend dev server (Vite on port 5176)
-    4. Ollama LLM (local inference on port 11434)
+    Registers three NSSM-managed Windows services so the production trio
+    (Vite frontend, GaApi backend, GaChatbot.Api backend) runs under a
+    dedicated low-privilege service account. Each service is independent
+    so an agent can kill or restart one without elevation and without
+    taking the other two down.
+
+    Services registered:
+      GA-Vite-5176       (Apps/ga-react-components, pnpm dev, port 5176)
+      GA-Api-5232        (GaApi, dotnet run, port 5232)
+      GA-Chatbot-5252    (GaChatbot.Api, dotnet run, port 5252)
+
+    The Cloudflared tunnel is intentionally NOT wrapped here. Use
+    `cloudflared service install` for that — it ships its own native
+    Windows service installer and runs as LOCAL SYSTEM by design.
+
+    This script is the RESEARCH + SCAFFOLD output for harness item #8
+    in docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md.
+    It MUST be run by the user (requires admin to register services).
+    Always dry-run with -WhatIf first.
+
 .PARAMETER Install
-    Install the service
+    Register the three services. Honours -WhatIf.
+
 .PARAMETER Uninstall
-    Remove the service
+    Remove the three services. Honours -WhatIf. Prefer the dedicated
+    Scripts/uninstall-ga-service.ps1 for symmetry.
+
 .PARAMETER Start
-    Start the service
+    Start all three services (or those installed). Honours -WhatIf.
+
 .PARAMETER Stop
-    Stop the service
+    Stop all three services. Honours -WhatIf.
+
 .PARAMETER Status
-    Show service status
+    Show service status, port listeners, and PID per service. Read-only.
+
+.PARAMETER ServiceAccount
+    Windows account that owns the service processes. Defaults to
+    'NT AUTHORITY\NetworkService' — a built-in low-privilege account
+    that does NOT require AD setup. To use a dedicated local user
+    instead, pass e.g. '.\ga-service' and supply -ServiceAccountPassword.
+
+.PARAMETER ServiceAccountPassword
+    Password for ServiceAccount if it's not a built-in virtual account.
+    SecureString. Ignored for NetworkService / LocalService.
+
+.PARAMETER NssmPath
+    Path to nssm.exe. Defaults to 'nssm' (looked up on PATH).
+    Install NSSM with: winget install nssm
+
 .EXAMPLE
+    # DRY RUN — see what would happen, change nothing.
+    .\install-ga-service.ps1 -Install -WhatIf
+
+.EXAMPLE
+    # Real install under NetworkService (no AD account needed).
     .\install-ga-service.ps1 -Install
-    .\install-ga-service.ps1 -Start
+
+.EXAMPLE
+    # Real install under a dedicated local account.
+    $pwd = Read-Host -AsSecureString "ga-service password"
+    .\install-ga-service.ps1 -Install -ServiceAccount '.\ga-service' -ServiceAccountPassword $pwd
+
+.EXAMPLE
+    .\install-ga-service.ps1 -Status
+
+.NOTES
+    See docs/runbooks/non-admin-service-install.md for the full runbook,
+    rationale, and rollback procedure.
 #>
 
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
 param(
     [switch]$Install,
     [switch]$Uninstall,
     [switch]$Start,
     [switch]$Stop,
-    [switch]$Status
+    [switch]$Status,
+    [string]$ServiceAccount = 'NT AUTHORITY\NetworkService',
+    [System.Security.SecureString]$ServiceAccountPassword,
+    [string]$NssmPath = 'nssm'
 )
 
-$ServiceName = "GuitarAlchemist"
-$DisplayName = "Guitar Alchemist Platform"
-$Description = "GaApi + Cloudflare tunnel + Frontend + Ollama"
-$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-# If run from Scripts/, go up one level
+$ErrorActionPreference = 'Stop'
+
+# ---------- repo paths ----------
+$RepoRoot = Split-Path -Parent $PSScriptRoot
 if (-not (Test-Path "$RepoRoot\AllProjects.slnx")) {
-    $RepoRoot = Split-Path -Parent $PSScriptRoot
+    throw "Cannot locate AllProjects.slnx from $RepoRoot. Run this script from Scripts/."
+}
+$LogDir = Join-Path $RepoRoot 'logs\services'
+
+# ---------- service definitions ----------
+# Each entry describes one independent NSSM-managed service.
+# WorkingDir, Exe and Args are passed verbatim to nssm.
+$Services = @(
+    @{
+        Name        = 'GA-Vite-5176'
+        Display     = 'Guitar Alchemist - Vite Frontend (5176)'
+        Description = 'pnpm dev for ga-react-components, port 5176. Part of demos.guitaralchemist.com.'
+        WorkingDir  = Join-Path $RepoRoot 'Apps\ga-react-components'
+        Exe         = 'pnpm.cmd'
+        Args        = 'dev --host --port 5176'
+        Port        = 5176
+        StdOut      = 'vite.log'
+        StdErr      = 'vite.err.log'
+    }
+    @{
+        Name        = 'GA-Api-5232'
+        Display     = 'Guitar Alchemist - GaApi (5232)'
+        Description = 'GaApi backend, dotnet run, port 5232. Music theory + voicings API.'
+        WorkingDir  = Join-Path $RepoRoot 'GaApi'
+        Exe         = 'dotnet.exe'
+        Args        = 'run --project GaApi.csproj --no-build --urls http://0.0.0.0:5232'
+        Port        = 5232
+        StdOut      = 'gaapi.log'
+        StdErr      = 'gaapi.err.log'
+    }
+    @{
+        Name        = 'GA-Chatbot-5252'
+        Display     = 'Guitar Alchemist - GaChatbot.Api (5252)'
+        Description = 'Public chatbot host, dotnet run, port 5252.'
+        WorkingDir  = Join-Path $RepoRoot 'GaChatbot.Api'
+        Exe         = 'dotnet.exe'
+        Args        = 'run --project GaChatbot.Api.csproj --no-build --urls http://0.0.0.0:5252'
+        Port        = 5252
+        StdOut      = 'chatbot.log'
+        StdErr      = 'chatbot.err.log'
+    }
+)
+
+# ---------- helpers ----------
+function Test-NssmAvailable {
+    $cmd = Get-Command $NssmPath -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        Write-Host "NSSM not found on PATH. Install with: winget install nssm" -ForegroundColor Yellow
+        Write-Host "Or download from https://nssm.cc/ and pass -NssmPath C:\path\to\nssm.exe" -ForegroundColor Yellow
+        return $false
+    }
+    return $true
 }
 
-$WrapperScript = "$RepoRoot\Scripts\ga-service-wrapper.ps1"
+function Test-IsElevated {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
 
+function Invoke-Nssm {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$NssmArgs)
+    & $NssmPath @NssmArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "nssm exited with code $LASTEXITCODE - args: $($NssmArgs -join ' ')"
+    }
+}
+
+function Get-PortPid {
+    param([int]$Port)
+    $line = netstat -ano | Select-String -Pattern (":{0}\s" -f $Port) | Select-Object -First 1
+    if (-not $line) { return $null }
+    $tokens = -split $line.ToString()
+    return $tokens[-1]
+}
+
+# ---------- STATUS (read-only, always safe) ----------
 if ($Status) {
-    $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
-    if ($svc) {
-        Write-Host "Service: $($svc.DisplayName)"
-        Write-Host "Status:  $($svc.Status)"
-        Write-Host ""
-
-        # Check individual processes
-        $processes = @(
-            @{ Name = "GaApi"; Port = 7001 },
-            @{ Name = "cloudflared"; Port = 0 },
-            @{ Name = "node (Vite)"; Port = 5176 },
-            @{ Name = "ollama"; Port = 11434 }
-        )
-        foreach ($p in $processes) {
-            if ($p.Port -gt 0) {
-                $listening = netstat -ano | Select-String ":$($p.Port)\s" | Select-Object -First 1
-                if ($listening) {
-                    Write-Host "  [OK] $($p.Name) on port $($p.Port)" -ForegroundColor Green
-                } else {
-                    Write-Host "  [--] $($p.Name) not detected on port $($p.Port)" -ForegroundColor Yellow
-                }
-            } else {
-                $proc = Get-Process -Name $p.Name -ErrorAction SilentlyContinue
-                if ($proc) {
-                    Write-Host "  [OK] $($p.Name) running (PID $($proc.Id))" -ForegroundColor Green
-                } else {
-                    Write-Host "  [--] $($p.Name) not running" -ForegroundColor Yellow
-                }
-            }
-        }
+    Write-Host ""
+    Write-Host "Guitar Alchemist service status" -ForegroundColor Cyan
+    Write-Host "Account: $ServiceAccount" -ForegroundColor DarkGray
+    Write-Host ""
+    foreach ($svc in $Services) {
+        $win = Get-Service -Name $svc.Name -ErrorAction SilentlyContinue
+        $portPid = Get-PortPid -Port $svc.Port
+        $svcState = if ($win) { $win.Status } else { 'NOT INSTALLED' }
+        $portInfo = if ($portPid) { "port $($svc.Port) PID $portPid" } else { "port $($svc.Port) idle" }
+        $color = if ($win -and $win.Status -eq 'Running') { 'Green' } elseif (-not $win) { 'Yellow' } else { 'Red' }
+        Write-Host ("  {0,-18} {1,-13} {2}" -f $svc.Name, $svcState, $portInfo) -ForegroundColor $color
+    }
+    Write-Host ""
+    Write-Host "Cloudflared tunnel (managed separately):" -ForegroundColor DarkGray
+    $cf = Get-Service -Name 'Cloudflared' -ErrorAction SilentlyContinue
+    if ($cf) {
+        $cfColor = if ($cf.Status -eq 'Running') { 'Green' } else { 'Red' }
+        Write-Host ("  {0,-18} {1}" -f 'Cloudflared', $cf.Status) -ForegroundColor $cfColor
     } else {
-        Write-Host "Service '$ServiceName' is not installed." -ForegroundColor Yellow
+        Write-Host "  Cloudflared       NOT INSTALLED - install with: cloudflared service install" -ForegroundColor Yellow
     }
     return
 }
 
+# ---------- INSTALL ----------
 if ($Install) {
-    Write-Host "Installing $DisplayName service..." -ForegroundColor Cyan
+    $nssmOk = Test-NssmAvailable
+    if (-not $nssmOk -and -not $WhatIfPreference) { return }
+    if (-not $nssmOk) {
+        Write-Host "(continuing in -WhatIf mode for dry-run preview without NSSM)" -ForegroundColor DarkGray
+    }
+    if (-not (Test-IsElevated)) {
+        Write-Host "Service registration requires an elevated PowerShell." -ForegroundColor Yellow
+        Write-Host "Re-run this script from an admin PowerShell." -ForegroundColor Yellow
+        if (-not $WhatIfPreference) { return }
+        Write-Host "(continuing in -WhatIf mode for dry-run preview)" -ForegroundColor DarkGray
+    }
 
-    # Create the wrapper script
-    $wrapperContent = @"
-# GA Service Wrapper — managed by Windows Service
-# Starts and monitors all GA platform components
+    if ($PSCmdlet.ShouldProcess($LogDir, "Create log directory")) {
+        New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+    }
 
-`$RepoRoot = "$RepoRoot"
-`$LogDir = "`$RepoRoot\logs"
-New-Item -ItemType Directory -Path `$LogDir -Force | Out-Null
+    foreach ($svc in $Services) {
+        $target = "service $($svc.Name) [$($svc.Exe) $($svc.Args)] in $($svc.WorkingDir) as $ServiceAccount"
+        if (-not $PSCmdlet.ShouldProcess($target, "nssm install")) { continue }
 
-# Start components
-`$procs = @()
-
-# 1. GaApi
-`$gaApiLog = "`$LogDir\gaapi.log"
-`$procs += Start-Process -FilePath "dotnet" -ArgumentList "run --project `$RepoRoot\Apps\ga-server\GaApi\GaApi.csproj --no-build" -WindowStyle Hidden -PassThru -RedirectStandardOutput `$gaApiLog -RedirectStandardError "`$LogDir\gaapi-err.log"
-Write-Output "Started GaApi (PID `$(`$procs[-1].Id))"
-
-# 2. Cloudflare tunnel
-`$procs += Start-Process -FilePath "cloudflared" -ArgumentList "tunnel run ga-demos" -WindowStyle Hidden -PassThru -RedirectStandardOutput "`$LogDir\cloudflared.log" -RedirectStandardError "`$LogDir\cloudflared-err.log"
-Write-Output "Started cloudflared tunnel (PID `$(`$procs[-1].Id))"
-
-# 3. Frontend dev server
-`$procs += Start-Process -FilePath "npm" -ArgumentList "run dev" -WorkingDirectory "`$RepoRoot\ReactComponents\ga-react-components" -WindowStyle Hidden -PassThru -RedirectStandardOutput "`$LogDir\vite.log" -RedirectStandardError "`$LogDir\vite-err.log"
-Write-Output "Started Vite dev server (PID `$(`$procs[-1].Id))"
-
-# 4. Ollama (if installed)
-`$ollamaPath = Get-Command ollama -ErrorAction SilentlyContinue
-if (`$ollamaPath) {
-    `$procs += Start-Process -FilePath "ollama" -ArgumentList "serve" -WindowStyle Hidden -PassThru -RedirectStandardOutput "`$LogDir\ollama.log" -RedirectStandardError "`$LogDir\ollama-err.log"
-    Write-Output "Started Ollama (PID `$(`$procs[-1].Id))"
-}
-
-# Monitor loop — restart crashed processes
-while (`$true) {
-    Start-Sleep -Seconds 30
-    foreach (`$p in `$procs) {
-        if (`$p.HasExited) {
-            Write-Output "Process `$(`$p.Id) exited with code `$(`$p.ExitCode), not restarting (manual intervention needed)"
+        $existing = Get-Service -Name $svc.Name -ErrorAction SilentlyContinue
+        if ($existing) {
+            Write-Host "Service $($svc.Name) already exists - skipping install. Remove with -Uninstall first." -ForegroundColor Yellow
+            continue
         }
+
+        # Resolve exe path (NSSM needs absolute)
+        $exeCmd = Get-Command $svc.Exe -ErrorAction SilentlyContinue
+        if (-not $exeCmd) { throw "Cannot find $($svc.Exe) on PATH for service $($svc.Name)." }
+        $exeAbs = $exeCmd.Source
+
+        Invoke-Nssm install $svc.Name $exeAbs $svc.Args
+        Invoke-Nssm set $svc.Name DisplayName $svc.Display
+        Invoke-Nssm set $svc.Name Description $svc.Description
+        Invoke-Nssm set $svc.Name AppDirectory $svc.WorkingDir
+        Invoke-Nssm set $svc.Name AppStdout (Join-Path $LogDir $svc.StdOut)
+        Invoke-Nssm set $svc.Name AppStderr (Join-Path $LogDir $svc.StdErr)
+        Invoke-Nssm set $svc.Name AppRotateFiles 1
+        Invoke-Nssm set $svc.Name AppRotateBytes 10485760  # 10MB
+        Invoke-Nssm set $svc.Name Start SERVICE_AUTO_START
+        Invoke-Nssm set $svc.Name AppExit Default Restart
+        Invoke-Nssm set $svc.Name AppRestartDelay 5000
+
+        # ObjectName = service account.
+        $builtIn = @('NT AUTHORITY\NetworkService','NT AUTHORITY\LocalService','LocalSystem')
+        if ($ServiceAccount -in $builtIn) {
+            Invoke-Nssm set $svc.Name ObjectName $ServiceAccount
+        }
+        elseif ($ServiceAccountPassword) {
+            $plain = [System.Net.NetworkCredential]::new('', $ServiceAccountPassword).Password
+            Invoke-Nssm set $svc.Name ObjectName $ServiceAccount $plain
+        }
+        else {
+            throw "ServiceAccount '$ServiceAccount' is not a built-in virtual account; pass -ServiceAccountPassword."
+        }
+
+        Write-Host "Installed $($svc.Name) as $ServiceAccount" -ForegroundColor Green
     }
-}
-"@
-    Set-Content -Path $WrapperScript -Value $wrapperContent -Force
 
-    # Use NSSM (Non-Sucking Service Manager) if available, otherwise sc.exe
-    $nssm = Get-Command nssm -ErrorAction SilentlyContinue
-    if ($nssm) {
-        & nssm install $ServiceName powershell.exe "-ExecutionPolicy Bypass -File `"$WrapperScript`""
-        & nssm set $ServiceName DisplayName $DisplayName
-        & nssm set $ServiceName Description $Description
-        & nssm set $ServiceName Start SERVICE_AUTO_START
-        & nssm set $ServiceName AppStdout "$RepoRoot\logs\service.log"
-        & nssm set $ServiceName AppStderr "$RepoRoot\logs\service-err.log"
-        Write-Host "Service installed via NSSM." -ForegroundColor Green
-    } else {
-        Write-Host "NSSM not found. Install with: winget install nssm" -ForegroundColor Yellow
-        Write-Host "Or use: sc.exe create $ServiceName binPath=`"powershell -File $WrapperScript`"" -ForegroundColor Yellow
-        Write-Host ""
-        Write-Host "Alternative: use Task Scheduler instead:" -ForegroundColor Cyan
-
-        # Create a scheduled task as fallback
-        $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$WrapperScript`""
-        $trigger = New-ScheduledTaskTrigger -AtStartup
-        $settings = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
-        $principal = New-ScheduledTaskPrincipal -UserId "$env:USERNAME" -LogonType S4U -RunLevel Highest
-
-        Register-ScheduledTask -TaskName $ServiceName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description $Description -Force
-        Write-Host "Scheduled task '$ServiceName' created (runs at startup)." -ForegroundColor Green
-    }
+    Write-Host ""
+    Write-Host "Next steps:" -ForegroundColor Cyan
+    Write-Host "  1. Grant the service account read access to $RepoRoot (icacls if needed)."
+    Write-Host "  2. Install cloudflared as a service:  cloudflared service install"
+    Write-Host "  3. Start the platform:                .\install-ga-service.ps1 -Start"
+    Write-Host "  4. Verify:                            .\install-ga-service.ps1 -Status"
     return
 }
 
+# ---------- UNINSTALL ----------
 if ($Uninstall) {
-    $nssm = Get-Command nssm -ErrorAction SilentlyContinue
-    if ($nssm) {
-        & nssm stop $ServiceName 2>$null
-        & nssm remove $ServiceName confirm
-    }
-    Unregister-ScheduledTask -TaskName $ServiceName -Confirm:$false -ErrorAction SilentlyContinue
-    Write-Host "Service/task removed." -ForegroundColor Green
-    return
-}
-
-if ($Start) {
-    $nssm = Get-Command nssm -ErrorAction SilentlyContinue
-    if ($nssm) {
-        & nssm start $ServiceName
-    } else {
-        Start-ScheduledTask -TaskName $ServiceName -ErrorAction SilentlyContinue
-        if ($?) {
-            Write-Host "Task started." -ForegroundColor Green
-        } else {
-            # Direct launch
-            Start-Process powershell.exe -ArgumentList "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$WrapperScript`"" -WindowStyle Hidden
-            Write-Host "Started directly." -ForegroundColor Green
+    $nssmOk = Test-NssmAvailable
+    if (-not $nssmOk -and -not $WhatIfPreference) { return }
+    foreach ($svc in $Services) {
+        $existing = Get-Service -Name $svc.Name -ErrorAction SilentlyContinue
+        if (-not $existing) {
+            Write-Host "$($svc.Name) not installed - skipping." -ForegroundColor DarkGray
+            continue
         }
+        if (-not $PSCmdlet.ShouldProcess($svc.Name, "nssm stop + remove")) { continue }
+        try { Invoke-Nssm stop $svc.Name } catch { Write-Host "stop failed (already stopped?): $_" -ForegroundColor DarkGray }
+        Invoke-Nssm remove $svc.Name confirm
+        Write-Host "Removed $($svc.Name)" -ForegroundColor Green
     }
     return
 }
 
+# ---------- START ----------
+if ($Start) {
+    if (-not (Test-NssmAvailable)) { return }
+    foreach ($svc in $Services) {
+        $existing = Get-Service -Name $svc.Name -ErrorAction SilentlyContinue
+        if (-not $existing) {
+            Write-Host "$($svc.Name) not installed - run -Install first." -ForegroundColor Yellow
+            continue
+        }
+        if (-not $PSCmdlet.ShouldProcess($svc.Name, "nssm start")) { continue }
+        Invoke-Nssm start $svc.Name
+        Write-Host "Started $($svc.Name)" -ForegroundColor Green
+    }
+    return
+}
+
+# ---------- STOP ----------
 if ($Stop) {
-    $nssm = Get-Command nssm -ErrorAction SilentlyContinue
-    if ($nssm) {
-        & nssm stop $ServiceName
-    } else {
-        Stop-ScheduledTask -TaskName $ServiceName -ErrorAction SilentlyContinue
+    if (-not (Test-NssmAvailable)) { return }
+    foreach ($svc in $Services) {
+        $existing = Get-Service -Name $svc.Name -ErrorAction SilentlyContinue
+        if (-not $existing) { continue }
+        if (-not $PSCmdlet.ShouldProcess($svc.Name, "nssm stop")) { continue }
+        try { Invoke-Nssm stop $svc.Name } catch { Write-Host "stop failed: $_" -ForegroundColor DarkGray }
+        Write-Host "Stopped $($svc.Name)" -ForegroundColor Green
     }
-    # Also kill child processes
-    Get-Process -Name "dotnet","cloudflared","node" -ErrorAction SilentlyContinue | Where-Object {
-        $_.MainWindowTitle -eq "" # background processes
-    } | Stop-Process -Force -ErrorAction SilentlyContinue
-    Write-Host "Stopped." -ForegroundColor Green
     return
 }
 
-Write-Host "Usage: .\install-ga-service.ps1 -Install | -Uninstall | -Start | -Stop | -Status"
+Write-Host "Usage:" -ForegroundColor Cyan
+Write-Host "  .\install-ga-service.ps1 -Install [-WhatIf] [-ServiceAccount '.\ga-service' -ServiceAccountPassword <secure>]"
+Write-Host "  .\install-ga-service.ps1 -Uninstall [-WhatIf]"
+Write-Host "  .\install-ga-service.ps1 -Start | -Stop | -Status"
+Write-Host ""
+Write-Host "Always dry-run with -WhatIf before -Install. See docs/runbooks/non-admin-service-install.md." -ForegroundColor DarkGray

--- a/Scripts/uninstall-ga-service.ps1
+++ b/Scripts/uninstall-ga-service.ps1
@@ -1,0 +1,64 @@
+<#
+.SYNOPSIS
+    Uninstall the Guitar Alchemist non-admin Windows services.
+
+.DESCRIPTION
+    Convenience wrapper around `install-ga-service.ps1 -Uninstall`.
+    Removes the three NSSM-managed services (GA-Vite-5176, GA-Api-5232,
+    GA-Chatbot-5252). Does NOT touch the Cloudflared service - remove
+    that separately with `cloudflared service uninstall`.
+
+    Always dry-run with -WhatIf first.
+
+.PARAMETER NssmPath
+    Path to nssm.exe. Defaults to 'nssm' on PATH.
+
+.PARAMETER IncludeCloudflared
+    Also run `cloudflared service uninstall`. Off by default because
+    the tunnel often outlives the local services.
+
+.EXAMPLE
+    .\uninstall-ga-service.ps1 -WhatIf
+
+.EXAMPLE
+    .\uninstall-ga-service.ps1
+
+.EXAMPLE
+    .\uninstall-ga-service.ps1 -IncludeCloudflared
+
+.NOTES
+    See docs/runbooks/non-admin-service-install.md for the rollback
+    procedure including log-file cleanup and ACL revert.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [string]$NssmPath = 'nssm',
+    [switch]$IncludeCloudflared
+)
+
+$ErrorActionPreference = 'Stop'
+
+$installScript = Join-Path $PSScriptRoot 'install-ga-service.ps1'
+if (-not (Test-Path $installScript)) {
+    throw "install-ga-service.ps1 not found next to this script at $installScript"
+}
+
+# Forward -WhatIf via $WhatIfPreference (CmdletBinding inherits common params).
+& $installScript -Uninstall -NssmPath $NssmPath -WhatIf:$WhatIfPreference
+
+if ($IncludeCloudflared) {
+    $cf = Get-Service -Name 'Cloudflared' -ErrorAction SilentlyContinue
+    if ($cf) {
+        if ($PSCmdlet.ShouldProcess('Cloudflared', 'cloudflared service uninstall')) {
+            & cloudflared service uninstall
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "cloudflared service uninstall exited with $LASTEXITCODE" -ForegroundColor Yellow
+            } else {
+                Write-Host "Removed Cloudflared service" -ForegroundColor Green
+            }
+        }
+    } else {
+        Write-Host "Cloudflared service not installed - nothing to remove." -ForegroundColor DarkGray
+    }
+}

--- a/docs/runbooks/non-admin-service-install.md
+++ b/docs/runbooks/non-admin-service-install.md
@@ -1,0 +1,197 @@
+# Non-Admin Service Install Runbook
+
+**Status:** Scaffold ready for install. Not yet executed.
+**Scope:** Harness item #8 from `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md`.
+**Date:** 2026-05-23
+**Owner:** Stephane (must run, requires admin).
+
+## Why this matters
+
+This session (2026-05-23) we lost ~25 minutes of demos.guitaralchemist.com uptime because two related bugs collided:
+
+1. **Port displacement** — Codex started a stray Vite from `Apps/ga-client` which stole port 5176 from the canonical `ga-react-components` instance (fixed in PR #289).
+2. **Elevated-PID lock** — GaApi PID 21036 was running with an elevated token. No agent in the user's PowerShell context could `Stop-Process` it to unblock an AppHost rebuild. The user had to manually kill it from an admin shell.
+
+Running Vite, GaApi, and GaChatbot.Api as Windows services owned by a **non-admin service account** breaks this class of bug:
+
+- The agent's user-mode PowerShell can run `Restart-Service GA-Api-5232` (allowed by Service Control Manager ACLs once configured) without needing to spawn an elevated child process or pass UAC.
+- The bin-lock problem disappears because the service owner is the only process holder; restarting the service releases the lock cleanly.
+- Each of the three production processes (Vite/GaApi/Chatbot) is independent — restarting one doesn't take the other two down. Today, killing the AppHost takes everything with it.
+
+The plan tagged this as **L effort / H impact** — high impact because it eliminates a recurring outage class, but L effort because it requires admin-level OS changes, a service account decision, and irreversible registration.
+
+## Architectural options considered
+
+### Option A (REJECTED): Wrap Aspire AppHost in a single service
+
+This is what the previous version of `install-ga-service.ps1` did. It registers one service that runs `dotnet run --project AllProjects.AppHost`. Looks simple, but:
+
+- AppHost itself is a dev-orchestration layer. It spawns GaApi/GaChatbot/MongoDB as child processes and routes traffic through the Aspire dashboard. Running it as a service in prod is off-label.
+- One service = one lifecycle. Restarting "the platform" restarts everything, including the in-process Aspire dashboard. The whole point of this exercise is **independent lifecycles**.
+- The child processes inherit the AppHost's token. If AppHost runs as NetworkService, that's fine; but if it ever needs admin (which it will, the moment someone adds a debugger or a port < 1024), the children become un-killable again — exactly the bug we're trying to solve.
+
+### Option B (REJECTED): `New-Service` with a dedicated AD account
+
+Native Windows `New-Service`/`sc.exe create` with a domain account. Robust for shops with Active Directory but:
+
+- Requires AD setup (not present on this machine).
+- Requires creating + managing service account credentials (rotation, vaulting).
+- `sc.exe` doesn't supervise — if the wrapped process exits, the service is "stopped" with no auto-restart. You end up writing a wrapper that loops `Start-Process` and `Wait-Process`, which is what NSSM already does correctly.
+
+### Option C (CHOSEN): NSSM + built-in virtual account
+
+Three independent services, each wrapping one process, all running under `NT AUTHORITY\NetworkService` by default:
+
+| Service | Working dir | Command | Port |
+|---|---|---|---|
+| `GA-Vite-5176` | `Apps/ga-react-components` | `pnpm dev --host --port 5176` | 5176 |
+| `GA-Api-5232` | `GaApi` | `dotnet run --project GaApi.csproj --no-build --urls http://0.0.0.0:5232` | 5232 |
+| `GA-Chatbot-5252` | `GaChatbot.Api` | `dotnet run --project GaChatbot.Api.csproj --no-build --urls http://0.0.0.0:5252` | 5252 |
+
+Rationale:
+
+- **NSSM** supervises (auto-restart on crash), rotates logs, captures stdout/stderr to disk, accepts service-account credentials.
+- **NetworkService** is a built-in low-privilege account: no password to rotate, can bind to TCP ports > 1024, has network egress, can't elevate. Zero AD setup.
+- **Three services** = three independent lifecycles. An agent can `Restart-Service GA-Api-5232` without touching Vite or Chatbot.
+- **Service Control Manager ACLs** can be tuned per-service to grant the developer user `Start/Stop/Restart` rights without granting admin elsewhere (`sc sdset GA-Api-5232 ...`). Out of scope for this scaffold; default ACL already lets the local Administrators group restart.
+- **No AppHost in prod path.** AppHost stays a dev tool. Production runs the same processes Aspire would have launched, just without the orchestrator wrapper.
+
+Cloudflared is **not** wrapped — it ships its own native Windows service installer (`cloudflared service install`) which is well-tested and runs as LocalSystem. The runbook installs both.
+
+## Prerequisites
+
+1. **NSSM installed.** `winget install nssm` (or download from <https://nssm.cc/>).
+2. **Admin PowerShell.** Service registration requires it; the post-install lifecycle does not.
+3. **`AllProjects.sln` built once.** `--no-build` is in the args so the service starts fast; this assumes a prior `dotnet build`.
+4. **pnpm install run once** in `Apps/ga-react-components/` so `node_modules` exists.
+5. **Cloudflared installed** if you want the public tunnel managed too: `winget install cloudflare.cloudflared`.
+
+## Service account permissions
+
+The service account (default `NT AUTHORITY\NetworkService`) needs:
+
+| Permission | Why | How |
+|---|---|---|
+| Read access to repo path (`C:\Users\spare\source\repos\ga`) | Read csproj, source, node_modules, dlls | `icacls "C:\Users\spare\source\repos\ga" /grant "NT AUTHORITY\NetworkService:(OI)(CI)RX" /T` |
+| Write access to `logs\services\` | NSSM stdout/stderr capture | Created by the install script; inherits from parent or grant explicitly |
+| Bind ports 5176/5232/5252 | Listen for HTTP | NetworkService can bind > 1024 by default; no action needed |
+| Network egress | LLM API calls, NuGet, npm | NetworkService has this by default |
+| Read access to `~/.aspire/`, `~/.nuget/`, `%LOCALAPPDATA%\pnpm-store` | Tooling caches | NetworkService can't read the developer's profile — see "Profile caches" below |
+
+### Profile caches (gotcha)
+
+`dotnet` and `pnpm` cache packages in the *invoking user's* profile by default. NetworkService has its own profile at `C:\Windows\ServiceProfiles\NetworkService\`. The first start under NetworkService will repopulate these caches there, which is fine but adds ~30-60s to the first start. Two ways to avoid:
+
+- **(A)** Pre-stage by running once as NetworkService via `psexec -s` before starting the service (advanced).
+- **(B)** Switch to a dedicated local user (`.\ga-service`) whose profile is `C:\Users\ga-service` and pre-warm the caches as that user. Required if you want reproducible cold-start times.
+
+For initial install, accept the slow first start.
+
+## Step-by-step install (user runs this)
+
+```powershell
+# 1. Pull latest main, build once.
+cd C:\Users\spare\source\repos\ga
+git pull
+dotnet build AllProjects.slnx -c Debug
+pnpm --filter ga-react-components install
+
+# 2. Dry-run the installer. CHANGES NOTHING.
+.\Scripts\install-ga-service.ps1 -Install -WhatIf
+# Inspect the output. You should see three "What if: Performing the operation..."
+# lines per service (nssm install, set DisplayName, etc.) plus the log-dir creation.
+
+# 3. Open an ADMIN PowerShell. Re-run for real.
+Start-Process powershell.exe -Verb RunAs
+# (in the new admin window:)
+cd C:\Users\spare\source\repos\ga
+.\Scripts\install-ga-service.ps1 -Install
+# Three services should report "Installed ... as NT AUTHORITY\NetworkService".
+
+# 4. Grant repo read access (one-time).
+icacls "C:\Users\spare\source\repos\ga" /grant "NT AUTHORITY\NetworkService:(OI)(CI)RX" /T
+
+# 5. Install cloudflared as a service (skip if you don't expose publicly).
+cloudflared service install
+# (cloudflared reads its tunnel config from ~/.cloudflared/config.yml)
+
+# 6. Start everything (this can be done from a NON-admin shell once installed).
+.\Scripts\install-ga-service.ps1 -Start
+
+# 7. Verify.
+.\Scripts\install-ga-service.ps1 -Status
+# Expect: three "Running" services, three live port-listeners with NetworkService PIDs.
+```
+
+## Verification
+
+After step 7, do all of these:
+
+1. **Status check:** `Scripts\install-ga-service.ps1 -Status` shows three `Running` services with PIDs and ports occupied.
+2. **Port owner is NetworkService:**
+   ```powershell
+   $portPid = (netstat -ano | sls ':5232\s' | select -First 1).ToString().Split()[-1]
+   Get-Process -Id $portPid | Select Name, Id, UserName
+   ```
+   `UserName` should be `NT AUTHORITY\NETWORK SERVICE`, not your developer account.
+3. **Non-admin can restart:** Open a *regular* (non-admin) PowerShell and run:
+   ```powershell
+   Restart-Service GA-Api-5232
+   ```
+   Should succeed without UAC prompt. If it fails with "access denied," your developer account isn't in the service ACL — fix with:
+   ```powershell
+   # From admin shell, one-time:
+   sc.exe sdset GA-Api-5232 "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPCR;;;<your-user-SID>)"
+   ```
+4. **Smoke test the three URLs:**
+   ```powershell
+   curl http://localhost:5176/         # Vite, expect HTML
+   curl http://localhost:5232/health   # GaApi
+   curl http://localhost:5252/health   # Chatbot
+   ```
+5. **Public tunnel smoke (if cloudflared installed):**
+   ```powershell
+   curl https://demos.guitaralchemist.com/api/health
+   ```
+6. **Log files appear:** `dir C:\Users\spare\source\repos\ga\logs\services\` should show `vite.log`, `gaapi.log`, `chatbot.log` with recent timestamps.
+7. **Reboot test (optional but recommended):** restart the machine, log in, check that all three services come up automatically (Start type = Automatic per NSSM config).
+
+## Rollback / uninstall
+
+```powershell
+# Dry-run first.
+.\Scripts\uninstall-ga-service.ps1 -WhatIf
+
+# Real uninstall (admin shell).
+.\Scripts\uninstall-ga-service.ps1
+# Pass -IncludeCloudflared if you also want the tunnel removed.
+
+# Revert repo ACL grant (optional, harmless to leave).
+icacls "C:\Users\spare\source\repos\ga" /remove "NT AUTHORITY\NetworkService" /T
+
+# Clean log dir (optional).
+Remove-Item C:\Users\spare\source\repos\ga\logs\services -Recurse -Force
+```
+
+Post-uninstall, go back to running the platform via `Scripts\start-all.ps1` or the Aspire dashboard for development.
+
+## What this scaffold does NOT do
+
+These are deliberately deferred until after the first install proves the model works:
+
+- **Per-service ACL setup** (`sc sdset`) for non-admin restart. Documented in Verification step 3.
+- **Cloudflared tunnel config templating.** The user's existing `~/.cloudflared/config.yml` is reused as-is.
+- **Health-check HTTP probes** wired into NSSM `AppEvents` for auto-restart on /health 5xx (NSSM can't do this natively; would need a sidecar).
+- **Cache pre-warming** as NetworkService (see "Profile caches" gotcha above).
+- **Aspire dashboard equivalent.** No equivalent service — use the three `*.log` files in `logs/services/` plus Windows Event Viewer (NSSM logs there).
+- **MongoDB.** Today it runs in a Docker container managed by Aspire. Running it as a Windows service would require either (a) MongoDB Community installed natively as a service or (b) Docker Desktop running as a service. Out of scope; the developer keeps Aspire/Docker for the data layer.
+
+## Surfaced to harness item #8
+
+This scaffold lands the install machinery and runbook. The plan-doc dashboard tracks item #8 as **ready-for-install** (not ✅ shipped) until the user has:
+
+1. Run `-Install` for real.
+2. Verified all seven verification steps pass.
+3. Confirmed the next time an agent needs to restart GaApi, no UAC prompt fires and no manual admin kill is required.
+
+The "shipped" trigger is observational: the next session where a process-lock or elevated-PID incident *should* have happened, but didn't, because the service model handled it.


### PR DESCRIPTION
## Summary

Scaffold + runbook for harness item #8 from `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md`: run Vite + GaApi + GaChatbot.Api as Windows services owned by a non-admin account, so the **elevated-PID-can't-be-killed-by-agent** class of bug (witnessed this session: GaApi PID 21036) is structurally eliminated.

- **Rewrites `Scripts/install-ga-service.ps1`** to register three independent NSSM services (GA-Vite-5176, GA-Api-5232, GA-Chatbot-5252) owned by `NT AUTHORITY\NetworkService`. Each service has its own lifecycle, so restarting one doesn't touch the other two. Adds full `-WhatIf` support, status reporting, and a service-account parameter (built-in virtual account by default, dedicated local user opt-in).
- **Adds `Scripts/uninstall-ga-service.ps1`** as a thin symmetric wrapper.
- **Adds `docs/runbooks/non-admin-service-install.md`** covering: why this matters, three architectural options considered (AppHost-wrap rejected, AD-account rejected, NSSM+NetworkService chosen) with rationale, prerequisites, service-account permissions, profile-cache gotcha, cloudflared placement, step-by-step install, 7-step verification, rollback.

## Scope

**Research + scaffold only.** This PR does NOT install the services — that requires admin + irreversible OS changes and is the user's call. The plan-doc dashboard should mark item #8 as ready-for-install (not shipped) until @spareilleux runs `-Install` and the next process-lock incident is structurally handled.

## Test plan

- [x] `Get-Command -Syntax` parses both scripts and exposes `-WhatIf` / `-Confirm`
- [x] `install-ga-service.ps1 -Install -WhatIf` shows three `What if: nssm install` previews + log-dir creation, changes nothing on disk
- [x] `install-ga-service.ps1 -Status` (read-only) correctly reports current process state — confirmed PID 21036 still occupying port 5232 on this machine, which is exactly the bug class this scaffold targets
- [x] `uninstall-ga-service.ps1 -WhatIf` runs cleanly, lists skipped services
- [x] Touches only `Scripts/` + `docs/runbooks/` — no workflow files, no CLAUDE.md, no items.json, no plan doc
- [ ] User runs `-Install` for real (admin shell required, scaffold ready)
- [ ] User confirms next session: agent restarts GA-Api-5232 without UAC prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)