### PR TITLE
fix(codex-p1): #294 — add yaml to ga-react-components devDependencies

### DIFF
--- a/ReactComponents/ga-react-components/package.json
+++ b/ReactComponents/ga-react-components/package.json
@@ -89,6 +89,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.7.0",
     "vite": "^5.4.8",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "yaml": "^2.6.0"
   }
 }


### PR DESCRIPTION
Triage of PR #294 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #294
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/294#discussion_r3293432409

## Problem

`scripts/gen-theme-from-design.mjs` imports `yaml`, but ga-react-components' package.json only added scripts — never declared `yaml` as a direct dependency. The package was present only via transitive hoisting. On clean installs (and in pre-commit), `npm run gen:theme` / `gen:theme:check` would fail with `ERR_MODULE_NOT_FOUND` because Node's module resolver doesn't see hoisted-only packages from a child workspace.

## Fix

Add `yaml ^2.6.0` to devDependencies. The script uses `YAML.parse` which is API-stable across yaml v1 and v2; v2 is the current major.

## Test plan
- [ ] CI green
- [ ] `pnpm install` in `ReactComponents/ga-react-components`, then `npm run gen:theme:check` runs without ERR_MODULE_NOT_FOUND.