### PR TITLE
feat(dashboard): AI annotations tab on /test#dev

### DIFF
--- a/ReactComponents/ga-react-components/src/components/AiAnnotations/AiAnnotationsCard.tsx
+++ b/ReactComponents/ga-react-components/src/components/AiAnnotations/AiAnnotationsCard.tsx
@@ -1,0 +1,353 @@
+// AI Annotations card — surfaces the @ai: in-source markers shipped from
+// ix (docs/contracts/2026-05-24-ai-annotation.contract.md).
+//
+// Data flow:
+//   ix-ai-annotations writes JSONL  ->  ix-ai-annotations-reconcile.json
+//   /dev-data/ai-annotations (vite middleware) reads both and serves a
+//   merged payload  ->  this card.
+//
+// The card is intentionally read-only. Filtering is client-side over the
+// payload; we refetch every 60s.
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Link as MuiLink,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import RuleIcon from '@mui/icons-material/Rule';
+import type {
+  Annotation,
+  AiAnnotationsPayload,
+  Certainty,
+  TruthValue,
+  AnnotationKind,
+} from './types';
+
+const TRUTH_VALUES: TruthValue[] = ['T', 'P', 'U', 'D', 'F', 'C'];
+
+// Demerzel-aligned colors. Tightly bounded palette so the eye groups
+// "verified vs. unknown vs. trouble" without effort.
+const TRUTH_COLORS: Record<TruthValue, { color: 'success' | 'info' | 'default' | 'warning' | 'error'; label: string }> = {
+  T: { color: 'success', label: 'True (verified)' },
+  P: { color: 'info', label: 'Probable (leans true)' },
+  U: { color: 'default', label: 'Unknown (insufficient evidence)' },
+  D: { color: 'warning', label: 'Doubtful (leans false)' },
+  F: { color: 'error', label: 'False (refuted)' },
+  C: { color: 'error', label: 'Contradictory (conflicting)' },
+};
+
+const CERTAINTY_VALUES: Certainty[] = [
+  'test',
+  'formal-proof',
+  'manually-reviewed',
+  'assumed',
+  'uncertain',
+  'inferred',
+  'dismissed',
+];
+
+const KIND_VALUES: AnnotationKind[] = [
+  'invariant',
+  'assumption',
+  'hypothesis',
+  'contract',
+  'smell',
+  'decision',
+  'hint',
+];
+
+function confidencePill(c: number): string {
+  if (c >= 0.9) return 'autonomous';
+  if (c >= 0.7) return 'with-note';
+  if (c >= 0.5) return 'confirm';
+  if (c >= 0.3) return 'escalate';
+  return 'do-not-act';
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+export const AiAnnotationsCard: React.FC = () => {
+  const [data, setData] = useState<AiAnnotationsPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [truthFilter, setTruthFilter] = useState<Set<TruthValue>>(new Set(TRUTH_VALUES));
+  const [certaintyFilter, setCertaintyFilter] = useState<Set<Certainty>>(new Set(CERTAINTY_VALUES));
+  const [kindFilter, setKindFilter] = useState<Set<AnnotationKind>>(new Set(KIND_VALUES));
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      fetch('/dev-data/ai-annotations')
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json() as Promise<AiAnnotationsPayload>;
+        })
+        .then((p) => {
+          if (!cancelled) {
+            setData(p);
+            setError(null);
+          }
+        })
+        .catch((e) => {
+          if (!cancelled) setError(String(e?.message ?? e));
+        });
+    };
+    load();
+    const id = window.setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const visible = useMemo(() => {
+    if (!data) return [];
+    return data.annotations.filter(
+      (a) =>
+        truthFilter.has(a.truth_value) &&
+        certaintyFilter.has(a.certainty) &&
+        kindFilter.has(a.kind),
+    );
+  }, [data, truthFilter, certaintyFilter, kindFilter]);
+
+  const verifiedPct = useMemo(() => {
+    if (!data || data.total === 0) return 0;
+    return Math.round(((data.verified_by_test ?? 0) / data.total) * 100);
+  }, [data]);
+
+  const trouble = useMemo(() => {
+    if (!data) return 0;
+    return (data.by_truth_value?.['C'] ?? 0) + (data.by_truth_value?.['F'] ?? 0);
+  }, [data]);
+
+  const toggleSet = <T extends string>(set: Set<T>, value: T, setter: (s: Set<T>) => void) => {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    setter(next);
+  };
+
+  return (
+    <Paper sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <RuleIcon fontSize="small" />
+          <Typography variant="h6">AI Annotations</Typography>
+          {data && (
+            <Typography variant="caption" color="text.secondary">
+              {data.total} markers • verified {verifiedPct}% • trouble {trouble} •{' '}
+              generated {new Date(data.generated_at).toLocaleString()}
+            </Typography>
+          )}
+        </Stack>
+
+        {error && (
+          <Alert severity="error">
+            Failed to load /dev-data/ai-annotations: {error}
+          </Alert>
+        )}
+
+        {!data && !error && (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <CircularProgress size={16} />
+            <Typography variant="caption" color="text.secondary">
+              Loading /dev-data/ai-annotations…
+            </Typography>
+          </Stack>
+        )}
+
+        {data?.empty && (
+          <Alert severity="info">
+            No annotations extracted yet. Drop <code>// @ai:invariant ... [T:test conf:0.95]</code>{' '}
+            markers in source files, then run <code>cargo run -p ix-ai-annotations</code> from the
+            ix repo.{' '}
+            <MuiLink
+              href="https://github.com/GuitarAlchemist/ix/blob/main/docs/contracts/2026-05-24-ai-annotation.contract.md"
+              target="_blank"
+              rel="noreferrer"
+            >
+              See the contract
+            </MuiLink>
+            .
+          </Alert>
+        )}
+
+        {data && !data.empty && (
+          <>
+            {/* Top stats */}
+            <Stack direction="row" spacing={2} flexWrap="wrap">
+              <Tooltip title="Annotations with truth_value=T AND a matched test file">
+                <Chip
+                  label={`% verified-by-test ${verifiedPct}%`}
+                  color="success"
+                  variant="outlined"
+                />
+              </Tooltip>
+              <Tooltip title="P (probable) + U (unknown). Need investigation.">
+                <Chip
+                  label={`P+U: ${(data.by_truth_value?.['P'] ?? 0) +
+                    (data.by_truth_value?.['U'] ?? 0)}`}
+                  color="info"
+                  variant="outlined"
+                />
+              </Tooltip>
+              <Tooltip title="C (contradictory) + F (refuted). Block merges unless waived.">
+                <Chip label={`C+F: ${trouble}`} color="error" variant="outlined" />
+              </Tooltip>
+              <Tooltip title="File touched after annotation was last updated.">
+                <Chip label={`stale: ${data.stale ?? 0}`} color="warning" variant="outlined" />
+              </Tooltip>
+            </Stack>
+
+            {/* Filters */}
+            <Stack spacing={1}>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  truth value
+                </Typography>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap" sx={{ mt: 0.5 }}>
+                  {TRUTH_VALUES.map((t) => (
+                    <Tooltip key={t} title={TRUTH_COLORS[t].label}>
+                      <Chip
+                        label={`${t} (${data.by_truth_value?.[t] ?? 0})`}
+                        size="small"
+                        color={TRUTH_COLORS[t].color}
+                        variant={truthFilter.has(t) ? 'filled' : 'outlined'}
+                        onClick={() => toggleSet(truthFilter, t, setTruthFilter)}
+                      />
+                    </Tooltip>
+                  ))}
+                </Stack>
+              </Box>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  certainty
+                </Typography>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap" sx={{ mt: 0.5 }}>
+                  {CERTAINTY_VALUES.map((c) => (
+                    <Chip
+                      key={c}
+                      label={`${c} (${data.by_certainty?.[c] ?? 0})`}
+                      size="small"
+                      variant={certaintyFilter.has(c) ? 'filled' : 'outlined'}
+                      onClick={() => toggleSet(certaintyFilter, c, setCertaintyFilter)}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  kind
+                </Typography>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap" sx={{ mt: 0.5 }}>
+                  {KIND_VALUES.map((k) => (
+                    <Chip
+                      key={k}
+                      label={`${k} (${data.by_kind?.[k] ?? 0})`}
+                      size="small"
+                      variant={kindFilter.has(k) ? 'filled' : 'outlined'}
+                      onClick={() => toggleSet(kindFilter, k, setKindFilter)}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            </Stack>
+
+            <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 480 }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>File:Line</TableCell>
+                    <TableCell>Kind</TableCell>
+                    <TableCell>Claim</TableCell>
+                    <TableCell>Truth</TableCell>
+                    <TableCell>Certainty</TableCell>
+                    <TableCell align="right">Conf</TableCell>
+                    <TableCell>Source</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {visible.map((a: Annotation) => (
+                    <TableRow key={a.id} hover>
+                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                        {a.location.path}:{a.location.line_start}
+                        {a.stale && (
+                          <Chip
+                            label="stale"
+                            color="warning"
+                            size="small"
+                            sx={{ ml: 0.5, height: 16, fontSize: '0.6rem' }}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Chip label={a.kind} size="small" variant="outlined" />
+                      </TableCell>
+                      <TableCell title={a.claim}>{truncate(a.claim, 80)}</TableCell>
+                      <TableCell>
+                        <Tooltip title={TRUTH_COLORS[a.truth_value].label}>
+                          <Chip
+                            label={a.truth_value}
+                            size="small"
+                            color={TRUTH_COLORS[a.truth_value].color}
+                          />
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="caption">{a.certainty}</Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Tooltip title={confidencePill(a.confidence)}>
+                          <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                            {a.confidence.toFixed(2)}
+                          </Typography>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="caption">{a.source.author}</Typography>
+                        {a.source.evidence && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: 'block', fontFamily: 'monospace' }}
+                          >
+                            {truncate(a.source.evidence, 40)}
+                          </Typography>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {visible.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={7} align="center">
+                        <Typography variant="caption" color="text.secondary">
+                          No annotations match the current filters.
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
+      </Stack>
+    </Paper>
+  );
+};
+
+export default AiAnnotationsCard;

--- a/ReactComponents/ga-react-components/src/components/AiAnnotations/index.ts
+++ b/ReactComponents/ga-react-components/src/components/AiAnnotations/index.ts
@@ -1,0 +1,8 @@
+export { AiAnnotationsCard } from './AiAnnotationsCard';
+export type {
+  Annotation,
+  AiAnnotationsPayload,
+  AnnotationKind,
+  Certainty,
+  TruthValue,
+} from './types';

--- a/ReactComponents/ga-react-components/src/components/AiAnnotations/types.ts
+++ b/ReactComponents/ga-react-components/src/components/AiAnnotations/types.ts
@@ -1,0 +1,66 @@
+// Shape mirrors docs/contracts/ai-annotation.schema.json over in ix.
+// We keep this duplication intentional — the dashboard is a downstream
+// consumer; the contract owner is ix.
+
+export type TruthValue = 'T' | 'P' | 'U' | 'D' | 'F' | 'C';
+
+export type AnnotationKind =
+  | 'invariant'
+  | 'assumption'
+  | 'hypothesis'
+  | 'contract'
+  | 'smell'
+  | 'decision'
+  | 'hint';
+
+export type Certainty =
+  | 'test'
+  | 'formal-proof'
+  | 'manually-reviewed'
+  | 'assumed'
+  | 'uncertain'
+  | 'inferred'
+  | 'dismissed';
+
+export interface Annotation {
+  schema_version: number;
+  id: string;
+  kind: AnnotationKind;
+  claim: string;
+  truth_value: TruthValue;
+  certainty: Certainty;
+  confidence: number;
+  source: {
+    author: string;
+    model?: string;
+    evidence?: string;
+  };
+  location: {
+    path: string;
+    line_start: number;
+    line_end: number;
+  };
+  created_at: string;
+  updated_at: string;
+  stale?: boolean;
+  reconciliation?: {
+    test_match?: string | null;
+    promoted_to_c_from?: TruthValue[];
+    weighted_truth_value?: TruthValue;
+    weighted_confidence?: number;
+  };
+}
+
+export interface AiAnnotationsPayload {
+  generated_at: string;
+  total: number;
+  by_truth_value: Record<string, number>;
+  by_certainty: Record<string, number>;
+  by_kind?: Record<string, number>;
+  verified_by_test?: number;
+  stale?: number;
+  contradictory?: number;
+  annotations: Annotation[];
+  /** True when neither the extractor nor the reconciler have produced data yet. */
+  empty?: boolean;
+}

--- a/ReactComponents/ga-react-components/src/pages/DevelopmentSection.tsx
+++ b/ReactComponents/ga-react-components/src/pages/DevelopmentSection.tsx
@@ -45,7 +45,9 @@ import InventoryIcon from '@mui/icons-material/Inventory';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import LayersIcon from '@mui/icons-material/Layers';
 import ConstructionIcon from '@mui/icons-material/Construction';
+import RuleIcon from '@mui/icons-material/Rule';
 import { HarnessTab } from '../components/Harness';
+import { AiAnnotationsCard } from '../components/AiAnnotations';
 
 interface DevLink {
   title: string;
@@ -1026,8 +1028,8 @@ const LayerMapCard: React.FC = () => {
 };
 
 
-type DevSubTab = 'summary' | 'architecture' | 'product' | 'project' | 'qa' | 'harness';
-const DEV_SUB_TABS: DevSubTab[] = ['summary', 'architecture', 'product', 'project', 'qa', 'harness'];
+type DevSubTab = 'summary' | 'architecture' | 'product' | 'project' | 'qa' | 'harness' | 'annotations';
+const DEV_SUB_TABS: DevSubTab[] = ['summary', 'architecture', 'product', 'project', 'qa', 'harness', 'annotations'];
 
 const readSubTabFromHash = (): DevSubTab => {
   if (typeof window === 'undefined') return 'summary';
@@ -1080,6 +1082,7 @@ export const DevelopmentSection: React.FC = () => {
           <Tab value="project"      label="Project"      icon={<GroupsIcon fontSize="small" />}      iconPosition="start" sx={{ minHeight: 44 }} />
           <Tab value="qa"           label="QA"           icon={<VerifiedIcon fontSize="small" />}    iconPosition="start" sx={{ minHeight: 44 }} />
           <Tab value="harness"      label="Harness"      icon={<ConstructionIcon fontSize="small" />} iconPosition="start" sx={{ minHeight: 44 }} />
+          <Tab value="annotations"  label="Annotations"  icon={<RuleIcon fontSize="small" />}         iconPosition="start" sx={{ minHeight: 44 }} />
         </Tabs>
       </Box>
 
@@ -1135,6 +1138,12 @@ export const DevelopmentSection: React.FC = () => {
         <Stack spacing={2}>
           <LoopsGoalsCard />
           <HarnessTab />
+        </Stack>
+      )}
+
+      {subTab === 'annotations' && (
+        <Stack spacing={2}>
+          <AiAnnotationsCard />
         </Stack>
       )}
     </Stack>

--- a/ReactComponents/ga-react-components/tests/dashboard/ai-annotations-tab.spec.ts
+++ b/ReactComponents/ga-react-components/tests/dashboard/ai-annotations-tab.spec.ts
@@ -1,0 +1,66 @@
+// AI Annotations tab — verifies /test#dev/annotations renders the
+// AiAnnotationsCard, with crossover-skip semantics for the deploy window.
+//
+// Catches:
+//   - /dev-data/ai-annotations middleware regression
+//   - AiAnnotationsCard import path / barrel breakage
+//   - DevelopmentSection tab list missing the 'annotations' value
+//
+// NOTE — like harness-tab.spec.ts, this runs against a LIVE URL by default
+// (playwright.dashboard.config.ts). Until the new tab deploys we MUST
+// tolerate the absence of /dev-data/ai-annotations and the absence of the
+// annotations Tab. Once the deploy catches up, the skip branch can be
+// removed.
+//
+// Crossover idiom: probe /dev-data/ai-annotations first. If it 404s or
+// returns HTML (Vite's index fallback), we know this build hasn't shipped
+// yet — test.skip.
+
+import { test, expect } from '@playwright/test';
+
+test.describe('AI Annotations tab', () => {
+  test('renders card + filters + table', async ({ page }) => {
+    // Crossover guard — does the deploy under test actually expose this?
+    const apiResp = await page.request.get('/dev-data/ai-annotations');
+    const ct = apiResp.headers()['content-type'] ?? '';
+    if (apiResp.status() >= 400 || !ct.includes('application/json')) {
+      test.skip(
+        true,
+        `Pre-deploy: /dev-data/ai-annotations not yet served (status ${apiResp.status()}, ct=${ct}). ` +
+          `Remove this skip branch after the new tab deploys.`,
+      );
+      return;
+    }
+
+    const payload = await apiResp.json();
+    // Schema sanity — the keys the card relies on.
+    expect(typeof payload.total, 'payload.total should be a number').toBe('number');
+    expect(typeof payload.by_truth_value, 'payload.by_truth_value should be an object').toBe(
+      'object',
+    );
+    expect(Array.isArray(payload.annotations), 'payload.annotations should be an array').toBe(true);
+
+    // Navigate to the tab and check it renders.
+    await page.goto('/test#dev/annotations', { waitUntil: 'domcontentloaded' });
+
+    // The card header text — must appear even when there are no annotations
+    // (empty-state hint still shows the heading).
+    await expect(
+      page.locator('text=/AI Annotations/i').first(),
+      'AI Annotations heading should appear',
+    ).toBeVisible({ timeout: 15_000 });
+
+    if (payload.empty || payload.total === 0) {
+      // Empty-state hint must mention the @ai: marker syntax so users know
+      // what to do next.
+      await expect(page.locator('text=/@ai:/').first()).toBeVisible({
+        timeout: 10_000,
+      });
+    } else {
+      // The truth-value filter row must surface at least the T and U chips.
+      await expect(page.locator('text=/truth value/i').first()).toBeVisible({
+        timeout: 10_000,
+      });
+    }
+  });
+});

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -390,6 +390,97 @@ function devDataPlugin(): Plugin {
         }
     }
 
+    // ── AI annotations (phase 2 of the ai-annotations campaign) ───────
+    //
+    // Reads two ix-produced files:
+    //   state/quality/ai-annotations.jsonl         (extractor output)
+    //   state/quality/ai-annotations-reconciliation.json (reconciler output)
+    //
+    // The reconciliation report supersedes the raw JSONL when present
+    // (richer schema, includes bucket counts). When neither exists we
+    // return an "empty" payload — the dashboard renders an onboarding
+    // hint instead of an error. See docs/contracts/2026-05-24-ai-annotation.contract.md
+    // (in the ix repo) for the field shapes.
+    function gatherAiAnnotations(): Record<string, unknown> {
+        const reconPath = path.join(repoRoot, 'state/quality/ai-annotations-reconciliation.json');
+        const jsonlPath = path.join(repoRoot, 'state/quality/ai-annotations.jsonl');
+        const now = new Date().toISOString();
+
+        if (existsSync(reconPath)) {
+            try {
+                const recon = JSON.parse(readFileSync(reconPath, 'utf-8')) as Record<string, unknown>;
+                return {
+                    generated_at: recon.generated_at ?? now,
+                    total: recon.total_annotations ?? 0,
+                    by_truth_value: recon.by_truth_value ?? {},
+                    by_certainty: recon.by_certainty ?? {},
+                    by_kind: recon.by_kind ?? {},
+                    verified_by_test: recon.verified_by_test ?? 0,
+                    stale: recon.stale ?? 0,
+                    contradictory: recon.contradictory ?? 0,
+                    annotations: recon.annotations ?? [],
+                };
+            } catch {
+                // fall through to JSONL
+            }
+        }
+
+        if (existsSync(jsonlPath)) {
+            try {
+                const lines = readFileSync(jsonlPath, 'utf-8')
+                    .split('\n')
+                    .map((l) => l.trim())
+                    .filter((l) => l.length > 0);
+                const annotations: Record<string, unknown>[] = [];
+                const byTv: Record<string, number> = {};
+                const byCert: Record<string, number> = {};
+                const byKind: Record<string, number> = {};
+                let stale = 0;
+                for (const line of lines) {
+                    try {
+                        const a = JSON.parse(line) as Record<string, unknown>;
+                        annotations.push(a);
+                        const tv = (a.truth_value as string) ?? 'U';
+                        byTv[tv] = (byTv[tv] ?? 0) + 1;
+                        const cert = (a.certainty as string) ?? 'uncertain';
+                        byCert[cert] = (byCert[cert] ?? 0) + 1;
+                        const k = (a.kind as string) ?? 'hint';
+                        byKind[k] = (byKind[k] ?? 0) + 1;
+                        if (a.stale) stale += 1;
+                    } catch {
+                        // skip malformed line
+                    }
+                }
+                return {
+                    generated_at: now,
+                    total: annotations.length,
+                    by_truth_value: byTv,
+                    by_certainty: byCert,
+                    by_kind: byKind,
+                    verified_by_test: 0,
+                    stale,
+                    contradictory: byTv['C'] ?? 0,
+                    annotations,
+                };
+            } catch {
+                // fall through
+            }
+        }
+
+        return {
+            generated_at: now,
+            total: 0,
+            by_truth_value: {},
+            by_certainty: {},
+            by_kind: {},
+            verified_by_test: 0,
+            stale: 0,
+            contradictory: 0,
+            annotations: [],
+            empty: true,
+        };
+    }
+
     // /loop and /goal runtime tracker — reads the append-only JSONL written by
     // .claude/hooks/loops-goals-tracker.ps1 (repo-local mirror lives at
     // state/.runtime-loops-goals.jsonl; the user-level canonical copy at
@@ -785,6 +876,15 @@ function devDataPlugin(): Plugin {
                 res.end(JSON.stringify({ generated_at: new Date().toISOString(), ...(payload as Record<string, unknown>) }));
             });
 
+            // ── /dev-data/ai-annotations — merged extractor + reconciler ──
+            // Always 200 (returns {empty:true} when no data exists, so the
+            // dashboard renders an onboarding hint instead of throwing).
+            server.middlewares.use('/dev-data/ai-annotations', (req, res, next) => {
+                if (req.method !== 'GET') { next(); return; }
+                res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+                res.end(JSON.stringify(gatherAiAnnotations()));
+            });
+
             // ── /dev-data/runtime-loops-goals — read latest projection ──
             // Returns active /loop + /goal invocations across all Claude
             // sessions on this machine, with age + last-activity decoration.
@@ -943,6 +1043,7 @@ function devDataPlugin(): Plugin {
                         harness: '/dev-data/harness',
                         algedonic: '/dev-data/algedonic',
                         runtime_loops_goals: '/dev-data/runtime-loops-goals',
+                        ai_annotations: '/dev-data/ai-annotations',
                         manifest: '/dev-data/manifest',
                     },
                     services: serviceTopology,
@@ -957,6 +1058,7 @@ function devDataPlugin(): Plugin {
                     harness: gatherHarness(),
                     algedonic: projectAlgedonic(),
                     runtime_loops_goals: gatherLoopsGoals(),
+                    ai_annotations: gatherAiAnnotations(),
                 };
                 res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
                 res.end(JSON.stringify(manifest, null, 2));


### PR DESCRIPTION
## Summary

Phase 2 of the AI source-code annotations campaign — surfaces ix-produced annotations on the GA dashboard.

> **Cross-repo**: depends on **ix#54** (schema + extractor) and **ix#55** (reconciler + MCP tool). Until ix writes \`state/quality/ai-annotations.jsonl\` / \`-reconciliation.json\`, the tab renders an onboarding hint, not an error.

## What's in this PR

- **New tab** "Annotations" on \`/test#dev/annotations\` (between Harness and end). Icon: \`RuleIcon\`.
- **\`src/components/AiAnnotations/AiAnnotationsCard.tsx\`**
  - Filter chips: truth_value (T/P/U/D/F/C — Demerzel-aligned), certainty (test/formal-proof/manually-reviewed/...), kind (invariant/assumption/hypothesis/...)
  - Top stats: % verified-by-test, P+U, C+F, stale count
  - Table: file:line monospace, kind chip, claim (truncated 80ch), truth chip, certainty, confidence (formatted to 2dp with pill tooltip: autonomous/with-note/confirm/escalate/do-not-act), source author + evidence
  - 60s polling, stale badge per-row, empty-state with contract link
- **Vite middleware** \`/dev-data/ai-annotations\`
  - Prefers \`state/quality/ai-annotations-reconciliation.json\` (rich)
  - Falls back to \`state/quality/ai-annotations.jsonl\` (raw extractor output)
  - Returns \`{empty:true}\` shape when neither exists — no 404
  - Added to \`/dev-data/manifest\` aggregate
- **Playwright test** with crossover-skip idiom from \`harness-tab.spec.ts\` (skips gracefully on pre-deploy live URLs)

## Out of scope (per campaign rules)

- No \`state/harness/items.json\` edits
- No \`.github/workflows/\` edits (Agent Blackbox)
- No \`npm install\` (junction node_modules from main repo)

## Test plan

- [x] \`npx tsc --noEmit\` — 0 errors (baseline 0)
- [x] Branch off origin/main, surgical additions only
- [ ] CI green (this PR)
- [ ] Once ix#54/#55 land + deploy, the crossover-skip drops out of the Playwright test

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>