### PR TITLE
feat(harness): semantic-regression chatbot suite (Phase 2 #1)

### DIFF
--- a/.github/workflows/semantic-regression-chatbot.yml
+++ b/.github/workflows/semantic-regression-chatbot.yml
@@ -1,0 +1,200 @@
+name: Semantic Regression — Chatbot Goldens
+
+# Phase 2 harness #1 — closes the "did the chatbot's answer get better or
+# worse with this PR?" loop. Today state/quality/chatbot-qa/golden-traces/
+# stores per-prompt reference answers (median elapsed + agent + verified
+# date — surfaced as QA badges in /chatbot/#showcase). Trace-shape diffs
+# are already covered by Scripts/compare-trace-to-canonical.ps1, but
+# nothing automated catches semantic drift in the answer text itself.
+#
+# What this does on a PR touching the chatbot or LLM-routing code:
+#   1. Spins up GaChatbot.Api locally on the runner.
+#   2. Replays each golden-trace prompt that has a stored reference answer
+#      (presence of run-1.json with response.naturalLanguageAnswer).
+#   3. Embeds reference + new answer via OpenAI text-embedding-3-small.
+#   4. Computes cosine(ref, new); flags any prompt with cosine < 0.85.
+#   5. Posts a PR comment with the table and writes a JSON artifact to
+#      state/quality/chatbot-qa/semantic-regression/<sha>.json so the
+#      dashboard QA tab can ingest it.
+#
+# Embedding choice — documented per the harness contract:
+#   ga_generate_voicing_embedding is a 228-dim *voicing* encoder (raw
+#   pitch-class geometry). It is the canonical surface for music-theory
+#   *voicings*, not prose chatbot answers. Prose answers are paragraphs of
+#   English text with markdown structure; voicing-geometry vectors would
+#   collapse them. text-embedding-3-small is the project's standing
+#   prose embedder (already used by Apps/ga-server/GaApi/Services/
+#   VectorSearchService.cs and GaDataCLI). We commit to one encoder per
+#   run and record it in the artifact so the dashboard never compares
+#   across encoders.
+#
+# Failure semantics:
+#   - Drift (cosine < threshold) is REPORTED, not fatal. The artifact +
+#     PR comment is the deliverable; the user decides if it ships.
+#   - Hard failures (chatbot didn't start, embedding API down, no
+#     OPENAI_API_KEY) mark the workflow as failed — silence is worse
+#     than a loud red X for a regression gate.
+#   - "No baseline yet" prompts (no run-1.json) are skipped with a note,
+#     not counted as drift. Reference baselines arrive incrementally.
+#
+# Cost guardrail:
+#   ~45 prompts × ~4 KB avg answer × 2 embeddings ≈ 90k input tokens
+#   per run. text-embedding-3-small is $0.02 / 1M input tokens, so
+#   ~$0.0018 / PR run. If a single run exceeds 50k tokens the workflow
+#   warns and the user can switch to sampling. See SAMPLE_SIZE input.
+
+on:
+  pull_request:
+    paths:
+      - 'Apps/GaChatbot.Api/**'
+      - 'Apps/ga-server/GaApi/**'
+      - 'Common/GA.Business.ML/**'
+      - 'state/quality/chatbot-qa/golden-traces/**'
+      - 'Scripts/replay-chatbot-goldens.ps1'
+      - '.github/workflows/semantic-regression-chatbot.yml'
+  workflow_dispatch:
+    inputs:
+      sample_size:
+        description: 'Sample N of M prompts (0 = all). Cost guardrail override.'
+        required: false
+        default: '0'
+      cosine_threshold:
+        description: 'Drift threshold (cosine < this is flagged). Default 0.85.'
+        required: false
+        default: '0.85'
+
+permissions:
+  contents: read
+  pull-requests: write    # post the regression-table comment
+
+concurrency:
+  group: semantic-regression-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  replay-and-diff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      COSINE_THRESHOLD: ${{ github.event.inputs.cosine_threshold || '0.85' }}
+      SAMPLE_SIZE: ${{ github.event.inputs.sample_size || '0' }}
+      CHATBOT_PORT: '5252'
+      CHATBOT_URL: 'http://localhost:5252'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+
+      - name: Guard — OPENAI_API_KEY present
+        shell: bash
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "::error::OPENAI_API_KEY secret is not configured. Cannot embed answers."
+            echo "Set it under Settings → Secrets → Actions, or skip this workflow until it is."
+            exit 1
+          fi
+          echo "OPENAI_API_KEY length: ${#OPENAI_API_KEY} (good)"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore + build chatbot
+        run: |
+          dotnet restore Apps/GaChatbot.Api/GaChatbot.Api.csproj
+          dotnet build  Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --no-restore
+
+      - name: Start chatbot in background
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          nohup dotnet run \
+            --project Apps/GaChatbot.Api/GaChatbot.Api.csproj \
+            --configuration Release \
+            --no-build \
+            --urls "${CHATBOT_URL}" \
+            > artifacts/chatbot.log 2>&1 &
+          echo $! > artifacts/chatbot.pid
+          echo "Chatbot PID: $(cat artifacts/chatbot.pid)"
+
+      - name: Wait for chatbot ready
+        shell: bash
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf "${CHATBOT_URL}/health" >/dev/null 2>&1 \
+               || curl -sf "${CHATBOT_URL}/api/chatbot/health" >/dev/null 2>&1; then
+              echo "Chatbot up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Chatbot did not become ready within 60s. Log tail:"
+          tail -100 artifacts/chatbot.log || true
+          exit 1
+
+      - name: Replay goldens and diff
+        id: replay
+        shell: pwsh
+        run: |
+          pwsh Scripts/replay-chatbot-goldens.ps1 `
+            -ChatbotUrl   $env:CHATBOT_URL `
+            -Threshold    ([double]$env:COSINE_THRESHOLD) `
+            -SampleSize   ([int]$env:SAMPLE_SIZE) `
+            -HeadSha      "${{ github.event.pull_request.head.sha || github.sha }}" `
+            -OutputDir    "state/quality/chatbot-qa/semantic-regression" `
+            -EmitMarkdown "artifacts/regression-comment.md"
+
+      - name: Stop chatbot
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/chatbot.pid ]; then
+            kill "$(cat artifacts/chatbot.pid)" 2>/dev/null || true
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: semantic-regression-${{ github.run_id }}
+          path: |
+            state/quality/chatbot-qa/semantic-regression/
+            artifacts/chatbot.log
+            artifacts/regression-comment.md
+          retention-days: 30
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'artifacts/regression-comment.md';
+            if (!fs.existsSync(path)) {
+              core.info('No regression comment artifact emitted; skipping PR comment.');
+              return;
+            }
+            const body = fs.readFileSync(path, 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            // Replace any prior bot comment with the same marker so the PR
+            // doesn't accumulate one per push.
+            const marker = '<!-- semantic-regression-chatbot -->';
+            const comments = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100
+            });
+            const prior = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body && c.body.includes(marker)
+            );
+            const finalBody = marker + '\n' + body;
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: prior.id, body: finalBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body: finalBody
+              });
+            }

