### PR TITLE
chore(dashboard): emit canonical envelope from readme-drift + voicing-analysis producers

### DIFF
--- a/Demos/VoicingAnalysisAudit/Program.cs
+++ b/Demos/VoicingAnalysisAudit/Program.cs
@@ -653,6 +653,154 @@ internal static class Program
     }
 
     // ================================================================
+    // CANONICAL DASHBOARD ENVELOPE
+    // ================================================================
+    // Wraps an AuditReport with the canonical envelope consumed by
+    // ReactComponents/ga-react-components/vite.config.ts `gatherQuality`
+    // (rendered as the voicing-analysis tile on /test#dev/summary).
+    //
+    // Mapping (per task brief 2026-05-24):
+    //   all 4 metrics at 100% / 0 failures → "ok"
+    //   any failure / metric < 100%        → "warn"
+    //   catastrophic (metric == 0)         → "error"
+    //
+    // The 4 metrics tracked:
+    //   1. Forte coverage (Pct)            — should be 100
+    //   2. Cross-instrument consistency    — Consistent / SharedSets
+    //   3. Chord recognition completeness  — 100 - NullChordName.Pct
+    //   4. Invariant cleanliness           — 0 failures across all 4 invariants
+    //
+    // metric_value is the AVERAGE of these 4 pass-rates as a 0..1 ratio.
+    private sealed record EnvelopeReport(
+        // ─── Canonical dashboard envelope (additive — ALL existing
+        // AuditReport fields are preserved verbatim below) ───
+        string domain,
+        string emitted_at,
+        string metric_name,
+        double metric_value,
+        string oracle_status,
+        string summary,
+        List<EnvelopeProblem> problems,
+        // ─── Original AuditReport, unwrapped and embedded ───
+        string Timestamp,
+        CorpusSection Corpus,
+        ChordRecognitionSection ChordRecognition,
+        HarmonicFunctionSection HarmonicFunction,
+        ForteCoverageSection ForteCoverage,
+        Dictionary<string, int> DropVoicingDistribution,
+        ConsistencySection CrossInstrumentConsistency,
+        Dictionary<string, int> CardinalityDistribution,
+        int TwoNoteWithChordName,
+        InvariantFailureSection InvariantFailures,
+        List<AnalyzerException> AnalyzerExceptions,
+        PerformanceSection Performance,
+        IssueSamplesSection IssueSamples);
+
+    private sealed record EnvelopeProblem(string metric, string detail);
+
+    private static EnvelopeReport WrapWithEnvelope(AuditReport r)
+    {
+        // Metric 1: Forte coverage — already a percentage (0..100).
+        var fortePct = r.ForteCoverage.Pct;
+        // Metric 2: Cross-instrument consistency — guard against div-by-zero.
+        var consistencyPct = r.CrossInstrumentConsistency.SharedSets > 0
+            ? 100.0 * r.CrossInstrumentConsistency.Consistent / r.CrossInstrumentConsistency.SharedSets
+            : 100.0;
+        // Metric 3: Chord recognition completeness — null/unknown are bad.
+        var totalRecognized = r.Corpus.Total;
+        var unrecognized = r.ChordRecognition.NullChordName.Count + r.ChordRecognition.UnknownChordName.Count;
+        var recognitionPct = totalRecognized > 0
+            ? 100.0 * (totalRecognized - unrecognized) / totalRecognized
+            : 100.0;
+        // Metric 4: Invariant cleanliness — binary; 100% if all four counters
+        // are zero, else degrade by share of the corpus that tripped any check.
+        var invFails = r.InvariantFailures.MidiNotesMismatch
+                       + r.InvariantFailures.NullPitchClassSet
+                       + r.InvariantFailures.NegativePhysicalLayout
+                       + r.InvariantFailures.IntervalSpreadInvariant;
+        var invariantPct = totalRecognized > 0
+            ? Math.Max(0.0, 100.0 - 100.0 * invFails / totalRecognized)
+            : 100.0;
+
+        // Headline metric: simple unweighted average of the 4 pass-rates,
+        // normalised to 0..1. Documented in the PR body.
+        var avgPct = (fortePct + consistencyPct + recognitionPct + invariantPct) / 4.0;
+        var metricValue = Math.Round(avgPct / 100.0, 4);
+
+        // Status mapping. "catastrophic" = any single metric collapsed to 0,
+        // OR the analyzer itself threw exceptions on at least one voicing.
+        const double EPS = 1e-9;
+        var catastrophic = fortePct <= EPS || recognitionPct <= EPS
+                           || invariantPct <= EPS || r.AnalyzerExceptions.Count > 0;
+        var anyDegradation = fortePct < 100.0 || consistencyPct < 100.0
+                             || recognitionPct < 100.0 || invFails > 0;
+        var oracleStatus = catastrophic ? "error"
+            : anyDegradation ? "warn"
+            : "ok";
+
+        // problems[] — at most 50; only non-passing metrics.
+        var problems = new List<EnvelopeProblem>(4);
+        if (fortePct < 100.0)
+        {
+            problems.Add(new EnvelopeProblem(
+                "forte_coverage",
+                $"{r.ForteCoverage.Resolved}/{r.ForteCoverage.Total} resolved ({fortePct:N3}%)"));
+        }
+        if (r.CrossInstrumentConsistency.SharedSets > 0
+            && r.CrossInstrumentConsistency.Consistent < r.CrossInstrumentConsistency.SharedSets)
+        {
+            problems.Add(new EnvelopeProblem(
+                "cross_instrument_consistency",
+                $"{r.CrossInstrumentConsistency.Consistent}/{r.CrossInstrumentConsistency.SharedSets} sets consistent ({consistencyPct:N2}%)"));
+        }
+        if (unrecognized > 0)
+        {
+            problems.Add(new EnvelopeProblem(
+                "chord_recognition",
+                $"{unrecognized} unrecognized ({r.ChordRecognition.NullChordName.Count} null + {r.ChordRecognition.UnknownChordName.Count} \"Unknown\")"));
+        }
+        if (invFails > 0)
+        {
+            problems.Add(new EnvelopeProblem(
+                "invariant_failures",
+                $"midi_mismatch={r.InvariantFailures.MidiNotesMismatch} null_pcs={r.InvariantFailures.NullPitchClassSet} neg_physical={r.InvariantFailures.NegativePhysicalLayout} interval_spread={r.InvariantFailures.IntervalSpreadInvariant}"));
+        }
+        if (r.AnalyzerExceptions.Count > 0)
+        {
+            problems.Add(new EnvelopeProblem(
+                "analyzer_exceptions",
+                $"{r.AnalyzerExceptions.Count} voicings threw during analysis"));
+        }
+        if (problems.Count > 50) problems = problems.GetRange(0, 50);
+
+        var summary = oracleStatus == "ok"
+            ? $"All 4 voicing metrics at 100% across {r.Corpus.Total:N0} voicings."
+            : $"{problems.Count} metric(s) below target across {r.Corpus.Total:N0} voicings (avg={avgPct:N2}%).";
+
+        return new EnvelopeReport(
+            domain: "voicing-analysis",
+            emitted_at: DateTime.UtcNow.ToString("O"),
+            metric_name: "voicing_analysis_avg_pass_rate",
+            metric_value: metricValue,
+            oracle_status: oracleStatus,
+            summary: summary,
+            problems: problems,
+            Timestamp: r.Timestamp,
+            Corpus: r.Corpus,
+            ChordRecognition: r.ChordRecognition,
+            HarmonicFunction: r.HarmonicFunction,
+            ForteCoverage: r.ForteCoverage,
+            DropVoicingDistribution: r.DropVoicingDistribution,
+            CrossInstrumentConsistency: r.CrossInstrumentConsistency,
+            CardinalityDistribution: r.CardinalityDistribution,
+            TwoNoteWithChordName: r.TwoNoteWithChordName,
+            InvariantFailures: r.InvariantFailures,
+            AnalyzerExceptions: r.AnalyzerExceptions,
+            Performance: r.Performance,
+            IssueSamples: r.IssueSamples);
+    }
+
+    // ================================================================
     // STDOUT SUMMARY + JSON WRITER
     // ================================================================
     private static void PrintStdoutSummary(AuditReport report, string outputPath)
