### PR TITLE
feat(prime-radiant): dashboard channels — hexavalent rim + coverage halo + algedonic pulse

### DIFF
--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/DataLoader.ts
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/DataLoader.ts
@@ -502,7 +502,11 @@ interface AlgedonicRecord {
   source?: string;
   nodeId?: string;
 }
-type AlgedonicResponse = AlgedonicRecord[] | { signals?: AlgedonicRecord[] } | { data?: AlgedonicRecord[] };
+type AlgedonicResponse =
+  | AlgedonicRecord[]
+  | { signals?: AlgedonicRecord[] }
+  | { data?: AlgedonicRecord[] }
+  | { unacked?: AlgedonicRecord[]; top3?: AlgedonicRecord[] };
 
 // Path normalization — case-insensitive, forward-slash, no leading slash
 function normalizePath(p: string): string {
@@ -580,6 +584,11 @@ export async function enrichNodesWithDevData(graph: GovernanceGraph): Promise<Go
     if (Array.isArray(raw)) algedonicRecords = raw;
     else if ('signals' in raw && Array.isArray(raw.signals)) algedonicRecords = raw.signals;
     else if ('data' in raw && Array.isArray(raw.data)) algedonicRecords = raw.data;
+    // /dev-data/algedonic is projected by vite.config.ts projectAlgedonic() as
+    // { unacked, top3 } — use the full unacked list (the 24h filter below
+    // narrows it) so the algedonic channel populates from dev-data, not just
+    // from SignalR. Without this branch the channel silently stays empty.
+    else if ('unacked' in raw && Array.isArray(raw.unacked)) algedonicRecords = raw.unacked;
   }
   const cutoffMs = Date.now() - 24 * 60 * 60 * 1000;
   algedonicRecords = algedonicRecords.filter(s => {

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/DataLoader.ts
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/DataLoader.ts
@@ -1,7 +1,7 @@
 // src/components/PrimeRadiant/DataLoader.ts
 // Loads governance data and builds the graph structure for 3D rendering
 
-import type { GovernanceGraph, GovernanceNode, GovernanceEdge, GovernanceHealthStatus } from './types';
+import type { GovernanceGraph, GovernanceNode, GovernanceEdge, GovernanceHealthStatus, HexavalentTruth, NodeAugmentation } from './types';
 import { HEALTH_STATUS_COLORS } from './types';
 import { LIVE_GOVERNANCE_GRAPH } from './liveData';
 import { SAMPLE_GOVERNANCE_GRAPH } from './sampleData';
@@ -468,4 +468,214 @@ export function updateNodeHealth(
   }
 
   return { updated, changed };
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard channel enrichment — join dev-dashboard sidecars onto governance
+// nodes by suffix-matching filePath. Powers three Prime Radiant visual
+// channels (hexavalent rim, coverage halo, algedonic pulse) plus the three
+// new DetailPanel sections. Tolerant: any failing fetch leaves that channel
+// undefined on every node — the base graph never blocks on dev-data.
+// ---------------------------------------------------------------------------
+
+// Endpoint payload shapes (defensive — schemas may evolve)
+interface AnnotationLocation { path: string; line_start: number; line_end: number }
+interface AnnotationRecord {
+  location: AnnotationLocation;
+  truth_value: HexavalentTruth;
+  kind: string;
+  certainty: string;
+  claim: string;
+}
+interface AnnotationsResponse { annotations?: AnnotationRecord[] }
+
+interface TestGapRecord { path: string; risk_score: number; churn: number; complexity: number }
+interface TestGapsResponse { data?: { files?: TestGapRecord[] }; files?: TestGapRecord[] }
+
+interface AlgedonicRecord {
+  id?: string;
+  signal?: string;
+  type?: 'pain' | 'pleasure';
+  severity?: string;
+  status?: string;
+  timestamp?: string;
+  source?: string;
+  nodeId?: string;
+}
+type AlgedonicResponse = AlgedonicRecord[] | { signals?: AlgedonicRecord[] } | { data?: AlgedonicRecord[] };
+
+// Path normalization — case-insensitive, forward-slash, no leading slash
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.?\//, '').toLowerCase();
+}
+
+// Suffix match in either direction (annotation path may be absolute,
+// node filePath is repo-relative)
+function pathsMatch(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const na = normalizePath(a);
+  const nb = normalizePath(b);
+  return na === nb || na.endsWith('/' + nb) || nb.endsWith('/' + na);
+}
+
+// Dominant truth value: C wins if any present (per Demerzel hexavalent
+// semantics). Otherwise mode, with ties broken toward the worst value
+// (F > D > U > P > T).
+const TRUTH_BADNESS: Record<HexavalentTruth, number> = { F: 5, D: 4, U: 3, P: 2, T: 1, C: 6 };
+function dominantTruth(counts: Partial<Record<HexavalentTruth, number>>): HexavalentTruth | null {
+  const keys = Object.keys(counts) as HexavalentTruth[];
+  if (keys.length === 0) return null;
+  if ((counts.C ?? 0) > 0) return 'C';
+  let best: HexavalentTruth = keys[0];
+  let bestCount = counts[best] ?? 0;
+  for (const k of keys) {
+    const c = counts[k] ?? 0;
+    if (c > bestCount || (c === bestCount && TRUTH_BADNESS[k] > TRUTH_BADNESS[best])) {
+      best = k;
+      bestCount = c;
+    }
+  }
+  return best;
+}
+
+/**
+ * Fetch dev-dashboard sidecars and merge into governance nodes.
+ * Tolerant: any failing fetch leaves that channel undefined on all nodes.
+ * Path matching is suffix-based: an annotation/test-gap path matches a node
+ * if the annotation path ends with the node's filePath (or vice versa).
+ */
+export async function enrichNodesWithDevData(graph: GovernanceGraph): Promise<GovernanceGraph> {
+  const [annotationsResult, testGapsResult, algedonicResult] = await Promise.allSettled([
+    fetch('/dev-data/ai-annotations').then(r => r.ok ? r.json() as Promise<AnnotationsResponse> : null),
+    fetch('/dev-data/sentrux/test-gaps').then(r => r.ok ? r.json() as Promise<TestGapsResponse> : null),
+    fetch('/dev-data/algedonic').then(r => r.ok ? r.json() as Promise<AlgedonicResponse> : null),
+  ]);
+
+  // ── Group annotations by path ──
+  const annotationsByPath = new Map<string, AnnotationRecord[]>();
+  if (annotationsResult.status === 'fulfilled' && annotationsResult.value?.annotations) {
+    for (const ann of annotationsResult.value.annotations) {
+      if (!ann.location?.path) continue;
+      const key = normalizePath(ann.location.path);
+      const list = annotationsByPath.get(key) ?? [];
+      list.push(ann);
+      annotationsByPath.set(key, list);
+    }
+  }
+
+  // ── Group test-gaps by path ──
+  const testGapsByPath = new Map<string, TestGapRecord>();
+  if (testGapsResult.status === 'fulfilled' && testGapsResult.value) {
+    const files = testGapsResult.value.data?.files ?? testGapsResult.value.files ?? [];
+    for (const gap of files) {
+      if (!gap.path) continue;
+      testGapsByPath.set(normalizePath(gap.path), gap);
+    }
+  }
+
+  // ── Normalize algedonic to a flat array, filter active + last 24h ──
+  let algedonicRecords: AlgedonicRecord[] = [];
+  if (algedonicResult.status === 'fulfilled' && algedonicResult.value) {
+    const raw = algedonicResult.value;
+    if (Array.isArray(raw)) algedonicRecords = raw;
+    else if ('signals' in raw && Array.isArray(raw.signals)) algedonicRecords = raw.signals;
+    else if ('data' in raw && Array.isArray(raw.data)) algedonicRecords = raw.data;
+  }
+  const cutoffMs = Date.now() - 24 * 60 * 60 * 1000;
+  algedonicRecords = algedonicRecords.filter(s => {
+    if (s.status && s.status !== 'active') return false;
+    if (s.timestamp) {
+      const ts = new Date(s.timestamp).getTime();
+      if (isFinite(ts) && ts < cutoffMs) return false;
+    }
+    return true;
+  });
+
+  // ── Merge onto nodes ──
+  const enrichedNodes = graph.nodes.map((node): GovernanceNode => {
+    const filePath = node.filePath;
+    const aug: NodeAugmentation = {};
+
+    if (filePath && annotationsByPath.size > 0) {
+      const matched: AnnotationRecord[] = [];
+      const nKey = normalizePath(filePath);
+      // Direct hit
+      const direct = annotationsByPath.get(nKey);
+      if (direct) matched.push(...direct);
+      // Suffix matches either direction
+      for (const [key, anns] of annotationsByPath) {
+        if (key === nKey) continue;
+        if (pathsMatch(key, filePath)) matched.push(...anns);
+      }
+      if (matched.length > 0) {
+        const by_truth_value: Partial<Record<HexavalentTruth, number>> = {};
+        for (const a of matched) {
+          by_truth_value[a.truth_value] = (by_truth_value[a.truth_value] ?? 0) + 1;
+        }
+        const recent = matched.slice(-5).reverse().map(a => ({
+          claim: a.claim,
+          kind: a.kind,
+          certainty: a.certainty,
+          truth_value: a.truth_value,
+          line_start: a.location.line_start,
+          line_end: a.location.line_end,
+        }));
+        aug.annotations = {
+          total: matched.length,
+          by_truth_value,
+          dominant: dominantTruth(by_truth_value),
+          recent,
+        };
+      }
+    }
+
+    if (filePath && testGapsByPath.size > 0) {
+      const nKey = normalizePath(filePath);
+      let gap = testGapsByPath.get(nKey);
+      if (!gap) {
+        for (const [key, g] of testGapsByPath) {
+          if (pathsMatch(key, filePath)) { gap = g; break; }
+        }
+      }
+      if (gap) {
+        aug.testGap = {
+          risk_score: Math.max(0, Math.min(1, gap.risk_score)),
+          churn: gap.churn,
+          complexity: gap.complexity,
+        };
+      }
+    }
+
+    if (algedonicRecords.length > 0) {
+      const recentSignals: NonNullable<NodeAugmentation['algedonic']>['recent'] = [];
+      for (const s of algedonicRecords) {
+        const matchesNode =
+          (s.nodeId && s.nodeId === node.id) ||
+          (s.source && filePath && pathsMatch(s.source, filePath)) ||
+          (s.source && s.source === node.id);
+        if (matchesNode) {
+          recentSignals.push({
+            id: s.id ?? '',
+            signal: s.signal ?? '',
+            type: s.type ?? 'pain',
+            severity: s.severity ?? 'info',
+            timestamp: s.timestamp ?? '',
+          });
+        }
+      }
+      if (recentSignals.length > 0) {
+        // Newest first, cap at 3
+        recentSignals.sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
+        aug.algedonic = { recent: recentSignals.slice(0, 3) };
+      }
+    }
+
+    // Only attach augmentation if at least one channel populated
+    if (aug.annotations || aug.testGap || aug.algedonic) {
+      return { ...node, augmentation: aug };
+    }
+    return node;
+  });
+
+  return { ...graph, nodes: enrichedNodes };
 }

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/DetailPanel.tsx
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/DetailPanel.tsx
@@ -2,10 +2,201 @@
 // React side panel showing selected governance node details
 
 import React, { useState, useCallback } from 'react';
-import type { GovernanceNode, GovernanceNodeType, FileTreeNode } from './types';
-import { HEALTH_COLORS, NODE_COLORS } from './types';
+import type { GovernanceNode, GovernanceNodeType, FileTreeNode, NodeAugmentation, HexavalentTruth } from './types';
+import { HEALTH_COLORS, NODE_COLORS, HEXAVALENT_COLORS } from './types';
 import { getHealthStatus } from './DataLoader';
 import type { GraphIndex } from './DataLoader';
+
+// ---------------------------------------------------------------------------
+// Dashboard channel sections — AI annotations / test coverage / algedonic
+// Collapsed <details> by default. Each gracefully handles missing
+// augmentation: shows "no data" inline when the channel is undefined.
+// ---------------------------------------------------------------------------
+
+const TRUTH_ORDER: HexavalentTruth[] = ['T', 'P', 'U', 'D', 'F', 'C'];
+
+const summaryStyle: React.CSSProperties = {
+  cursor: 'pointer',
+  fontSize: 11,
+  color: '#8b949e',
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+  padding: '6px 0',
+  userSelect: 'none',
+};
+
+const sectionStyle: React.CSSProperties = {
+  borderTop: '1px solid #21262d',
+  paddingTop: 4,
+  marginTop: 8,
+};
+
+const AnnotationsSection: React.FC<{ augmentation?: NodeAugmentation }> = ({ augmentation }) => {
+  const ann = augmentation?.annotations;
+  const total = ann?.total ?? 0;
+  return (
+    <details style={sectionStyle}>
+      <summary style={summaryStyle}>AI Annotations ({total})</summary>
+      <div style={{ padding: '6px 0 10px' }}>
+        {!ann ? (
+          <div style={{ fontSize: 11, color: '#484f58' }}>No annotations for this node.</div>
+        ) : (
+          <>
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 8 }}>
+              {TRUTH_ORDER.map(tv => {
+                const count = ann.by_truth_value[tv] ?? 0;
+                const color = HEXAVALENT_COLORS[tv];
+                const active = count > 0;
+                return (
+                  <span
+                    key={tv}
+                    title={`${tv}: ${count}`}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      fontSize: 10,
+                      fontFamily: 'monospace',
+                      background: active ? `${color}22` : 'transparent',
+                      color: active ? color : '#484f58',
+                      border: `1px solid ${active ? `${color}66` : '#21262d'}`,
+                      borderRadius: 4,
+                      padding: '2px 6px',
+                      opacity: active ? 1 : 0.5,
+                    }}
+                  >
+                    <span style={{ fontWeight: 'bold' }}>{tv}</span>
+                    <span>{count}</span>
+                  </span>
+                );
+              })}
+            </div>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {ann.recent.map((a, i) => (
+                <li
+                  key={`${a.line_start}-${i}`}
+                  style={{
+                    fontSize: 11,
+                    padding: '4px 6px',
+                    marginBottom: 3,
+                    background: '#0d1117',
+                    border: `1px solid ${HEXAVALENT_COLORS[a.truth_value]}33`,
+                    borderLeft: `3px solid ${HEXAVALENT_COLORS[a.truth_value]}`,
+                    borderRadius: 3,
+                  }}
+                >
+                  <div style={{ display: 'flex', gap: 6, fontSize: 9, color: '#8b949e', marginBottom: 2 }}>
+                    <span style={{ color: HEXAVALENT_COLORS[a.truth_value], fontWeight: 'bold' }}>{a.truth_value}</span>
+                    <span>{a.kind}</span>
+                    <span>conf:{a.certainty}</span>
+                    <span style={{ marginLeft: 'auto' }}>L{a.line_start}{a.line_start !== a.line_end ? `-${a.line_end}` : ''}</span>
+                  </div>
+                  <div style={{ color: '#e6edf3' }}>{a.claim}</div>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    </details>
+  );
+};
+
+const TestCoverageSection: React.FC<{ augmentation?: NodeAugmentation }> = ({ augmentation }) => {
+  const gap = augmentation?.testGap;
+  return (
+    <details style={sectionStyle}>
+      <summary style={summaryStyle}>Test Coverage</summary>
+      <div style={{ padding: '6px 0 10px' }}>
+        {!gap ? (
+          <div style={{ fontSize: 11, color: '#484f58' }}>No test-gap data for this node.</div>
+        ) : (() => {
+          const riskPct = Math.round(gap.risk_score * 100);
+          const barColor = riskPct < 33 ? '#33CC66' : riskPct < 66 ? '#FFB300' : '#FF4444';
+          return (
+            <>
+              <div style={{
+                height: 6,
+                background: '#161b22',
+                borderRadius: 3,
+                overflow: 'hidden',
+                marginBottom: 4,
+              }}>
+                <div style={{
+                  width: `${riskPct}%`,
+                  height: '100%',
+                  background: barColor,
+                  transition: 'width 0.3s ease',
+                }} />
+              </div>
+              <div style={{ display: 'flex', gap: 12, fontSize: 11, color: '#8b949e' }}>
+                <span>risk <span style={{ color: barColor, fontWeight: 600 }}>{riskPct}%</span></span>
+                <span>churn <span style={{ color: '#e6edf3' }}>{gap.churn}</span></span>
+                <span>cx <span style={{ color: '#e6edf3' }}>{gap.complexity}</span></span>
+              </div>
+            </>
+          );
+        })()}
+      </div>
+    </details>
+  );
+};
+
+function formatAge(ts: string): string {
+  if (!ts) return '';
+  const ms = Date.now() - new Date(ts).getTime();
+  if (!isFinite(ms) || ms < 0) return '';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+const RecentAlgedonicSection: React.FC<{ augmentation?: NodeAugmentation }> = ({ augmentation }) => {
+  const recent = augmentation?.algedonic?.recent ?? [];
+  return (
+    <details style={sectionStyle}>
+      <summary style={summaryStyle}>Recent Algedonic ({recent.length})</summary>
+      <div style={{ padding: '6px 0 10px' }}>
+        {recent.length === 0 ? (
+          <div style={{ fontSize: 11, color: '#484f58' }}>No recent signals.</div>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {recent.map(s => {
+              const sevColor =
+                s.severity === 'emergency' ? '#FF4444' :
+                s.severity === 'warning' ? '#FFB300' :
+                s.type === 'pleasure' ? '#FFD700' : '#8b949e';
+              return (
+                <li
+                  key={s.id || `${s.signal}-${s.timestamp}`}
+                  style={{
+                    fontSize: 11,
+                    padding: '4px 6px',
+                    marginBottom: 3,
+                    background: '#0d1117',
+                    borderLeft: `3px solid ${sevColor}`,
+                    borderRadius: 3,
+                    display: 'flex',
+                    gap: 6,
+                    alignItems: 'center',
+                  }}
+                >
+                  <span style={{ color: sevColor, fontSize: 9, fontWeight: 'bold', textTransform: 'uppercase' }}>{s.severity}</span>
+                  <span style={{ color: '#e6edf3', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.signal}</span>
+                  <span style={{ color: '#484f58', fontSize: 10 }}>{formatAge(s.timestamp)}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </details>
+  );
+};
 
 // ---------------------------------------------------------------------------
 // Props
@@ -430,6 +621,11 @@ export const DetailPanel: React.FC<DetailPanelProps> = ({
                 </div>
               </div>
             )}
+
+            {/* Dashboard channels — AI annotations / test coverage / algedonic */}
+            <AnnotationsSection augmentation={node.augmentation} />
+            <TestCoverageSection augmentation={node.augmentation} />
+            <RecentAlgedonicSection augmentation={node.augmentation} />
           </div>
         </>
       )}

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/ForceRadiant.tsx
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/ForceRadiant.tsx
@@ -13,9 +13,9 @@ import { createVolumetricCoreMaterialTSL } from './shaders/VolumetricCoreTSL';
 import { createSkyboxNebulaMaterialTSL } from './shaders/SkyboxNebulaTSL';
 import { createMilkyWayTextureMaterial } from './shaders/MilkyWayTextureTSL';
 import { resolveTexturePath } from '../../assets/space';
-import type { GovernanceGraph, GovernanceNode, GovernanceNodeType } from './types';
-import { HEALTH_COLORS, HEALTH_STATUS_COLORS, type GovernanceHealthStatus } from './types';
-import { loadGovernanceData, loadGovernanceDataAsync, getHealthStatus, startLivePolling, updateNodeHealth, type LivePollingHandle, type ViewerInfo, type CameraSyncData } from './DataLoader';
+import type { GovernanceGraph, GovernanceNode, GovernanceNodeType, NodeAugmentation } from './types';
+import { HEALTH_COLORS, HEALTH_STATUS_COLORS, HEXAVALENT_COLORS, type GovernanceHealthStatus } from './types';
+import { loadGovernanceData, loadGovernanceDataAsync, getHealthStatus, startLivePolling, updateNodeHealth, enrichNodesWithDevData, type LivePollingHandle, type ViewerInfo, type CameraSyncData } from './DataLoader';
 import { JurisdictionLegend } from './JurisdictionLegend';
 import { KeyboardLegend } from './KeyboardLegend';
 import { AuthProvider } from './AuthContext';
@@ -196,10 +196,12 @@ interface GraphNode extends NodeObject {
   val: number;        // size factor
   repo?: string;
   version?: string;
+  filePath?: string;  // needed for algedonic pulse matching by source path
   health?: GovernanceNode['health'];
   healthStatus?: GovernanceHealthStatus;
   children?: string[];
   metadata?: Record<string, unknown>;
+  augmentation?: NodeAugmentation; // dashboard channels — rim/halo/pulse data
   // force-graph adds these at runtime:
   x?: number;
   y?: number;
@@ -602,6 +604,45 @@ function createNodeObject(node: GraphNode): THREE.Object3D {
     group.userData._uncertaintyHalo = halo;
   }
 
+  // ── Dashboard channels ──
+  // 5. Hexavalent truth-value rim — thin ring around the node colored by the
+  // dominant AI-annotation truth-value. Always rendered (default U=gray)
+  // so the channel is visible even before enrichment lands.
+  const dominant = node.augmentation?.annotations?.dominant ?? 'U';
+  const rimColorHex = HEXAVALENT_COLORS[dominant];
+  const rimGeo = new THREE.RingGeometry(radius * 1.15, radius * 1.28, 48);
+  const rimMat = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(rimColorHex),
+    transparent: true,
+    opacity: node.augmentation?.annotations ? 0.85 : 0.25, // dim when no annotations
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+  });
+  const rim = new THREE.Mesh(rimGeo, rimMat);
+  rim.userData = { isDashboardRim: true };
+  group.add(rim);
+  group.userData._dashboardRim = rim;
+
+  // 6. Test-coverage halo — semi-transparent sphere; opacity = 1 - risk_score.
+  // Larger radius than the rim, additive blending so it reads as a glow.
+  // No augmentation yet → opacity 0 (invisible until data lands).
+  const haloOpacity = node.augmentation?.testGap
+    ? Math.max(0, Math.min(1, 1 - node.augmentation.testGap.risk_score)) * 0.35
+    : 0;
+  const coverageGeo = new THREE.SphereGeometry(radius * 1.6, 16, 12);
+  const coverageMat = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(0x66ff99), // soft green — "covered" reads positive
+    transparent: true,
+    opacity: haloOpacity,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+  });
+  const coverageHalo = new THREE.Mesh(coverageGeo, coverageMat);
+  coverageHalo.userData = { isCoverageHalo: true };
+  group.add(coverageHalo);
+  group.userData._coverageHalo = coverageHalo;
+
   return group;
 }
 
@@ -646,10 +687,12 @@ function toForceData(graph: GovernanceGraph): { nodes: GraphNode[]; links: Graph
     val: TYPE_SIZE[n.type] ?? 5,
     repo: n.repo,
     version: n.version,
+    filePath: n.filePath,
     health: n.health,
     healthStatus: n.healthStatus,
     children: n.children,
     metadata: n.metadata,
+    augmentation: n.augmentation,
   }));
 
   const links: GraphLink[] = graph.edges.map((e) => ({
@@ -1382,6 +1425,41 @@ export const ForceRadiant: React.FC<ForceRadiantProps> = ({
     const now = Date.now() * 0.001;
     const signalColor = signal.type === 'pain' ? '#FF4444' : '#FFD700';
 
+    // ─── Dashboard channel: 5-second glow pulse on the matching node ───
+    // Match by id OR by source path against node.filePath/id. Set pulseUntil
+    // so the tick loop can ease the glow back to baseline.
+    {
+      const graphNodes = (fg.graphData() as { nodes: GraphNode[] }).nodes;
+      const pulseUntil = Date.now() + 5000;
+      const matchSource = (signal.source ?? '').toLowerCase().replace(/\\/g, '/');
+      const matchNodeId = signal.nodeId;
+      for (const n of graphNodes) {
+        const nFilePath = n.filePath?.toLowerCase().replace(/\\/g, '/');
+        const matches =
+          (matchNodeId && n.id === matchNodeId) ||
+          (matchSource && nFilePath && (matchSource === nFilePath ||
+            matchSource.endsWith('/' + nFilePath) || nFilePath.endsWith('/' + matchSource))) ||
+          (matchSource && matchSource === n.id);
+        if (matches) {
+          if (!n.augmentation) n.augmentation = {};
+          const existingRecent = n.augmentation.algedonic?.recent ?? [];
+          n.augmentation.algedonic = {
+            recent: [
+              {
+                id: signal.id,
+                signal: signal.signal,
+                type: signal.type,
+                severity: signal.severity,
+                timestamp: signal.timestamp,
+              },
+              ...existingRecent,
+            ].slice(0, 3),
+            pulseUntil,
+          };
+        }
+      }
+    }
+
     // ─── Unit 4: Node ripple ───
     if (signal.nodeId) {
       const graphNodes = (fg.graphData() as { nodes: GraphNode[] }).nodes;
@@ -1459,10 +1537,20 @@ export const ForceRadiant: React.FC<ForceRadiantProps> = ({
     // Load data — try API first, fall back to static
     const initGraph = async () => {
       // Pre-load GLB models in parallel with governance data
-      const [graph] = await Promise.all([
+      const [baseGraph] = await Promise.all([
         liveDataUrl ? loadGovernanceDataAsync(liveDataUrl) : Promise.resolve(loadGovernanceData(data)),
         preloadBorgCubeModel(), // loads /models/borg-cube.glb if present
       ]);
+      if (disposed) return;
+
+      // Augment with dev-dashboard channels (annotations / test-gaps / algedonic).
+      // Fault-tolerant: any failure here is logged and the base graph renders as-is.
+      let graph = baseGraph;
+      try {
+        graph = await enrichNodesWithDevData(baseGraph);
+      } catch (err) {
+        console.warn('[PrimeRadiant] Dev-data enrichment failed, rendering base graph:', err);
+      }
       if (disposed) return;
       initScene(graph);
     };
@@ -2230,6 +2318,53 @@ export const ForceRadiant: React.FC<ForceRadiantProps> = ({
         const cachedHalo = group.userData._uncertaintyHalo as THREE.Mesh | undefined;
         if (cachedHalo) {
           updateUncertaintyHalo(cachedHalo, t, phase);
+        }
+
+        // ── Dashboard channels: rim + coverage halo + algedonic pulse ──
+        // Pulse: when a recent algedonic signal targeted this node, multiply
+        // its rim+halo opacity by 1.8 for 5s, then linearly ease to 1.0 over
+        // the last 1s of the window. After that, return to baseline.
+        let pulseMultiplier = 1.0;
+        const pulseUntil = n.augmentation?.algedonic?.pulseUntil;
+        if (pulseUntil) {
+          const nowMs = Date.now();
+          const remaining = pulseUntil - nowMs;
+          if (remaining > 0) {
+            // Last 1000 ms: linear ease from 1.8 → 1.0
+            pulseMultiplier = remaining < 1000
+              ? 1.0 + 0.8 * (remaining / 1000)
+              : 1.8;
+          } else {
+            // Pulse window closed — clear so we don't keep recomputing
+            if (n.augmentation?.algedonic) n.augmentation.algedonic.pulseUntil = undefined;
+          }
+        }
+
+        // Rim: keep color in sync with dominant truth-value (data may have
+        // arrived after the node was created with the default U=gray rim).
+        const cachedRim = group.userData._dashboardRim as THREE.Mesh | undefined;
+        if (cachedRim) {
+          const rimMat = cachedRim.material as THREE.MeshBasicMaterial;
+          const dominant = n.augmentation?.annotations?.dominant ?? 'U';
+          const targetHex = HEXAVALENT_COLORS[dominant];
+          const currentHex = '#' + rimMat.color.getHexString();
+          if (currentHex.toLowerCase() !== targetHex.toLowerCase()) {
+            rimMat.color.set(targetHex);
+          }
+          const baseOpacity = n.augmentation?.annotations ? 0.85 : 0.25;
+          rimMat.opacity = Math.min(1, baseOpacity * pulseMultiplier);
+          // Counter-rotate so rim always faces camera-ish — billboard via lookAt
+          cachedRim.quaternion.copy(fg.camera().quaternion);
+        }
+
+        // Coverage halo: opacity = (1 - risk_score) * 0.35, pulse-modulated.
+        const cachedCoverage = group.userData._coverageHalo as THREE.Mesh | undefined;
+        if (cachedCoverage) {
+          const covMat = cachedCoverage.material as THREE.MeshBasicMaterial;
+          const baseHaloOpacity = n.augmentation?.testGap
+            ? Math.max(0, Math.min(1, 1 - n.augmentation.testGap.risk_score)) * 0.35
+            : 0;
+          covMat.opacity = Math.min(1, baseHaloOpacity * pulseMultiplier);
         }
 
         // ── Governance Redshift / Blueshift — compliance drift as color shift ──

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/IxqlFormPanel.tsx
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/IxqlFormPanel.tsx
@@ -9,6 +9,7 @@ import type { FormFieldDef } from './IxqlControlParser';
 import { signalBus, useSignals } from './DashboardSignalBus';
 import { generateFormProof, publishRenderProof } from './RenderProof';
 import { isValidTransition, publishTransition, type HexavalentValue } from './HexavalentTemporal';
+import { HEXAVALENT_COLORS } from './types';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -19,17 +20,8 @@ export interface IxqlFormPanelProps {
 }
 
 // ---------------------------------------------------------------------------
-// Hexavalent colors
+// Hexavalent labels (colors imported from ./types for shared use)
 // ---------------------------------------------------------------------------
-
-const HEXAVALENT_COLORS: Record<string, string> = {
-  T: '#22c55e',
-  P: '#a3e635',
-  U: '#6b7280',
-  D: '#f97316',
-  F: '#ef4444',
-  C: '#d946ef',
-};
 
 const HEXAVALENT_LABELS: Record<string, string> = {
   T: 'True',

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/PrimeRadiant.tsx
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/PrimeRadiant.tsx
@@ -4,7 +4,7 @@
 import React, { Component, useCallback, useEffect, useRef, useState } from 'react';
 import type { GovernanceGraph, GovernanceNode, PrimeRadiantProps } from './types';
 import { NODE_COLORS, HEALTH_COLORS } from './types';
-import { loadGovernanceData, buildGraphIndex, searchNodes, getHealthStatus } from './DataLoader';
+import { loadGovernanceData, buildGraphIndex, searchNodes, getHealthStatus, enrichNodesWithDevData } from './DataLoader';
 import type { GraphIndex } from './DataLoader';
 import { RadiantEngine } from './RadiantEngine';
 import { DetailPanel } from './DetailPanel';
@@ -144,6 +144,15 @@ export const PrimeRadiant: React.FC<PrimeRadiantProps> = ({
       const graph = loadGovernanceData(data);
       setGraphData(graph);
       setGraphIndex(buildGraphIndex(graph));
+
+      // Augment with dev-dashboard channels (annotations / test-gaps / algedonic).
+      // Fault-tolerant: any failure is logged and the base graph stays rendered.
+      enrichNodesWithDevData(graph)
+        .then(enriched => {
+          setGraphData(enriched);
+          setGraphIndex(buildGraphIndex(enriched));
+        })
+        .catch(err => console.warn('[PrimeRadiant] Dev-data enrichment failed:', err));
 
       const handleNodeSelect = (node: GovernanceNode | null) => {
         setSelectedNode(node);

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/types.ts
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/types.ts
@@ -53,6 +53,53 @@ export interface FileTreeNode {
 }
 
 // ---------------------------------------------------------------------------
+// Hexavalent truth-value palette — shared between IxqlFormPanel and the
+// node-level "truth-value rim" channel on the Prime Radiant 3D viz.
+// Matches Demerzel/hexavalent-distribution.schema.json.
+// ---------------------------------------------------------------------------
+export type HexavalentTruth = 'T' | 'P' | 'U' | 'D' | 'F' | 'C';
+
+export const HEXAVALENT_COLORS: Record<HexavalentTruth, string> = {
+  T: '#22c55e',  // True — green
+  P: '#a3e635',  // Probable — lime
+  U: '#6b7280',  // Unknown — gray
+  D: '#f97316',  // Doubtful — orange
+  F: '#ef4444',  // False — red
+  C: '#d946ef',  // Contradictory — magenta
+};
+
+// ---------------------------------------------------------------------------
+// Dashboard augmentation — joined from dev-data endpoints
+// (AI annotations, sentrux test-gaps, algedonic signals) and merged onto
+// governance nodes by suffix-matching filePath. All fields are optional;
+// any failing fetch leaves its channel undefined on every node.
+// ---------------------------------------------------------------------------
+export interface NodeAugmentation {
+  annotations?: {
+    total: number;
+    by_truth_value: Partial<Record<HexavalentTruth, number>>;
+    dominant: HexavalentTruth | null;   // most frequent (ties → C if any, else worst of F/D/U/P/T)
+    recent: Array<{
+      claim: string;
+      kind: string;
+      certainty: string;
+      truth_value: HexavalentTruth;
+      line_start: number;
+      line_end: number;
+    }>;
+  };
+  testGap?: {
+    risk_score: number;       // 0..1
+    churn: number;
+    complexity: number;
+  };
+  algedonic?: {
+    recent: Array<{ id: string; signal: string; type: 'pain' | 'pleasure'; severity: string; timestamp: string }>;
+    pulseUntil?: number;      // unix ms — when the visual pulse should end
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Graph data structures
 // ---------------------------------------------------------------------------
 export interface GovernanceNode {
@@ -72,6 +119,7 @@ export interface GovernanceNode {
   scale?: number;                // LOD depth — 0=root, 1=constitution-articles, 2=clauses...
   metadata?: Record<string, unknown>;
   fileTree?: FileTreeNode[];
+  augmentation?: NodeAugmentation; // dev-dashboard channels (annotations / test-gaps / algedonic)
 }
 
 export interface GovernanceEdge {


### PR DESCRIPTION
## Summary
- Three node-level visual channels on Prime Radiant (`/test/prime-radiant`): hexavalent truth-value rim, test-coverage halo opacity, algedonic pulse.
- Three new DetailPanel sections: AI Annotations chips, Test Coverage bar, Recent Algedonic signals.
- Existing health-driven encoding (size/glow/particle-count) preserved unchanged — the three new channels stack on top.

## Design notes
- Hexavalent palette (T/P/U/D/F/C) promoted from \`IxqlFormPanel.tsx\` into \`types.ts\` for shared use.
- Path matching from dev-data endpoints to governance nodes is suffix-based, case-insensitive (handles backslash normalization).
- \`Promise.allSettled\` for the three dev-data fetches — any single failure leaves its channel undefined without blocking the base graph render.
- Contradictory truth value (\`C\`) wins the dominant-vote tie-break per Demerzel hexavalent semantics.

## What this does NOT do
- Does not add a production-API mirror for \`/dev-data/*\` endpoints. Prime Radiant is a dev/demo surface; if/when needed, mirror in \`GaApi/Controllers/DevDataController.cs\`.
- Does not visualize annotations on edges or globally — node-level only.
- Does not modify the existing health-status color tint, glow, or particle-count rules.

## Test plan
- [ ] Navigate to \`https://demos.guitaralchemist.com/test/prime-radiant?node=constitution-asimov.constitution\` and confirm: rim color visible, halo present if any annotations exist, panel sections render.
- [ ] Trigger algedonic signal via \`/test#dev/algedonic\` (test action button) and confirm a transient pulse appears on the matching node.
- [ ] Open DevTools, force \`/dev-data/sentrux/test-gaps\` to 500 — confirm graph still renders, halo simply absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)