### PR TITLE
feat(registry): C# capability-registry library mirroring ix pattern

### DIFF
--- a/AllProjects.slnx
+++ b/AllProjects.slnx
@@ -272,4 +272,6 @@
     <Project Path="Demos/Advanced/InternetContentDemo/InternetContentDemo.csproj" />
     <Project Path="GA.Data.MongoDB/GA.Data.MongoDB.csproj" />
     <Project Path="GenerateNatData/GenerateNatData.csproj" />
+    <Project Path="GuitarAlchemist.Registry/GuitarAlchemist.Registry.csproj" />
+    <Project Path="GuitarAlchemist.Registry.Tests/GuitarAlchemist.Registry.Tests.csproj" />
 </Solution>

--- a/GuitarAlchemist.Registry.Tests/GuitarAlchemist.Registry.Tests.csproj
+++ b/GuitarAlchemist.Registry.Tests/GuitarAlchemist.Registry.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+    <PackageReference Include="NUnit" Version="4.2.2"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GuitarAlchemist.Registry\GuitarAlchemist.Registry.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/GuitarAlchemist.Registry.Tests/RegistryDiscoveryTests.cs
+++ b/GuitarAlchemist.Registry.Tests/RegistryDiscoveryTests.cs
@@ -1,0 +1,68 @@
+namespace GuitarAlchemist.Registry.Tests;
+
+using System.Text.Json.Nodes;
+using GuitarAlchemist.Registry;
+
+[TestFixture]
+public class RegistryDiscoveryTests
+{
+    [GaSkill("test.echo", "test", Description = "Echoes the input JSON node.")]
+    public static JsonNode Echo(JsonNode input) => input;
+
+    [GaSkill("test.echo.tagged", "test", GovernanceTags = new[] { "deterministic", "pure" })]
+    public static JsonNode EchoTagged(JsonNode input) => input;
+
+    // Intentionally NOT annotated — must not appear in Registry.All.
+    public static JsonNode Unannotated(JsonNode input) => input;
+
+    [Test]
+    public void Discover_FindsAnnotatedMethod()
+    {
+        var skill = Registry.ByName("test.echo");
+
+        Assert.That(skill, Is.Not.Null, "Expected test.echo to be discovered");
+        Assert.That(skill!.Domain, Is.EqualTo("test"));
+        Assert.That(skill.Description, Is.EqualTo("Echoes the input JSON node."));
+    }
+
+    [Test]
+    public void Discover_InvokesHandler_Echoes()
+    {
+        var skill = Registry.ByName("test.echo");
+        Assert.That(skill, Is.Not.Null);
+
+        var input = JsonNode.Parse("""{"hello":"world","n":42}""")!;
+        var result = skill!.Handler(input);
+
+        Assert.That(result.ToJsonString(), Is.EqualTo(input.ToJsonString()));
+    }
+
+    [Test]
+    public void Discover_IgnoresUnannotated()
+    {
+        var names = Registry.All.Select(s => s.Name).ToList();
+
+        Assert.That(names, Does.Not.Contain("Unannotated"));
+        Assert.That(names, Does.Not.Contain("test.unannotated"));
+    }
+
+    [Test]
+    public void Discover_CapturesGovernanceTags()
+    {
+        var skill = Registry.ByName("test.echo.tagged");
+
+        Assert.That(skill, Is.Not.Null);
+        Assert.That(skill!.GovernanceTags, Is.EquivalentTo(new[] { "deterministic", "pure" }));
+    }
+
+    [Test]
+    public void Discover_DefaultSchema_IsEmptyJsonObject()
+    {
+        var skill = Registry.ByName("test.echo");
+        Assert.That(skill, Is.Not.Null);
+
+        var schema = skill!.Schema();
+        Assert.That(schema, Is.Not.Null);
+        Assert.That(schema.Count, Is.EqualTo(0));
+    }
+}

--- a/GuitarAlchemist.Registry/GaSkill.cs
+++ b/GuitarAlchemist.Registry/GaSkill.cs
@@ -1,0 +1,15 @@
+namespace GuitarAlchemist.Registry;
+
+using System.Text.Json.Nodes;
+
+/// <summary>
+/// A discovered skill — the runtime view of a method annotated with
+/// <see cref="GaSkillAttribute"/>. Materialised by <see cref="Registry"/>.
+/// </summary>
+public sealed record GaSkill(
+    string Name,
+    string Domain,
+    string Description,
+    Func<JsonNode, JsonNode> Handler,
+    Func<JsonObject> Schema,
+    IReadOnlyList<string> GovernanceTags);

--- a/GuitarAlchemist.Registry/GaSkillAttribute.cs
+++ b/GuitarAlchemist.Registry/GaSkillAttribute.cs
@@ -1,0 +1,30 @@
+namespace GuitarAlchemist.Registry;
+
+/// <summary>
+/// Marks a public static method as a discoverable Guitar Alchemist skill.
+/// Mirrors ix's <c>#[ix_skill]</c> proc-macro pattern; the registry scans
+/// loaded assemblies for this attribute and exposes the methods through a
+/// unified surface (CLI, MCP server, HTTP API).
+/// </summary>
+/// <remarks>
+/// The annotated method must be <c>public static</c> and accept a single
+/// <see cref="System.Text.Json.Nodes.JsonNode"/> argument, returning a
+/// <see cref="System.Text.Json.Nodes.JsonNode"/>. Optionally, a sibling
+/// static method named <c>{MethodName}Schema</c> returning
+/// <see cref="System.Text.Json.Nodes.JsonObject"/> may supply the JSON
+/// schema; otherwise an empty schema is used.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class GaSkillAttribute : Attribute
+{
+    public string Name { get; }
+    public string Domain { get; }
+    public string Description { get; init; } = "";
+    public string[] GovernanceTags { get; init; } = [];
+
+    public GaSkillAttribute(string name, string domain)
+    {
+        Name = name;
+        Domain = domain;
+    }
+}