--- a/Scripts/replay-chatbot-goldens.ps1
+++ b/Scripts/replay-chatbot-goldens.ps1
@@ -1,0 +1,390 @@
+# replay-chatbot-goldens.ps1 — semantic-regression diff for chatbot goldens
+#
+# Replays each prompt under state/quality/chatbot-qa/golden-traces/ that has a
+# stored reference answer (run-1.json with response.naturalLanguageAnswer)
+# against a running chatbot, embeds both answers via OpenAI text-embedding-3-
+# small, computes cosine similarity, and writes:
+#
+#   1. A structured JSON artifact at <OutputDir>/<HeadSha>.json conforming to
+#      semantic-regression-v1 (see state/quality/chatbot-qa/semantic-
+#      regression/SCHEMA.json).
+#   2. A markdown PR-comment table at <EmitMarkdown> (optional).
+#
+# Designed to be CI-callable AND locally-runnable. Locally:
+#
+#   pwsh Scripts/replay-chatbot-goldens.ps1                          # all prompts, default threshold
+#   pwsh Scripts/replay-chatbot-goldens.ps1 -SampleSize 5             # random 5
+#   pwsh Scripts/replay-chatbot-goldens.ps1 -Threshold 0.90           # stricter
+#   pwsh Scripts/replay-chatbot-goldens.ps1 -ChatbotUrl http://localhost:5252
+#
+# Requires: $env:OPENAI_API_KEY for embedding calls. Without it the script
+# fails fast — "we'll add semantic diff later" is the failure mode the
+# harness is designed to prevent.
+#
+# Why text-embedding-3-small and not ga_generate_voicing_embedding:
+#   The GA MCP voicing embedder produces 228-dim vectors from raw pitch-
+#   class geometry — perfect for voicings, useless for prose. Chatbot
+#   answers are markdown English. text-embedding-3-small is already the
+#   project's prose embedder (used by VectorSearchService.cs and
+#   GaDataCLI). One encoder per run, recorded in the artifact, prevents
+#   apples-to-oranges drift charts.
+#
+# Provider-replay discipline:
+#   The user's harness contract is explicit: replay against the SAME
+#   provider the original golden used. We surface response.agentId (e.g.
+#   skill.circleoffifths) and compare it against the new agentId. If they
+#   diverge we tag the prompt "provider_mismatch" and skip the cosine
+#   verdict — that's a routing test, not a semantic regression.
+
+[CmdletBinding()]
+param(
+    [string]$ChatbotUrl     = "http://localhost:5252",
+    [int]$TimeoutSeconds    = 120,
+    [double]$Threshold      = 0.85,
+    [int]$SampleSize        = 0,   # 0 == all
+    [string]$HeadSha        = "",
+    [string]$GoldensDir     = "state/quality/chatbot-qa/golden-traces",
+    [string]$OutputDir      = "state/quality/chatbot-qa/semantic-regression",
+    [string]$EmbeddingModel = "text-embedding-3-small",
+    [int]$TokenWarnBudget   = 50000,
+    [string]$EmitMarkdown   = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+# Resolve repo root (script lives in <repo>/Scripts/)
+$repoRoot   = Split-Path $PSScriptRoot -Parent
+$goldensAbs = Join-Path $repoRoot $GoldensDir
+$outputAbs  = Join-Path $repoRoot $OutputDir
+
+if (-not (Test-Path $goldensAbs)) {
+    throw "Goldens directory not found: $goldensAbs"
+}
+if (-not (Test-Path $outputAbs)) {
+    New-Item -ItemType Directory -Path $outputAbs -Force | Out-Null
+}
+
+# ── OpenAI guard ───────────────────────────────────────────────────────────
+$openAiKey = $env:OPENAI_API_KEY
+if ([string]::IsNullOrWhiteSpace($openAiKey)) {
+    throw "OPENAI_API_KEY not set. Cannot embed answers."
+}
+
+# ── Resolve HeadSha if not passed in (local runs) ──────────────────────────
+if ([string]::IsNullOrWhiteSpace($HeadSha)) {
+    try {
+        $HeadSha = (git -C $repoRoot rev-parse HEAD).Trim()
+    } catch {
+        $HeadSha = "unknown-$(Get-Date -Format yyyyMMddHHmmss)"
+    }
+}
+
+Write-Host "─── Semantic regression: chatbot goldens ───" -ForegroundColor Cyan
+Write-Host "Chatbot URL    : $ChatbotUrl"
+Write-Host "Goldens dir    : $goldensAbs"
+Write-Host "Output dir     : $outputAbs"
+Write-Host "Encoder        : $EmbeddingModel"
+Write-Host "Threshold      : $Threshold"
+Write-Host "Sample size    : $(if ($SampleSize -gt 0) { $SampleSize } else { 'all' })"
+Write-Host "Head SHA       : $HeadSha"
+
+# ── Discover prompts that have a reference answer ──────────────────────────
+$candidates = @()
+foreach ($dir in Get-ChildItem -Directory -Path $goldensAbs) {
+    $metaPath = Join-Path $dir.FullName "_meta.json"
+    $run1Path = Join-Path $dir.FullName "run-1.json"
+    if (-not (Test-Path $run1Path)) { continue }
+
+    try {
+        $run1 = Get-Content -LiteralPath $run1Path -Raw | ConvertFrom-Json
+    } catch {
+        Write-Host "  ! skip $($dir.Name): run-1.json unparseable ($($_.Exception.Message))" -ForegroundColor DarkYellow
+        continue
+    }
+
+    $refAnswer = $null
+    if ($run1.response -and $run1.response.naturalLanguageAnswer) {
+        $refAnswer = [string]$run1.response.naturalLanguageAnswer
+    }
+    if ([string]::IsNullOrWhiteSpace($refAnswer)) { continue }
+
+    $prompt   = if ($run1.prompt) { [string]$run1.prompt } else { $dir.Name }
+    $category = if ($run1.category) { [string]$run1.category } else { 'uncategorized' }
+    $refAgent = if ($run1.response.agentId) { [string]$run1.response.agentId } else { $null }
+
+    if (Test-Path $metaPath) {
+        try {
+            $meta = Get-Content -LiteralPath $metaPath -Raw | ConvertFrom-Json
+            if ($meta.prompt)   { $prompt   = [string]$meta.prompt }
+            if ($meta.category) { $category = [string]$meta.category }
+        } catch { }
+    }
+
+    $candidates += [pscustomobject]@{
+        Slug       = $dir.Name
+        Prompt     = $prompt
+        Category   = $category
+        RefAgent   = $refAgent
+        RefAnswer  = $refAnswer
+    }
+}
+
+if ($candidates.Count -eq 0) {
+    Write-Host "No prompts have a stored reference answer yet (need run-1.json with response.naturalLanguageAnswer)." -ForegroundColor Yellow
+    Write-Host "Writing an empty artifact so the dashboard sees the run happened." -ForegroundColor Yellow
+}
+
+# ── Optional sampling ──────────────────────────────────────────────────────
+if ($SampleSize -gt 0 -and $candidates.Count -gt $SampleSize) {
+    $candidates = $candidates | Get-Random -Count $SampleSize
+    Write-Host "Sampled $SampleSize of $($candidates.Count) prompts (cost guardrail)." -ForegroundColor Yellow
+}
+
+Write-Host "Replaying $($candidates.Count) prompt(s)."
+
+# ── OpenAI embedding helper ────────────────────────────────────────────────
+function Get-OpenAiEmbedding {
+    param([string]$Text, [string]$Model = $EmbeddingModel)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        throw "Refusing to embed empty text."
+    }
+
+    $body = @{ input = $Text; model = $Model } | ConvertTo-Json -Compress
+    $headers = @{
+        "Authorization" = "Bearer $openAiKey"
+        "Content-Type"  = "application/json"
+    }
+    $resp = Invoke-RestMethod `
+        -Method Post `
+        -Uri "https://api.openai.com/v1/embeddings" `
+        -Headers $headers `
+        -Body $body `
+        -TimeoutSec 30
+
+    $vec = $resp.data[0].embedding
+    $tokens = if ($resp.usage -and $resp.usage.total_tokens) { [int]$resp.usage.total_tokens } else { 0 }
+    return [pscustomobject]@{ Vector = $vec; Tokens = $tokens }
+}
+
+function Get-CosineSimilarity {
+    param($A, $B)
+    if ($A.Count -ne $B.Count) {
+        throw "Embedding dimension mismatch: $($A.Count) vs $($B.Count)."
+    }
+    $dot = 0.0; $na = 0.0; $nb = 0.0
+    for ($i = 0; $i -lt $A.Count; $i++) {
+        $av = [double]$A[$i]
+        $bv = [double]$B[$i]
+        $dot += $av * $bv
+        $na  += $av * $av
+        $nb  += $bv * $bv
+    }
+    if ($na -eq 0 -or $nb -eq 0) { return 0.0 }
+    return $dot / ([math]::Sqrt($na) * [math]::Sqrt($nb))
+}
+
+# ── Replay loop ────────────────────────────────────────────────────────────
+$results       = New-Object System.Collections.Generic.List[object]
+$totalTokens   = 0
+$okCount       = 0
+$driftCount    = 0
+$erroredCount  = 0
+$mismatchCount = 0
+$noBaselineCount = 0
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+foreach ($c in $candidates) {
+    $sessionId = "semreg-$($c.Slug)-$(Get-Date -Format yyyyMMddHHmmss)"
+    $body = @{ message = $c.Prompt; sessionId = $sessionId } | ConvertTo-Json -Compress
+
+    $entry = [ordered]@{
+        slug             = $c.Slug
+        prompt           = $c.Prompt
+        category         = $c.Category
+        provider_ref     = $c.RefAgent
+        provider_new     = $null
+        ref_cosine_self  = 1.0
+        new_cosine       = $null
+        delta            = $null
+        verdict          = $null
+        tokens           = 0
+        error            = $null
+    }
+
+    # Replay against live chatbot
+    try {
+        $resp = Invoke-RestMethod `
+            -Method Post `
+            -Uri "$ChatbotUrl/api/chatbot/chat" `
+            -ContentType "application/json" `
+            -Body $body `
+            -TimeoutSec $TimeoutSeconds
+    } catch {
+        $entry.verdict = "errored"
+        $entry.error   = "replay_http: $($_.Exception.Message)"
+        $erroredCount++
+        Write-Host "  x [$($c.Category)] $($c.Prompt): $($_.Exception.Message)" -ForegroundColor Red
+        $results.Add([pscustomobject]$entry) | Out-Null
+        continue
+    }
+
+    $newAnswer = if ($resp -and $resp.naturalLanguageAnswer) { [string]$resp.naturalLanguageAnswer } else { $null }
+    $newAgent  = if ($resp -and $resp.agentId) { [string]$resp.agentId } else { $null }
+    $entry.provider_new = $newAgent
+
+    if ([string]::IsNullOrWhiteSpace($newAnswer)) {
+        $entry.verdict = "errored"
+        $entry.error   = "replay_empty_answer"
+        $erroredCount++
+        Write-Host "  x [$($c.Category)] $($c.Prompt): empty answer in response" -ForegroundColor Red
+        $results.Add([pscustomobject]$entry) | Out-Null
+        continue
+    }
+
+    # Provider-replay discipline
+    if ($c.RefAgent -and $newAgent -and ($c.RefAgent -ne $newAgent)) {
+        $entry.verdict = "provider_mismatch"
+        $entry.error   = "ref agent '$($c.RefAgent)' != new '$newAgent' (routing change, not semantic regression)"
+        $mismatchCount++
+        Write-Host "  ~ [$($c.Category)] $($c.Prompt): provider drift $($c.RefAgent) -> $newAgent" -ForegroundColor DarkYellow
+        $results.Add([pscustomobject]$entry) | Out-Null
+        continue
+    }
+
+    # Embed both sides
+    try {
+        $eRef = Get-OpenAiEmbedding -Text $c.RefAnswer
+        $eNew = Get-OpenAiEmbedding -Text $newAnswer
+    } catch {
+        $entry.verdict = "errored"
+        $entry.error   = "embedding: $($_.Exception.Message)"
+        $erroredCount++
+        Write-Host "  x [$($c.Category)] $($c.Prompt): embedding failed - $($_.Exception.Message)" -ForegroundColor Red
+        $results.Add([pscustomobject]$entry) | Out-Null
+        continue
+    }
+
+    $tokensUsed = $eRef.Tokens + $eNew.Tokens
+    $totalTokens += $tokensUsed
+    $entry.tokens = $tokensUsed
+
+    $cos = Get-CosineSimilarity -A $eRef.Vector -B $eNew.Vector
+    $entry.new_cosine = [math]::Round($cos, 4)
+    $entry.delta      = [math]::Round($cos - 1.0, 4)
+
+    if ($cos -lt $Threshold) {
+        $entry.verdict = "drift"
+        $driftCount++
+        Write-Host "  ! [$($c.Category)] $($c.Prompt): cosine=$([math]::Round($cos,3)) (< $Threshold) DRIFT" -ForegroundColor Yellow
+    } else {
+        $entry.verdict = "ok"
+        $okCount++
+        Write-Host "  o [$($c.Category)] $($c.Prompt): cosine=$([math]::Round($cos,3)) ok"
+    }
+
+    $results.Add([pscustomobject]$entry) | Out-Null
+}
+
+$sw.Stop()
+
+# ── Cost guardrail warning ────────────────────────────────────────────────
+$costWarning = $null
+if ($totalTokens -gt $TokenWarnBudget) {
+    $costWarning = "Token usage $totalTokens exceeded warn budget $TokenWarnBudget. " +
+                   "Consider -SampleSize or moving the workflow from per-PR to weekly."
+    Write-Host ""
+    Write-Host "WARN: $costWarning" -ForegroundColor Yellow
+}
+
+# ── Write artifact ────────────────────────────────────────────────────────
+$artifact = [ordered]@{
+    schema           = "semantic-regression-v1"
+    head_sha         = $HeadSha
+    run_at           = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ" -AsUTC)
+    chatbot_url      = $ChatbotUrl
+    encoder          = $EmbeddingModel
+    threshold_cosine = $Threshold
+    sample_size      = $SampleSize
+    elapsed_seconds  = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+    cost_warning     = $costWarning
+    prompts          = $results.ToArray()
+    summary          = [ordered]@{
+        total              = $results.Count
+        ok                 = $okCount
+        drift              = $driftCount
+        errored            = $erroredCount
+        provider_mismatch  = $mismatchCount
+        no_baseline        = $noBaselineCount
+        total_tokens       = $totalTokens
+    }
+}
+
+$outPath = Join-Path $outputAbs ("{0}.json" -f $HeadSha)
+$artifact | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $outPath -Encoding UTF8
+Write-Host ""
+Write-Host "Wrote artifact: $outPath"
+
+# ── Markdown PR comment ───────────────────────────────────────────────────
+if (-not [string]::IsNullOrWhiteSpace($EmitMarkdown)) {
+    $emitAbs = if ([System.IO.Path]::IsPathRooted($EmitMarkdown)) {
+        $EmitMarkdown
+    } else {
+        Join-Path $repoRoot $EmitMarkdown
+    }
+    $emitDir = Split-Path $emitAbs -Parent
+    if ($emitDir -and -not (Test-Path $emitDir)) {
+        New-Item -ItemType Directory -Path $emitDir -Force | Out-Null
+    }
+
+    $lines = @()
+    $lines += "### Semantic regression: chatbot goldens"
+    $lines += ""
+    $lines += "- Encoder: ``$EmbeddingModel``"
+    $lines += "- Threshold: cosine < ``$Threshold`` is flagged"
+    $lines += "- Head SHA: ``$HeadSha``"
+    $lines += "- Summary: $okCount ok / $driftCount drift / $mismatchCount provider-mismatch / $erroredCount errored (of $($results.Count))"
+    $lines += "- Tokens: $totalTokens (warn budget $TokenWarnBudget)"
+    if ($costWarning) { $lines += "- ⚠ $costWarning" }
+    $lines += ""
+    $lines += "| Prompt | Provider | Ref cosine→self | New cosine | Δ | Verdict |"
+    $lines += "|---|---|---|---|---|---|"
+
+    foreach ($r in $results) {
+        $provider = if ($r.provider_new) { $r.provider_new } elseif ($r.provider_ref) { $r.provider_ref } else { '-' }
+        $cosRef   = '1.0'
+        $cosNew   = if ($null -ne $r.new_cosine) { ('{0:N3}' -f $r.new_cosine) } else { '-' }
+        $delta    = if ($null -ne $r.delta)      { ('{0:+0.000;-0.000;0.000}' -f $r.delta) } else { '-' }
+        $verdict  = switch ($r.verdict) {
+            'ok'                { 'OK' }
+            'drift'             { '⚠ DRIFT' }
+            'provider_mismatch' { 'provider-mismatch' }
+            'errored'           { 'errored' }
+            default             { '-' }
+        }
+        $shortPrompt = if ($r.prompt.Length -gt 60) { $r.prompt.Substring(0,57) + '...' } else { $r.prompt }
+        # Escape pipes inside prompt cells
+        $shortPrompt = $shortPrompt -replace '\|','\|'
+        $lines += "| $shortPrompt | $provider | $cosRef | $cosNew | $delta | $verdict |"
+    }
+
+    $lines += ""
+    $lines += "Artifact: ``$(Resolve-Path -Relative $outPath)`` (also uploaded as a workflow artifact)."
+    $lines += ""
+    $lines += "_Drift flags are advisory — they do not fail the build. Review the diff and merge if the new answer is intentional._"
+
+    ($lines -join "`n") | Set-Content -LiteralPath $emitAbs -Encoding UTF8
+    Write-Host "Wrote PR comment markdown: $emitAbs"
+}
+
+Write-Host ""
+Write-Host "─── Done in $($sw.Elapsed.TotalSeconds.ToString('0.0'))s ───" -ForegroundColor Cyan
+Write-Host "  ok: $okCount  drift: $driftCount  mismatch: $mismatchCount  errored: $erroredCount  tokens: $totalTokens"
+
+# Exit code: 0 on completion regardless of drift count (drift is reported,
+# not fatal). Non-zero only if the run itself couldn't produce data.
+if ($results.Count -eq 0 -and $candidates.Count -gt 0) {
+    Write-Host "All replay attempts errored — surfacing as workflow failure." -ForegroundColor Red
+    exit 2
+}
+exit 0

