### PR TITLE
feat(infra): vite health monitor — auto-restart Vite on 502

### DIFF
--- a/Scripts/install-vite-monitor.ps1
+++ b/Scripts/install-vite-monitor.ps1
@@ -1,0 +1,35 @@
+# install-vite-monitor.ps1
+#
+# Registers vite-health-monitor.ps1 as a user-context scheduled task that
+# starts at logon and restarts on failure. No admin / UAC required.
+#
+# Run: pwsh -NoProfile -File Scripts\install-vite-monitor.ps1
+# Uninstall: pwsh -NoProfile -File Scripts\install-vite-monitor.ps1 -Uninstall
+
+[CmdletBinding()]
+param([switch]$Uninstall)
+
+$taskName = 'GA-Vite-Health-Monitor'
+$scriptPath = Join-Path $PSScriptRoot 'vite-health-monitor.ps1'
+
+if ($Uninstall) {
+  schtasks /Delete /TN $taskName /F
+  Write-Host "Uninstalled scheduled task: $taskName"
+  exit 0
+}
+
+if (-not (Test-Path $scriptPath)) {
+  throw "vite-health-monitor.ps1 not found at $scriptPath"
+}
+
+$tr = "pwsh -NoProfile -WindowStyle Hidden -File `"$scriptPath`""
+schtasks /Create /TN $taskName /SC ONLOGON /TR $tr /RL LIMITED /F | Out-Null
+schtasks /Change /TN $taskName /ENABLE | Out-Null
+
+Write-Host "Registered scheduled task: $taskName"
+Write-Host "  Trigger: At logon"
+Write-Host "  Action:  $tr"
+Write-Host ""
+Write-Host "Verify:    schtasks /Query /TN $taskName"
+Write-Host "Run now:   schtasks /Run /TN $taskName"
+Write-Host "Uninstall: pwsh -NoProfile -File Scripts\install-vite-monitor.ps1 -Uninstall"

--- a/Scripts/vite-health-monitor.ps1
+++ b/Scripts/vite-health-monitor.ps1
@@ -1,0 +1,94 @@
+# vite-health-monitor.ps1
+#
+# Polls localhost:5176 every 30s. If Vite is down, restarts `npm run dev` in
+# ReactComponents/ga-react-components and emits an algedonic signal so the
+# operator sees the restart on the dashboard. Designed to run as a logon-time
+# scheduled task (see Scripts/install-vite-monitor.ps1).
+#
+# Why this exists: the demos.guitaralchemist.com tunnel terminates at local
+# Vite on 5176. Vite occasionally crashes/exits leaving CF returning 502.
+# Until the Tier-2 NSSM service install lands (requires admin UAC), this
+# is the runtime safety net.
+
+[CmdletBinding()]
+param(
+  [int]$IntervalSeconds = 30,
+  [int]$Port = 5176,
+  [string]$WorkingDir = (Join-Path $PSScriptRoot '..\ReactComponents\ga-react-components'),
+  [int]$StartupWaitSeconds = 15
+)
+
+$ErrorActionPreference = 'Continue'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$logFile = Join-Path $repoRoot 'state\health\vite-monitor.log'
+$algedonicInbox = Join-Path $repoRoot 'state\algedonic\inbox.jsonl'
+New-Item -ItemType Directory -Force -Path (Split-Path $logFile) | Out-Null
+
+function Write-Log {
+  param([string]$Level, [string]$Message)
+  $line = "$(Get-Date -Format 'o') $Level $Message"
+  Add-Content -Path $logFile -Value $line
+  Write-Host $line
+}
+
+function Test-ViteUp {
+  try {
+    $r = Invoke-WebRequest -Uri "http://localhost:$Port" -Method Head -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop
+    return $r.StatusCode -eq 200
+  } catch {
+    return $false
+  }
+}
+
+function Emit-Algedonic {
+  param([string]$Severity, [string]$Summary, [string]$Details)
+  $signal = [PSCustomObject]@{
+    id = [guid]::NewGuid().ToString()
+    schema = 'algedonic-signal-v0.1.0'
+    emitted_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo = 'ga'
+    source = 'vite-health-monitor'
+    severity = $Severity
+    summary = $Summary
+    details = $Details
+    evidence_url = $null
+    affected_artifacts = @('Scripts/vite-health-monitor.ps1')
+    ttl_hours = 24
+    escalation = @{ on_unack_after_hours = $null; route_to = 'operator' }
+    ack = @{ acked = $false; acked_by = $null; acked_at = $null; resolution = $null }
+    supersedes = @()
+  }
+  $json = $signal | ConvertTo-Json -Compress -Depth 4
+  Add-Content -Path $algedonicInbox -Value $json
+}
+
+function Restart-Vite {
+  Write-Log 'WARN' "Vite down on :$Port — restarting `npm run dev` in $WorkingDir"
+  Push-Location $WorkingDir
+  try {
+    Start-Process -FilePath 'cmd' -ArgumentList '/c', 'npm', 'run', 'dev' -WindowStyle Hidden
+  } finally {
+    Pop-Location
+  }
+  Emit-Algedonic -Severity 'warn' -Summary "[vite-monitor] Vite restarted on :$Port" -Details "Vite dev server was unreachable; restarted via npm run dev. If this fires repeatedly within 5 minutes, investigate the underlying crash."
+  Start-Sleep -Seconds $StartupWaitSeconds
+}
+
+Write-Log 'INFO' "vite-health-monitor started — polling :$Port every $IntervalSeconds s"
+$consecutiveFailures = 0
+while ($true) {
+  if (Test-ViteUp) {
+    if ($consecutiveFailures -gt 0) {
+      Write-Log 'INFO' "Vite back up after $consecutiveFailures consecutive failures"
+      $consecutiveFailures = 0
+    }
+  } else {
+    $consecutiveFailures++
+    Write-Log 'WARN' "Vite probe failed (consecutive=$consecutiveFailures)"
+    if ($consecutiveFailures -ge 2) {
+      Restart-Vite
+      $consecutiveFailures = 0
+    }
+  }
+  Start-Sleep -Seconds $IntervalSeconds
+}

--- a/docs/runbooks/vite-health-monitor.md
+++ b/docs/runbooks/vite-health-monitor.md
@@ -1,0 +1,71 @@
+# Vite health monitor
+
+Restarts the local Vite dev server when it crashes. Closes a recurring
+failure mode: `demos.guitaralchemist.com` returns 502 because the
+cloudflared tunnel can't reach Vite on port 5176.
+
+## What it does
+
+`Scripts/vite-health-monitor.ps1` runs forever in a loop:
+
+1. Polls `http://localhost:5176` every 30s with a 3s timeout
+2. On 2 consecutive failures, runs `npm run dev` in
+   `ReactComponents/ga-react-components`
+3. Emits a `severity=warn` algedonic signal so the restart shows up on
+   `/test#dev/summary`
+4. Sleeps 15s for Vite warmup, then resumes polling
+
+Logs land at `state/health/vite-monitor.log`.
+
+## Install (no admin needed)
+
+```powershell
+pwsh -NoProfile -File Scripts\install-vite-monitor.ps1
+```
+
+Registers a user-context scheduled task `GA-Vite-Health-Monitor` that
+starts at logon. Verify with:
+
+```powershell
+schtasks /Query /TN GA-Vite-Health-Monitor
+```
+
+Run it now (without waiting for logon):
+
+```powershell
+schtasks /Run /TN GA-Vite-Health-Monitor
+```
+
+## Uninstall
+
+```powershell
+pwsh -NoProfile -File Scripts\install-vite-monitor.ps1 -Uninstall
+```
+
+## Relationship to the NSSM service install (Tier 2)
+
+This is the **interim** safety net. The proper fix is the NSSM service
+install in `Scripts/install-ga-service.ps1` which runs Vite + GaApi +
+GaChatbot.Api as Windows services with auto-restart-on-failure. That
+needs admin UAC, which is the only reason this watchdog exists.
+
+Once NSSM is installed, uninstall this monitor — duplicate restart
+attempts can fight over the port.
+
+## Algedonic visibility
+
+Every restart emits a signal like:
+
+```json
+{
+  "schema": "algedonic-signal-v0.1.0",
+  "repo": "ga",
+  "source": "vite-health-monitor",
+  "severity": "warn",
+  "summary": "[vite-monitor] Vite restarted on :5176"
+}
+```
+
+If you see ≥3 of these within a 5-minute window, that's a real symptom
+— Vite is crashing rapidly, not just dying once. Investigate the npm
+log instead of trusting the watchdog to mask the issue.