--- a/GuitarAlchemist.Registry/GuitarAlchemist.Registry.csproj
+++ b/GuitarAlchemist.Registry/GuitarAlchemist.Registry.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/GuitarAlchemist.Registry/Registry.cs
+++ b/GuitarAlchemist.Registry/Registry.cs
@@ -1,0 +1,128 @@
+namespace GuitarAlchemist.Registry;
+
+using System.Reflection;
+using System.Text.Json.Nodes;
+
+/// <summary>
+/// Discovers and indexes <see cref="GaSkillAttribute"/>-tagged methods across
+/// all loaded assemblies. The result is cached on first access.
+/// </summary>
+/// <remarks>
+/// Discovery scans <c>AppDomain.CurrentDomain.GetAssemblies()</c> for public
+/// static methods marked with <see cref="GaSkillAttribute"/>. For each match
+/// it builds a <see cref="GaSkill"/> with a delegate Handler bound to the
+/// method. Schema resolution: if a sibling method named
+/// <c>{MethodName}Schema</c> exists with the signature <c>() =&gt; JsonObject</c>,
+/// it is used; otherwise an empty <see cref="JsonObject"/> is returned.
+/// </remarks>
+public static class Registry
+{
+    private static readonly Lazy<IReadOnlyDictionary<string, GaSkill>> Index =
+        new(BuildIndex);
+
+    /// <summary>All discovered skills, keyed by name.</summary>
+    public static IEnumerable<GaSkill> All => Index.Value.Values;
+
+    /// <summary>Look up a skill by name; returns null when absent.</summary>
+    public static GaSkill? ByName(string name) =>
+        Index.Value.TryGetValue(name, out var skill) ? skill : null;
+
+    private static IReadOnlyDictionary<string, GaSkill> BuildIndex()
+    {
+        Dictionary<string, GaSkill> dict = new(StringComparer.Ordinal);
+        foreach (var skill in Discover())
+        {
+            dict[skill.Name] = skill;
+        }
+        return dict;
+    }
+
+    private static IEnumerable<GaSkill> Discover()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                // Some assemblies (test hosts, dynamic ones) may fail to fully
+                // load — keep the types we can read and skip the rest.
+                types = [.. ex.Types.Where(t => t is not null).Cast<Type>()];
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var type in types)
+            {
+                MethodInfo[] methods;
+                try
+                {
+                    methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var method in methods)
+                {
+                    var attr = method.GetCustomAttribute<GaSkillAttribute>();
+                    if (attr is null) continue;
+
+                    var built = TryBuildSkill(attr, method);
+                    if (built is not null) yield return built;
+                }
+            }
+        }
+    }
+
+    private static GaSkill? TryBuildSkill(GaSkillAttribute attr, MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+        if (parameters.Length != 1 ||
+            !typeof(JsonNode).IsAssignableFrom(parameters[0].ParameterType) ||
+            !typeof(JsonNode).IsAssignableFrom(method.ReturnType))
+        {
+            // Skills must have signature: static JsonNode (JsonNode input)
+            return null;
+        }
+
+        Func<JsonNode, JsonNode> handler = input =>
+        {
+            var result = method.Invoke(null, [input]);
+            return (JsonNode)result!;
+        };
+
+        Func<JsonObject> schema = ResolveSchema(method);
+
+        return new GaSkill(
+            Name: attr.Name,
+            Domain: attr.Domain,
+            Description: attr.Description,
+            Handler: handler,
+            Schema: schema,
+            GovernanceTags: attr.GovernanceTags);
+    }
+
+    private static Func<JsonObject> ResolveSchema(MethodInfo method)
+    {
+        var schemaMethod = method.DeclaringType?.GetMethod(
+            $"{method.Name}Schema",
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        if (schemaMethod is not null && typeof(JsonObject).IsAssignableFrom(schemaMethod.ReturnType))
+        {
+            return () => (JsonObject)schemaMethod.Invoke(null, null)!;
+        }
+
+        return () => [];
+    }
+}


### PR DESCRIPTION
## Summary
- New `GuitarAlchemist.Registry` C# library: `[GaSkill]` attribute + reflection-based `Registry.All` / `Registry.ByName(name)`.
- NUnit test project (5 tests) verifying discovery + handler invocation + unannotated-method exclusion + governance tags + default schema.
- Mirrors ix's `#[ix_skill]` pattern per `ix/docs/MIRROR-TO-ECOSYSTEM.md`.

## What this does NOT do (follow-up PRs)
- Does not annotate existing ga tools — that's a separate sweep to keep this reviewable.
- Does not wire into GaApi / MCP surface.
- Does not add parity test for ga's tool count (waits on annotation pass).

## Deviation from brief
- Brief specified xUnit; switched to NUnit to match the repo's established test convention (all existing test projects use NUnit 4.2.2 + NUnit3TestAdapter, with `<Using Include="NUnit.Framework"/>`). Per CLAUDE.md, matching existing style is the priority.
- Used file-scoped namespaces + `using` directives inside namespace (required by repo's `EnforceCodeStyleInBuild=true` + `WarningsAsErrors=IDE0065`).

## Test plan
- [x] \`dotnet build GuitarAlchemist.Registry\` succeeds (0 warnings, 0 errors).
- [x] \`dotnet test GuitarAlchemist.Registry.Tests\` reports 5 passing tests (Duration ~104 ms).
- [x] No changes to other projects (only `AllProjects.slnx` modified for solution wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)