--- a/state/quality/chatbot-qa/semantic-regression/README.md
+++ b/state/quality/chatbot-qa/semantic-regression/README.md
@@ -1,0 +1,114 @@
+# Semantic-regression artifacts
+
+One JSON per PR head SHA, written by `.github/workflows/semantic-regression-chatbot.yml`
+(producer script: `Scripts/replay-chatbot-goldens.ps1`).
+
+## What this closes
+
+Today `state/quality/chatbot-qa/golden-traces/<slug>/` stores per-prompt
+reference answers + median elapsed + agent + verified date (surfaced as QA
+badges in `/chatbot/#showcase`). `Scripts/compare-trace-to-canonical.ps1`
+catches drift in the **trace shape** (steps, agent ids, attributes), but
+nothing automated catches drift in the **answer text itself** — a router
+or skill change can keep the trace shape pristine while replacing a 3 KB
+explanation of the circle of fifths with a one-line shrug.
+
+This harness closes that gap: replay each golden, embed both sides, diff
+cosine, post a PR comment, persist the JSON for the dashboard.
+
+## Schema (semantic-regression-v1)
+
+```json
+{
+  "schema": "semantic-regression-v1",
+  "head_sha": "abc123...",
+  "run_at": "2026-05-23T18:42:00Z",
+  "chatbot_url": "http://localhost:5252",
+  "encoder": "text-embedding-3-small",
+  "threshold_cosine": 0.85,
+  "sample_size": 0,
+  "elapsed_seconds": 42.7,
+  "cost_warning": null,
+  "prompts": [
+    {
+      "slug": "explain-the-circle-of-fifths",
+      "prompt": "Explain the circle of fifths",
+      "category": "theory",
+      "provider_ref": "skill.circleoffifths",
+      "provider_new": "skill.circleoffifths",
+      "ref_cosine_self": 1.0,
+      "new_cosine": 0.91,
+      "delta": -0.09,
+      "verdict": "ok",
+      "tokens": 1840,
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 14,
+    "ok": 13,
+    "drift": 1,
+    "errored": 0,
+    "provider_mismatch": 0,
+    "no_baseline": 0,
+    "total_tokens": 28910
+  }
+}
+```
+
+### Verdict values
+
+| verdict | meaning |
+|---|---|
+| `ok` | `cosine ≥ threshold`. No semantic drift detected. |
+| `drift` | `cosine < threshold` (default 0.85). Answer text moved enough to be worth a human review. Advisory only — does **not** fail the build. |
+| `provider_mismatch` | The PR routed this prompt to a different agent (`provider_new ≠ provider_ref`). That's a routing test, not a semantic regression — cosine is omitted. |
+| `errored` | Replay or embedding failed. Surfaced as a workflow failure if every prompt errors; ignored otherwise. |
+
+## Encoder choice
+
+`text-embedding-3-small` (1536 dims, OpenAI). Documented in the workflow YAML
+header. Why not `ga_generate_voicing_embedding` (the GA MCP voicing
+embedder)? That tool produces 228-dim vectors from raw pitch-class
+geometry — perfect for voicings, useless for paragraphs of markdown
+English. Chatbot answers are prose. `text-embedding-3-small` is already
+the project's standing prose embedder (`Apps/ga-server/GaApi/Services/
+VectorSearchService.cs`, `Tools/GaDataCLI/`).
+
+One encoder per run. The `encoder` field is recorded so the dashboard
+never compares cosines across encoders.
+
+## Cost guardrail
+
+Each prompt makes 2 embedding calls (reference + new answer). With ~45
+goldens × ~4 KB avg answer ≈ ~90k input tokens per full run.
+`text-embedding-3-small` is $0.02 / 1M input tokens → roughly **$0.0018
+per PR run** at full corpus. If a single run exceeds 50k input tokens
+the artifact's `cost_warning` field is populated and the PR comment
+surfaces it. Use the workflow's `sample_size` input (or the script's
+`-SampleSize N` parameter) to subsample if cost becomes a concern, or
+move the workflow off per-PR onto a weekly cron.
+
+## Retention
+
+90 days as workflow artifacts (GitHub default). The on-disk
+`<sha>.json` files in this directory are committed and live for the
+life of the repo — they're small (~5–15 KB) and the dashboard's QA tab
+needs the history to draw a trend line. Prune via the same rotation
+that `state/quality/chatbot-qa/*.json` daily snapshots use if/when
+volume becomes a problem (currently ~1 file per merged PR; ~365 / yr
+upper bound assuming a merged PR every day).
+
+## Running locally
+
+```powershell
+# Start the chatbot first (Apps/GaChatbot.Api on :5252).
+# Then:
+$env:OPENAI_API_KEY = "sk-..."
+pwsh Scripts/replay-chatbot-goldens.ps1
+```
+
+Outputs go to `state/quality/chatbot-qa/semantic-regression/<HEAD>.json`
+(local HEAD SHA by default; override with `-HeadSha`).
+
+Optional: `-EmitMarkdown path/to/comment.md` writes the PR-comment table.

--- a/state/quality/chatbot-qa/semantic-regression/SCHEMA.json
+++ b/state/quality/chatbot-qa/semantic-regression/SCHEMA.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guitaralchemist.com/schemas/semantic-regression-v1.json",
+  "title": "Semantic Regression Run (chatbot goldens)",
+  "description": "One artifact per PR head SHA, written by Scripts/replay-chatbot-goldens.ps1. Captures cosine similarity between each prompt's stored reference answer and the PR-HEAD chatbot's fresh answer. Consumed by the dashboard QA tab and by ix-quality-trend if/when a SemanticRegressionSnapshot is added there.",
+  "type": "object",
+  "required": ["schema", "head_sha", "run_at", "encoder", "threshold_cosine", "prompts", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "schema":           { "const": "semantic-regression-v1" },
+    "head_sha":         { "type": "string", "minLength": 7 },
+    "run_at":           { "type": "string", "format": "date-time" },
+    "chatbot_url":      { "type": "string" },
+    "encoder":          { "type": "string", "description": "Embedding model id. One per run. Examples: text-embedding-3-small, ga_generate_voicing_embedding (not appropriate for prose — see README)." },
+    "threshold_cosine": { "type": "number", "minimum": 0, "maximum": 1 },
+    "sample_size":      { "type": "integer", "minimum": 0, "description": "0 == all prompts; N > 0 == random N sampled for cost." },
+    "elapsed_seconds":  { "type": "number", "minimum": 0 },
+    "cost_warning":     { "type": ["string", "null"] },
+    "prompts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["slug", "prompt", "category", "verdict"],
+        "additionalProperties": false,
+        "properties": {
+          "slug":            { "type": "string" },
+          "prompt":          { "type": "string" },
+          "category":        { "type": "string" },
+          "provider_ref":    { "type": ["string", "null"], "description": "agent.id from the stored reference run." },
+          "provider_new":    { "type": ["string", "null"], "description": "agent.id from this PR HEAD's replay." },
+          "ref_cosine_self": { "type": "number", "const": 1.0 },
+          "new_cosine":      { "type": ["number", "null"], "minimum": -1, "maximum": 1 },
+          "delta":           { "type": ["number", "null"], "description": "new_cosine - 1.0 (negative == drift away from reference)." },
+          "verdict":         { "enum": ["ok", "drift", "provider_mismatch", "errored", "no_baseline"] },
+          "tokens":          { "type": "integer", "minimum": 0 },
+          "error":           { "type": ["string", "null"] }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "ok", "drift", "errored"],
+      "additionalProperties": false,
+      "properties": {
+        "total":             { "type": "integer", "minimum": 0 },
+        "ok":                { "type": "integer", "minimum": 0 },
+        "drift":             { "type": "integer", "minimum": 0 },
+        "errored":           { "type": "integer", "minimum": 0 },
+        "provider_mismatch": { "type": "integer", "minimum": 0 },
+        "no_baseline":       { "type": "integer", "minimum": 0 },
+        "total_tokens":      { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Closes the "did the chatbot's answer get better or worse with this PR?" loop. Trace-shape diffs are already covered by `Scripts/compare-trace-to-canonical.ps1`, but nothing automated catches drift in the answer *text*. A router or skill change can keep the trace shape pristine while replacing a 3 KB explanation of the circle of fifths with a one-line shrug.
- Replays each prompt under `state/quality/chatbot-qa/golden-traces/*` that has a stored reference answer, embeds reference + new answer via OpenAI `text-embedding-3-small`, computes cosine, posts a single sticky PR comment with the table, and persists `semantic-regression-v1` JSON to `state/quality/chatbot-qa/semantic-regression/<sha>.json` for the dashboard QA tab to ingest.
- Provider-replay discipline: if the new `agent.id` differs from the reference's `agent.id`, the prompt is tagged `provider_mismatch` and cosine is skipped — that's a routing test, not a semantic regression.

## Files
- `.github/workflows/semantic-regression-chatbot.yml` — PR-triggered on `Apps/GaChatbot.Api/**`, `Apps/ga-server/GaApi/**`, `Common/GA.Business.ML/**`, golden-traces, or the workflow/script themselves.
- `Scripts/replay-chatbot-goldens.ps1` — local-runnable equivalent, full CLI surface for ad-hoc runs.
- `state/quality/chatbot-qa/semantic-regression/{README.md,SCHEMA.json,.gitkeep}` — schema, retention, encoder-choice rationale, cost guardrail.

## Encoder rationale
`text-embedding-3-small`, not `ga_generate_voicing_embedding`. The MCP voicing embedder is 228-dim raw pitch-class geometry — perfect for voicings, useless for paragraphs of markdown English. `text-embedding-3-small` is already the project's prose embedder (`VectorSearchService.cs`, `GaDataCLI`). One encoder per run, recorded in artifact, so the dashboard never compares cosines across encoders.

## Cost guardrail
~45 goldens × ~4 KB avg × 2 embeddings ≈ 90k input tokens / run → ~**$0.0018 / PR**. Token total recorded in artifact; `cost_warning` field populated above 50k. Workflow `sample_size` input + script `-SampleSize` let the user subsample if needed.

## Failure semantics
- **Drift is REPORTED, not fatal.** PR comment + artifact are the deliverable; the user decides if it ships.
- **Hard failures fail loudly**: chatbot didn't start, `OPENAI_API_KEY` missing, every replay errored → workflow red. Silence is worse than red for a regression gate.
- **No-baseline prompts** (no `run-1.json` with answer yet) are skipped, not counted as drift. Reference baselines arrive incrementally.

## Heads-up on workflow-file blocking
This PR adds a `.github/workflows/*.yml` file, which trips Agent Blackbox's `policy.blocked_path` rule. User pre-authorized admin-merge for this work; the orchestrator will admin-merge if Risk Report is the only failing check.

## Test plan
- [x] PowerShell script parses (`[Parser]::ParseFile`, no errors).
- [x] YAML parses (10 steps, single job).
- [x] SCHEMA.json parses.
- [x] Local zero-baseline smoke (no `run-1.json` present yet on `origin/main`) → script logs "no prompts with reference answer yet", writes a valid empty artifact, exits 0.
- [x] Local `OPENAI_API_KEY`-missing path fails fast with a clear error (the guardrail this harness exists to enforce).
- [ ] First live run lands when this PR triggers itself (the workflow file path is in its own trigger list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)