### PR TITLE
fix(codex-p1): #304 — update shadow camera projection after frustum edits

### DIFF
--- a/ReactComponents/ga-react-components/src/components/ModalMeadow/ModalMeadow.tsx
+++ b/ReactComponents/ga-react-components/src/components/ModalMeadow/ModalMeadow.tsx
@@ -356,6 +356,12 @@ export const ModalMeadow: React.FC<ModalMeadowProps> = ({
       sun.shadow.camera.far = 260;
       sun.shadow.bias = -0.0008;
       sun.shadow.normalBias = 0.04;
+      // Three.js OrthographicCamera caches its projection matrix — mutating
+      // left/right/top/bottom/near/far does NOT re-derive it. Without this
+      // call the shadow camera kept its default 1×1 projection, clipping
+      // shadows outside that tiny footprint instead of the SHADOW_HALF=90
+      // bounds we just wrote. Recompute once after every frustum edit.
+      sun.shadow.camera.updateProjectionMatrix();
     }
 
     // Scratch objects we reuse each frame to avoid GC pressure.


### PR DESCRIPTION
Triage of PR #304 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #304
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/304#discussion_r3293556394

## Problem

`ModalMeadow` set `sun.shadow.camera.left/right/top/bottom/near/far` for `SHADOW_HALF=90` coverage, but never called `updateProjectionMatrix()`. Three.js `OrthographicCamera` caches its projection matrix and does **not** re-derive it on read from those properties — the shadow camera kept its default 1×1 projection in `perf=high|medium`, clipping all shadows outside that tiny default footprint instead of the intended 180-unit `SHADOW_HALF` coverage.

## Fix

Single call to `sun.shadow.camera.updateProjectionMatrix()` after the frustum assignments.

## Test plan
- [ ] Manual: open ModalMeadow in `perf=high`, confirm tree/hill shadows extend across the SHADOW_HALF=90 area instead of disappearing past ~1 unit.
- [ ] Typecheck: 183 errors (baseline 185).