### PR TITLE
fix(quality): add invariants-snapshot.yml to close 36-day silent-rot

### DIFF
--- a/.github/workflows/invariants-snapshot.yml
+++ b/.github/workflows/invariants-snapshot.yml
@@ -1,0 +1,145 @@
+name: Invariants Snapshot
+
+# Daily snapshot producer for state/quality/invariants/. Closes the
+# silent-rot surfaced 2026-05-23 by /backlog-groom: the most recent
+# snapshot was 2026-04-17, leaving the structural-quality oracle blind
+# for 36 days. Schema consumed by ix/crates/ix-quality-trend (and the
+# rendered report at docs/quality/invariant-coverage.md).
+#
+# Producer: ix sibling crate ix-invariant-coverage
+#   Binaries:
+#     ix-invariant-produce  → emits firings JSON from built-in checkers
+#     ix-invariant-coverage → ingests firings + catalog, emits a markdown
+#                             report (rank / orphans / coverage gaps)
+#
+# The historical commit 83aadd85 (2026-04-17) shows the canonical layout:
+# the same firings JSON that the optic-k-rebuild skill copies into
+# state/baseline/<date>-firings.json is the snapshot that goes into
+# state/quality/invariants/<date>.json. The producer itself is pure
+# (no GA index dependency), so this runs whether or not the OPTIC-K
+# index has been rebuilt — what it measures is the checker catalog,
+# not the live corpus.
+#
+# Schedule rationale: 08:00 UTC — runs after chatbot-qa-snapshot (06:00)
+# and embeddings-snapshot (07:00) so a downstream multi-domain trend run
+# at ~09:00 sees all three producers' fresh data.
+#
+# Failure semantics:
+#   - Rust build failure → workflow fails AND emits an algedonic warn
+#     signal so the operator sees the silent-rot loop closing.
+#   - Producer failure → workflow fails + algedonic warn.
+#   - Snapshot identical to existing day → quiet success (no empty commit).
+
+on:
+  schedule:
+    - cron: '0 8 * * *'   # 08:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: invariants-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout ga
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Checkout ix sibling
+        uses: actions/checkout@v4
+        with:
+          repository: GuitarAlchemist/ix
+          path: ix
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ix -> target
+
+      - name: Build ix-invariant-coverage (both bins)
+        working-directory: ix
+        run: |
+          cargo build --release -p ix-invariant-coverage --bin ix-invariant-produce
+          cargo build --release -p ix-invariant-coverage --bin ix-invariant-coverage
+
+      - name: Produce firings + stage snapshot
+        id: stage
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          DST_DIR="state/quality/invariants"
+          DST="${DST_DIR}/${DATE}.json"
+          mkdir -p "$DST_DIR"
+          ix/target/release/ix-invariant-produce --pretty --out "$DST"
+          # Mirror into state/baseline/ so the rebuild-skill workflow and the
+          # historical layout stay consistent.
+          mkdir -p state/baseline
+          cp "$DST" "state/baseline/${DATE}-firings.json"
+          echo "snapshot_path=$DST" >> "$GITHUB_OUTPUT"
+          echo "snapshot_date=$DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Regenerate coverage report
+        run: |
+          set -euo pipefail
+          mkdir -p docs/quality
+          ix/target/release/ix-invariant-coverage \
+            --catalog docs/methodology/invariants-catalog.md \
+            --firings "${{ steps.stage.outputs.snapshot_path }}" \
+            --out docs/quality/invariant-coverage.md
+
+      - name: Commit snapshot if new
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          SNAP: ${{ steps.stage.outputs.snapshot_path }}
+          DATE: ${{ steps.stage.outputs.snapshot_date }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$SNAP" "state/baseline/${DATE}-firings.json" docs/quality/invariant-coverage.md
+          if git diff --cached --quiet; then
+            echo "Snapshot identical to existing — nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore(quality): invariants snapshot ${DATE} [skip ci]"
+          git push
+
+      - name: Upload snapshot artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: invariants-snapshot-${{ github.run_id }}
+          path: |
+            state/quality/invariants/
+            state/baseline/*-firings.json
+            docs/quality/invariant-coverage.md
+          retention-days: 90
+
+      - name: Emit algedonic warn on failure
+        if: failure()
+        shell: pwsh
+        env:
+          RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+        run: |
+          if (-not (Test-Path Scripts/algedonic-emit.ps1)) {
+            Write-Host "algedonic-emit.ps1 not present — skipping signal"
+            exit 0
+          }
+          pwsh Scripts/algedonic-emit.ps1 `
+            -Severity warn `
+            -Repo ga `
+            -Source invariants-snapshot `
+            -Summary "Invariants snapshot workflow failed — pipeline producing no data" `
+            -Details "The daily invariants snapshot did not produce a new state/quality/invariants/YYYY-MM-DD.json. The structural-quality trend will drift stale until the next successful run. See evidence_url for the failing job logs." `
+            -EvidenceUrl "$env:RUN_URL" `
+            -AffectedArtifacts state/quality/invariants/


### PR DESCRIPTION
## Summary
- **Root cause:** `state/quality/invariants/` had been silently stale for 36 days because **no scheduled workflow ever wrote it**. The directory was bootstrapped by a one-time manual run of the `optic-k-rebuild` skill (commit `83aadd85`, 2026-04-17), and the producer (`ix-invariant-produce` in the sibling `ix` repo) was only invoked by hand thereafter. Subsequent runs went to `state/baseline/YYYY-MM-DD-firings.json` (the skill's own output path) but never propagated to the trend directory.
- **Fix:** New `.github/workflows/invariants-snapshot.yml`, modeled after `embeddings-snapshot.yml` and `chatbot-qa-snapshot.yml`. Checks out the `ix` sibling, builds `ix-invariant-coverage` (both bins), runs `ix-invariant-produce` daily at 08:00 UTC, writes `state/quality/invariants/YYYY-MM-DD.json` (and mirrors to `state/baseline/`), regenerates `docs/quality/invariant-coverage.md`, commits with `[skip ci]`.
- **Algedonic closure:** On workflow failure, emits a `severity=warn` signal via `Scripts/algedonic-emit.ps1` (using its actual parameter names: `-Severity / -Repo / -Source / -Summary / -Details / -EvidenceUrl / -AffectedArtifacts`), so the next silent-rot is surfaced immediately instead of 36 days later.

## Root cause finding
- Producer **is not broken** — I ran `ix-invariant-produce.exe --pretty` locally; output shape matches the historical 2026-04-17 snapshot byte-for-byte.
- Producer **was never wired to a schedule** — no IX workflow and no GA workflow invokes `ix-invariant-produce`. The only references in either repo are inside `optic-k-rebuild/SKILL.md` (manual rebuild docs) and the `2026-05-12-icv-format-reconciliation-plan.md` (one-off note).
- Cross-repo verdict: **fixable in GA alone**. The IX binary is fine; only the schedule was missing. No IX PR needed.

## Daily-write restoration
This **restores daily writes** (not just documents the gap). The workflow runs `ix-invariant-produce` directly from a fresh `ix` checkout each day, so it has no dependency on the GA-side OPTIC-K rebuild cadence — what it measures is the invariant-checker catalog, which is pure Rust against the bundled exemplar set.

## Touched files
- `.github/workflows/invariants-snapshot.yml` (new, 145 lines)

## Constraints satisfied
- Workflow-only change (admin-merge ready per Agent Blackbox)
- Did not touch CLAUDE.md / AGENTS.md / governance
- Did not touch typecheck baseline
- Worked off `origin/main` in `C:/tmp/ga-invariants-fix` worktree
- No overlap with `chatbot-qa-snapshotter-fix-agent`, `stale-plans-triage-agent`, or `harness-tab-redesign-agent`

## Test plan
- [ ] Manually trigger via Actions → "Invariants Snapshot" → Run workflow on main after merge
- [ ] Verify the resulting commit lands `state/quality/invariants/<today>.json` + `state/baseline/<today>-firings.json` + regenerated `docs/quality/invariant-coverage.md`
- [ ] Wait for next 08:00 UTC cron and confirm a second dated snapshot appears
- [ ] Inject a deliberate failure (e.g. break the ix sibling checkout step temporarily) and confirm `state/algedonic/inbox.jsonl` receives a `severity=warn` line from `source=invariants-snapshot`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>