### PR TITLE
feat(chatbot): AFK harness — autonomous develop+QA loop with dashboard

### DIFF
--- a/.claude/skills/ga-chatbot-afk-harness/SKILL.md
+++ b/.claude/skills/ga-chatbot-afk-harness/SKILL.md
@@ -53,7 +53,10 @@ no editing protected paths; caps `max_commits_per_session=50`,
 ```
 A. NEVER push, open/merge a PR, deploy, or apply a review-bypass label.
    The harness produces COMMITS ON A BRANCH only. A human arms it and a
-   human (or a separate reviewed flow) lands it.
+   human (or a separate reviewed flow) lands it. This includes DELEGATED
+   flows: /auto-optimize's Step 4 normally runs `gh pr create` after a batch
+   — when the harness invokes it you MUST suppress that (see Step 2.0), so an
+   unattended run never opens a PR behind your back.
 B. NEVER fabricate a metric. If the backend is unreachable, emit a
    `blocked` status with the real reason and STOP. A degraded run is
    recorded honestly, never as pass_pct=100%.
@@ -76,21 +79,39 @@ C. EMIT status via Scripts/afk-harness-status.ps1 at every phase boundary
    per `docs/runbooks/chatbot-deploy.md`, then re-arm.)
 4. Create/checkout `branch`. Emit `state=running phase=qa-snapshot branch=<branch>`.
 
+> **SCALE — read this first.** Both oracles report `pass_pct` on a **0..100**
+> scale (e.g. `94`, `100`). `target_metric`, `afk-harness-status.ps1 -DetPct/-SemPct`,
+> and the dashboard are all **0..1 fractions**. So you MUST divide every
+> `pass_pct` by 100 before comparing it to `target_metric` or passing it to the
+> status writer. Skipping this makes `94 >= 0.97` true and the harness exits
+> "done" on a 94% run (and the dashboard shows 9400%). Always normalize.
+
 ### Step 1 — Baseline QA snapshot
 1. Run the deterministic oracle: `pwsh Scripts/run-prompt-corpus.ps1 -Snapshot`.
-   Read the resulting `pass_pct` → `-DetPct`.
-2. If `semantic=true`: run the `/ga-chatbot-qa-panel` workflow; read
-   `state/quality/chatbot-qa-semantic/<date>.json` `pass_pct` → `-SemPct`.
-3. Emit `phase=qa-snapshot` with both metrics + `target_metric`. If
-   `DetPct >= target_metric` already → skip to Step 3 (done).
+   Read `pass_pct` (0..100) from the snapshot and compute `det = pass_pct / 100`
+   → pass as `-DetPct det`.
+2. If `semantic=true`: run the `/ga-chatbot-qa-panel` workflow; read its
+   `state/quality/chatbot-qa-semantic/<date>.json` `pass_pct` (also 0..100),
+   compute `sem = pass_pct / 100` → `-SemPct sem`.
+3. Emit `phase=qa-snapshot` with both fractions + `target_metric`. If
+   `det >= target_metric` already → skip to Step 3 (done).
+
+**Step 2.0 — suppress delegated PR creation (Law A).** `/auto-optimize`'s Step 4
+opens a PR with `gh pr create` once commits land. The harness must NOT let that
+happen. When you invoke it, append an explicit instruction: *"Do NOT run Step 4 /
+`gh pr create` / any push or PR — commit on the current branch only; the AFK
+harness owns landing."* If a given `/auto-optimize` version cannot be told to skip
+its PR step, do NOT delegate — drive the cycle inline instead (pick worst prompt →
+fix → `/chatbot-qa-roundtrip-validate` → `git commit` on branch / revert).
 
 ### Step 2 — Improvement cycles (the AFK loop)
-Repeat until `DetPct >= target_metric`, `max_iterations` reached, plateau
-(baseline `plateau_threshold`), caps hit, or a killswitch appears:
-1. Run `/auto-optimize domain=chatbot-qa oracle_script_path=Scripts/run-prompt-corpus.ps1 baseline_path=state/quality/chatbot-qa/baseline.json max_iterations=<batch_size>`.
+Repeat until `det >= target_metric` (fractions, per the SCALE note),
+`max_iterations` reached, plateau (baseline `plateau_threshold`), caps hit, or a
+killswitch appears:
+1. Run `/auto-optimize domain=chatbot-qa oracle_script_path=Scripts/run-prompt-corpus.ps1 baseline_path=state/quality/chatbot-qa/baseline.json max_iterations=<batch_size>` **with the no-PR instruction from Step 2.0**.
    This does the real work: picks the worst prompt, proposes a fix, runs
    `/chatbot-qa-roundtrip-validate`, and commits on the branch or reverts.
-2. After each batch, re-read `pass_pct`; emit one status update per outcome:
+2. After each batch, re-read `pass_pct` and **normalize `det = pass_pct / 100`**; emit one status update per outcome (always pass fractions to `-DetPct`):
    - accepted → `-Kind commit -Iteration <n> -Commits <c> -DetPct <x> -Event "accepted fix for <prompt-id> (<+Δpp>)"`
    - reverted → `-Kind revert -Iteration <n> -Event "reverted <prompt-id>: <reject reason>"`
 3. Re-check killswitch/halt each iteration (Law C of auto-optimize). If set → emit `state=killed`, STOP.

--- a/.claude/skills/ga-chatbot-afk-harness/SKILL.md
+++ b/.claude/skills/ga-chatbot-afk-harness/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: "GA Chatbot AFK Harness"
+description: "End-to-end autonomous (AFK) harness that develops AND QAs the GA chatbot. Orchestrates the existing Level-3 /auto-optimize dev loop + the semantic /ga-chatbot-qa-panel judge workflow, instruments every step to a dashboard the human can watch, and enforces branch-only / never-merge safety. Use to run unattended chatbot-quality improvement with full human visibility. Refuses to run if the backend is down, a killswitch/halt marker is present, or scope_boundary is violated."
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, Skill
+last_verified: 2026-05-29
+---
+
+# /ga-chatbot-afk-harness
+
+The **orchestration layer** for fully-AFK GA chatbot development + QA. It does
+NOT reimplement the improvement loop — it wires together pieces that already
+exist and adds the three things they lacked: a semantic QA signal, live
+instrumentation for a human dashboard, and one safe "arm and walk away" entry.
+
+```
+            ┌──────────────────────── this harness ────────────────────────┐
+preflight → │  QA snapshot           dev cycles            QA snapshot      │ → exit
+            │  (det oracle +         (/auto-optimize,      (re-measure)     │
+            │   semantic panel)       Iron Laws + rollback)                 │
+            └───────────────── status → dashboard at every step ───────────┘
+```
+
+## What it composes (do NOT duplicate these)
+
+| Piece | Role | Owned by |
+|---|---|---|
+| `Scripts/run-prompt-corpus.ps1` | deterministic oracle (`pass_pct`) | existing |
+| `/ga-chatbot-qa-panel` (workflow) | semantic judge panel → `state/quality/chatbot-qa-semantic/` | this session |
+| `/auto-optimize` | Level-3 dev loop: pick worst → fix → roundtrip → commit/revert | existing |
+| `/chatbot-qa-roundtrip-validate` | per-commit rollback gate | existing |
+| `state/quality/chatbot-qa/baseline.json` | metric + scope_boundary + caps | existing |
+| `Scripts/afk-harness-status.ps1` | instrumentation writer → dashboard | this session |
+| `Tools/afk-dashboard/index.html` | human UI | this session |
+
+## Inputs (skill args, `key=value`)
+
+| Input | Default | Meaning |
+|---|---|---|
+| `target_metric` | `0.97` | exit when deterministic `pass_pct` ≥ this |
+| `max_iterations` | `10` | hard cap on dev cycles (also bounded by baseline caps) |
+| `batch_size` | `1` | `/auto-optimize` cycles per status-emit batch (smaller = livelier dashboard) |
+| `branch` | `afk/chatbot-qa-<date>` | the harness commits here; it NEVER pushes/merges |
+| `semantic` | `true` | run `/ga-chatbot-qa-panel` for the richer signal each snapshot |
+
+## Iron Laws (inherited + added)
+
+Inherits ALL of `/auto-optimize`'s Iron Laws (no commit without roundtrip pass;
+no editing protected paths; caps `max_commits_per_session=50`,
+`max_wall_clock_minutes=480`; always release `.lock`; honor
+`state/.loop-halted`, `state/quality/chatbot-qa/.STOP`, and
+`~/.demerzel/HALT-ALL`). The harness adds:
+
+```
+A. NEVER push, open/merge a PR, deploy, or apply a review-bypass label.
+   The harness produces COMMITS ON A BRANCH only. A human arms it and a
+   human (or a separate reviewed flow) lands it.
+B. NEVER fabricate a metric. If the backend is unreachable, emit a
+   `blocked` status with the real reason and STOP. A degraded run is
+   recorded honestly, never as pass_pct=100%.
+C. EMIT status via Scripts/afk-harness-status.ps1 at every phase boundary
+   and after every accepted/reverted cycle — code owns the status, so a
+   crashed loop still leaves an honest last state on the dashboard.
+```
+
+## Procedure
+
+### Step 0 — Preflight (refuse-to-run gates)
+1. Pick `run_id = <UTCyyyyMMddTHHmmZ>-afk`. Emit `state=preflight phase=preflight`.
+2. Halt/killswitch checks (reuse `/auto-optimize` Step 0 exactly): if
+   `state/.loop-halted`, `state/quality/chatbot-qa/.STOP`, or a live
+   `~/.demerzel/HALT-ALL` marker is present → emit `state=killed`, explain, STOP.
+3. **Backend preflight**: `POST http://localhost:5252/api/chatbot/chat` with
+   `{"message":"What is a major triad"}`. If not a real non-empty
+   `naturalLanguageAnswer` → emit `state=blocked`,
+   `-Blocker "backend_unavailable: GaChatbot.Api :5252"`, STOP. (Bring it up
+   per `docs/runbooks/chatbot-deploy.md`, then re-arm.)
+4. Create/checkout `branch`. Emit `state=running phase=qa-snapshot branch=<branch>`.
+
+### Step 1 — Baseline QA snapshot
+1. Run the deterministic oracle: `pwsh Scripts/run-prompt-corpus.ps1 -Snapshot`.
+   Read the resulting `pass_pct` → `-DetPct`.
+2. If `semantic=true`: run the `/ga-chatbot-qa-panel` workflow; read
+   `state/quality/chatbot-qa-semantic/<date>.json` `pass_pct` → `-SemPct`.
+3. Emit `phase=qa-snapshot` with both metrics + `target_metric`. If
+   `DetPct >= target_metric` already → skip to Step 3 (done).
+
+### Step 2 — Improvement cycles (the AFK loop)
+Repeat until `DetPct >= target_metric`, `max_iterations` reached, plateau
+(baseline `plateau_threshold`), caps hit, or a killswitch appears:
+1. Run `/auto-optimize domain=chatbot-qa oracle_script_path=Scripts/run-prompt-corpus.ps1 baseline_path=state/quality/chatbot-qa/baseline.json max_iterations=<batch_size>`.
+   This does the real work: picks the worst prompt, proposes a fix, runs
+   `/chatbot-qa-roundtrip-validate`, and commits on the branch or reverts.
+2. After each batch, re-read `pass_pct`; emit one status update per outcome:
+   - accepted → `-Kind commit -Iteration <n> -Commits <c> -DetPct <x> -Event "accepted fix for <prompt-id> (<+Δpp>)"`
+   - reverted → `-Kind revert -Iteration <n> -Event "reverted <prompt-id>: <reject reason>"`
+3. Re-check killswitch/halt each iteration (Law C of auto-optimize). If set → emit `state=killed`, STOP.
+
+### Step 3 — Final snapshot + exit
+1. Re-run the deterministic oracle and (if enabled) `/ga-chatbot-qa-panel`.
+2. Emit `state=done phase=exit` with final `DetPct`/`SemPct`, `commits`, and a
+   `-Event` summarizing outcome vs target.
+3. Drop a `state/handoffs/<ts>-claude-code.md` note: branch name, commits made,
+   final metrics, and the explicit next human action (review + land the branch).
+   **Do not land it yourself.**
+
+## Arming modes (how the human runs it AFK)
+
+- **Bounded, in-session:** `/goal deterministic pass_pct >= 0.97 for chatbot corpus` then `/ga-chatbot-afk-harness target_metric=0.97`. Claude keeps working across turns until the goal evaluator confirms.
+- **Interval:** `/loop /ga-chatbot-afk-harness` (only if repo preflight reports `LOOP_READY=true`).
+- **Headless / true AFK:** `claude -p "/ga-chatbot-afk-harness target_metric=0.97 max_iterations=20"` — runs unattended; tool prompts follow the configured allowlist.
+
+## Watching it (UI)
+
+Serve the repo root and open the dashboard:
+```bash
+python -m http.server 8099    # from repo root
+# → http://localhost:8099/Tools/afk-dashboard/
+```
+It auto-refreshes every 5s from `state/quality/chatbot-qa/afk-runs/latest-status.json`
++ the run's `.jsonl` event log. Full details in
+`docs/runbooks/ga-chatbot-afk-harness.md`.
+
+## Stopping
+Create `state/quality/chatbot-qa/.STOP` (this domain) or `state/.loop-halted`
+(all loops). The harness checks both every iteration and exits gracefully,
+leaving completed commits intact.

