### PR TITLE
feat(harness): AI annotation hygiene in /grade-last-pr + pre-merge gate (phase 3)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,26 @@
             "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/Scripts/digest-activity-tracker.ps1"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/Scripts/ai-annotation-scan.ps1"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/Scripts/ai-annotation-merge-gate.ps1"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/.claude/skills/grade-last-pr/SKILL.md
+++ b/.claude/skills/grade-last-pr/SKILL.md
@@ -122,6 +122,48 @@ If the API returns no Codex comments at all, record `"codex_review": { "status":
 
 This is the **Codex review gate**: a `low` grade with a P0/P1 attached is a signal to revert or to fast-follow with a fix PR, not just a number in an artifact.
 
+### 5b. AI annotation hygiene (ai-annotations gate)
+
+The ai-annotations campaign (`docs/contracts/2026-05-24-ai-annotation.contract.md` in ix) drops `@ai:invariant`, `@ai:assumption`, etc. markers in source. When the reconciler runs, it writes a report to `state/quality/ai-annotations-reconciliation.json` (path is shared across repos; ga sees the ix-produced file when run side-by-side, or copies it via the federation pattern).
+
+Before computing the grade in step 6:
+
+```bash
+RECON="state/quality/ai-annotations-reconciliation.json"
+if [ -f "$RECON" ]; then
+  CHANGED_FILES=$(git show HEAD --name-only --pretty=format: | tr -d '\r')
+  # Pull annotations that live in any of the changed files
+  RELEVANT=$(jq --argjson files "$(echo "$CHANGED_FILES" | jq -R -s 'split("\n") | map(select(length > 0))')" \
+    '.annotations | map(select(.location.path as $p | $files | index($p)))' "$RECON")
+  C_COUNT=$(echo "$RELEVANT" | jq '[.[] | select(.truth_value == "C")] | length')
+  F_COUNT=$(echo "$RELEVANT" | jq '[.[] | select(.truth_value == "F" and (.reconciliation.test_match // null) == null)] | length')
+  STALE_COUNT=$(echo "$RELEVANT" | jq '[.[] | select(.stale == true)] | length')
+fi
+```
+
+**Annotation-driven grade adjustment** — apply AFTER Codex adjustment, record in `reasons`:
+
+| Unresolved in changed files | Effect on grade |
+|---|---|
+| Any **C** (contradictory) annotation | Degrade one tier (`high → medium`, `medium → low`). Cite the contradicting annotations in `reasons` with `path:line` references. |
+| Any **F** (refuted) annotation without a `dismissed` certainty | Degrade one tier. Cite which claims got refuted. |
+| Any **stale** annotation (file mtime > annotation.updated_at + 7d) | Informational. List in `reasons` so the author can refresh; do not change the tier. |
+
+Record under `ai_annotations` in the grade card:
+
+```json
+"ai_annotations": {
+  "status": "reviewed",
+  "in_changed_files": 12,
+  "unresolved": { "C": 0, "F": 1, "stale": 2 },
+  "findings": [
+    {"truth_value": "F", "kind": "invariant", "path": "src/foo.rs", "line": 42, "claim": "..." }
+  ]
+}
+```
+
+If `ai-annotations-reconciliation.json` doesn't exist, set `"ai_annotations": { "status": "not_run" }` and skip the adjustment — don't penalize PRs in a repo where the campaign hasn't shipped yet.
+
 ### 6. Compute the alignment score
 
 Three buckets — no in-between. Be honest, not generous.

--- a/Scripts/ai-annotation-merge-gate.ps1
+++ b/Scripts/ai-annotation-merge-gate.ps1
@@ -1,0 +1,98 @@
+# ai-annotation-merge-gate.ps1 — PreToolUse(Bash) hook.
+#
+# Intercepts `gh pr merge ...` commands and blocks the merge if the
+# reconciliation report (state/quality/ai-annotations-reconciliation.json)
+# shows unresolved C (contradictory) or F (refuted, non-dismissed)
+# annotations in files touched by the PR.
+#
+# Mirrors the Codex review gate shipped in PR #338 — same pattern, different
+# signal. Exit code 2 with a message on stderr asks Claude (or the user) to
+# either fix the underlying annotation or explicitly override.
+
+$ErrorActionPreference = 'Continue'
+
+try {
+    $payload = $input | ConvertFrom-Json -ErrorAction Stop
+    $command = $payload.tool_input.command
+    if (-not $command) { exit 0 }
+
+    # Only fire on `gh pr merge` (covers `--squash`, `--auto`, `-s`, etc.)
+    if ($command -notmatch '\bgh\s+pr\s+merge\b') { exit 0 }
+
+    # Allow an explicit override via env var (set once, expires with the shell).
+    if ($env:AI_ANNOTATIONS_GATE_OVERRIDE -eq '1') {
+        Write-Host "[ai-annotation gate] override active (AI_ANNOTATIONS_GATE_OVERRIDE=1) — allowing merge" -ForegroundColor Yellow
+        exit 0
+    }
+
+    $repo = if ($env:CLAUDE_PROJECT_DIR) { $env:CLAUDE_PROJECT_DIR } else { (Get-Location).Path }
+    $recon = Join-Path $repo 'state/quality/ai-annotations-reconciliation.json'
+    if (-not (Test-Path $recon)) {
+        # No reconciler output -> nothing to gate on. Don't block.
+        exit 0
+    }
+
+    $data = $null
+    try {
+        $data = Get-Content -LiteralPath $recon -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        # Malformed report -> don't block (the next reconciler run will fix it).
+        exit 0
+    }
+
+    if (-not $data.annotations) { exit 0 }
+
+    # Discover PR-touched files. The current branch's diff against origin/main
+    # is a fast approximation that doesn't require gh.
+    $changedFiles = @()
+    try {
+        $diffOutput = & git diff --name-only origin/main...HEAD 2>$null
+        if ($LASTEXITCODE -eq 0 -and $diffOutput) {
+            $changedFiles = $diffOutput -split "`n" | Where-Object { $_.Trim().Length -gt 0 }
+        }
+    } catch {
+        # Fall back to all annotations if git diff fails.
+    }
+    $changedSet = @{}
+    foreach ($f in $changedFiles) {
+        $normalized = $f.Trim().Replace('\', '/')
+        if ($normalized) { $changedSet[$normalized] = $true }
+    }
+
+    $bad = New-Object System.Collections.ArrayList
+    foreach ($a in $data.annotations) {
+        $path = $a.location.path
+        if ($changedSet.Count -gt 0 -and -not $changedSet.ContainsKey($path)) { continue }
+        $tv = $a.truth_value
+        $cert = $a.certainty
+        if ($tv -eq 'C') {
+            [void]$bad.Add(@{ kind = 'C'; path = $path; line = $a.location.line_start; claim = $a.claim })
+        } elseif ($tv -eq 'F' -and $cert -ne 'dismissed') {
+            [void]$bad.Add(@{ kind = 'F'; path = $path; line = $a.location.line_start; claim = $a.claim })
+        }
+    }
+
+    if ($bad.Count -eq 0) { exit 0 }
+
+    Write-Host ''
+    Write-Host "[ai-annotation gate] Blocking 'gh pr merge' -- $($bad.Count) unresolved annotation(s) in changed files:" -ForegroundColor Red
+    foreach ($b in $bad | Select-Object -First 10) {
+        $line = "  [$($b.kind)] $($b.path):$($b.line) -- $($b.claim)"
+        if ($line.Length -gt 220) { $line = $line.Substring(0, 220) + '...' }
+        Write-Host $line -ForegroundColor Red
+    }
+    if ($bad.Count -gt 10) {
+        Write-Host "  ... and $($bad.Count - 10) more" -ForegroundColor Red
+    }
+    Write-Host ''
+    Write-Host "Resolve by:" -ForegroundColor Yellow
+    Write-Host "  - fixing the underlying code so the next reconciler run flips the truth value" -ForegroundColor Yellow
+    Write-Host "  - editing the @ai: marker (e.g., promote F -> C with [C:dismissed] if intentionally retired)" -ForegroundColor Yellow
+    Write-Host '  - one-shot override: $env:AI_ANNOTATIONS_GATE_OVERRIDE=1; gh pr merge ...  (use only with reviewer sign-off)' -ForegroundColor Yellow
+    Write-Host ''
+    # Exit 2 -> Claude Code surfaces stderr to the assistant; the Bash call fails.
+    exit 2
+} catch {
+    # Hooks must fail-open on internal errors.
+    exit 0
+}

