### PR TITLE
feat(harness): /test-plan skill + auto-fire workflow + state/quality/test-plans/

### DIFF
--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: test-plan
+description: Diff-driven test-plan proposer for non-trivial PRs. Resolves the PR, categorizes each changed file by language/layer and test surface, weights by risk class (pure-additive / refactor / api-change / one-way-door), and emits a structured proposal of unit + integration + E2E + chatbot test cases keyed to the actual lines that changed. Writes to state/quality/test-plans/<head-sha>.md and posts a sticky PR comment. PROPOSES — never auto-writes test code; the human writes the tests.
+allowed-tools: Bash, Read, Write, Grep, Glob
+last_verified: 2026-05-23
+karpathy_rule: R4-goal-driven-execution (every PR declares verifiable success criteria — a test plan IS those criteria)
+related_plan: docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md
+---
+
+# /test-plan
+
+Closes the **"developer forgot to write a test plan"** gap. Reads a PR diff,
+maps each changed file to its likely test surface, and emits a structured set
+of test cases the author (human or agent) should add before merge.
+
+Invoked as `/test-plan` for the current branch's open PR, or
+`/test-plan <PR#>` for a specific number.
+
+Sister skills:
+
+- `/grade-last-pr` — post-merge intent-vs-delivery (looks backward).
+- `/council` — pre-merge gate for one-way doors (escalated review).
+- `/test-plan` — pre-merge test-coverage proposer (this skill; daily use).
+
+Together they form the **before / during / after** triangle of PR quality.
+
+## When to run
+
+- **Right after a PR opens** — the `.github/workflows/test-plan-suggester.yml`
+  fires automatically on `opened` + `synchronize` if the PR body lacks a
+  `## Test plan` section. Re-runs on every push to update the proposal.
+- **Before requesting review** — if you wrote a thin `## Test plan` and want
+  a second opinion on what else to test.
+- **When grading an agent-authored PR low for coverage** — re-run after the
+  agent fixes its plan, before merging.
+
+**Do NOT** invoke for:
+
+- Typo PRs (< 5 changed lines, no logic change) — overhead exceeds value.
+- Pure-documentation PRs (only `*.md` outside tests/docs/contracts) — no
+  test surface.
+- Revert PRs — the test plan is "the prior PR's test plan, rerun" (use
+  `/grade-last-pr` on the revert instead).
+- Unmerged PRs you're about to abandon — wasted budget.
+
+## What this skill does NOT do
+
+- **Never auto-writes test code.** Writing tests requires understanding intent,
+  fixture layout, and the team's test style — that's an engineering call, not
+  a heuristic. A future `/test-write` skill could take the proposal as input;
+  this skill stops at the proposal.
+- **Never blocks merge.** The workflow posts a comment; it is advisory. The
+  blocking gate for one-way doors is `/council`. For routine PRs, the review
+  process is the gate.
+- **Never edits the PR body.** Adds a sticky comment with marker
+  `<!-- test-plan -->`. The author owns the body; the bot owns the comment.
+
+## How to run
+
+### 1. Resolve the PR
+
+```bash
+PR_NUM="${1:-$(gh pr view --json number --jq .number 2>/dev/null)}"
+if [ -z "$PR_NUM" ]; then
+  echo "No PR on current branch and no PR number passed. Aborting."
+  exit 1
+fi
+
+gh pr view "$PR_NUM" --json title,body,baseRefName,headRefName,headRefOid,files,additions,deletions,url,author \
+  > /tmp/test-plan-pr-$PR_NUM.json
+```
+
+Skip-suppression: if the PR body contains `[skip test-plan]` (case-insensitive,
+anywhere in the body), exit clean with `suppressed by author`. This mirrors
+the convention from other bot workflows.
+
+### 2. Capture the diff
+
+```bash
+BASE=$(jq -r .baseRefName /tmp/test-plan-pr-$PR_NUM.json)
+git fetch origin "$BASE" --depth=50 2>/dev/null || true
+git diff --stat "origin/$BASE...HEAD" > /tmp/test-plan-stat-$PR_NUM.txt
+git diff "origin/$BASE...HEAD" > /tmp/test-plan-diff-$PR_NUM.patch
+```
+
+Cap the per-file diff load at **100 KB** when reading into the prompt — large
+generated files (lockfiles, snapshots) blow the budget and add no signal.
+The stat output is always cheap; read it in full.
+
+### 3. Categorize changes (the heuristic)
+
+This is the **load-bearing heuristic** of the skill. It is intentionally
+small — a few path-prefix matches and a couple of content regexes. Document
+overrides inline so future humans can tune.
+
+#### 3a. Language / layer (by path prefix)
+
+| Path prefix | Layer | Default test type |
+|---|---|---|
+| `Common/GA.Business.Core/**/*.cs` | .NET domain | unit (xUnit) |
+| `Common/GA.Business.ML/**/*.cs` | .NET ML pipeline | unit + integration (corpus fixture) |
+| `Apps/ga-server/GaApi/Controllers/**/*.cs` | .NET HTTP API | integration (WebApplicationFactory) |
+| `Apps/ga-server/GaApi/**/*.cs` (non-controller) | .NET API internals | unit |
+| `Apps/ga-server/GaMcpServer/**/*.cs` | .NET MCP server | integration (MCP handshake) |
+| `Common/GA.Business.DSL/**/*.fs` | F# DSL | unit (Expecto) |
+| `ReactComponents/ga-react-components/src/**/*.{ts,tsx}` | TS/React SPA | unit (Vitest) + E2E (Playwright) for routes |
+| `ReactComponents/ga-react-components/vite.config.ts` | Vite middleware | integration (curl the endpoint in dev mode) |
+| `ReactComponents/ga-react-components/tests/**/*.spec.ts` | Existing E2E | the PR is itself a test — no proposal needed for that file |
+| `Scripts/**/*.ps1` | PowerShell tooling | runbook smoke (manual) + `-WhatIf` lint |
+| `.github/workflows/**/*.yml` | CI/CD | workflow lint (actionlint) + dry-run via `workflow_dispatch` |
+| `docs/contracts/*.{md,json}` | Cross-repo contracts | schema validation + cross-repo integration test |
+| `docs/plans/**/*.md` | Plan doc | none (planning artifact, not code) |
+| `state/**/*.json` | State artifact | schema validation only |
+| `**/*.md` (other) | Documentation | none |
+
+#### 3b. Test surface (by content regex on the diff hunks)
+
+Run cheap regexes against the diff to refine the per-file surface. Multiple
+matches stack (a controller that calls a recognizer hits both rows).
+
+| Regex (in added lines, `^+` prefix) | Surface refinement |
+|---|---|
+| `public\s+(class\|interface\|record)` (C#) or `export\s+(function\|const\|class)` (TS) | **API surface** — proposal MUST include a contract test |
+| `\[HttpGet\|\[HttpPost\|\[Route\b` | **HTTP endpoint** — propose integration test against the route |
+| `useState\|useEffect\|useMemo\b` | **React state** — propose Vitest component test |
+| `<[A-Z][A-Za-z]+` in `.tsx` (new JSX element) | **Render surface** — propose Playwright assertion |
+| `IRecognizer\|ICanonical\|ChordRecognizer\b` | **Recognizer path** — propose chatbot prompt covering it |
+| `OpticK\|VoicingSearch\|EmbeddingSchema\b` | **OPTIC-K path** — propose voicing-search integration test |
+| `await\s+\w+\.(GetAsync\|PostAsync)` | **External call** — propose mock test + timeout test |
+| `throw\s+new\b` (added) | **New error path** — propose negative-case test |
+
+If no regex hits, fall back to the path-prefix default.
+
+#### 3c. Risk class (per-PR)
+
+Pick **one** for the whole PR:
+
+| Class | Criteria | Test-density multiplier |
+|---|---|---|
+| **pure-additive** | All changes are new files; no existing-file modifications; no deletions. | 1× |
+| **refactor** | Renames, extracts, moves; tests likely still pass; behavior unchanged in intent. | 1.5× (regression catching) |
+| **api-change** | Public surface modified (signature change in `public` C#, exported TS, controller route, contract schema). | 2× |
+| **one-way-door** | Touches any path in `/council`'s door list (OPTIC-K dim, contract schema, public controller route, SPA route, installer). | 3× + flag for `/council` |
+
+If `one-way-door`, the proposal MUST include a one-liner:
+
+> **One-way-door touched** — consider running `/council <PR#>` before merge.
+
+### 4. Generate the proposal
+
+Write to **both** the session and `state/quality/test-plans/<head-sha>.md`.
+Use the template below verbatim — section order matters because the comment
+parser truncates at the `## Coverage gaps surfaced` header to fit GitHub's
+65 KB comment limit on overgrown PRs.
+
+```markdown
+# Test plan — PR #<N> (<head_sha_short>)
+
+**Generated:** <RFC3339 UTC>
+**Author:** @<gh-login>
+**Scope:** <one-sentence diff summary: "N files, +A/-D, touching <layers>">
+**Risk class:** <pure-additive | refactor | api-change | one-way-door>
+
+<one-way-door warning if applicable>
+
+## Unit tests (N proposed)
+
+- [ ] **<Namespace.Class>**: <one-line case description> (file: `<path>:<line>`)
+  - Rationale: <why this case — cite the diff hunk in 1 sentence>
+- [ ] ...
+
+## Integration tests (N proposed)
+
+- [ ] **<endpoint or boundary>**: <one-line case description>
+  - Rationale: <why — what end-to-end path this exercises>
+- [ ] ...
+
+## E2E tests (Playwright) (N proposed)
+
+- [ ] **<route or user flow>**: <expected assertion>
+  - Rationale: <what the user sees that the PR changes>
+- [ ] ...
+
+## Chatbot prompts (N proposed)
+
+- [ ] "<prompt text the chatbot should now handle correctly>"
+  - Existing similar prompt: `state/quality/chatbot-qa/golden-traces/<closest>/...` (or "none yet")
+  - Why now: <what new code path this PR adds that could regress this prompt>
+- [ ] ...
+
+## Coverage gaps surfaced
+
+- **No test covers** `<path>:<line>` (<reason — new branch, new error path, new public API>)
+- ...
+
+## Rubric
+
+This plan was generated by **/test-plan** using:
+- **Diff-driven**: proposals are keyed to changed lines, not the whole module.
+- **Surface-aware**: each layer maps to its canonical test type (unit → integration → e2e → chatbot).
+- **Risk-weighted**: <risk class> PRs get <multiplier>× the baseline density.
+- **Coverage-gap-aware**: new code paths with no existing test are called out explicitly.
+
+The heuristic itself lives in `.claude/skills/test-plan/SKILL.md` §3.
+Override with judgment — the proposal is advisory, not prescriptive.
+```
+
+Density baseline: 1 unit case per public method touched; 1 integration case
+per endpoint or boundary; 1 E2E per user-visible route; 1 chatbot prompt per
+recognizer/OPTIC-K-touching diff. Multiply by the risk class.
+
+Cap each section at **10 items**. If you have more, the heuristic is firing
+on a refactor — pick the highest-risk ones and note `+N more candidates not
+listed` at the bottom of the section.
+
+### 5. Write the artifact
+
+```bash
+mkdir -p state/quality/test-plans
+OUT="state/quality/test-plans/${HEAD_SHA}.md"
+# Write the markdown to $OUT.
+
+# Sidecar JSON with structured metadata (for trend analysis):
+META="state/quality/test-plans/${HEAD_SHA}.meta.json"
+cat > "$META" <<EOF
+{
+  "schema": "test-plan-v1",
+  "pr_number": ${PR_NUM},
+  "head_sha": "${HEAD_SHA}",
+  "risk_class": "${RISK_CLASS}",
+  "proposal_counts": {
+    "unit": ${UNIT_COUNT},
+    "integration": ${INTEGRATION_COUNT},
+    "e2e": ${E2E_COUNT},
+    "chatbot": ${CHATBOT_COUNT},
+    "coverage_gaps": ${GAP_COUNT}
+  },
+  "layers_touched": [${LAYERS_JSON}],
+  "generated_at": "${NOW_UTC}",
+  "generator": "claude-opus-4-7"
+}
+EOF
+```
+
+Validate against `state/quality/test-plans/SCHEMA.json` before writing the
+meta file — if `jq` or `ajv` is available, lint it. Otherwise, eyeball
+required fields.
+
+### 6. Post the PR comment
+
+```bash
+gh pr comment "$PR_NUM" --body "$(cat <<EOF
+<!-- test-plan -->
+## Proposed test plan (heuristic)
+
+$(cat state/quality/test-plans/${HEAD_SHA}.md)
+
+---
+
+_Generated by [\`/test-plan\`](.claude/skills/test-plan/SKILL.md) — see \`state/quality/test-plans/${HEAD_SHA}.md\` for the persisted artifact. To suppress, add \`[skip test-plan]\` to the PR body._
+EOF
+)"
+```
+
+If a comment with the `<!-- test-plan -->` marker already exists, **update
+it in place** rather than appending a new one — the sticky-comment pattern
+keeps the conversation readable. The workflow uses `actions/github-script`
+to handle the upsert; standalone runs from a session use:
+
+```bash
+EXISTING=$(gh pr view "$PR_NUM" --json comments \
+  --jq '.comments[] | select(.body | startswith("<!-- test-plan -->")) | .url' | head -1)
+if [ -n "$EXISTING" ]; then
+  COMMENT_ID="${EXISTING##*#issuecomment-}"
+  gh api -X PATCH "repos/{owner}/{repo}/issues/comments/$COMMENT_ID" \
+    -f body="$NEW_BODY"
+else
+  gh pr comment "$PR_NUM" --body "$NEW_BODY"
+fi
+```
+
+### 7. Print the terminal summary
+
+One concise block. Keep it under 12 lines.
+
+```
+PR #321 test plan · risk: refactor
+  base → head: main → feat/qa-tab-render-quality-readme @ 04476aac
+  files:       2 changed, +74/-1
+  layers:      TS/React (1), Vite middleware (1)
+
+  proposed:
+  • 3 unit  • 2 integration  • 2 E2E  • 0 chatbot
+  • 1 coverage gap surfaced
+
+  artifact: state/quality/test-plans/04476aac9972a8771fbfd36f297faaa1460e465b.md
+  comment:  https://github.com/GuitarAlchemist/ga/pull/321#issuecomment-...
+```
+
+## Edge cases
+
+- **PR with > 100 changed files.** Group by directory in the proposal; cap
+  total cases at 30. A PR that big needs splitting, not testing.
+- **PR with only generated files.** (lockfile bumps, schema regen) — exit
+  with `no test surface; generated changes only`. Don't post a comment.
+- **PR opened by a bot (dependabot/renovate).** Skip; bot author detection
+  matches `/-bot$/` or `dependabot` in `author.login`. Bot PRs have their
+  own gates.
+- **Draft PR.** Run anyway — the proposal helps the author firm up the plan
+  before ready-for-review. Mark `draft: true` in the sidecar JSON.
+- **Force-push that rewrites history.** New `head_sha` → new artifact. The
+  prior artifact stays for audit history (mirrors `/council`'s convention).
+- **Body has `## Test plan` but it's empty / a checkbox stub.** Treat as
+  missing; post the proposal as a starter draft for the author to flesh out.
+- **PR from a known agent author** (Co-Authored-By Claude / Codex / Mercury
+  in any commit message in the range). Post the proposal as a **second
+  opinion** even if `## Test plan` exists — agents are the most likely to
+  miss coverage, and the cost of a duplicate proposal is one comment.
+
+## Anti-patterns
+
+- **Proposing tests for unchanged code.** The whole point of "diff-driven" is
+  that the cases hang off the diff. If you find yourself listing tests for
+  a module just because it exists, you've drifted into "audit" — wrong
+  skill, use `/octo:review`.
+- **Proposing exhaustive coverage.** A test plan for a 2-file diff that
+  lists 40 cases is noise. The author will skip the comment. Cap at the
+  density-baseline × risk-class multiplier; if it overflows, the section
+  cap (10) kicks in.
+- **Auto-generating test code.** The skill MUST stop at the proposal. Test
+  code is intent + fixtures + style — a future skill, not this one.
+- **Re-posting on every push without sticky-comment dedup.** Spam. Use the
+  marker upsert.
+- **Treating the proposal as a checklist gate.** This skill is advisory. The
+  blocking gates are `/council` (one-way doors) and the review process
+  (everything else).
+- **Running on the AGENTS.md / CLAUDE.md PR.** No code surface; exit clean.
+
+## Heuristic tuning notes
+
+The path-prefix table and the content regex table in §3 are the leverage
+points. To tune:
+
+1. Find a PR where the proposal was wrong (too many or too few cases).
+2. Identify whether the miss was a *path* mismatch (added a new layer) or
+   a *content* mismatch (new pattern that should hit one of the regexes).
+3. Edit §3a or §3b in this file.
+4. Note the change in the commit message; the heuristic is a one-way door
+   in spirit (drift in test density is a real cost) — small additive tweaks
+   are fine, but bulk rewrites should be plan-reviewed.
+
+The sidecar JSON's `proposal_counts` field exists precisely so we can
+graph proposal density over time and notice when the heuristic starts
+over- or under-firing for a given layer.
+
+## Why this exists
+
+Karpathy R4: "Task completed != goal achieved." A test plan is the
+operational form of "goal" — it declares the criteria the PR's author
+believes the change satisfies, in the form of cases the team can mechanize.
+
+Today, every PR has a `## Test plan` checklist in the template, but:
+
+- Humans skip it ("I'll add tests after merge").
+- Agents under-fill it (the prompt cap on PR-body generation truncates
+  before the test plan).
+- Reviewers don't enforce it (no automated gate; "looks fine, merging").
+
+`/test-plan` makes the proposal cheap to generate and visible at PR time,
+shifting the test-design conversation **left** of merge. The artifact is
+persisted so the next session can read what was proposed vs what landed
+(another input for `/grade-last-pr`).
+
+The skill PROPOSES; the human writes. The skill is read-only on the codebase
+(comments only on the PR). Both properties are load-bearing — they keep the
+skill cheap, fast, and trust-worthy.
+
+## Related
+
+- `/grade-last-pr` (`.claude/skills/grade-last-pr/SKILL.md`) — post-merge
+  intent grade. A `medium` or `low` grade frequently traces back to a thin
+  test plan; this skill closes that gap upstream.
+- `/council` (`.claude/skills/council/SKILL.md`) — escalated gate for
+  one-way-door PRs. This skill's `one-way-door` risk class auto-suggests
+  invoking it.
+- `/backlog-groom` (`.claude/skills/backlog-groom/SKILL.md`) — proposes
+  next work; this skill helps verify what just got picked.
+- `state/quality/test-plans/README.md` — artifact directory contract.
+- `state/quality/test-plans/SCHEMA.json` — sidecar JSON Schema
+  (`test-plan-v1`).
+- `.github/workflows/test-plan-suggester.yml` — the auto-fire workflow.
+- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` —
+  parent plan; this skill is a Phase 2+ harness item.

--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -70,9 +70,12 @@ gh pr view "$PR_NUM" --json title,body,baseRefName,headRefName,headRefOid,files,
   > /tmp/test-plan-pr-$PR_NUM.json
 ```
 
-Skip-suppression: if the PR body contains `[skip test-plan]` (case-insensitive,
-anywhere in the body), exit clean with `suppressed by author`. This mirrors
-the convention from other bot workflows.
+Skip-suppression: if the PR body contains `[skip test-plan]` on its own line
+(case-insensitive, with optional surrounding whitespace), exit clean with
+`suppressed by author`. The marker must be on its own line so that PR bodies
+that *describe* the skill (mentioning the marker inside a backtick code span)
+do not accidentally suppress the workflow on themselves. This mirrors the
+convention from other bot workflows.
 
 ### 2. Capture the diff
 

--- a/.github/workflows/test-plan-suggester.yml
+++ b/.github/workflows/test-plan-suggester.yml
@@ -1,0 +1,541 @@
+name: Test Plan Suggester
+
+# Phase 2+ harness item — see docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md
+# and .claude/skills/test-plan/SKILL.md.
+#
+# Diff-driven test-plan proposer. On PR opened/synchronize:
+#   1. If body contains "[skip test-plan]" anywhere — exit clean.
+#   2. If body has a "## Test plan" section AND the PR is not from a known agent
+#      author — exit clean (developer wrote one themselves).
+#   3. Otherwise: assemble a heuristic proposal via the lightweight bash
+#      assembler below (mirrors the SKILL.md heuristic; richer ranking comes
+#      from invoking /test-plan interactively in a session) and post it as a
+#      sticky PR comment with marker <!-- test-plan -->.
+#
+# Always posts on every push for agent-authored PRs as a "second opinion"
+# even when the body already has a test plan section — agents are the most
+# likely to miss coverage and the cost is one comment.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # One run per PR; cancel in-flight runs if a new commit lands.
+  group: test-plan-suggester-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  suggest:
+    name: Assemble + post test-plan proposal
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip draft PRs unless they're ready-for-review — drafts churn too fast.
+    if: github.event.pull_request.draft != true || github.event.action == 'ready_for_review'
+    steps:
+      - name: Checkout PR head (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Decide whether to post
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # 1. Skip-suppression marker in body
+          if echo "${PR_BODY:-}" | grep -qiE '\[skip test-plan\]'; then
+            echo "decision=skip-marker" >> "$GITHUB_OUTPUT"
+            echo "Reason: PR body contains [skip test-plan]"
+            exit 0
+          fi
+
+          # 2. Bot-author skip (dependabot / renovate / *-bot)
+          if echo "$PR_AUTHOR" | grep -qiE '(dependabot|renovate|^.*-bot$)'; then
+            echo "decision=skip-bot" >> "$GITHUB_OUTPUT"
+            echo "Reason: PR author '$PR_AUTHOR' looks like a bot"
+            exit 0
+          fi
+
+          # 3. Detect "## Test plan" section in body (case-insensitive)
+          HAS_TP="false"
+          if echo "${PR_BODY:-}" | grep -qiE '^##\s+test plan\b'; then
+            HAS_TP="true"
+          fi
+          echo "has_test_plan_section=$HAS_TP" >> "$GITHUB_OUTPUT"
+
+          # 4. Detect agent-authored PR via commit trailers in the PR range
+          AGENT_AUTHORED="false"
+          if git log --format='%B' "${BASE_SHA}..${HEAD_SHA}" 2>/dev/null \
+              | grep -qiE 'Co-Authored-By:\s*(Claude|Codex|Mercury|Gemini|GPT)'; then
+            AGENT_AUTHORED="true"
+          fi
+          echo "agent_authored=$AGENT_AUTHORED" >> "$GITHUB_OUTPUT"
+
+          # 5. Decision matrix
+          #    - has test plan + human author    → skip (author owns it)
+          #    - has test plan + agent author    → post as second opinion
+          #    - no test plan + any author       → post
+          if [ "$HAS_TP" = "true" ] && [ "$AGENT_AUTHORED" = "false" ]; then
+            echo "decision=skip-has-plan" >> "$GITHUB_OUTPUT"
+            echo "Reason: PR body has '## Test plan' section and author is human"
+            exit 0
+          fi
+
+          echo "decision=post" >> "$GITHUB_OUTPUT"
+          if [ "$AGENT_AUTHORED" = "true" ] && [ "$HAS_TP" = "true" ]; then
+            echo "Reason: agent-authored PR — posting second opinion"
+          else
+            echo "Reason: no '## Test plan' section in body"
+          fi
+
+      - name: Assemble proposal (lightweight, no Claude runtime in CI)
+        id: assemble
+        if: steps.gate.outputs.decision == 'post'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HAS_TP: ${{ steps.gate.outputs.has_test_plan_section }}
+          AGENT: ${{ steps.gate.outputs.agent_authored }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p state/quality/test-plans
+          OUT="state/quality/test-plans/${HEAD_SHA}.md"
+          META="state/quality/test-plans/${HEAD_SHA}.meta.json"
+          COMMENT="/tmp/test-plan-comment.md"
+          NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          SHORT_SHA="${HEAD_SHA:0:8}"
+
+          echo "out=$OUT" >> "$GITHUB_OUTPUT"
+          echo "meta=$META" >> "$GITHUB_OUTPUT"
+          echo "comment=$COMMENT" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+          # --- Diff stat + per-file change counts ---
+          git fetch origin "$BASE_REF" --depth=50 2>/dev/null || true
+          CHANGED_FILES=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || true)
+          STAT=$(git diff --shortstat "${BASE_SHA}...${HEAD_SHA}" || true)
+          NUM_FILES=$(echo "$CHANGED_FILES" | grep -c . || true)
+
+          # --- Layer detection (mirrors SKILL.md §3a) ---
+          declare -A LAYER_FILES
+          declare -A LAYER_LABEL
+          LAYER_LABEL[dotnet-domain]=".NET domain"
+          LAYER_LABEL[dotnet-ml]=".NET ML pipeline"
+          LAYER_LABEL[dotnet-api-controller]=".NET HTTP API (controller)"
+          LAYER_LABEL[dotnet-api-internal]=".NET API internals"
+          LAYER_LABEL[mcp-server]=".NET MCP server"
+          LAYER_LABEL[fsharp-dsl]="F# DSL"
+          LAYER_LABEL[react-spa]="TS/React SPA"
+          LAYER_LABEL[vite-middleware]="Vite middleware"
+          LAYER_LABEL[react-e2e]="Playwright E2E spec"
+          LAYER_LABEL[powershell-tooling]="PowerShell tooling"
+          LAYER_LABEL[ci-workflow]="CI/CD workflow"
+          LAYER_LABEL[contract]="Cross-repo contract"
+          LAYER_LABEL[plan-doc]="Plan doc"
+          LAYER_LABEL[state-artifact]="State artifact"
+          LAYER_LABEL[docs]="Documentation"
+          LAYER_LABEL[other]="Other"
+
+          classify_file() {
+            local f="$1"
+            case "$f" in
+              Common/GA.Business.ML/*) echo "dotnet-ml" ;;
+              Common/GA.Business.Core/*) echo "dotnet-domain" ;;
+              Common/GA.Business.DSL/*.fs) echo "fsharp-dsl" ;;
+              Apps/ga-server/GaApi/Controllers/*) echo "dotnet-api-controller" ;;
+              Apps/ga-server/GaApi/*) echo "dotnet-api-internal" ;;
+              Apps/ga-server/GaMcpServer/*) echo "mcp-server" ;;
+              ReactComponents/ga-react-components/tests/*.spec.ts) echo "react-e2e" ;;
+              ReactComponents/ga-react-components/vite.config.ts) echo "vite-middleware" ;;
+              ReactComponents/ga-react-components/src/*) echo "react-spa" ;;
+              Scripts/*.ps1) echo "powershell-tooling" ;;
+              .github/workflows/*) echo "ci-workflow" ;;
+              docs/contracts/*) echo "contract" ;;
+              docs/plans/*) echo "plan-doc" ;;
+              state/*) echo "state-artifact" ;;
+              docs/*) echo "docs" ;;
+              *.md) echo "docs" ;;
+              *) echo "other" ;;
+            esac
+          }
+
+          # Default test-type density per layer (unit, integration, e2e, chatbot)
+          density_for() {
+            case "$1" in
+              dotnet-domain)         echo "1 0 0 0" ;;
+              dotnet-ml)             echo "1 1 0 1" ;;
+              dotnet-api-controller) echo "0 1 0 0" ;;
+              dotnet-api-internal)   echo "1 0 0 0" ;;
+              mcp-server)            echo "0 1 0 0" ;;
+              fsharp-dsl)            echo "1 0 0 0" ;;
+              react-spa)             echo "1 0 1 0" ;;
+              vite-middleware)       echo "0 1 0 0" ;;
+              react-e2e)             echo "0 0 0 0" ;;  # the PR IS the test
+              powershell-tooling)    echo "0 1 0 0" ;;
+              ci-workflow)           echo "0 1 0 0" ;;
+              contract)              echo "0 1 0 0" ;;
+              plan-doc|state-artifact|docs|other) echo "0 0 0 0" ;;
+            esac
+          }
+
+          LAYERS_SEEN=()
+          declare -A LAYER_FILE_LIST
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            L=$(classify_file "$f")
+            if [ -z "${LAYER_FILE_LIST[$L]+x}" ]; then
+              LAYER_FILE_LIST[$L]="$f"
+              LAYERS_SEEN+=("$L")
+            else
+              LAYER_FILE_LIST[$L]="${LAYER_FILE_LIST[$L]}|$f"
+            fi
+          done <<< "$CHANGED_FILES"
+
+          # --- Risk class (per-PR) ---
+          # one-way-door: matches /council's door list
+          # api-change:   added public/exported symbols
+          # refactor:     existing-file modifications + deletions
+          # pure-additive: only new files
+          RISK="pure-additive"
+
+          # Pure-additive check: every changed file is "A" (added) per git diff
+          ADD_ONLY="true"
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            STATUS=$(echo "$line" | cut -f1)
+            if [ "$STATUS" != "A" ]; then
+              ADD_ONLY="false"
+              break
+            fi
+          done < <(git diff --name-status "${BASE_SHA}...${HEAD_SHA}" || true)
+
+          if [ "$ADD_ONLY" = "false" ]; then
+            RISK="refactor"
+          fi
+
+          # API-change check: added public/exported symbols
+          if git diff "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null \
+              | grep -qE '^\+[[:space:]]*(public[[:space:]]+(class|interface|record|enum|struct)|export[[:space:]]+(function|const|class|interface|type)|\[HttpGet|\[HttpPost|\[Route\b)'; then
+            RISK="api-change"
+          fi
+
+          # One-way-door check: explicit path list (mirrors /council §When-to-run)
+          DOOR_PATHS=()
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs) DOOR_PATHS+=("$f") ;;
+              docs/contracts/*.contract.md|docs/contracts/*.schema.json) DOOR_PATHS+=("$f") ;;
+              Apps/ga-server/GaApi/Controllers/*.cs) DOOR_PATHS+=("$f") ;;
+              ReactComponents/ga-react-components/src/main.tsx) DOOR_PATHS+=("$f") ;;
+              Scripts/install-*.ps1|Scripts/uninstall-*.ps1) DOOR_PATHS+=("$f") ;;
+            esac
+          done <<< "$CHANGED_FILES"
+          if [ ${#DOOR_PATHS[@]} -gt 0 ]; then
+            RISK="one-way-door"
+          fi
+
+          # Risk multiplier
+          case "$RISK" in
+            pure-additive) MULT=1 ;;
+            refactor)      MULT=2 ;;  # bash int — represents 1.5× rounded up
+            api-change)    MULT=2 ;;
+            one-way-door)  MULT=3 ;;
+          esac
+
+          # --- Per-section counts ---
+          UNIT=0; INT=0; E2E=0; CHAT=0; GAPS=0
+          for L in "${LAYERS_SEEN[@]}"; do
+            FILE_COUNT=$(echo "${LAYER_FILE_LIST[$L]}" | tr '|' '\n' | grep -c . || true)
+            read U I E C <<< "$(density_for "$L")"
+            UNIT=$(( UNIT + U * FILE_COUNT * MULT ))
+            INT=$(( INT + I * FILE_COUNT * MULT ))
+            E2E=$(( E2E + E * FILE_COUNT * MULT ))
+            CHAT=$(( CHAT + C * FILE_COUNT * MULT ))
+          done
+
+          # Content-regex refinements (cheap, additive)
+          if git diff "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null \
+              | grep -qE '^\+.*(IRecognizer|ICanonical|ChordRecognizer)\b'; then
+            CHAT=$(( CHAT + 1 ))
+          fi
+          if git diff "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null \
+              | grep -qE '^\+.*(OpticK|VoicingSearch|EmbeddingSchema)\b'; then
+            INT=$(( INT + 1 ))
+          fi
+          if git diff "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null \
+              | grep -qE '^\+.*throw[[:space:]]+new\b'; then
+            UNIT=$(( UNIT + 1 ))
+          fi
+
+          # Section cap (mirrors SKILL.md §4 — keep proposals readable)
+          cap10() { if [ "$1" -gt 10 ]; then echo 10; else echo "$1"; fi; }
+          UNIT=$(cap10 "$UNIT"); INT=$(cap10 "$INT"); E2E=$(cap10 "$E2E"); CHAT=$(cap10 "$CHAT")
+
+          # --- Coverage gaps: paths touched with no co-changed *.test.* or *.spec.* sibling ---
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            # Skip files that ARE tests
+            case "$f" in
+              *.test.*|*.spec.*|*Test.cs|*Tests.cs|*.Tests/*|*tests/*|*/test/*) continue ;;
+            esac
+            # Skip docs/state/plan files (no expected test surface)
+            L=$(classify_file "$f")
+            case "$L" in
+              docs|plan-doc|state-artifact|other) continue ;;
+            esac
+            # Check whether the PR also touched any matching test file
+            BASE_NAME=$(basename "$f" | sed 's/\.[^.]*$//')
+            if ! echo "$CHANGED_FILES" | grep -qiE "(${BASE_NAME}\.test\.|${BASE_NAME}\.spec\.|${BASE_NAME}Tests?\.cs)"; then
+              GAPS=$(( GAPS + 1 ))
+            fi
+          done <<< "$CHANGED_FILES"
+          GAPS=$(cap10 "$GAPS")
+
+          # --- Layer summary string for the Scope line ---
+          LAYER_SUMMARY=""
+          for L in "${LAYERS_SEEN[@]}"; do
+            FILE_COUNT=$(echo "${LAYER_FILE_LIST[$L]}" | tr '|' '\n' | grep -c . || true)
+            LABEL="${LAYER_LABEL[$L]:-$L}"
+            if [ -z "$LAYER_SUMMARY" ]; then
+              LAYER_SUMMARY="${LABEL} (${FILE_COUNT})"
+            else
+              LAYER_SUMMARY="${LAYER_SUMMARY}, ${LABEL} (${FILE_COUNT})"
+            fi
+          done
+
+          # --- Write the markdown artifact ---
+          {
+            echo "# Test plan — PR #${PR_NUM} (${SHORT_SHA})"
+            echo
+            echo "**Generated:** ${NOW_UTC}"
+            echo "**Author:** @${PR_AUTHOR}"
+            echo "**Scope:** ${NUM_FILES} file(s) changed,${STAT#* }; touching ${LAYER_SUMMARY:-no recognized layer}."
+            echo "**Risk class:** ${RISK}"
+            echo
+            if [ "$RISK" = "one-way-door" ]; then
+              echo "> **One-way-door touched** — consider running \`/council ${PR_NUM}\` before merge."
+              echo "> Door paths:"
+              for d in "${DOOR_PATHS[@]}"; do
+                echo "> - \`$d\`"
+              done
+              echo
+            fi
+
+            echo "## Unit tests (${UNIT} proposed)"
+            echo
+            if [ "$UNIT" -gt 0 ]; then
+              count=0
+              for L in "${LAYERS_SEEN[@]}"; do
+                read U _ _ _ <<< "$(density_for "$L")"
+                [ "$U" -eq 0 ] && continue
+                for f in $(echo "${LAYER_FILE_LIST[$L]}" | tr '|' '\n'); do
+                  [ -z "$f" ] && continue
+                  [ "$count" -ge "$UNIT" ] && break 2
+                  echo "- [ ] **${LAYER_LABEL[$L]}** \`${f}\`: add unit case(s) for the changed branch."
+                  echo "  - Rationale: layer default for ${L}; diff modifies behavior, baseline unit coverage expected."
+                  count=$(( count + 1 ))
+                done
+              done
+            else
+              echo "_No unit-test surface detected._"
+            fi
+            echo
+
+            echo "## Integration tests (${INT} proposed)"
+            echo
+            if [ "$INT" -gt 0 ]; then
+              count=0
+              for L in "${LAYERS_SEEN[@]}"; do
+                read _ I _ _ <<< "$(density_for "$L")"
+                [ "$I" -eq 0 ] && continue
+                for f in $(echo "${LAYER_FILE_LIST[$L]}" | tr '|' '\n'); do
+                  [ -z "$f" ] && continue
+                  [ "$count" -ge "$INT" ] && break 2
+                  echo "- [ ] **${LAYER_LABEL[$L]}** \`${f}\`: integration test through the boundary this file owns."
+                  echo "  - Rationale: layer default for ${L}; verifies end-to-end wiring, not just the unit logic."
+                  count=$(( count + 1 ))
+                done
+              done
+            else
+              echo "_No integration-test surface detected._"
+            fi
+            echo
+
+            echo "## E2E tests (Playwright) (${E2E} proposed)"
+            echo
+            if [ "$E2E" -gt 0 ]; then
+              count=0
+              for L in "${LAYERS_SEEN[@]}"; do
+                read _ _ E _ <<< "$(density_for "$L")"
+                [ "$E" -eq 0 ] && continue
+                for f in $(echo "${LAYER_FILE_LIST[$L]}" | tr '|' '\n'); do
+                  [ -z "$f" ] && continue
+                  [ "$count" -ge "$E2E" ] && break 2
+                  echo "- [ ] **${LAYER_LABEL[$L]}** \`${f}\`: Playwright spec asserting the user-visible change."
+                  echo "  - Rationale: route or component change; user-flow regression bait."
+                  count=$(( count + 1 ))
+                done
+              done
+            else
+              echo "_No user-visible surface detected._"
+            fi
+            echo
+
+            echo "## Chatbot prompts (${CHAT} proposed)"
+            echo
+            if [ "$CHAT" -gt 0 ]; then
+              echo "- [ ] Add ${CHAT} prompt(s) covering the recognizer / OPTIC-K path(s) modified by this PR."
+              echo "  - Existing similar prompts: \`state/quality/chatbot-qa/golden-traces/\` (browse for closest)"
+              echo "  - Why now: changed recognizer / voicing code can silently regress chatbot answers — add a golden trace."
+            else
+              echo "_No recognizer / OPTIC-K path detected in the diff._"
+            fi
+            echo
+
+            echo "## Coverage gaps surfaced"
+            echo
+            if [ "$GAPS" -gt 0 ]; then
+              count=0
+              while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                case "$f" in
+                  *.test.*|*.spec.*|*Test.cs|*Tests.cs|*.Tests/*|*tests/*|*/test/*) continue ;;
+                esac
+                L=$(classify_file "$f")
+                case "$L" in
+                  docs|plan-doc|state-artifact|other) continue ;;
+                esac
+                BASE_NAME=$(basename "$f" | sed 's/\.[^.]*$//')
+                if ! echo "$CHANGED_FILES" | grep -qiE "(${BASE_NAME}\.test\.|${BASE_NAME}\.spec\.|${BASE_NAME}Tests?\.cs)"; then
+                  [ "$count" -ge "$GAPS" ] && break
+                  echo "- **No co-changed test** for \`${f}\` (layer: ${L})"
+                  count=$(( count + 1 ))
+                fi
+              done <<< "$CHANGED_FILES"
+            else
+              echo "_No coverage gaps surfaced — every modified file has a co-changed test sibling._"
+            fi
+            echo
+
+            echo "## Rubric"
+            echo
+            echo "This plan was generated by **the test-plan-suggester workflow** (lightweight assembler — mirrors \`.claude/skills/test-plan/SKILL.md\` heuristic):"
+            echo
+            echo "- **Diff-driven**: proposals are keyed to changed files / lines, not the whole module."
+            echo "- **Surface-aware**: each layer maps to its canonical test type (unit → integration → e2e → chatbot)."
+            echo "- **Risk-weighted**: \`${RISK}\` PRs get ${MULT}× the baseline density."
+            echo "- **Coverage-gap-aware**: files with no co-changed test sibling are called out explicitly."
+            echo
+            echo "Run \`/test-plan ${PR_NUM}\` in a session for the richer per-line proposal with rationale citations."
+            echo "Override at will — this is advisory, not prescriptive."
+          } > "$OUT"
+
+          # --- Sidecar JSON (built with printf to keep YAML-friendly indentation) ---
+          LAYERS_JSON=$(printf '"%s",' "${LAYERS_SEEN[@]}" | sed 's/,$//')
+          {
+            printf '{\n'
+            printf '  "schema": "test-plan-v1",\n'
+            printf '  "pr_number": %s,\n' "$PR_NUM"
+            printf '  "head_sha": "%s",\n' "$HEAD_SHA"
+            printf '  "risk_class": "%s",\n' "$RISK"
+            printf '  "proposal_counts": {\n'
+            printf '    "unit": %s,\n' "$UNIT"
+            printf '    "integration": %s,\n' "$INT"
+            printf '    "e2e": %s,\n' "$E2E"
+            printf '    "chatbot": %s,\n' "$CHAT"
+            printf '    "coverage_gaps": %s\n' "$GAPS"
+            printf '  },\n'
+            printf '  "layers_touched": [%s],\n' "$LAYERS_JSON"
+            printf '  "generated_at": "%s",\n' "$NOW_UTC"
+            printf '  "generator": "workflow-bash-assembler",\n'
+            printf '  "author_is_agent": %s,\n' "$AGENT"
+            printf '  "body_has_test_plan_section": %s\n' "$HAS_TP"
+            printf '}\n'
+          } > "$META"
+
+          # --- Comment body ---
+          {
+            echo "<!-- test-plan -->"
+            echo "## Proposed test plan (heuristic)"
+            echo
+            if [ "$AGENT" = "true" ] && [ "$HAS_TP" = "true" ]; then
+              echo "_Your PR body already has a \`## Test plan\` section. This is an automatic **second opinion** because the PR is agent-authored (Co-Authored-By trailer detected). Add \`[skip test-plan]\` to the body to disable._"
+              echo
+            fi
+            cat "$OUT"
+            echo
+            echo "---"
+            echo
+            echo "_Generated by [\`.github/workflows/test-plan-suggester.yml\`](/.github/workflows/test-plan-suggester.yml) · persisted artifact: \`state/quality/test-plans/${HEAD_SHA}.md\` · suppress with \`[skip test-plan]\` in PR body._"
+          } > "$COMMENT"
+
+          echo "----- BEGIN PROPOSAL -----"
+          cat "$COMMENT"
+          echo "----- END PROPOSAL -----"
+
+      - name: Upload proposal artifact
+        if: steps.gate.outputs.decision == 'post'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-plan-${{ steps.assemble.outputs.head_sha }}
+          path: |
+            state/quality/test-plans/${{ steps.assemble.outputs.head_sha }}.md
+            state/quality/test-plans/${{ steps.assemble.outputs.head_sha }}.meta.json
+          retention-days: 90
+
+      - name: Post / update PR comment
+        if: steps.gate.outputs.decision == 'post'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- test-plan -->';
+            const path = '${{ steps.assemble.outputs.comment }}';
+            if (!fs.existsSync(path)) {
+              core.warning(`Comment file ${path} not produced; skipping comment post.`);
+              return;
+            }
+            const body = fs.readFileSync(path, 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.data.find(c =>
+              c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated existing test-plan comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info('Posted new test-plan comment.');
+            }
+
+      - name: Log skip reason
+        if: steps.gate.outputs.decision != 'post'
+        shell: bash
+        run: |
+          echo "Skipped: ${{ steps.gate.outputs.decision }}"
+          echo "  has_test_plan_section=${{ steps.gate.outputs.has_test_plan_section }}"
+          echo "  agent_authored=${{ steps.gate.outputs.agent_authored }}"

--- a/.github/workflows/test-plan-suggester.yml
+++ b/.github/workflows/test-plan-suggester.yml
@@ -56,10 +56,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 1. Skip-suppression marker in body
-          if echo "${PR_BODY:-}" | grep -qiE '\[skip test-plan\]'; then
+          # 1. Skip-suppression marker in body. Must appear on its own line
+          #    (with optional surrounding whitespace) to avoid false positives
+          #    when the marker is *quoted* inside the PR body — e.g. a PR that
+          #    documents this very skill will mention `[skip test-plan]` inside
+          #    a backtick code span without intending to suppress.
+          if printf '%s\n' "${PR_BODY:-}" | grep -qiE '^[[:space:]]*\[skip test-plan\][[:space:]]*$'; then
             echo "decision=skip-marker" >> "$GITHUB_OUTPUT"
-            echo "Reason: PR body contains [skip test-plan]"
+            echo "Reason: PR body contains [skip test-plan] on its own line"
             exit 0
           fi
 

--- a/state/quality/test-plans/README.md
+++ b/state/quality/test-plans/README.md
@@ -1,0 +1,138 @@
+# state/quality/test-plans — Test Plan Proposals
+
+Append-only archive of **diff-driven test plan proposals** produced by the
+`/test-plan` skill (see `.claude/skills/test-plan/SKILL.md`) and posted as
+sticky PR comments by `.github/workflows/test-plan-suggester.yml`.
+
+Each PR head SHA produces two files — a human-readable markdown proposal
+and a structured JSON sidecar:
+
+```
+state/quality/test-plans/
+├── README.md                 ← this file
+├── SCHEMA.json               ← JSON Schema (test-plan-v1) for the sidecar
+├── .gitkeep
+├── <head-sha>.md             ← the proposal (markdown, what the PR comment shows)
+└── <head-sha>.meta.json      ← structured metadata (sidecar — for trend analysis)
+```
+
+`<head-sha>` is the **full 40-char Git SHA** at proposal time, so files sort
+chronologically and never collide on a short-SHA prefix. A new push to the
+PR produces a new SHA and a new pair of files; the prior pair stays for
+history.
+
+## Why this exists
+
+Closes the **"developer forgot to write a test plan"** gap. Today, every PR
+template has a `## Test plan` checklist, but humans skip it ("I'll add tests
+after merge"), agents under-fill it (token cap truncates), and reviewers
+don't enforce it.
+
+`/test-plan` shifts the test-design conversation **left** of merge by
+emitting a concrete proposal at PR-open time — keyed to the actual diff,
+not the whole module. The artifact is persisted so:
+
+- The PR comment stays in sync with the proposal (sticky-comment upsert).
+- A future `/grade-last-pr` invocation can read what was *proposed* vs what
+  *landed* (closes the intent-vs-delivery loop on the test-coverage axis).
+- We can graph proposal density per layer over time and detect when the
+  heuristic starts over- or under-firing.
+
+Pairs with `/grade-last-pr` (backward-looking) and `/council` (escalated
+gate for one-way doors) to form a before / during / after triangle of PR
+quality.
+
+## Schema (sidecar JSON: test-plan-v1)
+
+The `.meta.json` sidecar is the structured form. The `.md` is the prose
+form that appears in the PR comment and the artifact directory.
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema` | string | Literal `"test-plan-v1"`. |
+| `pr_number` | integer | The PR number. |
+| `head_sha` | string | Full 40-char head commit SHA. |
+| `risk_class` | enum | One of `pure-additive`, `refactor`, `api-change`, `one-way-door`. |
+| `proposal_counts` | object | `{ unit, integration, e2e, chatbot, coverage_gaps }`. All integers ≥ 0. |
+| `layers_touched` | string[] | Layer slugs (e.g. `dotnet-domain`, `react-spa`, `vite-middleware`). |
+| `generated_at` | string | RFC3339 UTC. When the proposal was written. |
+| `generator` | string | Model name (e.g. `claude-opus-4-7`). |
+| `suppressed` | bool | Optional. `true` when author put `[skip test-plan]` in the body. |
+| `author_is_agent` | bool | Optional. `true` when commit trailers include `Co-Authored-By: <agent>`. |
+| `body_has_test_plan_section` | bool | Optional. `true` when PR body already has `## Test plan`. |
+
+Validate against `SCHEMA.json`:
+
+```bash
+# If npx ajv is available:
+npx -y ajv-cli@5 validate -s state/quality/test-plans/SCHEMA.json \
+  -d state/quality/test-plans/<head-sha>.meta.json
+```
+
+## Markdown artifact layout
+
+Section order matters — the auto-fire workflow's sticky-comment poster may
+truncate at the `## Coverage gaps surfaced` header if the proposal exceeds
+GitHub's 65 KB comment limit on overgrown PRs.
+
+```
+# Test plan — PR #N (<short-sha>)
+
+**Generated:** ...
+**Author:** @gh-login
+**Scope:** ...
+**Risk class:** ...
+
+## Unit tests (N proposed)
+## Integration tests (N proposed)
+## E2E tests (Playwright) (N proposed)
+## Chatbot prompts (N proposed)
+## Coverage gaps surfaced
+## Rubric
+```
+
+The full template lives in `.claude/skills/test-plan/SKILL.md` §4 and is the
+source of truth.
+
+## What goes here vs elsewhere
+
+| Question | File |
+|---|---|
+| "What tests should this open PR add before merge?" | `state/quality/test-plans/<head-sha>.md` |
+| "Did the merged PR deliver what its title said?" | `state/quality/pr-grades/<merge-sha>.json` (via `/grade-last-pr`) |
+| "Did this one-way-door PR pass the council gate?" | `state/quality/council/<head-sha>.json` (via `/council`) |
+| "What is the QA trend across the codebase?" | `state/quality/dashboard-playwright/` etc. |
+| "What new tests actually got written?" | the PR diff itself + the next `/grade-last-pr` run |
+
+## Retention policy
+
+Keep all proposals indefinitely. Each pair (`.md` + `.meta.json`) is
+typically 4–15 KB; even 10,000 PRs is < 150 MB. Do **not** prune.
+
+The trend signal in `proposal_counts` over time is what tells us whether
+the heuristic in the SKILL needs tuning — drift in `unit:integration:e2e`
+ratios is a quality-of-process signal worth keeping.
+
+## Re-proposing
+
+Force-pushes that change `head_sha` produce a new artifact pair; the prior
+pair stays for audit history. This mirrors `/council`'s convention (verdicts
+pin to the commit they judged) and is intentional — the proposal at
+SHA A might differ materially from the proposal at SHA B after a force-push.
+
+If `/test-plan` is invoked twice on the **same** `head_sha` (e.g. by a
+human after the auto-fire workflow ran), the second run **overwrites** the
+pair — no `prior_proposals[]` history. The proposal is a snapshot of the
+heuristic at a moment in time; it's not graded prose like `/grade-last-pr`.
+
+## Related
+
+- `.claude/skills/test-plan/SKILL.md` — the producer; full heuristic in §3.
+- `.github/workflows/test-plan-suggester.yml` — auto-fire workflow that
+  posts the sticky comment on PR `opened` + `synchronize`.
+- `SCHEMA.json` — JSON Schema for the sidecar (`test-plan-v1`).
+- `.claude/skills/grade-last-pr/SKILL.md` — the backward-looking sibling.
+- `.claude/skills/council/SKILL.md` — the escalated-gate sibling.
+- `../README.md` — parent `state/quality/` directory contract.
+- `docs/plans/2026-05-23-arch-harness-engineering-adoption-plan.md` — the
+  parent plan that motivates the cybernetic-loop family.

--- a/state/quality/test-plans/SCHEMA.json
+++ b/state/quality/test-plans/SCHEMA.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/ga/state/quality/test-plans/SCHEMA.json",
+  "title": "Test Plan Proposal (sidecar)",
+  "description": "Structured metadata sidecar for diff-driven test-plan proposals produced by the /test-plan skill. The human-readable proposal lives next to this file as <head-sha>.md.",
+  "type": "object",
+  "required": [
+    "schema",
+    "pr_number",
+    "head_sha",
+    "risk_class",
+    "proposal_counts",
+    "layers_touched",
+    "generated_at",
+    "generator"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "test-plan-v1",
+      "description": "Schema discriminator. Bump only on field removal/rename; additive changes do not need a bump."
+    },
+    "pr_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "GitHub PR number the proposal targets."
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Full 40-char head commit SHA at proposal time. A new push to the PR produces a new SHA and a new artifact pair."
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": ["pure-additive", "refactor", "api-change", "one-way-door"],
+      "description": "Per-PR risk classification driving test-density multipliers. See SKILL.md §3c."
+    },
+    "proposal_counts": {
+      "type": "object",
+      "required": ["unit", "integration", "e2e", "chatbot", "coverage_gaps"],
+      "additionalProperties": false,
+      "properties": {
+        "unit":          { "type": "integer", "minimum": 0 },
+        "integration":   { "type": "integer", "minimum": 0 },
+        "e2e":           { "type": "integer", "minimum": 0 },
+        "chatbot":       { "type": "integer", "minimum": 0 },
+        "coverage_gaps": { "type": "integer", "minimum": 0 }
+      },
+      "description": "Per-section proposal counts. Each section is capped at 10 in the markdown artifact; values above 10 mean the heuristic is firing on a refactor."
+    },
+    "layers_touched": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "description": "Layer slugs derived from the path-prefix table in SKILL.md §3a (e.g. 'dotnet-domain', 'react-spa', 'vite-middleware', 'fsharp-dsl', 'mcp-server', 'ci-workflow', 'contract', 'powershell-tooling')."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 UTC timestamp when the proposal was written."
+    },
+    "generator": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Model identifier that generated the proposal (e.g. 'claude-opus-4-7', 'workflow-bash-assembler')."
+    },
+    "suppressed": {
+      "type": "boolean",
+      "description": "True when the PR body contained '[skip test-plan]' and the skill exited without posting. The artifact is still written for audit."
+    },
+    "author_is_agent": {
+      "type": "boolean",
+      "description": "True when any commit in the PR range has a 'Co-Authored-By: <known agent>' trailer (Claude / Codex / Mercury / etc.). Agents get the proposal as a second opinion even when the body has a test plan section."
+    },
+    "body_has_test_plan_section": {
+      "type": "boolean",
+      "description": "True when the PR body has a '## Test plan' section at proposal time (case-insensitive match). Drives the auto-fire workflow's decision to post or skip."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes the **"developer forgot to write a test plan"** gap. Three coordinated pieces:

1. **`.claude/skills/test-plan/SKILL.md`** — invoked as `/test-plan` (current branch) or `/test-plan <PR#>`. Resolves the PR, categorizes each changed file by language/layer (10 path-prefix rules) and test surface (8 content regexes), weights by risk class (`pure-additive` / `refactor` / `api-change` / `one-way-door`), and emits a structured proposal of unit + integration + E2E + chatbot cases keyed to the actual changed lines. Persisted artifact + sticky PR comment (marker `<!-- test-plan -->`).

2. **`.github/workflows/test-plan-suggester.yml`** — fires on PR `opened` / `synchronize` / `reopened` / `ready_for_review`. Lightweight bash assembler (no Claude runtime in CI) mirrors the skill's heuristic. Decision matrix:
   - `[skip test-plan]` in body → skip
   - bot author → skip
   - has `## Test plan` + human author → skip (author owns it)
   - has `## Test plan` + **agent author** → post second opinion
   - no `## Test plan` → post

3. **`state/quality/test-plans/`** — README, JSON Schema (`test-plan-v1`) for sidecar metadata, `.gitkeep`. Each PR head SHA produces a pair: `<head-sha>.md` (proposal) + `<head-sha>.meta.json` (counts + layers + risk class for trend analysis).

## Before / during / after triangle of PR quality

| Skill | Phase | Output |
|---|---|---|
| `/test-plan` (this PR) | pre-merge | proposed test cases (advisory) |
| `/council` (PR #310) | pre-merge | escalated verdict for one-way doors (blocking) |
| `/grade-last-pr` (PR #309) | post-merge | intent-vs-delivery grade (audit) |

## Workflow self-demo

This PR body intentionally lacks a `## Test plan` section so the auto-fire workflow will post a proposal as its own first artifact. Watch the bot comment land after CI runs.

Dry-run against PR #321 (the QA-tab one — already merged) produced: `risk=refactor, unit=3, int=2, e2e=2, chat=0, gaps=2` — sensible for a 2-file React/Vite change with no co-changed test siblings.

## Hard constraints respected

- `.github/workflows/test-plan-suggester.yml` will trip Agent Blackbox `policy.blocked_path` — admin-merge ready (user pre-authorized).
- No touch to `CLAUDE.md` / `AGENTS.md` / governance.
- No touch to `state/harness/items.json` or harness plan markdown.
- Typecheck baseline unaffected (~185 unchanged — markdown + workflow + JSON only).
- Stayed strictly in `.claude/skills/`, `.github/workflows/`, `state/quality/test-plans/` lanes — no overlap with the parallel algedonic-vsm-agent (touches `.github/workflows/ecosystem-health.yml` + `state/algedonic/`).

## Why this exists (Karpathy R4)

"Task completed != goal achieved." A test plan is the operational form of "goal" — the criteria the author believes the change satisfies, in cases the team can mechanize. Today, humans skip the `## Test plan` template, agents under-fill it (prompt cap), and reviewers don't enforce it. `/test-plan` makes the proposal cheap to generate and visible at PR time, shifting the test-design conversation **left** of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)