### PR TITLE
fix(codex-p1): #330 — compare loop timestamps numerically

### DIFF
--- a/ReactComponents/ga-react-components/src/dev-data/parsers.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.ts
@@ -231,7 +231,19 @@ export function projectLoopsGoals(
             const existing = byId.get(rec.id);
             const recAct = rec.last_activity_at ?? rec.started_at ?? '';
             const existingAct = existing?.last_activity_at ?? existing?.started_at ?? '';
-            if (!existing || recAct >= existingAct) {
+            // Compare numerically — hook events use second precision
+            // (`yyyy-MM-ddTHH:mm:ssZ`) while dashboard stop events use
+            // `toISOString()` with milliseconds. Lexicographic compare on
+            // mixed formats made `...00.123Z` sort BEFORE `...00Z`, so a
+            // newer completion event could be ignored and the row stayed
+            // active after pressing Stop. `Date.parse` collapses both to
+            // epoch ms; NaN falls back to ordering an unparseable value
+            // before a parseable one so we never starve a valid update.
+            const recMs = Date.parse(recAct);
+            const existingMs = Date.parse(existingAct);
+            const recCmp = Number.isNaN(recMs) ? -Infinity : recMs;
+            const existingCmp = Number.isNaN(existingMs) ? -Infinity : existingMs;
+            if (!existing || recCmp >= existingCmp) {
                 byId.set(rec.id, {
                     id: rec.id,
                     kind: rec.kind,


### PR DESCRIPTION
Triage of PR #330 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #330
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/330#discussion_r3293851701

## Problem

`projectLoopsGoals()` in `parsers.ts` used lexicographic string compare to pick the latest record per id. The projection consumes events from two sources with different timestamp formats:

- Hook events: second precision (`yyyy-MM-ddTHH:mm:ssZ`)
- Dashboard stop events: `toISOString()` with milliseconds (`...00.123Z`)

For records emitted in the same second, `...00.123Z` sorts **before** `...00Z` lexically, so a newer completion event could be discarded and the loop row stayed marked active after pressing Stop.

## Fix

Parse both timestamps with `Date.parse` so the compare runs in epoch ms. Unparseable values fall to `-Infinity` so a malformed timestamp never starves a valid update.

## Test plan
- [ ] CI green
- [ ] Existing parsers tests still pass (this is the same-id-latest-wins path)
- [ ] Manual smoke: start a loop, press Stop within the same second a hook event lands, confirm the row clears