### PR TITLE
fix(codex-p1): #307 — aim camera at selected ring body, not summed anchors

### DIFF
--- a/ReactComponents/ga-react-components/src/components/TonalOrbit/TonalOrbit.tsx
+++ b/ReactComponents/ga-react-components/src/components/TonalOrbit/TonalOrbit.tsx
@@ -528,17 +528,19 @@ export const TonalOrbit: React.FC<TonalOrbitProps> = ({
       const depth = focusDepth(focus);
       const dist = CAMERA_DIST_BY_DEPTH[depth];
 
-      // Look-at: focused body's anchor on its orbit. Falls back to origin.
+      // Look-at: the deepest focused body's WORLD position. Chord and
+      // scale meshes are placed on concentric rings centered at the origin
+      // (see setPitchFocus: `new THREE.Vector3(cos*CHORD_RADIUS, 0,
+      // sin*CHORD_RADIUS)` — NOT nested around the parent pitch). Summing
+      // pitch + chord (+ scale) anchors used to translate the look-target
+      // by an extra ring radius per drill level, so chord focus pointed
+      // roughly one pitch-ring radius past the clicked chord and the
+      // camera framed empty space. Aim at the deepest anchor directly.
       let look = new THREE.Vector3(0, 0, 0);
       if (focus.scale && focus.chord && focus.pitch) {
-        const p = pitchAnchor(focus.pitch);
-        const c = chordAnchor(focus.chord, focus.pitch);
-        const s = scaleAnchor(focus.scale, focus.chord, focus.pitch);
-        look = new THREE.Vector3().addVectors(p, c).add(s);
+        look = scaleAnchor(focus.scale, focus.chord, focus.pitch);
       } else if (focus.chord && focus.pitch) {
-        const p = pitchAnchor(focus.pitch);
-        const c = chordAnchor(focus.chord, focus.pitch);
-        look = new THREE.Vector3().addVectors(p, c);
+        look = chordAnchor(focus.chord, focus.pitch);
       } else if (focus.pitch) {
         look = pitchAnchor(focus.pitch);
       }


### PR DESCRIPTION
Triage of PR #307 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #307
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/307#discussion_r3293611172

## Problem

`updateCameraTarget()` computed the look-at as `p + c (+ s)`, but chord and scale meshes are placed on concentric rings centered at the **origin** (see `setPitchFocus`'s `new THREE.Vector3(cos*CHORD_RADIUS, 0, sin*CHORD_RADIUS)` — not nested around the parent pitch).

Summing anchors translated the look-target by an extra ring radius per drill level, so chord focus pointed roughly one pitch-ring radius past the clicked chord and the camera framed empty space.

## Fix

Aim at the deepest focused anchor directly (scale > chord > pitch > origin), matching how the meshes are actually positioned in world space.

## Note: stacks cleanly with PR #341 (the camera-anchors-from-active-mode fix)

#341 fixes `chordAnchor`/`scaleAnchor` to read from the *correct* mode helper. This PR fixes how those anchors are *consumed* by the look-target. Either order of merge works.

## Test plan
- [ ] Manual: drill into a pitch → chord → mode, confirm camera centers on each clicked body.
- [ ] Verified typecheck: 183 errors (baseline 185).