### PR TITLE
feat(tonal-orbit): Mode A / Mode B chord-mode toggle (Root vs Key chords)

### DIFF
--- a/ReactComponents/ga-react-components/src/components/TonalOrbit/TonalOrbit.tsx
+++ b/ReactComponents/ga-react-components/src/components/TonalOrbit/TonalOrbit.tsx
@@ -46,12 +46,15 @@ import {
   PITCH_BODIES,
   chordsForPitch,
   scalesForChord,
+  keyChordsForPitch,
+  keyModesForPitch,
   focusDepth,
   type Body,
   type PitchBody,
   type ChordBody,
   type ScaleBody,
   type FocusState,
+  type ChordMode,
 } from './data';
 import { SPACE_TOP, SPACE_BOTTOM } from './palette';
 import { TonalOrbitAudio } from './audio';
@@ -63,6 +66,17 @@ export interface TonalOrbitProps {
   perf?: PerfMode;
   /** When true the camera auto-cycles through the hierarchy (Cast-friendly). */
   tour?: boolean;
+  /**
+   * Which chord/scale system the orbit shows:
+   *   - 'root' (default): mid-orbit = 8 chord families on the focused
+   *     pitch as root (Cmaj, Cm, C7, ...); outer-orbit = 7 scales
+   *     curated per chord family. All share the focused pitch's root.
+   *   - 'key': mid-orbit = 7 diatonic triads of the focused pitch's
+   *     major key (I, ii, iii, IV, V, vi, vii° — each with its own
+   *     root); outer-orbit = 7 modes of that major key, each rooted
+   *     on its scale degree (Ionian, Dorian, Phrygian, ...).
+   */
+  chordMode?: ChordMode;
   /** Fires when the focus state changes (parent renders the HUD/breadcrumb). */
   onFocusChange?: (focus: FocusState) => void;
   /**
@@ -80,6 +94,19 @@ export interface TonalOrbitApi {
   setOrbiting: (on: boolean) => void;
   /** Toggle audio drone. */
   setAudioEnabled: (on: boolean) => void;
+  /**
+   * Swap chord-mode in place. Rebuilds the chord (+ scale, in Mode B)
+   * orbit around the focused pitch without tearing down the renderer,
+   * star, lights, or starfield. If no pitch is focused yet this just
+   * stores the new mode for the next focus.
+   */
+  setChordMode: (mode: ChordMode) => void;
+  /**
+   * Programmatic focus by pitch class (0..11), used by headless test
+   * harnesses to capture the chord-orbit state without simulating
+   * mouse coordinates onto a small planet target.
+   */
+  focusPitchByPc: (pc: number) => void;
 }
 
 // ─── Layout tunables ──────────────────────────────────────────────────────────