--- a/Scripts/ai-annotation-scan.ps1
+++ b/Scripts/ai-annotation-scan.ps1
@@ -1,0 +1,129 @@
+# ai-annotation-scan.ps1 — PostToolUse(Edit|Write) hook.
+#
+# After Claude (or any tool) edits a file, scan that single file for new or
+# changed @ai: annotations and append them to
+# state/quality/ai-annotations.jsonl. This is the incremental complement to
+# the full ix-ai-annotations CLI which scans the whole workspace.
+#
+# Best-effort by design: hooks should never block the agent. Every failure
+# path silently exits 0 — the next full scan from ix will reconcile.
+#
+# See docs/contracts/2026-05-24-ai-annotation.contract.md (in ix) for the
+# marker syntax + JSONL schema.
+
+$ErrorActionPreference = 'Continue'
+
+try {
+    $payload = $input | ConvertFrom-Json -ErrorAction Stop
+    $filePath = $payload.tool_input.file_path
+    if (-not $filePath) { exit 0 }
+    if (-not (Test-Path $filePath)) { exit 0 }
+
+    # Resolve repo root (the working directory of the agent).
+    $repo = if ($env:CLAUDE_PROJECT_DIR) { $env:CLAUDE_PROJECT_DIR } else { (Get-Location).Path }
+    $outDir = Join-Path $repo 'state/quality'
+    $outFile = Join-Path $outDir 'ai-annotations.jsonl'
+    if (-not (Test-Path $outDir)) { New-Item -ItemType Directory -Force -Path $outDir | Out-Null }
+
+    # Extensions we'll scan. Mirrors the Rust walker's SCANNABLE_EXTS.
+    $scanExts = @('.rs', '.cs', '.fs', '.fsx', '.fsi', '.ts', '.tsx', '.js', '.jsx',
+                  '.py', '.rb', '.go', '.java', '.swift', '.c', '.h', '.cpp', '.hpp',
+                  '.lua', '.sql', '.hs', '.sh', '.ps1', '.psm1', '.yml', '.yaml',
+                  '.toml', '.html', '.htm', '.xml', '.md')
+    $ext = [System.IO.Path]::GetExtension($filePath).ToLowerInvariant()
+    if ($scanExts -notcontains $ext) { exit 0 }
+
+    # Repo-relative path with forward slashes (matches the Rust walker output).
+    $relPath = $filePath
+    if ($filePath.StartsWith($repo, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $relPath = $filePath.Substring($repo.Length).TrimStart('\', '/').Replace('\', '/')
+    }
+
+    # Pattern matches the same syntax as crates/ix-ai-annotations/src/parser.rs.
+    # Comment markers: //, ///, //!, #, --, /*, <!--.
+    $commentRe = '^\s*(?:///|//!|//|#!|#|--|/\*|<!--)\s*'
+    $markerRe = '@ai:([a-zA-Z_-]+)\s+(.+?)\s+\[([TPUDFC]):([a-z][a-z\-]*)(?:\s+conf:([0-9]*\.?[0-9]+))?(?:\s+src:([^\]]+?))?\]'
+
+    $kindsValid = @('invariant', 'assumption', 'hypothesis', 'contract', 'smell', 'decision', 'hint')
+    $certValid = @('test', 'formal-proof', 'manually-reviewed', 'assumed', 'uncertain', 'inferred', 'dismissed')
+
+    $now = (Get-Date).ToUniversalTime().ToString("o")
+    $lines = Get-Content -LiteralPath $filePath -ErrorAction Stop
+    $newEntries = New-Object System.Collections.ArrayList
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        $line = $lines[$i]
+        if ($line -notmatch $commentRe) { continue }
+        if ($line -notmatch $markerRe) { continue }
+        $kind = $Matches[1]
+        $claim = $Matches[2].Trim()
+        $tv = $Matches[3]
+        $cert = $Matches[4]
+        $confStr = $Matches[5]
+        $evidence = if ($Matches[6]) { $Matches[6].Trim() } else { $null }
+        if ($kindsValid -notcontains $kind) { continue }
+        if ($certValid -notcontains $cert) { continue }
+        $conf = if ($confStr) { [double]$confStr } else { 0.5 }
+        $lineNum = $i + 1
+
+        # Deterministic id mirroring types::annotation_id (sha256 of path:line:Kind:claim).
+        # The Rust code uses `{:?}` Debug format for the kind, which produces e.g. "Invariant".
+        $kindPascal = ($kind.Substring(0, 1).ToUpper() + $kind.Substring(1).ToLower()).Replace('-', '')
+        $idKey = "{0}:{1}:{2}:{3}" -f $relPath, $lineNum, $kindPascal, $claim
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($idKey)
+            $hash = $sha.ComputeHash($bytes)
+            $hashHex = -join ($hash | ForEach-Object { $_.ToString('x2') })
+        } finally {
+            $sha.Dispose()
+        }
+        $id = "sha256:$hashHex"
+
+        $entry = [ordered]@{
+            schema_version = 1
+            id             = $id
+            kind           = $kind
+            claim          = $claim
+            truth_value    = $tv
+            certainty      = $cert
+            confidence     = $conf
+            source         = [ordered]@{
+                author = 'claude'
+            }
+            location       = [ordered]@{
+                path       = $relPath
+                line_start = $lineNum
+                line_end   = $lineNum
+            }
+            created_at     = $now
+            updated_at     = $now
+        }
+        if ($evidence) { $entry.source.evidence = $evidence }
+        [void]$newEntries.Add($entry)
+    }
+
+    if ($newEntries.Count -eq 0) { exit 0 }
+
+    # Read existing JSONL (if any), drop lines for this file (we replace
+    # per-file entries entirely on each hook fire), then append the fresh set.
+    $existing = @()
+    if (Test-Path $outFile) {
+        $existing = Get-Content -LiteralPath $outFile -ErrorAction SilentlyContinue | Where-Object {
+            $_.Trim().Length -gt 0
+        } | Where-Object {
+            try {
+                $obj = $_ | ConvertFrom-Json -ErrorAction Stop
+                $obj.location.path -ne $relPath
+            } catch {
+                $false
+            }
+        }
+    }
+
+    $newLines = $newEntries | ForEach-Object { $_ | ConvertTo-Json -Compress -Depth 6 }
+    Set-Content -LiteralPath $outFile -Value (@($existing) + @($newLines)) -Encoding UTF8
+    exit 0
+} catch {
+    # Hooks must not block the agent.
+    exit 0
+}