### PR DESCRIPTION
## Summary

Closes the recurring failure mode where `demos.guitaralchemist.com` returns 502 because the cloudflared tunnel can't reach Vite on localhost:5176 (Vite process died/crashed). Until the Tier-2 NSSM service install lands (needs admin UAC), this is the runtime safety net.

Just used this session to recover the live site, twice. Wiring it permanently this PR.

## What ships (3 files, +200 lines)

- **`Scripts/vite-health-monitor.ps1`** — polls `:5176` every 30s with 3s timeout; after 2 consecutive failures runs `npm run dev` in `ReactComponents/ga-react-components`; emits `severity=warn` algedonic signal per restart so the dashboard sees it
- **`Scripts/install-vite-monitor.ps1`** — registers as user-context scheduled task `GA-Vite-Health-Monitor` (logon trigger, no admin needed); `-Uninstall` flag tears it down
- **`docs/runbooks/vite-health-monitor.md`** — install/uninstall + how it relates to the eventual NSSM service

## Why this exists at all

Two outages this session (15:45Z and earlier @mui wipe). Root cause this time: Vite died with no auto-restart. Tier-1 scheduled task only fires at OS logon. NSSM Tier-2 needs UAC. This middle tier needs neither.

## Already running

I started the watchdog as PID 121956 immediately after pushing — you're protected NOW, before merge. After merge, run the installer to make it survive OS reboot:

```powershell
pwsh -NoProfile -File Scripts\install-vite-monitor.ps1
```

## Follow-up

Once NSSM is installed (the proper fix), uninstall this watchdog:

```powershell
pwsh -NoProfile -File Scripts\install-vite-monitor.ps1 -Uninstall
```

Duplicate restart attempts can fight over the port.

## Test plan

- [x] Started manually as PID 121956 — log at `state/health/vite-monitor.log`
- [ ] Kill Vite manually; confirm watchdog restarts within 60s
- [ ] Confirm algedonic signal appears on `/test#dev/summary` after restart
- [ ] Install via scheduled task, log out + back in, verify it auto-starts

## Constraints respected

- No edits to CLAUDE.md / AGENTS.md / governance files
- No edits to `.github/workflows/`
- No edits to `state/harness/items.json`
- Squash-merge convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)