### PR TITLE
fix(codex-p1): #325 — persist algedonic signal on failure path

### DIFF
--- a/.github/workflows/invariants-snapshot.yml
+++ b/.github/workflows/invariants-snapshot.yml
@@ -143,3 +143,18 @@ jobs:
             -Details "The daily invariants snapshot did not produce a new state/quality/invariants/YYYY-MM-DD.json. The structural-quality trend will drift stale until the next successful run. See evidence_url for the failing job logs." `
             -EvidenceUrl "$env:RUN_URL" `
             -AffectedArtifacts state/quality/invariants/
+
+      - name: Upload algedonic inbox on failure
+        # algedonic-emit appends to the runner workspace's
+        # state/algedonic/inbox.jsonl, but the workflow never commits that
+        # path on the failure path. Without this artifact upload, the warn
+        # signal is discarded when the job ends — re-introducing the
+        # silent-rot risk this workflow is meant to close. Retention
+        # matches the snapshot artifact above.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: algedonic-inbox-${{ github.run_id }}
+          path: state/algedonic/inbox.jsonl
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
Triage of PR #325 P1 finding from Codex.

**Classification**: REAL
**Original PR**: #325
**Codex comment**: https://github.com/GuitarAlchemist/ga/pull/325#discussion_r3293829425

## Problem

`invariants-snapshot.yml` emits a `warn`-level algedonic signal to `state/algedonic/inbox.jsonl` on workflow failure, but the runner workspace is wiped when the job ends and the failure path never commits the inbox. The "algedonic closure" the workflow promised never reached operators — every build/produce/push failure was silently discarded.

## Fix

Add an `actions/upload-artifact` step gated on `if: failure()` that uploads `inbox.jsonl` with 90-day retention (matches the snapshot artifact). Operators can now reach the signal via the run's artifacts tab even when the commit/push step itself failed.

## Test plan
- [ ] Manually break the workflow (e.g. force the `cargo run` step to fail), confirm the run's Artifacts tab now contains `algedonic-inbox-<run_id>` with the warn line.