### PR TITLE
fix(codex-p1): #289 — point ga-client dev callers at dev:legacy

### DIFF
--- a/Apps/ga-client/playwright.config.ts
+++ b/Apps/ga-client/playwright.config.ts
@@ -68,9 +68,15 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
+  /* Run your local dev server before starting the tests.
+   * Uses `dev:legacy` because `dev` is intentionally sabotaged with
+   * process.exit(1) — ga-client is the legacy demo client and the
+   * canonical dev server is ReactComponents/ga-react-components. The
+   * `:legacy` script binds vite to port 5173 explicitly so it never
+   * competes with port 5176 (the tunneled demos.guitaralchemist.com).
+   */
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run dev:legacy',
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/Scripts/start-chatbot-dev.ps1
+++ b/Scripts/start-chatbot-dev.ps1
@@ -51,7 +51,11 @@ Write-Host "  Chatbot API starting (Job $($apiJob.Id))..." -ForegroundColor Gree
 $frontendJob = Start-Job -ScriptBlock {
     Set-Location $using:frontendDir
     $env:VITE_GA_API_URL = $using:apiUrl
-    npm run dev -- --host --port $using:FrontendPort 2>&1
+    # `dev` is intentionally sabotaged with process.exit(1) — ga-client is
+    # the legacy demo client; the `:legacy` alias runs vite without the
+    # port-5176 guard. We pass --host/--port through so this script can
+    # still drive the FrontendPort parameter.
+    npm run dev:legacy -- --host --port $using:FrontendPort 2>&1
 }
 Write-Host "  Frontend starting (Job $($frontendJob.Id))..." -ForegroundColor Green
 
@@ -95,7 +99,11 @@ try {
             $frontendJob = Start-Job -ScriptBlock {
                 Set-Location $using:frontendDir
                 $env:VITE_GA_API_URL = $using:apiUrl
-                npm run dev -- --host --port $using:FrontendPort 2>&1
+                # `dev` is intentionally sabotaged with process.exit(1) — ga-client is
+    # the legacy demo client; the `:legacy` alias runs vite without the
+    # port-5176 guard. We pass --host/--port through so this script can
+    # still drive the FrontendPort parameter.
+    npm run dev:legacy -- --host --port $using:FrontendPort 2>&1
             }
         }
     }


### PR DESCRIPTION
Triage of PR #289 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #289
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/289#discussion_r3293390871

## Problem

PR #289 sabotaged `Apps/ga-client/package.json`'s `dev` script with `process.exit(1)` to stop accidental port-5176 collisions with the canonical `ReactComponents/ga-react-components` dev server. But two existing workflows still called `npm run dev` for ga-client and now fail to boot at all:

- `Apps/ga-client/playwright.config.ts:73` — E2E webServer
- `Scripts/start-chatbot-dev.ps1:54, 98` — dev stack launcher (initial + restart)

## Fix

Switch both callers to `npm run dev:legacy`, which runs vite without the port-5176 guard. `start-chatbot-dev.ps1` still passes `--host --port $FrontendPort` (default 5173), and `dev:legacy` forwards extra args.

## Why this approach over restoring `dev`

The sabotage exists for a reason (the canonical dev server is `ga-react-components`). Keeping `dev` sabotaged and updating callers (2 files) is less surface than re-introducing the port-5176 risk to every contributor who types `npm run dev` in `Apps/ga-client`.

## Test plan
- [ ] `cd Apps/ga-client && npm run test:e2e` (Playwright launches dev:legacy on 5173)
- [ ] `Scripts/start-chatbot-dev.ps1 -FrontendPort 5173` — confirm both API + frontend come up