@@ -769,7 +917,12 @@ internal static class Program
             WriteIndented = true,
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
         };
-        File.WriteAllText(path, JsonSerializer.Serialize(report, options));
+        // Emit the canonical dashboard envelope at the top level (additive
+        // wrapper — every original AuditReport field is preserved verbatim
+        // inside the same JSON object). See WrapWithEnvelope for the
+        // oracle_status / metric_value derivation.
+        var envelope = WrapWithEnvelope(report);
+        File.WriteAllText(path, JsonSerializer.Serialize(envelope, options));
     }
 
     private static string Pad(string s, int w) => s.Length >= w ? s : s.PadRight(w);

--- a/ReactComponents/ga-react-components/src/pages/DevelopmentSection.tsx
+++ b/ReactComponents/ga-react-components/src/pages/DevelopmentSection.tsx
@@ -262,7 +262,13 @@ const QualityCard: React.FC = () => {
     const metricValue = d.metric_value as number | undefined;
     const oracleStatus = d.oracle_status as string | undefined;
     const emittedAt = d.emitted_at as string | undefined;
-    const summary = d.summary as string | undefined;
+    // Defensive narrowing: a few producers (notably readme-drift) keep a
+    // structured `summary` object for back-compat with their own consumers
+    // — coercing it via `as string` would crash React with "Objects are not
+    // valid as a React child". Only render `summary` when it's actually a
+    // string; otherwise leave it out of this row (the metric_value + chip
+    // still convey status).
+    const summary = typeof d.summary === 'string' ? d.summary : undefined;
     const problems = d.problems as unknown[] | undefined;
 
     const statusColor = oracleStatus === 'ok' ? 'success' : oracleStatus === 'warn' ? 'warning' : oracleStatus ? 'error' : 'default';

--- a/Scripts/readme-drift-survey.ps1
+++ b/Scripts/readme-drift-survey.ps1
@@ -78,6 +78,10 @@ function Get-DriftStatus([int]$days) {
 }
 
 $now = Get-Date
+# Canonical dashboard envelope fields (oracle_status, metric_*, emitted_at,
+# problems) are added at the end of the survey once counts are known. They
+# are ADDITIVE — the existing `summary` object stays as-is because the
+# readme-drift-sensor.yml workflow reads `$report.summary.total` etc.
 $report = [pscustomobject]@{
     schema_version = 1
     domain         = 'readme-drift'
@@ -151,6 +155,49 @@ foreach ($repo in $Repos) {
         'very-stale' { $report.summary.very_stale++ }
     }
 }
+
+# ── Canonical dashboard envelope (additive; consumed by
+#    ReactComponents/ga-react-components/vite.config.ts `gatherQuality`
+#    and rendered as the readme-drift tile on /test#dev/summary).
+#
+#    Mapping:
+#      very_stale>0 || absent>0 → "error"
+#      stale>0 || borderline>0  → "warn"
+#      else                     → "ok"
+#
+#    `metric_value` is the freshness ratio ok/total (0.0–1.0). `absent`
+#    repos are NOT in the denominator because the survey already classifies
+#    them separately (missing checkout, not stale content).
+$oracleStatus =
+    if ($report.summary.very_stale -gt 0 -or $report.summary.absent -gt 0) { 'error' }
+    elseif ($report.summary.stale -gt 0 -or $report.summary.borderline -gt 0) { 'warn' }
+    else { 'ok' }
+
+$metricValue =
+    if ($report.summary.total -gt 0) {
+        [math]::Round($report.summary.ok / $report.summary.total, 4)
+    } else { 0.0 }
+
+# Build problems list (capped at 50) for any repo that isn't `ok`.
+$problems = @()
+foreach ($r in $report.repos) {
+    if ($r.status -ne 'ok') {
+        $problems += [pscustomobject]@{
+            path   = $r.repo
+            status = $r.status
+        }
+    }
+    if ($problems.Count -ge 50) { break }
+}
+
+# Attach envelope fields at the TOP level (Add-Member is the idiomatic
+# way to extend a pscustomobject without rebuilding it). Order in JSON
+# is insertion order, so they appear after the existing fields.
+$report | Add-Member -NotePropertyName 'emitted_at'   -NotePropertyValue $now.ToUniversalTime().ToString('o')
+$report | Add-Member -NotePropertyName 'metric_name'  -NotePropertyValue 'readme_freshness_ratio'
+$report | Add-Member -NotePropertyName 'metric_value' -NotePropertyValue $metricValue
+$report | Add-Member -NotePropertyName 'oracle_status' -NotePropertyValue $oracleStatus
+$report | Add-Member -NotePropertyName 'problems'     -NotePropertyValue $problems
 
 $json = $report | ConvertTo-Json -Depth 5
 $json


### PR DESCRIPTION
## Summary
Two quality-snapshot producers (`readme-drift-survey.ps1` and `VoicingAnalysisAudit`) now emit the canonical envelope (`oracle_status`, `metric_value`, `domain`, `emitted_at`, `metric_name`, `problems`) at the top level of their JSON output. Both tiles should flip from DEGRADED (grey/default chip) to OK (green chip) on the next dashboard refresh, since their underlying data is already healthy — they just weren't speaking the dashboard's contract.

## Context
Per the 2026-05-24 triage report, several of the red tiles on `/test#dev/summary` aren't actually broken — the producers pre-date the canonical envelope. This PR fixes 2 of them (`invariants` is in the ix repo and lands separately).

## oracle_status mapping
| Producer | ok | warn | error |
|---|---|---|---|
| readme-drift | none stale, none absent | `stale>0` or `borderline>0` | `very_stale>0` or `absent>0` |
| voicing-analysis | all 4 metrics 100%, 0 failures, 0 analyzer exceptions | any single metric <100% OR invariant_failures>0 | any metric collapses to 0 OR analyzer exceptions >0 |

## headline metric_value
- **readme-drift**: `metric_name = "readme_freshness_ratio"`, `metric_value = ok / total` (0..1, excluding `absent` from denominator since those are missing-checkout, not stale content).
- **voicing-analysis**: `metric_name = "voicing_analysis_avg_pass_rate"`, `metric_value = avg(forte_pct, cross_instrument_consistency_pct, chord_recognition_pct, invariant_cleanliness_pct) / 100`. Documented in the code comment above `WrapWithEnvelope`. I picked an unweighted average over the four metrics tracked in the audit; happy to switch to weighted or to ForteCoverage alone if reviewers prefer a single headline.

## Additive constraint note (one deviation worth flagging)
The brief lists `summary` (string) as part of the canonical envelope. `readme-drift` already has a top-level `summary` field that is an OBJECT (`{total, ok, borderline, stale, very_stale, absent}`), and that object is consumed by `.github/workflows/readme-drift-sensor.yml` at `$report.summary.total`, `$report.summary.ok` etc. when generating the weekly tracking issue. Since the brief also says **do not touch `.github/workflows/`** AND **do not rename existing fields**, the only safe move is to omit the envelope `summary` STRING from `readme-drift` and let the existing object stay. `voicing-analysis` has no such collision and emits the canonical `summary` string normally.

Companion one-liner in `DevelopmentSection.tsx` narrows the cast of `d.summary` from `as string | undefined` to `typeof === 'string' ? d.summary : undefined`. Without this, React would throw \"Objects are not valid as a React child\" when rendering the readme-drift row — pre-existing latent bug surfaced once `oracle_status` is present and the row starts rendering normally.

## What this PR does NOT do
- `chatbot-qa` display fix — separate root cause per triage.
- `embeddings` index guard — GREEN-BUT-DEAD producer, separate PR.
- `ix-invariant-produce` envelope — separate ix repo PR.
- Dashboard schema enforcement (would be a follow-up).
- No `.github/workflows/` touched (per constraint).
- No `state/harness/items.json` touched.
- No `CLAUDE.md` / `AGENTS.md` / governance touched.

## Verification
- `dotnet build Demos/VoicingAnalysisAudit -c Debug` → 0 errors (build log clean modulo pre-existing IDE0028 style warnings).
- Local dry-run of `Scripts/readme-drift-survey.ps1` writes JSON with top-level `oracle_status`, `metric_name`, `metric_value`, `emitted_at`, `domain`, `problems`. Existing `summary` object preserved verbatim.
- Did NOT run VoicingAnalysisAudit end-to-end (requires OPTIC-K corpus + ~80s runtime — over the 2-minute skip threshold in the brief). Verified by code inspection that `WrapWithEnvelope(report)` is the only path through `WriteJsonReport`.

## Test plan
- [ ] Next CI run of `quality-snapshot.yml` writes `state/quality/voicing-analysis/<date>.json` with `oracle_status` at the top level.
- [ ] Next CI run of `readme-drift-sensor.yml` writes `state/quality/readme-drift/<date>.json` with `oracle_status` at the top level AND the existing `summary` object intact (sensor workflow still generates the tracking-issue body without errors).
- [ ] Dashboard tiles for `voicing-analysis` and `readme-drift` flip from default-grey to green/amber on next dashboard refresh.
- [ ] `ix-quality-trend` parses both new snapshots without error (additive-only, all existing fields preserved).

Generated with Claude Code