### PR TITLE
fix(codex-p1): #331 — allow shared write to algedonic inbox

### DIFF
--- a/GaMcpServer/AlgedonicEmitter.cs
+++ b/GaMcpServer/AlgedonicEmitter.cs
@@ -227,13 +227,23 @@ public sealed class AlgedonicEmitter
         // ceiling means a single Write is atomic on the file systems we ship
         // on (NTFS, ext4); the lock just keeps concurrent emits from
         // interleaving partial lines.
+        //
+        // FileShare.ReadWrite: the inbox is explicitly a cross-process shared
+        // append target (Scripts/algedonic-emit.ps1 and the .NET emitter both
+        // write to it). FileShare.Read would block a concurrent PowerShell
+        // emit and surface as an IOException that Emit() catches and logs
+        // but drops — silently losing security/governance signals on
+        // contention. The <4 KB-per-line ceiling keeps each append atomic
+        // on NTFS/ext4; this in-process lock keeps our own threads from
+        // interleaving, and OS append-mode handles inter-process atomicity
+        // within that same ceiling.
         lock (_writeGate)
         {
             using var stream = new FileStream(
                 _inboxPath,
                 FileMode.Append,
                 FileAccess.Write,
-                FileShare.Read);
+                FileShare.ReadWrite);
             using var writer = new StreamWriter(stream, Utf8NoBom);
             writer.WriteLine(jsonLine);
         }


### PR DESCRIPTION
Triage of PR #331 P1 finding from Codex.

**Classification**: REAL

**Original PR**: #331
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/331#discussion_r3293875914

## Problem

`GaMcpServer/AlgedonicEmitter.cs` opened the inbox with `FileShare.Read`, which blocks other processes (notably the PowerShell emitter at `Scripts/algedonic-emit.ps1`) from appending concurrently. When the PS emitter held the file, the .NET `Emit()` would throw `IOException`, log it, and drop the governance signal silently — exactly the failure mode the algedonic channel is supposed to prevent.

## Fix

Switch to `FileShare.ReadWrite`. Both emitters can now append concurrently. NTFS/ext4 keep <4 KB appends atomic (the contract's per-signal ceiling), and the in-process lock still serialises threads within this process.

## Test plan
- [ ] CI green
- [ ] Smoke: run `Scripts/algedonic-emit.ps1` + an MCP-triggered .NET emit in parallel; confirm both lines land in `state/algedonic/inbox.jsonl` with no `IOException` in logs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>