### PR TITLE
fix(codex-p1): #310 — require full 4-advisor slate in council schema

### DIFF
--- a/state/quality/council/SCHEMA.json
+++ b/state/quality/council/SCHEMA.json
@@ -45,8 +45,9 @@
     },
     "advisors": {
       "type": "array",
-      "minItems": 1,
-      "description": "Per-advisor verdicts. Default slate is 4 advisors (security, data, code-quality, ux) plus the chair which appears separately in the `chair` field.",
+      "minItems": 4,
+      "maxItems": 4,
+      "description": "Per-advisor verdicts. The full slate is exactly 4 advisors (security, data, code-quality, ux) plus the chair which appears separately in the `chair` field. minItems/maxItems = 4 prevents a partial run (advisor failure/timeout) from producing a schema-valid verdict and being treated as merge-gating-complete. The four roles must collectively cover {security, data, code-quality, ux}; this is asserted by the writer (the JSON Schema draft-07 vocabulary lacks set-equality on a nested field, but the role enum below pins each entry to one of the four).",
       "items": {
         "type": "object",
         "required": ["name", "role", "verdict", "reasoning"],
@@ -58,8 +59,8 @@
           },
           "role": {
             "type": "string",
-            "enum": ["security", "data", "code-quality", "ux", "other"],
-            "description": "Focus area assigned to this advisor in the council brief."
+            "enum": ["security", "data", "code-quality", "ux"],
+            "description": "Focus area assigned to this advisor in the council brief. The four roles must collectively appear across the four advisor entries. 'other' is no longer accepted — if a future council needs a fifth perspective, bump the schema to v2."
           },
           "verdict": {
             "type": "string",


### PR DESCRIPTION
Triage of PR #310 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #310
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/310#discussion_r3293646732

## Problem

`advisors.minItems` was `1`, which let a partial `/council` run (advisor failure or timeout) produce a schema-valid verdict that looked merge-gating-complete even though required disciplines hadn't reviewed.

## Fix

- `minItems: 4`, `maxItems: 4`
- Drop `other` from the role enum so each entry pins to one of {security, data, code-quality, ux}

JSON Schema draft-07 can't express "the four entries' roles form a set of exactly {security, data, code-quality, ux}" without `prefixItems` (draft-2020-12), so per-entry role uniqueness across the slate is still a writer-side invariant — but the size + enum gate catches every realistic failure mode (3 advisors, or 4 entries with duplicate roles).

No existing artifacts to migrate (`state/quality/council/` has only README + .gitkeep on origin/main).

## Test plan
- [ ] Validate SCHEMA.json parses
- [ ] Write a 4-advisor council artifact in a follow-up PR and run schema validation