@@ -119,6 +146,7 @@ interface OrbitMesh {
 export const TonalOrbit: React.FC<TonalOrbitProps> = ({
   perf = 'high',
   tour = false,
+  chordMode = 'root',
   onFocusChange,
   onReady,
 }) => {
@@ -130,6 +158,11 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
   callbacksRef.current = { onFocusChange, onReady };
   const tourRef = useRef<boolean>(tour);
   tourRef.current = tour;
+  // Mode is read via ref inside the scene closure so a prop change can
+  // flow through without re-mounting Three. The actual orbit rebuild on
+  // mode change happens in `api.setChordMode()` below.
+  const chordModeRef = useRef<ChordMode>(chordMode);
+  chordModeRef.current = chordMode;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -542,19 +575,43 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
         audio.setState({ rootMidi: null, chordIntervals: null, shimmerSemitone: null });
         return;
       }
+      // Drone root midi:
+      //   - If a chord is focused, use the CHORD's root. In Mode A the
+      //     chord shares the pitch's root (no audible difference), but in
+      //     Mode B every diatonic chord has its own root (Dm under C,
+      //     etc.) so the drone follows the chord — sounds like a
+      //     progression in the key, not different qualities on one root.
+      //   - Else fall back to the focused pitch's midi.
+      // PITCH_BODIES sets midi = 60 + pc, so (midi - pc) = 60 (C4) for
+      // every pitch; adding chord.rootPc gives the chord's root MIDI in
+      // the same octave the pitch drone uses, keeping the audio in a
+      // consistent register across chord changes.
+      const octaveBaseMidi = focus.pitch.midi - focus.pitch.pc; // = 60
+      const rootMidi = focus.chord
+        ? octaveBaseMidi + focus.chord.rootPc
+        : focus.pitch.midi;
       // Shimmer = scale's "characteristic" interval — the semitone farthest
-      // from the chord's notes (i.e. the most colourful tone). Falls back
-      // to the seventh.
+      // from the chord's notes (i.e. the most colourful tone). Mode B: the
+      // shimmer pitch lives on the SCALE's root, not the chord's; we
+      // express it as a semitone offset above the rootMidi (chord root)
+      // so the audio engine adds it directly.
       let shimmer: number | null = null;
       if (focus.scale && focus.chord) {
+        // Offset between scale-root and chord-root, normalised to 0..11.
+        const offset = ((focus.scale.rootPc - focus.chord.rootPc) % 12 + 12) % 12;
         const chordSet = new Set(focus.chord.family.intervals);
-        const candidates = focus.scale.scale.intervals.filter((i) => !chordSet.has(i));
+        // Look for a characteristic scale tone not already in the chord
+        // — measured relative to the chord root by adding `offset` to
+        // each scale interval. Use the middle candidate for stable feel.
+        const candidates = focus.scale.scale.intervals
+          .map((i) => (i + offset) % 12)
+          .filter((i) => !chordSet.has(i));
         if (candidates.length > 0) {
           shimmer = candidates[Math.floor(candidates.length / 2)];
         }
       }
       audio.setState({
-        rootMidi: focus.pitch.midi,
+        rootMidi,
         chordIntervals: focus.chord ? focus.chord.family.intervals : null,
         shimmerSemitone: shimmer,
       });
@@ -578,9 +635,11 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
       focus.scale = null;
 
       if (pitch) {
-        // Build chord orbit around the focused pitch.
+        // Build chord orbit around the focused pitch. Source depends on
+        // chord-mode: Mode A = 8 chord families on the pitch as root;
+        // Mode B = 7 diatonic triads of the pitch's major key.
         chordRing = addOrbitRing(CHORD_RADIUS, 0xb88c4c, 0.14);
-        const chords = chordsForPitch(pitch);
+        const chords = chordModeRef.current === 'key' ? keyChordsForPitch(pitch) : chordsForPitch(pitch);
         chords.forEach((cb, i) => {
           const baseAngle = (i / chords.length) * Math.PI * 2;
           // Chord bodies orbit in their own ring around the origin (not
@@ -590,6 +649,22 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
           const z = Math.sin(baseAngle) * CHORD_RADIUS;
           orbitMeshes.push(buildBody(cb, CHORD_BODY_SIZE, baseAngle, new THREE.Vector3(x, 0, z), pitch));
         });
+
+        // In Mode B the outer scale-ring is the SAME for every chord on
+        // this pitch — all 7 modes belong to the same parent key. We
+        // build it up-front so it's visible alongside the chord ring;
+        // tapping a chord doesn't rebuild the modes (just changes the
+        // audio + camera focus).
+        if (chordModeRef.current === 'key') {
+          scaleRing = addOrbitRing(SCALE_RADIUS, 0x9c4cb8, 0.12);
+          const modes = keyModesForPitch(pitch);
+          modes.forEach((sb, i) => {
+            const baseAngle = (i / modes.length) * Math.PI * 2;
+            const x = Math.cos(baseAngle) * SCALE_RADIUS;
+            const z = Math.sin(baseAngle) * SCALE_RADIUS;
+            orbitMeshes.push(buildBody(sb, SCALE_BODY_SIZE, baseAngle, new THREE.Vector3(x, 0, z), pitch));
+          });
+        }
 
         // Adjust star colour to the focused pitch.
         starUniforms.uColor.value.copy(pitch.color.clone().lerp(new THREE.Color('#fff2c4'), 0.5));
@@ -605,17 +680,23 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
     };
 
     const setChordFocus = (chord: ChordBody | null) => {
-      const scaleMeshes = orbitMeshes.filter((m) => m.body.kind === 'scale');
-      removeMeshes(scaleMeshes);
-      for (let i = orbitMeshes.length - 1; i >= 0; i--) {
-        if (orbitMeshes[i].body.kind === 'scale') orbitMeshes.splice(i, 1);
+      // In Mode A the scale ring is per-chord, so we rebuild it on every
+      // chord change. In Mode B the scale ring belongs to the parent
+      // pitch (same 7 modes for any chord on that pitch); we leave it
+      // intact and only update audio + camera.
+      if (chordModeRef.current === 'root') {
+        const scaleMeshes = orbitMeshes.filter((m) => m.body.kind === 'scale');
+        removeMeshes(scaleMeshes);
+        for (let i = orbitMeshes.length - 1; i >= 0; i--) {
+          if (orbitMeshes[i].body.kind === 'scale') orbitMeshes.splice(i, 1);
+        }
+        removeRing(scaleRing); scaleRing = null;
       }
-      removeRing(scaleRing); scaleRing = null;
 
       focus.chord = chord;
       focus.scale = null;
 
-      if (chord) {
+      if (chord && chordModeRef.current === 'root') {
         scaleRing = addOrbitRing(SCALE_RADIUS, 0x9c4cb8, 0.12);
         const scales = scalesForChord(chord);
         scales.forEach((sb, i) => {
@@ -650,6 +731,22 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
         audioEnabled = on;
         if (on) audio.start();
         updateAudio();
+      },
+      setChordMode: (mode) => {
+        if (mode === chordModeRef.current) return;
+        chordModeRef.current = mode;
+        // Re-run the focus pipeline against the same pitch so the chord +
+        // scale orbits get rebuilt under the new mode. If no pitch is
+        // focused yet, the next setPitchFocus call will pick up the new
+        // mode automatically.
+        const currentPitch = focus.pitch;
+        if (currentPitch) {
+          setPitchFocus(currentPitch);
+        }
+      },
+      focusPitchByPc: (pc) => {
+        const pitch = PITCH_BODIES.find((p) => p.pc === ((pc % 12) + 12) % 12);
+        if (pitch) setPitchFocus(pitch);
       },
     };
     const orbitingRef = { value: true };

--- a/ReactComponents/ga-react-components/src/components/TonalOrbit/data.ts
+++ b/ReactComponents/ga-react-components/src/components/TonalOrbit/data.ts
@@ -108,6 +108,94 @@ export function chordsForPitch(pitch: PitchBody): ChordBody[] {
 }
 
 // ──────────────────────────────────────────────────────────────────────
+// Mode B: "Key chords" — diatonic chords and modes of the focused pitch's
+// major key.
+//
+// Where Mode A ("Root chords") asks "what chords can I build ON this
+// pitch as the root?" (Cmaj, Cm, C7, Cmaj7, ...), Mode B asks "what
+// chords belong to this pitch's major KEY?" (in C major: C, Dm, Em, F,
+// G, Am, B°). The roots vary across the orbit; the qualities are fixed
+// by the major-scale diatonic pattern.
+//
+// The seven diatonic triad qualities of a major key, in scale-degree
+// order I, ii, iii, IV, V, vi, vii°:
+// ──────────────────────────────────────────────────────────────────────
+
+/** Semitone offsets of the major scale (Ionian) above the tonic. */
+const MAJOR_SCALE_INTERVALS = [0, 2, 4, 5, 7, 9, 11] as const;
+
+/** Roman-numeral labels for the seven diatonic chord positions. */
+const DIATONIC_DEGREE_LABELS = ['I', 'ii', 'iii', 'IV', 'V', 'vi', 'vii°'] as const;
+
+/** Chord-family key per scale degree (parallels Roman numerals). */
+const DIATONIC_FAMILY_KEYS: readonly string[] = ['Major', 'Minor', 'Minor', 'Major', 'Major', 'Minor', 'Dim'];
+
+/**
+ * Diatonic triads of `pitch`'s major key. Returns 7 ChordBody entries
+ * whose roots step through the major scale and whose qualities follow
+ * the I-ii-iii-IV-V-vi-vii° pattern. Each chord's `rootPc` is the
+ * chord's own root pitch class (NOT the parent pitch).
+ */
+export function keyChordsForPitch(pitch: PitchBody): ChordBody[] {
+  return MAJOR_SCALE_INTERVALS.map((step, degreeIdx) => {
+    const rootPc = (pitch.pc + step) % 12;
+    const familyKey = DIATONIC_FAMILY_KEYS[degreeIdx];
+    const family = CHORD_FAMILIES.find((f) => f.key === familyKey)!;
+    const rootName = PITCH_CLASS_NAMES[rootPc];
+    const rootColor = pitchClassColor(rootPc);
+    return {
+      kind: 'chord',
+      family,
+      rootPc,
+      // Display: "I · C", "ii · Dm", "iii · Em", ... — Roman numeral up
+      // front so the user reads the diatonic structure immediately, then
+      // the actual chord symbol.
+      displayName: `${DIATONIC_DEGREE_LABELS[degreeIdx]} · ${rootName}${family.suffix}`,
+      // Tint by the CHORD's root colour (not the parent pitch's), so
+      // adjacent diatonic chords show their distinct circle-of-fifths
+      // hues — visually reinforces that the roots are different.
+      color: family.baseColor.clone().lerp(rootColor, 0.4),
+    };
+  });
+}
+
+// Names + intervals of the seven modes of the major scale, in
+// scale-degree order. Used for Mode B's outer ring (a ring of 7 modes
+// of the focused pitch's major key, each rooted on its scale degree).
+const MAJOR_MODE_KEYS = ['ionian', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'aeolian', 'locrian'] as const;
+
+/**
+ * The seven modes of `pitch`'s major key, each rooted on its scale
+ * degree. Returns 7 ScaleBody entries: C Ionian, D Dorian, E Phrygian,
+ * F Lydian, G Mixolydian, A Aeolian, B Locrian (for pitch = C).
+ *
+ * In Mode B this outer ring is the SAME for any chord chosen within the
+ * parent pitch — all seven modes belong to the same parent key. The
+ * focused chord on the mid ring corresponds to one of these modes by
+ * scale-degree position (chord on degree 2 ↔ Dorian, etc.).
+ */
+export function keyModesForPitch(pitch: PitchBody): ScaleBody[] {
+  return MAJOR_SCALE_INTERVALS.map((step, degreeIdx) => {
+    const rootPc = (pitch.pc + step) % 12;
+    const scaleKey = MAJOR_MODE_KEYS[degreeIdx];
+    const scale = ALL_SCALES.find((s) => s.key === scaleKey)!;
+    const rootName = PITCH_CLASS_NAMES[rootPc];
+    const rootColor = pitchClassColor(rootPc);
+    const familyColor = SCALE_FAMILY_COLORS[scale.familyBucket] ?? new THREE.Color('#9ad0ff');
+    return {
+      kind: 'scale',
+      scale,
+      rootPc,
+      displayName: `${rootName} ${scale.display}`,
+      color: familyColor.clone().lerp(rootColor, 0.3),
+    };
+  });
+}
+
+/** Which chord-system the orbit is showing — set via URL `?chord-mode=`. */
+export type ChordMode = 'root' | 'key';
+
+// ──────────────────────────────────────────────────────────────────────
 // Scale (outer orbit, 7 bodies per chord)
 // ──────────────────────────────────────────────────────────────────────
 

--- a/ReactComponents/ga-react-components/src/components/TonalOrbit/index.ts
+++ b/ReactComponents/ga-react-components/src/components/TonalOrbit/index.ts
@@ -1,4 +1,4 @@
 export { TonalOrbit } from './TonalOrbit';
 export type { TonalOrbitProps, TonalOrbitApi, PerfMode } from './TonalOrbit';
-export type { Body, PitchBody, ChordBody, ScaleBody, FocusState, ChordFamily, ScaleFamily } from './data';
-export { PITCH_BODIES, CHORD_FAMILIES, ALL_SCALES, focusPath, focusDepth } from './data';
+export type { Body, PitchBody, ChordBody, ScaleBody, FocusState, ChordFamily, ScaleFamily, ChordMode } from './data';
+export { PITCH_BODIES, CHORD_FAMILIES, ALL_SCALES, focusPath, focusDepth, keyChordsForPitch, keyModesForPitch } from './data';

--- a/ReactComponents/ga-react-components/src/pages/TonalOrbitTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/TonalOrbitTest.tsx
@@ -31,6 +31,7 @@ import {
   type FocusState,
   type TonalOrbitApi,
   type PerfMode,
+  type ChordMode,
 } from '../components/TonalOrbit';
 
 const detectDefaultPerf = (): PerfMode => {
@@ -54,6 +55,44 @@ const readTourFromUrl = (): boolean => {
   if (typeof window === 'undefined') return false;
   const q = new URLSearchParams(window.location.search).get('tour');
   return q === 'auto' || q === '1' || q === 'true';
+};
+
+const readChordModeFromUrl = (): ChordMode => {
+  if (typeof window === 'undefined') return 'root';
+  const q = new URLSearchParams(window.location.search).get('chord-mode');
+  return q === 'key' ? 'key' : 'root'; // default is Mode A (root chords)
+};
+
+// Pitch-class name → PC lookup for the auto-focus harness URL syntax.
+const PC_BY_NAME: Record<string, number> = {
+  C: 0, 'C#': 1, Db: 1, D: 2, 'D#': 3, Eb: 3, E: 4, F: 5,
+  'F#': 6, Gb: 6, G: 7, 'G#': 8, Ab: 8, A: 9, 'A#': 10, Bb: 10, B: 11,
+};
+
+/**
+ * Optional auto-focus harness — when URL has `?auto-focus=<pitchName>`
+ * (e.g. `?auto-focus=C`), programmatically focuses that pitch 1.5s after
+ * mount via the imperative API. Lets a headless screenshot capture the
+ * focused state (chord + optionally scale orbits visible) without
+ * having to guess pitch-planet screen coordinates. Records the chosen
+ * pitch on `<body data-auto-focus="...">` so a dump-dom probe can tell
+ * whether the harness ran.
+ */
+const armAutoFocus = (): void => {
+  if (typeof window === 'undefined') return;
+  const pitchName = new URLSearchParams(window.location.search).get('auto-focus');
+  if (!pitchName) return;
+  const pc = PC_BY_NAME[pitchName];
+  if (pc === undefined) return;
+  setTimeout(() => {
+    const api = (window as unknown as { __tonalOrbitApi?: TonalOrbitApi }).__tonalOrbitApi;
+    if (!api) {
+      document.body.setAttribute('data-auto-focus', `FAIL_NO_API:${pitchName}`);
+      return;
+    }
+    api.focusPitchByPc(pc);
+    document.body.setAttribute('data-auto-focus', `${pitchName}:pc=${pc}`);
+  }, 1500);
 };
 
 /**
@@ -105,16 +144,29 @@ const TonalOrbitTest: React.FC = () => {
   // Read once on mount — perf tier change requires remount of the scene.
   const perf = useMemo<PerfMode>(readPerfFromUrl, []);
   const tour = useMemo<boolean>(readTourFromUrl, []);
-  React.useEffect(() => { armZoomTest(); }, []);
+  React.useEffect(() => { armZoomTest(); armAutoFocus(); }, []);
 
   const [focus, setFocus] = useState<FocusState>({ pitch: null, chord: null, scale: null });
   const [audioOn, setAudioOn] = useState<boolean>(true);
   const [orbitingOn, setOrbitingOn] = useState<boolean>(true);
+  // Chord mode: 'root' (Mode A — chord families on the focused pitch as
+  // root) or 'key' (Mode B — diatonic chords of the focused pitch's
+  // major key, with the 7 modes of that key in the outer ring).
+  const [chordMode, setChordMode] = useState<ChordMode>(readChordModeFromUrl);
   const apiRef = React.useRef<TonalOrbitApi | null>(null);
 
   const handleFocus = useCallback((f: FocusState) => setFocus(f), []);
   const handleReady = useCallback((api: TonalOrbitApi) => {
     apiRef.current = api;
+    // Push the URL-driven mode into the scene the moment the API hooks up.
+    api.setChordMode(chordMode);
+    // Expose the API on window for headless-screenshot probes so they
+    // don't have to guess pitch-planet screen coordinates. Gated behind
+    // the same `?auto-focus=` URL param the rest of the harness uses.
+    if (typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('auto-focus')) {
+      (window as unknown as { __tonalOrbitApi?: TonalOrbitApi }).__tonalOrbitApi = api;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const path = focusPath(focus);
@@ -128,6 +180,18 @@ const TonalOrbitTest: React.FC = () => {
     setOrbitingOn(on);
     apiRef.current?.setOrbiting(on);
   };
+  const toggleChordMode = (next: ChordMode) => {
+    if (next === chordMode) return;
+    setChordMode(next);
+    apiRef.current?.setChordMode(next);
+    // Reflect the new mode in the URL so it survives page reloads / shares.
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (next === 'root') url.searchParams.delete('chord-mode'); // keep default URL clean
+      else url.searchParams.set('chord-mode', next);
+      window.history.replaceState({}, '', url.toString());
+    }
+  };
 
   return (
     <DemoErrorBoundary demoName="Tonal Orbit">
@@ -140,8 +204,91 @@ const TonalOrbitTest: React.FC = () => {
         disableGutters
         sx={{ width: '100%', height: '100%', overflow: 'hidden', position: 'relative', backgroundColor: '#000' }}
       >
-        <TonalOrbit perf={perf} tour={tour} onFocusChange={handleFocus} onReady={handleReady} />
+        <TonalOrbit perf={perf} tour={tour} chordMode={chordMode} onFocusChange={handleFocus} onReady={handleReady} />
         <CastButton label="Cast" />
+
+        {/* Chord-mode pill. Switches the chord/scale orbit between
+            "Root chords" (Mode A — chord qualities on the focused pitch
+            as root) and "Key chords" (Mode B — diatonic chords of the
+            focused pitch's major key + the 7 modes of that key). The
+            mode change rebuilds only the chord/scale orbit, not the
+            renderer or starfield.
+
+            Placement: top-centre on tablet+ (sm and up); on mobile (xs)
+            the breadcrumb + Cast button squeeze the centre, so the
+            pill drops below them (top: 60). The "MODE" label is
+            collapsed on mobile to keep the pill narrow. */}
+        <Paper
+          elevation={3}
+          sx={{
+            position: 'absolute',
+            top: { xs: 60, sm: 16 },
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            px: 1,
+            py: 0.5,
+            backgroundColor: 'rgba(0, 0, 0, 0.55)',
+            backdropFilter: 'blur(8px)',
+            border: '1px solid rgba(155, 195, 255, 0.35)',
+            borderRadius: 1.5,
+            pointerEvents: 'auto',
+            zIndex: 5,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <Typography
+            sx={{
+              color: '#7da8cf', fontFamily: 'monospace', fontSize: 11, letterSpacing: 1,
+              mr: 1,
+              display: { xs: 'none', sm: 'inline' }, // MODE label takes too much room on mobile
+            }}
+          >
+            MODE
+          </Typography>
+          <Box
+            role="button"
+            tabIndex={0}
+            aria-pressed={chordMode === 'root'}
+            onClick={() => toggleChordMode('root')}
+            sx={{
+              cursor: 'pointer',
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 1,
+              fontFamily: 'monospace',
+              fontSize: 12,
+              color: chordMode === 'root' ? '#0a0e2a' : '#cfe7ff',
+              backgroundColor: chordMode === 'root' ? '#9bc3ff' : 'transparent',
+              userSelect: 'none',
+              transition: 'background-color 120ms ease, color 120ms ease',
+            }}
+          >
+            Root chords
+          </Box>
+          <Box
+            role="button"
+            tabIndex={0}
+            aria-pressed={chordMode === 'key'}
+            onClick={() => toggleChordMode('key')}
+            sx={{
+              cursor: 'pointer',
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 1,
+              fontFamily: 'monospace',
+              fontSize: 12,
+              color: chordMode === 'key' ? '#0a0e2a' : '#cfe7ff',
+              backgroundColor: chordMode === 'key' ? '#9bc3ff' : 'transparent',
+              userSelect: 'none',
+              transition: 'background-color 120ms ease, color 120ms ease',
+            }}
+          >
+            Key chords
+          </Box>
+        </Paper>
 
         {/* Breadcrumb — top-left. Clicking pops focus. Right-side max-width
             leaves a 120px gutter for the CastButton (top-right) so the two


### PR DESCRIPTION
## Summary

Adds a `Mode: Root chords / Key chords` HUD pill that swaps the chord + scale orbits between two music-theory views of the focused pitch. Default behaviour is unchanged (Mode A = Root chords); Mode B is opt-in via the pill or `?chord-mode=key` URL param.

### Mode A — Root chords (default)

Mid-orbit shows the 8 chord families on the focused pitch as root:
`Cmaj, Cm, Cmaj7, Cm7, C7, Cdim, Caug, Csus4` for pitch C.
Outer-orbit shows 7 curated scales per chord family (built per chord, same as v1).
Audio: all chords share the focused pitch's root — drone stays on C, chord-quality intervals layer on top.

### Mode B — Key chords (new)

Mid-orbit shows the 7 diatonic triads of the focused pitch's major key:
`I=C, ii=Dm, iii=Em, IV=F, V=G, vi=Am, vii°=B°` for pitch C. Each chord has its own root and is tinted by that root's circle-of-fifths colour, so the ring reads as a chromatic progression instead of \"same root, different qualities\".

Outer-orbit shows the 7 modes of that major key (C Ionian, D Dorian, E Phrygian, F Lydian, G Mixolydian, A Aeolian, B Locrian), built up-front alongside the chord ring — all 7 modes belong to the same parent key, so the outer ring is shared across all chord clicks (no rebuild per chord).

Audio: drone follows the **chord's** root. Toggling between diatonic chords sounds like a progression in the key (Dm → D drone + min triad; G → G drone + maj triad; ...). Mode-shimmer uses the scale's own root, expressed relative to the chord root so the engine's additive pipeline keeps working.

## Visual proof

| viewport | Mode A focused on C | Mode B focused on C |
|---|---|---|
| 1920×1080 | 8 small chord-planets clustered (same root) + outer ring | 7 chord-planets spread out (distinct root colours) + 7 modes visible simultaneously |
| 768×1024 | pill at top-centre with `MODE` label visible | same |
| 414×896 | pill drops below breadcrumb row, `MODE` label collapsed | same |

The visual diff between the two modes is immediately obvious — Mode A clusters tightly with one colour family; Mode B fans out into chromatic / circle-of-fifths chords.

## Files

- `src/components/TonalOrbit/data.ts` — new `keyChordsForPitch(pitch)`, `keyModesForPitch(pitch)`, `ChordMode` type. Diatonic chords use Roman-numeral display (`I · C`, `ii · Dm`, …) so the scale-degree structure reads at a glance.
- `src/components/TonalOrbit/TonalOrbit.tsx` — new `chordMode` prop (read via ref so parent updates don't tear down Three.js), new `api.setChordMode(mode)` rebuilds chord + scale orbits in place without disposing the renderer/composer/star/starfield. Audio now uses `chord.rootPc` for drone root. Also adds `api.focusPitchByPc` for headless tests.
- `src/components/TonalOrbit/index.ts` — re-exports.
- `src/pages/TonalOrbitTest.tsx` — adds the mode pill (top-centre on sm+, below breadcrumb on xs with `MODE` label collapsed), URL state sync (`?chord-mode=…`), and an opt-in `?auto-focus=<pitchName>` harness for headless regression screenshots.

## Test plan

- [ ] Visit `/test/tonal-orbit` — default is Mode A. Tap pitch C → 8 small chord planets, all blue-tinted (same root).
- [ ] Click \"Key chords\" pill → orbit rebuilds to 7 chromatic chord planets + 7 modes visible at once.
- [ ] Toggle Drone on, then click around the chord planets in Mode B — drone root audibly changes (D, E, F, G, A, B for ii–vii°).
- [ ] URL: `?chord-mode=key` loads directly into Mode B; toggling back to Root drops the param.
- [ ] Mobile (375–414px): pill sits below the breadcrumb row, no overlap with Cast button or breadcrumb.
- [ ] Regression: `?test=zoom` still passes (camera persists after user interaction); `?tour=auto` still cycles.
- [ ] Typecheck baseline unchanged (185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)