### PR TITLE
fix(codex-p1): #317 — derive camera anchors from active chord-mode source

### DIFF
--- a/ReactComponents/ga-react-components/src/components/TonalOrbit/TonalOrbit.tsx
+++ b/ReactComponents/ga-react-components/src/components/TonalOrbit/TonalOrbit.tsx
@@ -761,13 +761,28 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
       return new THREE.Vector3(Math.cos(a) * PITCH_RADIUS, 0, Math.sin(a) * PITCH_RADIUS);
     }
     function chordAnchor(c: ChordBody, _p: PitchBody): THREE.Vector3 {
-      const chords = chordsForPitch(_p);
-      const i = chords.findIndex((x) => x.family.key === c.family.key);
+      // Derive the chord ring from the SAME source the ring was built from
+      // (see setPitchFocus). In Mode A (root chords) the chord set is
+      // chordsForPitch — 8 unique family.key entries. In Mode B (key
+      // chords) it's keyChordsForPitch — 7 diatonic chords whose families
+      // can repeat (I/IV/V are all Major). Matching on family.key alone
+      // would land on the first repeat, sending the camera to the wrong
+      // body. Match on (rootPc, family.key) so it's unique in both modes.
+      const chords = chordModeRef.current === 'key'
+        ? keyChordsForPitch(_p)
+        : chordsForPitch(_p);
+      const i = chords.findIndex((x) => x.family.key === c.family.key && x.rootPc === c.rootPc);
       const a = (i / chords.length) * Math.PI * 2;
       return new THREE.Vector3(Math.cos(a) * CHORD_RADIUS, 0, Math.sin(a) * CHORD_RADIUS);
     }
     function scaleAnchor(s: ScaleBody, c: ChordBody, _p: PitchBody): THREE.Vector3 {
-      const scales = scalesForChord(c);
+      // Mode A: the outer scale ring is scalesForChord(c) (per-chord).
+      // Mode B: the outer scale ring is keyModesForPitch(_p) — the same
+      // seven modes for every chord on the focused pitch. Pull from the
+      // matching source so the look-target lines up with the rendered ring.
+      const scales = chordModeRef.current === 'key'
+        ? keyModesForPitch(_p)
+        : scalesForChord(c);
       const i = scales.findIndex((x) => x.scale.key === s.scale.key);
       const a = (i / scales.length) * Math.PI * 2;
       return new THREE.Vector3(Math.cos(a) * SCALE_RADIUS, 0, Math.sin(a) * SCALE_RADIUS);


### PR DESCRIPTION
Triage of PR #317 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #317
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/317#discussion_r3293704099

## Problem

`chordAnchor()` / `scaleAnchor()` in `TonalOrbit.tsx` always used the Mode A helpers (`chordsForPitch`, `scalesForChord`) to compute camera look-targets, but `setPitchFocus` builds the actual rings from Mode A or Mode B (`keyChordsForPitch`, `keyModesForPitch`) based on `chordModeRef.current`.

In Mode B ("key" mode) the chord set has 7 diatonic chords whose family keys repeat (I, IV, V are all Major; ii, iii, vi are all Minor), so matching on `family.key` alone returned the first repeat and pointed the camera at the wrong planet. Reproducible by focusing a pitch in `?chord-mode=key` and selecting IV, V, or vi.

## Fix

- Branch on `chordModeRef.current` in both anchor functions so they pull from the same helper the ring was built from.
- Match chords by `(rootPc, family.key)` so the anchor is unique in both modes. (Mode A still works — `rootPc` is the same for every chord on a given pitch.)
- Scales: keyModes already has 7 distinct `scale.key` values, so the existing scale.key match is sufficient.

## Verification

- Typecheck: 183 errors (unchanged from baseline of 185).
- No new code paths — same shape, just routed through the active mode's helper.

## Test plan
- [ ] Manual: `?chord-mode=key`, focus a pitch, tap IV/V/vi → camera lerps to the clicked body, breadcrumb matches.
- [ ] Manual: `?chord-mode=root` regression — still focuses correctly.