--- a/.claude/workflows/ga-chatbot-qa-panel.js
+++ b/.claude/workflows/ga-chatbot-qa-panel.js
@@ -1,0 +1,321 @@
+export const meta = {
+  name: 'ga-chatbot-qa-panel',
+  description: 'Run the GA chatbot prompt corpus through a multi-lens semantic judge panel with hexavalent consensus',
+  whenToUse:
+    'Daily/local semantic QA of the GA chatbot. Complements (does NOT replace) the deterministic ' +
+    'PromptCorpusTests.cs invariant gate: this layer judges correctness, grounding, and helpfulness ' +
+    'that substring checks cannot see. Requires the live GaChatbot.Api backend (default :5252).',
+  phases: [
+    { title: 'Probe', detail: 'confirm backend live + discover chat endpoint/request shape; load corpus' },
+    { title: 'Evaluate', detail: 'per prompt: query live chatbot, then judge the answer with N lenses + consensus' },
+    { title: 'Synthesize', detail: 'aggregate hexavalent verdicts → write semantic snapshot JSON' },
+  ],
+}
+
+// ── Config (override via Workflow args: { host, limit }) ──────────────────────
+// host  : GaChatbot.Api base URL (default http://localhost:5252)
+// limit : cap the number of (non-skipped) prompts evaluated — for smoke runs.
+const HOST = (args && args.host) || 'http://localhost:5252'
+const LIMIT = args && Number.isFinite(args.limit) ? args.limit : null
+const CORPUS = 'Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml'
+const SNAPSHOT_DIR = 'state/quality/chatbot-qa-semantic'
+
+// The judge panel: each lens is an INDEPENDENT reviewer with a distinct failure
+// mode it is responsible for catching. Diversity > redundancy — three identical
+// judges only catch what one catches.
+const LENSES = [
+  {
+    key: 'musical-correctness',
+    brief:
+      'You are a music-theory expert. Judge ONLY whether the music theory in the answer is FACTUALLY CORRECT ' +
+      '(intervals, scale/mode spellings, chord tones, key relationships, voicings). Ignore style and length. ' +
+      'A confidently-stated wrong interval or misspelled mode is F. A correct but terse answer is still T.',
+  },
+  {
+    key: 'grounding-hallucination',
+    brief:
+      'You are a hallucination auditor. Judge ONLY whether every SPECIFIC claim is grounded and non-fabricated: ' +
+      'invented chord/voicing names, made-up fret numbers, fake citations, or "returned no matches"/"not yet ' +
+      'implemented"/leaked SKILL.md preamble are F (or C if the answer also asserts the opposite elsewhere). ' +
+      'A correctly-hedged "I don\'t have that" is U, not F.',
+  },
+  {
+    key: 'completeness-helpfulness',
+    brief:
+      'You are a guitarist user. Judge ONLY whether the answer actually ANSWERS the asked question at useful ' +
+      'depth. Off-topic, evasive, or stub answers are F. Correct but missing the obvious follow-the-question ' +
+      'detail is P. Fully useful is T.',
+  },
+]
+
+// ── Schemas (force structured agent output) ───────────────────────────────────
+const PROBE_SCHEMA = {
+  type: 'object',
+  required: ['healthy', 'endpoint', 'requestTemplate', 'answerField'],
+  properties: {
+    healthy: { type: 'boolean', description: 'true only if the chat endpoint returned a real answer to a probe request' },
+    endpoint: { type: 'string', description: 'full chat URL actually used, e.g. http://localhost:5252/api/chatbot/chat' },
+    requestTemplate: { type: 'string', description: 'JSON request body with the literal token {{PROMPT}} where the user text goes' },
+    answerField: { type: 'string', description: 'response JSON field holding the natural-language answer (e.g. naturalLanguageAnswer)' },
+    note: { type: 'string' },
+  },
+}
+
+const PROMPTS_SCHEMA = {
+  type: 'object',
+  required: ['prompts'],
+  properties: {
+    prompts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['prompt', 'category'],
+        properties: {
+          prompt: { type: 'string' },
+          category: { type: 'string' },
+          contains: { type: 'array', items: { type: 'string' } },
+          contains_any: { type: 'array', items: { type: 'string' } },
+          not_contains: { type: 'array', items: { type: 'string' } },
+          routes_to: { type: 'string' },
+          min_length: { type: 'number' },
+        },
+      },
+    },
+  },
+}
+
+const GEN_SCHEMA = {
+  type: 'object',
+  required: ['answer', 'elapsed_ms', 'reached_backend'],
+  properties: {
+    answer: { type: 'string' },
+    elapsed_ms: { type: 'number' },
+    reached_backend: { type: 'boolean', description: 'false if the request errored / 5xx / no answer field' },
+    agentId: { type: 'string' },
+    deterministic_pass: { type: 'boolean', description: 'do the declared contains/not_contains/routes_to invariants hold? (best-effort substring check)' },
+    deterministic_notes: { type: 'string' },
+  },
+}
+
+const JUDGE_SCHEMA = {
+  type: 'object',
+  required: ['truth', 'certainty', 'rationale'],
+  properties: {
+    // Hexavalent T/P/U/F/C per the ecosystem convention (a single judge never
+    // emits D — D is the AGGREGATE state when judges split T/P vs F).
+    truth: { type: 'string', enum: ['T', 'P', 'U', 'F', 'C'] },
+    certainty: { type: 'number', description: '0..1, per Demerzel thresholds' },
+    rationale: { type: 'string', description: 'one or two sentences, cite the specific claim that drove the verdict' },
+  },
+}
+
+const SYNTH_SCHEMA = {
+  type: 'object',
+  required: ['written_path', 'summary'],
+  properties: {
+    written_path: { type: 'string' },
+    summary: { type: 'string' },
+    pass_pct: { type: ['number', 'null'] },
+    evaluated: { type: 'number' },
+  },
+}
+
+// ── Hexavalent consensus (deterministic, in-script for reproducibility) ───────
+// Combine the panel's per-lens verdicts into one hexavalent verdict.
+//   C (contradiction) is sticky: any high-certainty C dominates.
+//   Disagreement between the {T,P} camp and the {F} camp → D (disputed).
+//   Otherwise majority among {T,P,F,U}; U on a tie; P when T and P mix.
+// pass = consensus ∈ {T, P}.
+function consensus(verdicts) {
+  const v = verdicts.filter(Boolean)
+  if (v.length === 0) return { truth: 'U', certainty: 0, pass: false, reason: 'no judge returned a verdict' }
+
+  const strongC = v.filter((x) => x.truth === 'C' && x.certainty >= 0.7)
+  if (strongC.length > 0) {
+    return { truth: 'C', certainty: mean(strongC.map((x) => x.certainty)), pass: false, reason: 'a judge found an internal/ground-truth contradiction' }
+  }
+
+  const good = v.filter((x) => (x.truth === 'T' || x.truth === 'P') && x.certainty >= 0.6)
+  const bad = v.filter((x) => (x.truth === 'F' || x.truth === 'C') && x.certainty >= 0.6)
+  if (good.length > 0 && bad.length > 0) {
+    return { truth: 'D', certainty: mean(v.map((x) => x.certainty)), pass: false, reason: 'panel split: some judges T/P, others F/C' }
+  }
+
+  // Tally remaining (no strong cross-camp split).
+  const tally = { T: 0, P: 0, U: 0, F: 0, C: 0 }
+  for (const x of v) tally[x.truth] += 1
+  const top = Object.keys(tally).sort((a, b) => tally[b] - tally[a])
+  // Tie at the top → fall back to U (honest uncertainty, not a coin flip).
+  let truth = top[0]
+  if (tally[top[0]] === tally[top[1]]) truth = 'U'
+  // If any T but also any P (and no F), the honest aggregate is P (a gap exists somewhere).
+  if ((truth === 'T') && tally.P > 0) truth = 'P'
+  const pass = truth === 'T' || truth === 'P'
+  return { truth, certainty: mean(v.map((x) => x.certainty)), pass, reason: `majority ${truth} (${JSON.stringify(tally)})` }
+}
+
+function mean(xs) {
+  if (!xs.length) return 0
+  return Math.round((xs.reduce((a, b) => a + b, 0) / xs.length) * 1000) / 1000
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// PHASE 1 — Probe backend + load corpus (in parallel; both are prerequisites)
+// ════════════════════════════════════════════════════════════════════════════
+phase('Probe')
+
+const [probe, corpus] = await parallel([
+  () =>
+    agent(
+      `Confirm the GA chatbot backend is live and discover its exact request/response shape.\n` +
+      `1. Read ${CORPUS.replace('prompts.yaml', 'PromptCorpusTests.cs')} around the POST call (~line 185) to find the exact ` +
+      `chat route, the request JSON body shape, and the response field that holds the natural-language answer.\n` +
+      `2. The known facts: host base is ${HOST}, route is /api/chatbot/chat, answer field is "naturalLanguageAnswer", ` +
+      `agent id is "agentId". Confirm these against the source.\n` +
+      `3. Send ONE probe request (curl or Invoke-RestMethod) with a trivial prompt like "What is a major triad". ` +
+      `Set healthy=true ONLY if you get back a non-empty answer in the answer field. A connection refused / 5xx / ` +
+      `empty body means healthy=false — do NOT fabricate.\n` +
+      `Return requestTemplate as the JSON body with the literal token {{PROMPT}} where the user text belongs.`,
+      { label: 'probe:backend', phase: 'Probe', schema: PROBE_SCHEMA },
+    ),
+  () =>
+    agent(
+      `Read the GA chatbot corpus at ${CORPUS}. It is YAML under a top-level "prompts:" key. ` +
+      `Return every entry whose "skip" is not true, preserving prompt, category, contains, contains_any, ` +
+      `not_contains, routes_to, and min_length. Do not invent entries — only what the file contains.`,
+      { label: 'load:corpus', phase: 'Probe', schema: PROMPTS_SCHEMA },
+    ),
+])
+
+// Never fabricate a pass rate when the backend never answered (feedback_green_but_dead).
+if (!probe || !probe.healthy) {
+  log(`Backend NOT healthy at ${HOST} — writing a degraded snapshot (pass_pct=null), not a fabricated score.`)
+  phase('Synthesize')
+  const degraded = await agent(
+    `Write a DEGRADED semantic-QA snapshot. Run \`date -u +%Y-%m-%dT%H:%M:%SZ\` for the timestamp and ` +
+    `\`date -u +%Y-%m-%d\` for the filename. Create the file ${SNAPSHOT_DIR}/<date>.json (mkdir -p the dir) with:\n` +
+    `{ "timestamp": <ts>, "layer": "semantic-panel", "degraded": true, ` +
+    `"degraded_reason": "backend_unavailable", "pass_pct": null, "total_prompts": ${(corpus && corpus.prompts ? corpus.prompts.length : 0)}, ` +
+    `"evaluated": 0, "note": ${JSON.stringify('Probe could not reach ' + HOST + ': ' + (probe ? probe.note : 'no probe result'))} }\n` +
+    `Return the written path and a one-line summary.`,
+    { label: 'synth:degraded', phase: 'Synthesize', schema: SYNTH_SCHEMA },
+  )
+  return { degraded: true, host: HOST, snapshot: degraded }
+}
+
+let prompts = (corpus && corpus.prompts) || []
+if (LIMIT != null) prompts = prompts.slice(0, LIMIT)
+log(`Backend healthy. Evaluating ${prompts.length} prompt(s) through a ${LENSES.length}-lens panel.`)
+
+// ════════════════════════════════════════════════════════════════════════════
+// PHASE 2 — Per prompt: generate (live) → judge panel → consensus
+// Pipeline (no barrier): a prompt can be in judging while another is still
+// generating. Wall-clock = slowest single chain, not sum of stage maxima.
+// ════════════════════════════════════════════════════════════════════════════
+phase('Evaluate')
+
+const records = await pipeline(
+  prompts,
+  // Stage 1 — query the SAME host the corpus targets, faithful to PromptCorpusTests.
+  (p) =>
+    agent(
+      `Query the live GA chatbot and report its answer verbatim.\n` +
+      `Endpoint: ${probe.endpoint}\n` +
+      `Request body (substitute the prompt for {{PROMPT}}, JSON-escaped): ${probe.requestTemplate}\n` +
+      `Answer field in the response: ${probe.answerField}; routed agent id field: agentId.\n` +
+      `User prompt: ${JSON.stringify(p.prompt)}\n` +
+      `Measure elapsed_ms around the request. If the call errors / 5xx / empty answer, set reached_backend=false ` +
+      `and leave answer "".\n` +
+      `Also do a best-effort deterministic check: does the answer satisfy these declared invariants? ` +
+      `contains(all, case-insensitive)=${JSON.stringify(p.contains || [])}, ` +
+      `contains_any=${JSON.stringify(p.contains_any || [])}, not_contains=${JSON.stringify(p.not_contains || [])}, ` +
+      `min_length=${p.min_length || 0}, routes_to=${JSON.stringify(p.routes_to || null)} (compare to agentId). ` +
+      `Set deterministic_pass accordingly and note any miss.`,
+      { label: `gen:${p.category}`, phase: 'Evaluate', schema: GEN_SCHEMA },
+    ).then((g) => ({ ...g, prompt: p.prompt, category: p.category })),
+
+  // Stage 2 — N independent lenses judge the answer, then deterministic consensus.
+  async (g) => {
+    if (!g || !g.reached_backend || !g.answer) {
+      return { ...g, consensus: { truth: 'U', certainty: 0, pass: false, reason: 'no answer to judge' }, judges: [] }
+    }
+    const judges = await parallel(
+      LENSES.map((lens) => () =>
+        agent(
+          `${lens.brief}\n\n` +
+          `Question the user asked: ${JSON.stringify(g.prompt)}\n` +
+          `Category: ${g.category}\n` +
+          `Chatbot's answer:\n"""\n${g.answer}\n"""\n\n` +
+          `Return a hexavalent verdict (T/P/U/F/C) for YOUR lens only, with certainty 0..1 and a one-sentence ` +
+          `rationale citing the specific claim that drove it. Default to U if you genuinely cannot tell.`,
+          { label: `judge:${lens.key}`, phase: 'Evaluate', schema: JUDGE_SCHEMA },
+        ).then((v) => (v ? { ...v, lens: lens.key } : null)),
+      ),
+    )
+    return { ...g, judges: judges.filter(Boolean), consensus: consensus(judges) }
+  },
+)
+
+const evaluated = records.filter(Boolean)
+
+// ════════════════════════════════════════════════════════════════════════════
+// PHASE 3 — Aggregate + write the semantic snapshot (sibling to the deterministic
+// one; we never overwrite the locked ix-quality-trend schema).
+// ════════════════════════════════════════════════════════════════════════════
+phase('Synthesize')
+
+// Aggregate in-script so the numbers are reproducible and don't depend on an LLM.
+const passes = evaluated.filter((r) => r.consensus.pass).length
+const passPct = evaluated.length ? Math.round((passes / evaluated.length) * 1000) / 10 : null
+const byCategory = {}
+const byTruth = { T: 0, P: 0, U: 0, D: 0, F: 0, C: 0 }
+const latencies = []
+for (const r of evaluated) {
+  byTruth[r.consensus.truth] += 1
+  if (Number.isFinite(r.elapsed_ms)) latencies.push(r.elapsed_ms)
+  const c = (byCategory[r.category] = byCategory[r.category] || { n: 0, pass: 0 })
+  c.n += 1
+  if (r.consensus.pass) c.pass += 1
+}
+for (const k of Object.keys(byCategory)) {
+  const c = byCategory[k]
+  c.pass_pct = c.n ? Math.round((c.pass / c.n) * 1000) / 10 : null
+}
+const avgMs = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null
+
+const snapshot = {
+  layer: 'semantic-panel',
+  total_prompts: prompts.length,
+  evaluated: evaluated.length,
+  pass_pct: passPct,
+  avg_response_ms: avgMs,
+  panel: { size: LENSES.length, lenses: LENSES.map((l) => l.key) },
+  by_category: byCategory,
+  by_truth_value: byTruth,
+  prompts: evaluated.map((r) => ({
+    prompt: r.prompt,
+    category: r.category,
+    consensus: r.consensus.truth,
+    pass: r.consensus.pass,
+    certainty: r.consensus.certainty,
+    reason: r.consensus.reason,
+    deterministic_pass: r.deterministic_pass ?? null,
+    agentId: r.agentId ?? null,
+    elapsed_ms: r.elapsed_ms ?? null,
+    judges: r.judges.map((j) => ({ lens: j.lens, truth: j.truth, certainty: j.certainty, rationale: j.rationale })),
+  })),
+}
+
+const written = await agent(
+  `Write this semantic-QA snapshot to disk.\n` +
+  `1. Run \`date -u +%Y-%m-%dT%H:%M:%SZ\` (timestamp) and \`date -u +%Y-%m-%d\` (filename date).\n` +
+  `2. mkdir -p ${SNAPSHOT_DIR}\n` +
+  `3. Write ${SNAPSHOT_DIR}/<date>.json containing this object with a "timestamp" field prepended:\n` +
+  `${JSON.stringify(snapshot)}\n` +
+  `Write it as valid pretty-printed JSON. Return the written path, the pass_pct (${passPct}), evaluated count ` +
+  `(${evaluated.length}), and a one-line summary of the by_truth_value distribution.`,
+  { label: 'synth:write', phase: 'Synthesize', schema: SYNTH_SCHEMA },
+)
+
+log(`Semantic panel: ${passes}/${evaluated.length} pass (${passPct ?? 'n/a'}%). Truth dist: ${JSON.stringify(byTruth)}`)
+return { host: HOST, pass_pct: passPct, evaluated: evaluated.length, by_truth_value: byTruth, snapshot: written }

--- a/Scripts/afk-fleet-aggregate.ps1
+++ b/Scripts/afk-fleet-aggregate.ps1
@@ -1,0 +1,101 @@
+# afk-fleet-aggregate.ps1 — collect the latest QA-loop signal from every repo in
+# the GuitarAlchemist fleet into ONE feed the unified dashboard reads.
+#
+# Why an aggregator (not cross-repo fetch in the browser): a static dashboard
+# can only fetch under one served root, but the feeds live in sibling repos
+# (../ix, ../Demerzel). This script has filesystem access, so it reads all of
+# them and writes a single ga/state/quality/ecosystem/afk-fleet.json. Mirrors
+# the existing fleet-status.yml / ecosystem-health.yml aggregation pattern.
+#
+# Run from the ga repo:  pwsh Scripts/afk-fleet-aggregate.ps1
+# Then the unified dashboard (Tools/afk-fleet-dashboard/) shows all repos.
+
+[CmdletBinding()]
+param()
+$ErrorActionPreference = "Stop"
+$gaRoot   = Split-Path $PSScriptRoot -Parent
+$parent   = Split-Path $gaRoot -Parent
+$ixRoot   = Join-Path $parent "ix"
+$demRoot  = Join-Path $parent "Demerzel"
+$outDir   = Join-Path $gaRoot "state/quality/ecosystem"
+$outPath  = Join-Path $outDir "afk-fleet.json"
+if (-not (Test-Path $outDir)) { New-Item -ItemType Directory -Path $outDir -Force | Out-Null }
+
+function Read-JsonSafe([string]$path) {
+    if ($path -and (Test-Path $path)) {
+        try { return Get-Content -Raw $path | ConvertFrom-Json } catch { return $null }
+    }
+    return $null
+}
+function Latest([string]$dir, [string]$filter) {
+    if (-not (Test-Path $dir)) { return $null }
+    Get-ChildItem -Path $dir -Filter $filter -File -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty FullName
+}
+
+$repos = @()
+
+# ── ga — chatbot AFK harness (live develop+QA loop) ───────────────────────────
+$gaStatus = Read-JsonSafe (Join-Path $gaRoot "state/quality/chatbot-qa/afk-runs/latest-status.json")
+$gaTargets = Latest (Join-Path $gaRoot "state/quality/chatbot-qa/afk-runs") "*.targets.json"
+$gaTargetCount = if ($gaTargets) { (Read-JsonSafe $gaTargets).queued_targets.Count } else { 0 }
+if ($gaStatus) {
+    $repos += [ordered]@{
+        repo = "ga"; domain = "chatbot-qa"; kind = "afk-harness"
+        state = $gaStatus.state; updated_at = $gaStatus.updated_at
+        primary_label = "deterministic"; primary_pct = $gaStatus.current.deterministic_pass_pct
+        secondary_label = "semantic";    secondary_pct = $gaStatus.current.semantic_pass_pct
+        target = $gaStatus.target_metric; queued_targets = $gaTargetCount
+        detail = $gaStatus.last_event; source = "ga/state/quality/chatbot-qa/afk-runs/latest-status.json"
+    }
+} else {
+    $repos += [ordered]@{ repo = "ga"; domain = "chatbot-qa"; kind = "afk-harness"; state = "no-data"; detail = "no harness run yet" }
+}
+
+# ── ix — adversarial LLM judge panel ──────────────────────────────────────────
+$ixPanel = Latest (Join-Path $ixRoot "state/adversarial") "llm-panel-*.json"
+$ixObj = if ($ixPanel) { Read-JsonSafe $ixPanel } else { Read-JsonSafe (Join-Path $ixRoot "state/adversarial/summary.json") }
+if ($ixObj) {
+    $pct = if ($null -ne $ixObj.agreement_pct) { [double]$ixObj.agreement_pct / 100.0 } `
+           elseif ($null -ne $ixObj.match_rate) { [double]$ixObj.match_rate } else { $null }
+    $repos += [ordered]@{
+        repo = "ix"; domain = "adversarial-qa"; kind = "llm-panel"
+        state = if ($ixObj.degraded) { "degraded" } elseif ($ixPanel) { "done" } else { "baseline" }
+        updated_at = $ixObj.timestamp
+        primary_label = "agreement"; primary_pct = $pct
+        secondary_label = $null; secondary_pct = $null
+        verdicts = $ixObj.by_truth_value; graded = $ixObj.graded
+        detail = if ($ixPanel) { "llm-panel: $($ixObj.graded) graded" } else { "deterministic baseline ($($ixObj.pipeline_version)); LLM panel not yet run on schedule" }
+        source = if ($ixPanel) { "ix/$(Split-Path $ixPanel -Leaf)" } else { "ix/state/adversarial/summary.json" }
+    }
+} else {
+    $repos += [ordered]@{ repo = "ix"; domain = "adversarial-qa"; kind = "llm-panel"; state = "no-data"; detail = "no adversarial feed" }
+}
+
+# ── Demerzel — QA tribunal verdicts ───────────────────────────────────────────
+$demVerdict = $null
+$vdir = Join-Path $demRoot "state/quality/verdicts"
+if (Test-Path $vdir) {
+    $demVerdict = Get-ChildItem -Path $vdir -Recurse -Filter "*.json" -File -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
+if ($demVerdict) {
+    $v = Read-JsonSafe $demVerdict.FullName
+    $repos += [ordered]@{
+        repo = "Demerzel"; domain = "qa-tribunal"; kind = "verdict"
+        state = if ($v.verdict -eq "block") { "blocked" } elseif ($v.verdict -eq "pass") { "done" } else { "running" }
+        updated_at = $v.produced_at
+        primary_label = "verdict"; primary_text = "$($v.verdict) ($($v.risk_tier))"
+        detail = $v.narrative; source = "Demerzel/state/quality/verdicts/$($demVerdict.Name)"
+    }
+} else {
+    $repos += [ordered]@{ repo = "Demerzel"; domain = "qa-tribunal"; kind = "verdict"; state = "no-data"; detail = "no verdicts emitted yet — run /demerzel-tribunal-panel on a PR" }
+}
+
+$fleet = [ordered]@{
+    schema_version = 1
+    generated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    repos = $repos
+}
+($fleet | ConvertTo-Json -Depth 8) | Set-Content -Path $outPath -Encoding utf8
+Write-Host "afk-fleet: aggregated $($repos.Count) repos -> $outPath"

--- a/Scripts/afk-harness-status.ps1
+++ b/Scripts/afk-harness-status.ps1
@@ -1,0 +1,105 @@
+# afk-harness-status.ps1 — instrumentation writer for the GA chatbot AFK harness.
+#
+# The harness (.claude/skills/ga-chatbot-afk-harness) calls this at every phase
+# so the dashboard (tools/afk-dashboard/index.html) always has fresh, truthful
+# state — the human can see exactly what the autonomous loop is doing without
+# reading the transcript. It does TWO things per call:
+#   1. Appends one event line to state/quality/chatbot-qa/afk-runs/<run_id>.jsonl
+#   2. Merges the provided fields into .../afk-runs/latest-status.json
+#
+# This is deliberately the ONLY way the harness reports progress: code, not the
+# LLM's memory, owns the status — so a crashed/killed loop still leaves an
+# honest last-known state on disk ("instrument before you ship").
+#
+# Usage:
+#   pwsh Scripts/afk-harness-status.ps1 -RunId 20260529T204500Z-afk `
+#        -State running -Phase improve -Iteration 3 -Commits 2 `
+#        -DetPct 0.94 -SemPct 0.88 -TargetMetric 0.97 -Branch afk/chatbot-qa `
+#        -Kind commit -Event "accepted fix for grad-014 (+2.0pp)"
+#
+# State values:  preflight | running | blocked | degraded | done | killed
+# Kind values:   phase | target_selected | fix_proposed | roundtrip | commit |
+#                revert | degraded | blocked | exit
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RunId,
+    [string]$State,
+    [string]$Phase,
+    [Nullable[int]]$Iteration,
+    [Nullable[int]]$Commits,
+    [Nullable[int]]$MaxIterations,
+    [Nullable[double]]$DetPct,        # deterministic oracle pass_pct (0..1)
+    [Nullable[double]]$SemPct,        # semantic judge-panel pass_pct (0..1)
+    [Nullable[double]]$TargetMetric,  # exit target (0..1)
+    [string]$Branch,
+    [string]$Kind,                    # event kind (see header)
+    [string]$Event,                   # human-readable event detail
+    [string]$Blocker,                 # if set, appended to blockers[] and state implied blocked
+    [string]$Domain = "chatbot-qa"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot   = Split-Path $PSScriptRoot -Parent
+$runsDir    = Join-Path $repoRoot "state/quality/$Domain/afk-runs"
+$statusPath = Join-Path $runsDir "latest-status.json"
+$eventsPath = Join-Path $runsDir "$RunId.jsonl"
+if (-not (Test-Path $runsDir)) { New-Item -ItemType Directory -Path $runsDir -Force | Out-Null }
+
+$nowUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+# ── 1. Append an event line (only when something happened) ────────────────────
+if ($Kind -or $Event) {
+    $evt = [ordered]@{
+        ts     = $nowUtc
+        run_id = $RunId
+        kind   = if ($Kind) { $Kind } else { "phase" }
+        detail = if ($Event) { $Event } else { $Phase }
+    }
+    if ($null -ne $Iteration) { $evt["iteration"] = [int]$Iteration }
+    if ($null -ne $DetPct)    { $evt["det"] = [double]$DetPct }   # lets the dashboard plot a trend
+    if ($null -ne $SemPct)    { $evt["sem"] = [double]$SemPct }
+    ($evt | ConvertTo-Json -Compress) | Add-Content -Path $eventsPath -Encoding utf8
+}
+
+# ── 2. Merge fields into latest-status.json ───────────────────────────────────
+$status = @{}
+if (Test-Path $statusPath) {
+    try { $status = Get-Content -Raw $statusPath | ConvertFrom-Json -AsHashtable } catch { $status = @{} }
+}
+if (-not $status.ContainsKey("schema_version")) { $status["schema_version"] = 1 }
+if (-not $status.ContainsKey("run_id") -or $status["run_id"] -ne $RunId) {
+    # New run → reset started_at, blockers.
+    $status["run_id"]     = $RunId
+    $status["started_at"] = $nowUtc
+    $status["blockers"]   = @()
+}
+$status["domain"]      = $Domain
+$status["updated_at"]  = $nowUtc
+$status["events_file"] = "afk-runs/$RunId.jsonl"
+$status["killswitch"]  = "state/quality/$Domain/.STOP"
+$status["global_halt"] = "state/.loop-halted"
+
+if ($State)            { $status["state"]          = $State }
+if ($Phase)            { $status["phase"]          = $Phase }
+if ($null -ne $Iteration)     { $status["iteration"]      = [int]$Iteration }
+if ($null -ne $MaxIterations) { $status["max_iterations"] = [int]$MaxIterations }
+if ($null -ne $Commits)       { $status["commits"]        = [int]$Commits }
+if ($null -ne $TargetMetric)  { $status["target_metric"]  = [double]$TargetMetric }
+if ($Branch)           { $status["branch"]         = $Branch }
+if ($Event)            { $status["last_event"]     = $Event }
+
+if ($null -ne $DetPct -or $null -ne $SemPct) {
+    $cur = if ($status.ContainsKey("current")) { $status["current"] } else { @{} }
+    if ($null -ne $DetPct) { $cur["deterministic_pass_pct"] = [double]$DetPct }
+    if ($null -ne $SemPct) { $cur["semantic_pass_pct"]      = [double]$SemPct }
+    $status["current"] = $cur
+}
+if ($Blocker) {
+    $b = @($status["blockers"]) + $Blocker | Where-Object { $_ } | Select-Object -Unique
+    $status["blockers"] = @($b)
+    if (-not $State) { $status["state"] = "blocked" }
+}
+
+($status | ConvertTo-Json -Depth 8) | Set-Content -Path $statusPath -Encoding utf8
+Write-Host "afk-status: run=$RunId state=$($status['state']) phase=$($status['phase']) -> $statusPath"

--- a/Tools/afk-dashboard/index.html
+++ b/Tools/afk-dashboard/index.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>GA Chatbot — AFK Harness Dashboard</title>
+<style>
+  :root {
+    --bg:#0d1117; --panel:#161b22; --border:#30363d; --txt:#c9d1d9; --dim:#8b949e;
+    --ok:#3fb950; --warn:#d29922; --bad:#f85149; --info:#58a6ff; --accent:#bc8cff;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; background:var(--bg); color:var(--txt); }
+  header { padding:14px 20px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:14px; flex-wrap:wrap; }
+  header h1 { font-size:16px; margin:0; font-weight:600; }
+  .pill { padding:3px 10px; border-radius:999px; font-size:12px; font-weight:600; text-transform:uppercase; letter-spacing:.04em; }
+  .pill.running{ background:rgba(88,166,255,.15); color:var(--info); }
+  .pill.preflight{ background:rgba(210,153,34,.15); color:var(--warn); }
+  .pill.blocked,.pill.killed,.pill.degraded{ background:rgba(248,81,73,.15); color:var(--bad); }
+  .pill.done{ background:rgba(63,185,80,.15); color:var(--ok); }
+  .pill.unknown{ background:rgba(139,148,158,.15); color:var(--dim); }
+  main { padding:20px; display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:16px; max-width:1400px; }
+  .card { background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:16px; }
+  .card h2 { font-size:12px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim); margin:0 0 12px; }
+  .metric-row { display:flex; gap:18px; flex-wrap:wrap; }
+  .metric { flex:1; min-width:120px; }
+  .metric .v { font-size:30px; font-weight:700; }
+  .metric .l { font-size:11px; color:var(--dim); text-transform:uppercase; letter-spacing:.05em; }
+  .bar { height:8px; background:#21262d; border-radius:4px; overflow:hidden; margin-top:6px; }
+  .bar > i { display:block; height:100%; background:var(--ok); }
+  .kv { display:flex; justify-content:space-between; gap:10px; padding:3px 0; border-bottom:1px dashed #21262d; }
+  .kv:last-child{ border-bottom:0; }
+  .kv .k { color:var(--dim); }
+  .blockers li { color:var(--bad); }
+  .timeline { max-height:420px; overflow:auto; }
+  .evt { display:grid; grid-template-columns:74px 96px 1fr; gap:10px; padding:6px 0; border-bottom:1px solid #21262d; font-size:13px; }
+  .evt .t { color:var(--dim); font-size:11px; }
+  .evt .k { font-weight:600; font-size:11px; text-transform:uppercase; }
+  .k.commit{color:var(--ok);} .k.revert{color:var(--warn);} .k.blocked,.k.degraded,.k.exit{color:var(--bad);}
+  .k.phase{color:var(--info);} .k.target_selected{color:var(--accent);} .k.roundtrip,.k.fix_proposed{color:var(--txt);}
+  svg { width:100%; height:120px; display:block; }
+  .legend { font-size:11px; color:var(--dim); margin-top:6px; }
+  .footer { padding:10px 20px; color:var(--dim); font-size:12px; border-top:1px solid var(--border); display:flex; justify-content:space-between; flex-wrap:wrap; gap:10px;}
+  code { background:#21262d; padding:1px 6px; border-radius:4px; color:var(--accent); }
+  .muted { color:var(--dim); }
+  a { color:var(--info); }
+</style>
+</head>
+<body>
+<header>
+  <h1>🤖 GA Chatbot — AFK Harness</h1>
+  <span id="state" class="pill unknown">…</span>
+  <span id="phase" class="muted"></span>
+  <span style="flex:1"></span>
+  <span class="muted" id="updated"></span>
+</header>
+
+<main>
+  <section class="card">
+    <h2>QA metrics</h2>
+    <div class="metric-row">
+      <div class="metric">
+        <div class="v" id="det">–</div><div class="l">deterministic pass</div>
+        <div class="bar"><i id="detbar" style="width:0"></i></div>
+      </div>
+      <div class="metric">
+        <div class="v" id="sem">–</div><div class="l">semantic-panel pass</div>
+        <div class="bar"><i id="sembar" style="width:0;background:var(--accent)"></i></div>
+      </div>
+      <div class="metric">
+        <div class="v" id="target">–</div><div class="l">target</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Run</h2>
+    <div class="kv"><span class="k">run id</span><span id="runid">–</span></div>
+    <div class="kv"><span class="k">branch</span><span id="branch">–</span></div>
+    <div class="kv"><span class="k">iteration</span><span id="iter">–</span></div>
+    <div class="kv"><span class="k">commits</span><span id="commits">–</span></div>
+    <div class="kv"><span class="k">started</span><span id="started">–</span></div>
+  </section>
+
+  <section class="card" id="blockcard" style="display:none">
+    <h2>⛔ Blockers</h2>
+    <ul class="blockers" id="blockers"></ul>
+  </section>
+
+  <section class="card">
+    <h2>Metric trend (this run)</h2>
+    <svg id="trend" viewBox="0 0 400 120" preserveAspectRatio="none"></svg>
+    <div class="legend"><span style="color:var(--ok)">■</span> deterministic &nbsp; <span style="color:var(--accent)">■</span> semantic</div>
+  </section>
+
+  <section class="card" style="grid-column:1/-1">
+    <h2>Event timeline</h2>
+    <div class="timeline" id="timeline"><span class="muted">loading…</span></div>
+  </section>
+</main>
+
+<div class="footer">
+  <span>Stop the loop anytime: create <code id="ks">state/quality/chatbot-qa/.STOP</code> (domain) or <code>state/.loop-halted</code> (global).</span>
+  <span>Auto-refresh 5s · <span id="err" style="color:var(--bad)"></span></span>
+</div>
+
+<script>
+// Data root: dashboard is served from repo root; status lives under state/.
+// Override with ?root=/some/path if you serve from elsewhere.
+const ROOT = new URLSearchParams(location.search).get('root') || '/state/quality/chatbot-qa/afk-runs';
+const fmtPct = v => (v==null || isNaN(v)) ? '–' : (Math.round(v*1000)/10)+'%';
+const since = iso => { if(!iso) return ''; const s=(Date.now()-Date.parse(iso))/1000; if(s<60)return Math.round(s)+'s ago'; if(s<3600)return Math.round(s/60)+'m ago'; return Math.round(s/3600)+'h ago'; };
+const $ = id => document.getElementById(id);
+
+async function getJSON(path){ const r = await fetch(path + '?_=' + Date.now()); if(!r.ok) throw new Error(path+' '+r.status); return r.json(); }
+async function getText(path){ const r = await fetch(path + '?_=' + Date.now()); if(!r.ok) throw new Error(path+' '+r.status); return r.text(); }
+
+function setState(s){
+  const el=$('state'); const v=(s||'unknown').toLowerCase();
+  el.className='pill '+(['running','preflight','blocked','killed','degraded','done'].includes(v)?v:'unknown');
+  el.textContent=s||'unknown';
+}
+
+function drawTrend(events){
+  const svg=$('trend'); svg.innerHTML='';
+  const pts=events.filter(e=>e.det!=null||e.sem!=null);
+  if(pts.length<1){ svg.innerHTML='<text x="8" y="60" fill="#8b949e" font-size="11">no metric samples yet</text>'; return; }
+  const W=400,H=120,pad=6;
+  const line=(key,color)=>{
+    const ys=pts.map(e=>e[key]).filter(v=>v!=null);
+    if(!ys.length) return '';
+    const n=pts.length;
+    const path=pts.map((e,i)=>{ const v=e[key]; if(v==null)return null;
+      const x=pad+(n===1?(W-2*pad)/2:(i/(n-1))*(W-2*pad)); const y=H-pad-v*(H-2*pad);
+      return (i===0?'M':'L')+x.toFixed(1)+' '+y.toFixed(1); }).filter(Boolean).join(' ');
+    return `<path d="${path}" fill="none" stroke="${color}" stroke-width="2"/>`;
+  };
+  // gridline at target
+  svg.innerHTML = line('det','#3fb950') + line('sem','#bc8cff');
+}
+
+function renderTimeline(events){
+  const tl=$('timeline');
+  if(!events.length){ tl.innerHTML='<span class="muted">no events yet</span>'; return; }
+  tl.innerHTML = events.slice().reverse().map(e=>{
+    const t=(e.ts||'').replace('T',' ').replace('Z','').slice(11);
+    const extra=[e.iteration!=null?'#'+e.iteration:'', e.det!=null?'det '+fmtPct(e.det):'', e.sem!=null?'sem '+fmtPct(e.sem):''].filter(Boolean).join(' · ');
+    return `<div class="evt"><span class="t">${t}</span><span class="k ${e.kind}">${e.kind||''}</span><span>${e.detail||''}${extra?' <span class="muted">['+extra+']</span>':''}</span></div>`;
+  }).join('');
+}
+
+async function refresh(){
+  try{
+    const st = await getJSON(ROOT+'/latest-status.json');
+    $('err').textContent='';
+    setState(st.state);
+    $('phase').textContent = st.phase ? '· '+st.phase : '';
+    $('updated').textContent = st.updated_at ? 'updated '+since(st.updated_at) : '';
+    $('det').textContent = fmtPct(st.current?.deterministic_pass_pct);
+    $('sem').textContent = fmtPct(st.current?.semantic_pass_pct);
+    $('target').textContent = fmtPct(st.target_metric);
+    $('detbar').style.width = ((st.current?.deterministic_pass_pct||0)*100)+'%';
+    $('sembar').style.width = ((st.current?.semantic_pass_pct||0)*100)+'%';
+    $('runid').textContent = st.run_id||'–';
+    $('branch').textContent = st.branch||'–';
+    $('iter').textContent = (st.iteration!=null?st.iteration:'–')+(st.max_iterations?(' / '+st.max_iterations):'');
+    $('commits').textContent = st.commits!=null?st.commits:'–';
+    $('started').textContent = st.started_at ? since(st.started_at) : '–';
+    if(st.killswitch) $('ks').textContent = st.killswitch;
+
+    const blockers = st.blockers||[];
+    $('blockcard').style.display = blockers.length ? '' : 'none';
+    $('blockers').innerHTML = blockers.map(b=>`<li>${b}</li>`).join('');
+
+    // events (newline-delimited JSON)
+    let events=[];
+    if(st.events_file){
+      try{
+        const raw = await getText(ROOT+'/'+st.events_file.replace(/^afk-runs\//,''));
+        events = raw.trim().split(/\r?\n/).filter(Boolean).map(l=>{try{return JSON.parse(l)}catch{return null}}).filter(Boolean);
+      }catch(e){ /* events optional */ }
+    }
+    drawTrend(events);
+    renderTimeline(events);
+  }catch(e){
+    $('err').textContent = 'no run found ('+e.message+')';
+    setState('unknown');
+    $('timeline').innerHTML = '<span class="muted">No harness run on disk yet. Arm the harness (see runbook) — status will appear here within seconds.</span>';
+  }
+}
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>

--- a/Tools/afk-fleet-dashboard/index.html
+++ b/Tools/afk-fleet-dashboard/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>GuitarAlchemist — QA Fleet</title>
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--border:#30363d;--txt:#c9d1d9;--dim:#8b949e;
+    --ok:#3fb950;--warn:#d29922;--bad:#f85149;--info:#58a6ff;--accent:#bc8cff;}
+  *{box-sizing:border-box}
+  body{margin:0;font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;background:var(--bg);color:var(--txt)}
+  header{padding:16px 22px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  header h1{font-size:17px;margin:0;font-weight:600}
+  .sub{color:var(--dim);font-size:12px}
+  main{padding:22px;display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:18px;max-width:1500px}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:18px;position:relative;overflow:hidden}
+  .card::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;background:var(--dim)}
+  .card.done::before{background:var(--ok)} .card.running::before,.card.baseline::before{background:var(--info)}
+  .card.blocked::before,.card.degraded::before,.card.killed::before{background:var(--bad)}
+  .card.preflight::before{background:var(--warn)} .card.no-data::before{background:#30363d}
+  .chead{display:flex;align-items:center;justify-content:space-between;margin-bottom:4px}
+  .repo{font-size:18px;font-weight:700}
+  .domain{color:var(--dim);font-size:12px}
+  .pill{padding:3px 10px;border-radius:999px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+  .pill.done{background:rgba(63,185,80,.15);color:var(--ok)}
+  .pill.running,.pill.baseline{background:rgba(88,166,255,.15);color:var(--info)}
+  .pill.blocked,.pill.degraded,.pill.killed{background:rgba(248,81,73,.15);color:var(--bad)}
+  .pill.preflight{background:rgba(210,153,34,.15);color:var(--warn)}
+  .pill.no-data{background:rgba(139,148,158,.12);color:var(--dim)}
+  .metrics{display:flex;gap:22px;margin:14px 0 10px;flex-wrap:wrap}
+  .m .v{font-size:28px;font-weight:700} .m .l{font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:.05em}
+  .m .v.text{font-size:18px}
+  .bar{height:6px;background:#21262d;border-radius:3px;overflow:hidden;margin-top:5px;width:120px}
+  .bar>i{display:block;height:100%;background:var(--ok)}
+  .detail{color:var(--dim);font-size:12.5px;border-top:1px dashed #21262d;padding-top:10px;margin-top:4px}
+  .badge{display:inline-block;background:#21262d;color:var(--accent);border-radius:5px;padding:1px 7px;font-size:11px;margin-left:6px}
+  .src{color:var(--dim);font-size:11px;margin-top:8px;word-break:break-all}
+  .footer{padding:12px 22px;color:var(--dim);font-size:12px;border-top:1px solid var(--border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+  code{background:#21262d;padding:1px 6px;border-radius:4px;color:var(--accent)}
+  #err{color:var(--bad)}
+</style>
+</head>
+<body>
+<header>
+  <h1>🛰️ GuitarAlchemist — QA Fleet</h1>
+  <span class="sub" id="gen"></span>
+  <span style="flex:1"></span>
+  <span class="sub">one feed · all repos · auto-refresh 8s</span>
+</header>
+<main id="grid"><span class="sub">loading…</span></main>
+<div class="footer">
+  <span>Refresh the feed: <code>pwsh Scripts/afk-fleet-aggregate.ps1</code> (reads ga + ix + Demerzel)</span>
+  <span id="err"></span>
+</div>
+<script>
+const FEED = new URLSearchParams(location.search).get('feed') || '/state/quality/ecosystem/afk-fleet.json';
+const pct = v => (v==null||isNaN(v))?'–':(Math.round(v*1000)/10)+'%';
+const since = iso => { if(!iso) return ''; const s=(Date.now()-Date.parse(iso))/1000; if(isNaN(s))return ''; if(s<60)return Math.round(s)+'s ago'; if(s<3600)return Math.round(s/60)+'m ago'; return Math.round(s/3600)+'h ago'; };
+
+function metric(label, v){
+  if(v==null) return '';
+  return `<div class="m"><div class="v">${pct(v)}</div><div class="l">${label}</div><div class="bar"><i style="width:${(v*100)||0}%"></i></div></div>`;
+}
+function card(r){
+  const st=(r.state||'no-data');
+  const primary = r.primary_text
+    ? `<div class="m"><div class="v text">${r.primary_text}</div><div class="l">${r.primary_label||''}</div></div>`
+    : metric(r.primary_label, r.primary_pct);
+  const secondary = (r.secondary_pct!=null) ? metric(r.secondary_label, r.secondary_pct) : '';
+  const tgt = r.queued_targets ? `<span class="badge">${r.queued_targets} target${r.queued_targets>1?'s':''} queued</span>` : '';
+  const targetLine = (r.target!=null) ? `<span class="badge">target ${pct(r.target)}</span>` : '';
+  const verd = r.verdicts ? `<span class="badge">T:${r.verdicts.T||0} P:${r.verdicts.P||0} U:${r.verdicts.U||0} D:${r.verdicts.D||0} F:${r.verdicts.F||0} C:${r.verdicts.C||0}</span>` : '';
+  return `<section class="card ${st}">
+    <div class="chead"><div><span class="repo">${r.repo}</span> <span class="domain">${r.domain||''}</span></div>
+      <span class="pill ${st}">${st}</span></div>
+    <div class="sub">${r.kind||''} ${r.updated_at?('· '+since(r.updated_at)):''} ${targetLine} ${tgt} ${verd}</div>
+    <div class="metrics">${primary}${secondary}</div>
+    <div class="detail">${r.detail||''}</div>
+    ${r.source?`<div class="src">${r.source}</div>`:''}
+  </section>`;
+}
+async function refresh(){
+  try{
+    const r = await fetch(FEED+'?_='+Date.now());
+    if(!r.ok) throw new Error(FEED+' '+r.status);
+    const f = await r.json();
+    document.getElementById('err').textContent='';
+    document.getElementById('gen').textContent = f.generated_at ? ('aggregated '+since(f.generated_at)) : '';
+    document.getElementById('grid').innerHTML = (f.repos||[]).map(card).join('');
+  }catch(e){
+    document.getElementById('err').textContent = 'feed error: '+e.message;
+    document.getElementById('grid').innerHTML = '<span class="sub">No fleet feed yet. Run <code>pwsh Scripts/afk-fleet-aggregate.ps1</code> from the ga repo, and serve from repo root.</span>';
+  }
+}
+refresh(); setInterval(refresh, 8000);
+</script>
+</body>
+</html>

--- a/docs/runbooks/ga-chatbot-afk-harness.md
+++ b/docs/runbooks/ga-chatbot-afk-harness.md
@@ -1,0 +1,146 @@
+# Runbook — GA Chatbot AFK Harness
+
+**What it is:** a runnable, instrumented system that lets the GA chatbot
+*improve itself* unattended — it QAs the chatbot, fixes the worst-scoring
+prompt, re-QAs to prove it didn't regress, commits on a branch, and repeats —
+while a live dashboard shows a human exactly what's happening. "AFK" = away
+from keyboard: you arm it, watch the dashboard, and review the branch it
+produces. It **never merges or deploys on its own.**
+
+This runbook is the human's map. The machine-followed logic lives in the skill
+`.claude/skills/ga-chatbot-afk-harness/SKILL.md`.
+
+---
+
+## 1. The loop at a glance
+
+```mermaid
+flowchart TD
+    A[Arm: /goal · /loop · claude -p] --> P{Preflight}
+    P -->|backend down / killswitch / halt| BLK[Emit BLOCKED/KILLED · STOP]
+    P -->|ok| S0[QA snapshot:\ndeterministic oracle + semantic panel]
+    S0 --> L{pass_pct >= target?}
+    L -->|yes| DONE[Final snapshot · handoff note · STOP]
+    L -->|no| C[/auto-optimize cycle:\npick worst → fix → roundtrip gate/]
+    C -->|roundtrip pass| CM[commit on branch]
+    C -->|roundtrip reject| RV[revert]
+    CM --> I[emit status → dashboard]
+    RV --> I
+    I --> K{killswitch / caps / plateau?}
+    K -->|no| L
+    K -->|yes| DONE
+    DONE --> H[Human reviews + lands branch]
+```
+
+Every box that changes state calls `Scripts/afk-harness-status.ps1`, which
+writes `state/quality/chatbot-qa/afk-runs/latest-status.json` + a per-run
+`.jsonl` event log. **Code owns the status**, so even a crashed or killed loop
+leaves an honest last-known state on the dashboard.
+
+## 2. What's reused vs. new
+
+This harness is an **orchestrator**, not a new loop. It deliberately reuses the
+Level-3 machinery ga already had:
+
+| Reused (do not duplicate) | New in this harness |
+|---|---|
+| `/auto-optimize` — the dev loop (Iron Laws, caps, lock, rollback) | `.claude/skills/ga-chatbot-afk-harness/` — orchestrator |
+| `/chatbot-qa-roundtrip-validate` — per-commit gate | `Scripts/afk-harness-status.ps1` — instrumentation |
+| `Scripts/run-prompt-corpus.ps1` — deterministic oracle | `Tools/afk-dashboard/index.html` — human UI |
+| `state/quality/chatbot-qa/baseline.json` — metric + caps | `/ga-chatbot-qa-panel` — semantic QA signal |
+
+The semantic panel matters because the deterministic oracle only checks
+substrings/routing; the panel (3 independent lenses + hexavalent T/P/U/D/F/C
+consensus) catches *wrong-but-well-formatted* answers the oracle passes.
+
+## 3. Arming it (3 modes)
+
+> Preconditions: GaChatbot.Api up on `:5252` (`docs/runbooks/chatbot-deploy.md`),
+> no `state/.loop-halted`, no `state/quality/chatbot-qa/.STOP`, no live
+> `~/.demerzel/HALT-ALL`.
+
+```bash
+# A. Bounded, in-session (recommended first run)
+/goal deterministic pass_pct >= 0.97 for chatbot corpus
+/ga-chatbot-afk-harness target_metric=0.97 max_iterations=10
+
+# B. Interval (only if repo preflight says LOOP_READY=true)
+/loop /ga-chatbot-afk-harness
+
+# C. Headless / true AFK
+claude -p "/ga-chatbot-afk-harness target_metric=0.97 max_iterations=20"
+```
+
+## 4. Watching it — the dashboard
+
+```bash
+python -m http.server 8099      # from the ga repo root
+# open http://localhost:8099/Tools/afk-dashboard/
+```
+
+The dashboard (zero dependencies, auto-refresh 5s) shows:
+
+- **State pill** — `preflight · running · blocked · degraded · killed · done`
+- **QA metrics** — deterministic pass %, semantic-panel pass %, target
+- **Run card** — run id, branch, iteration / max, commits, elapsed
+- **Blockers** — e.g. "backend_unavailable: GaChatbot.Api :5252" (shown only when blocked)
+- **Metric trend** — deterministic + semantic over the run's cycles
+- **Event timeline** — every phase, target-selected, commit, revert, with Δpp
+
+Before the first arming it reads "No harness run on disk yet" — expected.
+Serving from a different root? append `?root=/your/path/afk-runs`.
+
+## 5. Safety model (read before arming headless)
+
+The harness can edit GA source autonomously, so the rails are explicit:
+
+1. **Branch-only.** All commits land on `afk/chatbot-qa-<date>`. The harness
+   **never** pushes, opens/merges a PR, deploys, or applies a review-bypass
+   label. A human reviews and lands.
+2. **Rollback-gated.** No commit happens unless `/chatbot-qa-roundtrip-validate`
+   confirms the metric didn't regress (`regression_threshold` 0.02), the
+   canonical-trace gate holds, and no protected path changed.
+3. **Caps.** `max_commits_per_session=50`, `max_wall_clock_minutes=480`,
+   plateau exit after 5 sub-threshold cycles (from `baseline.json`).
+4. **Killswitches (checked every iteration).**
+   - `state/quality/chatbot-qa/.STOP` — stop this domain.
+   - `state/.loop-halted` — stop all loops in the repo.
+   - `~/.demerzel/HALT-ALL` — ecosystem-wide overseer halt.
+5. **Honest degrade.** Backend down ⇒ `blocked` status + stop. Never a
+   fabricated pass rate. (See the `feedback_green_but_dead` discipline.)
+6. **Protected paths** (oracle, baselines, gates, signature fixtures) require an
+   operator-only `[allow-protected: <path>]` commit marker — the loop cannot
+   edit the contract it is measured against.
+
+## 6. Landing the work (human-gated)
+
+When a run finishes it drops `state/handoffs/<ts>-claude-code.md` with the
+branch, commits, and final metrics. To land:
+
+```bash
+git log --oneline main..afk/chatbot-qa-<date>     # review every commit
+gh pr create --base main --head afk/chatbot-qa-<date>
+# Before merge: scan Codex bot comments; resolve P0/P1 (see CLAUDE.md).
+```
+
+## 7. File map
+
+| Path | Purpose |
+|---|---|
+| `.claude/skills/ga-chatbot-afk-harness/SKILL.md` | orchestrator logic |
+| `Scripts/afk-harness-status.ps1` | status/event writer |
+| `Tools/afk-dashboard/index.html` | dashboard UI |
+| `state/quality/chatbot-qa/afk-runs/latest-status.json` | current status (UI source) |
+| `state/quality/chatbot-qa/afk-runs/<run_id>.jsonl` | per-run event log |
+| `state/quality/chatbot-qa/baseline.json` | metric, caps, scope_boundary, protected paths |
+| `state/quality/chatbot-qa-semantic/<date>.json` | semantic-panel snapshots |
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Dashboard "No harness run" | not armed yet, or served from wrong root | arm it, or pass `?root=` |
+| State stuck `blocked` | GaChatbot.Api down on :5252 | start backend, re-arm |
+| Loop exits immediately `killed` | a `.STOP` / `.loop-halted` / HALT-ALL marker present | remove the marker if intended |
+| No commits despite low pass | every fix was roundtrip-rejected, or plateau | inspect timeline reverts; the corpus shape may be exhausted |
+| Metric trend empty | only phase events so far (no cycle completed) | wait for the first cycle |


### PR DESCRIPTION
@
Runnable, documented, instrumented **AFK harness** for unattended GA-chatbot develop+QA, plus the semantic judge-panel workflow it uses.

**Orchestrator, not a new loop** — reuses `/auto-optimize` (dev loop, Iron Laws, rollback, killswitch), `/chatbot-qa-roundtrip-validate`, `run-prompt-corpus.ps1`, `baseline.json`. New: orchestrator skill, `Scripts/afk-harness-status.ps1` (instrumentation), `Tools/afk-dashboard/index.html` (live UI), runbook, and `.claude/workflows/ga-chatbot-qa-panel.js` (semantic panel → hexavalent T/P/U/D/F/C consensus).

**Safety**: branch-only / never push-merge-deploy-label; rollback-gated; caps; killswitches (`.STOP` / `state/.loop-halted` / `~/.demerzel/HALT-ALL`); honest-degrade (blocks, never fabricates pass_pct).

**Validated**: node --check, PS1 parse, headless dashboard render, AND a live bounded dry-run against GaChatbot.Api (3 prompts → 3/3 semantic pass, panel caught 2 real soft-spots). Non-build-graph assets, so the full dotnet gate does not exercise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@