### PR DESCRIPTION
## Summary

Phase 3 (ga side) of the AI source-code annotations campaign. Wires hooks + pre-merge gate + grade-last-pr integration. The ix side ships in **ix#56** (one-line CLAUDE.md /correct rule).

Depends on **ix#54** (schema + extractor) and **ix#55** (reconciler) producing the reports the hooks consume. Until they land, the hooks are inert (fail-open).

## What's in this PR

### 1. \`/grade-last-pr\` skill — new section 5b "AI annotation hygiene"
- Reads \`state/quality/ai-annotations-reconciliation.json\`
- Filters annotations to files changed by the PR (via \`git show HEAD --name-only\`)
- Degrades grade one tier for unresolved C (contradictory) or F (refuted, non-dismissed)
- Lists stale annotations as informational (no tier change)
- New \`ai_annotations\` field in the grade card schema
- Gracefully no-ops when the report is missing (\`status: not_run\`)

### 2. \`Scripts/ai-annotation-scan.ps1\` — PostToolUse(Edit|Write)
- Incremental scan of just the edited file
- Replaces per-file entries in \`state/quality/ai-annotations.jsonl\`
- Mirrors the Rust parser regex byte-for-byte
- Deterministic SHA-256 id matching \`ix-ai-annotations::types::annotation_id\`
- **Fail-open**: hooks never block the agent

### 3. \`Scripts/ai-annotation-merge-gate.ps1\` — PreToolUse(Bash)
- Intercepts \`gh pr merge\` commands
- Blocks (exit 2) if reconciliation report shows unresolved C/F in PR-touched files (\`git diff origin/main...HEAD\`)
- Override via \`$env:AI_ANNOTATIONS_GATE_OVERRIDE=1\` (one-shot)
- Pattern mirrors the Codex review gate from PR #338

### 4. \`.claude/settings.json\` wiring
- PostToolUse(Edit|Write) → \`ai-annotation-scan.ps1\`
- new PreToolUse(Bash) → \`ai-annotation-merge-gate.ps1\`

## Smoke tests run locally

- [x] Scan extracts 1 annotation from a fresh file → writes JSONL line with correct sha256 id
- [x] Gate trips on synthetic C annotation → exit 2 with red banner
- [x] Gate respects \`AI_ANNOTATIONS_GATE_OVERRIDE\` override
- [x] settings.json parses as valid JSON

## Out of scope (per campaign rules)

- No \`state/harness/items.json\` edits
- No \`.github/workflows/\` edits (Agent Blackbox)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>