### PR TITLE
fix(chatbot): voicing search actually works — OPTK strategy + exhaustive chord parser + geometric fallback

### DIFF
--- a/Apps/GaChatbot.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/Apps/GaChatbot.Api/Extensions/ServiceCollectionExtensions.cs
@@ -140,15 +140,25 @@ public static class ServiceCollectionExtensions
             return System.IO.File.Exists(configured) ? configured : null;
         }
 
-        for (var dir = new System.IO.DirectoryInfo(AppContext.BaseDirectory);
-             dir is not null;
-             dir = dir.Parent)
+        // Walk up toward the repo root. Guard the walk: DirectoryInfo.Parent/FullName can
+        // throw on pathological mounts (PathTooLong / Security), and this runs at host
+        // startup — degrade to CPU (return null) rather than aborting boot, per the contract.
+        try
         {
-            var candidate = System.IO.Path.Combine(dir.FullName, "state", "voicings", "optick.index");
-            if (System.IO.File.Exists(candidate))
+            for (var dir = new System.IO.DirectoryInfo(AppContext.BaseDirectory);
+                 dir is not null;
+                 dir = dir.Parent)
             {
-                return candidate;
+                var candidate = System.IO.Path.Combine(dir.FullName, "state", "voicings", "optick.index");
+                if (System.IO.File.Exists(candidate))
+                {
+                    return candidate;
+                }
             }
+        }
+        catch (Exception)
+        {
+            // fall through to null → CPU fallback
         }
 
         return null;

--- a/Apps/GaChatbot.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/Apps/GaChatbot.Api/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using GA.Infrastructure.Documentation;
 using GA.Infrastructure.Persistence.Repositories;
 using GaChatbot.Api.Services;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 public static class ServiceCollectionExtensions
 {
@@ -61,7 +62,43 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<IProgressionCorpusRepository, InMemoryProgressionCorpusRepository>();
             services.AddSingleton<SchemaDiscoveryService>();
             services.AddSingleton<VoicingIndexingService>();
-            services.AddSingleton<IVoicingSearchStrategy, CpuVoicingSearchStrategy>();
+
+            // Voicing search strategy. The chatbot encodes queries with MusicalQueryEncoder
+            // (124-dim OPTK compact vectors), so it must score against the matching OPTK mmap
+            // index — exactly what GaApi and GaMcpServer already do successfully.
+            // CpuVoicingSearchStrategy instead scores those 124-dim musical vectors against
+            // per-voicing 768-dim text embeddings; the dimension mismatch makes its
+            // CosineSimilarity return 0.0 for EVERY voicing, collapsing the ranking to corpus
+            // insertion order and returning arbitrary wrong chords at score 0.000. Prefer the
+            // dimension-clean OPTK index; fall back to CPU only when it is genuinely absent.
+            services.AddSingleton<IVoicingSearchStrategy>(sp =>
+            {
+                var logger = sp.GetRequiredService<ILogger<EnhancedVoicingSearchService>>();
+                var indexPath = ResolveOpticIndexPath(configuration);
+                if (indexPath is not null)
+                {
+                    try
+                    {
+                        var strategy = new OptickSearchStrategy(indexPath);
+                        logger.LogInformation("Chatbot voicing search using OPTK index at {Path}", indexPath);
+                        return strategy;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex,
+                            "OPTK index at {Path} failed to open; falling back to CPU voicing search", indexPath);
+                    }
+                }
+                else
+                {
+                    logger.LogWarning(
+                        "OPTK voicing index not found (set VoicingSearch:OpticIndexPath or " +
+                        "GA_OPTICK_INDEX_PATH, or place it under state/voicings/optick.index); " +
+                        "falling back to CPU voicing search — relevance scores will be degraded.");
+                }
+
+                return new CpuVoicingSearchStrategy();
+            });
             services.AddSingleton<EnhancedVoicingSearchService>();
             services.AddMemoryCache();
             services.AddSingleton<MusicalQueryEncoder>();
@@ -84,5 +121,36 @@ public static class ServiceCollectionExtensions
         }
 
         return services;
+    }
+
+    /// <summary>
+    ///     Resolves the OPTK voicing index path the same way GaMcpServer does: an explicit
+    ///     <c>VoicingSearch:OpticIndexPath</c> config value or <c>GA_OPTICK_INDEX_PATH</c>
+    ///     environment override first, then a walk up from the entry directory toward the
+    ///     repo root looking for <c>state/voicings/optick.index</c>. Returns <see langword="null"/>
+    ///     when the index is absent so the caller can degrade to CPU search instead of
+    ///     throwing at host startup.
+    /// </summary>
+    private static string? ResolveOpticIndexPath(IConfiguration configuration)
+    {
+        var configured = configuration["VoicingSearch:OpticIndexPath"]
+                         ?? Environment.GetEnvironmentVariable("GA_OPTICK_INDEX_PATH");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            return System.IO.File.Exists(configured) ? configured : null;
+        }
+
+        for (var dir = new System.IO.DirectoryInfo(AppContext.BaseDirectory);
+             dir is not null;
+             dir = dir.Parent)
+        {
+            var candidate = System.IO.Path.Combine(dir.FullName, "state", "voicings", "optick.index");
+            if (System.IO.File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 }

--- a/Common/GA.Business.ML/Agents/VoicingAgent.cs
+++ b/Common/GA.Business.ML/Agents/VoicingAgent.cs
@@ -83,6 +83,20 @@ public sealed class VoicingAgent(
         var results = await voicingSearch.SearchAsync(
             request.Query, Generator, limit, filters, cancellationToken);
 
+        // Geometric fallback. The OPTK index is ranked by pitch-class geometry, but a hard
+        // ChordName filter rejects voicings the corpus never labelled with this exact symbol
+        // (e.g. "G7b13", "Amaj7#5", "Galt") even when pc-matching voicings plainly exist. The
+        // query vector already encodes the chord's pitch classes, so when the name-filtered
+        // search finds nothing, retry on geometry alone — keeping the instrument/mode/tag
+        // filters — so ANY valid chord grounds in real voicings instead of dropping to the LLM.
+        // (Safe to retry: this is the dimension-clean OPTK strategy; on the old CPU strategy a
+        // retry returned score-0.000 garbage, which is why an earlier attempt was reverted.)
+        if (results.Count == 0 && filters is { ChordName: not null })
+        {
+            results = await voicingSearch.SearchAsync(
+                request.Query, Generator, limit, filters with { ChordName = null }, cancellationToken);
+        }
+
         if (results.Count == 0)
         {
             return new AgentResponse

--- a/Common/GA.Business.ML/Search/EnhancedVoicingSearchService.cs
+++ b/Common/GA.Business.ML/Search/EnhancedVoicingSearchService.cs
@@ -195,7 +195,11 @@ public class EnhancedVoicingSearchService(
 
     private void EnsureInitialized()
     {
-        if (!IsInitialized)
+        // Only strategies that need a warmup (CPU/GPU in-memory) are gated. A self-contained
+        // strategy like OPTK (mmap loaded at construction) reports RequiresWarmup == false and
+        // serves immediately, so a query arriving before the background warmup finishes no
+        // longer throws "Service not initialized" (the cold-start race).
+        if (!IsInitialized && searchStrategy.RequiresWarmup)
         {
             throw new InvalidOperationException("Service not initialized. Call InitializeEmbeddingsAsync first.");
         }

--- a/Common/GA.Business.ML/Search/IVoicingSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/IVoicingSearchStrategy.cs
@@ -49,6 +49,16 @@ public interface IVoicingSearchStrategy
     VoicingSearchPerformance Performance { get; }
 
     /// <summary>
+    ///     Whether this strategy needs <see cref="InitializeAsync"/> / the host warmup before
+    ///     it can serve queries. Strategies that load their corpus at construction (e.g. the
+    ///     OPTK mmap reader) are ready immediately and return <see langword="false"/>, so the
+    ///     service must NOT gate their queries behind a warmup that does nothing for them —
+    ///     that gating is the cold-start "Service not initialized" race. Defaults to true so
+    ///     existing in-memory strategies (CPU/GPU) keep their initialize-then-serve contract.
+    /// </summary>
+    bool RequiresWarmup => true;
+
+    /// <summary>
     ///     Initialize the strategy with voicing data
     /// </summary>
     Task InitializeAsync(IEnumerable<VoicingEmbedding> voicings);

--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -1,5 +1,6 @@
 namespace GA.Business.ML.Search;
 
+using System.Text.RegularExpressions;
 using Embeddings;
 using Embeddings.Services;
 using Rag.Models;
@@ -182,59 +183,13 @@ public sealed class MusicalQueryEncoder(
 /// </summary>
 public static class ChordPitchClasses
 {
-    // Quality → offsets from root (semitones within one octave).
-    private static readonly Dictionary<string, int[]> Qualities = new(StringComparer.OrdinalIgnoreCase)
-    {
-        [""]          = [0, 4, 7],                    // major triad
-        ["maj"]       = [0, 4, 7],
-        ["m"]         = [0, 3, 7],                    // minor triad
-        ["min"]       = [0, 3, 7],
-        ["dim"]       = [0, 3, 6],
-        ["aug"]       = [0, 4, 8],
-        ["sus2"]      = [0, 2, 7],
-        ["sus4"]      = [0, 5, 7],
-        ["5"]         = [0, 7],                       // power chord
-        ["7"]         = [0, 4, 7, 10],                // dominant 7
-        ["maj7"]      = [0, 4, 7, 11],
-        ["M7"]        = [0, 4, 7, 11],
-        ["m7"]        = [0, 3, 7, 10],
-        ["min7"]      = [0, 3, 7, 10],
-        ["m7b5"]      = [0, 3, 6, 10],                // half-diminished
-        ["dim7"]      = [0, 3, 6, 9],
-        ["7sus4"]     = [0, 5, 7, 10],
-        ["6"]         = [0, 4, 7, 9],
-        ["m6"]        = [0, 3, 7, 9],
-        ["9"]         = [0, 4, 7, 10, 2],
-        ["maj9"]      = [0, 4, 7, 11, 2],
-        ["m9"]        = [0, 3, 7, 10, 2],
-        ["11"]        = [0, 4, 7, 10, 2, 5],
-        ["13"]        = [0, 4, 7, 10, 2, 5, 9],
-        ["add9"]      = [0, 4, 7, 2],
-
-        // Extended / altered qualities — jazz and fusion vocabulary
-        ["mmaj7"]     = [0, 3, 7, 11],                // minor-major 7
-        ["minmaj7"]   = [0, 3, 7, 11],
-        ["m(maj7)"]   = [0, 3, 7, 11],
-        ["maj13"]     = [0, 4, 7, 11, 2, 5, 9],
-        ["m11"]       = [0, 3, 7, 10, 2, 5],
-        ["m13"]       = [0, 3, 7, 10, 2, 5, 9],
-        ["9#11"]      = [0, 4, 7, 10, 2, 6],          // "Lydian dominant" flavor
-        ["maj9#11"]   = [0, 4, 7, 11, 2, 6],
-        ["13#11"]     = [0, 4, 7, 10, 2, 6, 9],
-        ["7b9"]       = [0, 4, 7, 10, 1],
-        ["7#9"]       = [0, 4, 7, 10, 3],             // "Hendrix chord" intervals
-        ["7b5"]       = [0, 4, 6, 10],
-        ["7#5"]       = [0, 4, 8, 10],
-        ["aug7"]      = [0, 4, 8, 10],
-        ["+7"]        = [0, 4, 8, 10],
-        ["13b9"]      = [0, 4, 7, 10, 1, 5, 9],
-        ["7alt"]      = [0, 4, 10, 1, 3, 6, 8],       // altered dominant: b9 #9 b5 b13
-        ["69"]        = [0, 4, 7, 9, 2],
-        ["6/9"]       = [0, 4, 7, 9, 2],              // conventional notation with slash
-        ["sus4add9"]  = [0, 5, 7, 2],
-        ["sus2add11"] = [0, 2, 5, 7],
-    };
-
+    // Chord-quality resolution is COMPOSITIONAL (see TryComputeChordOffsets): the parser
+    // builds the interval set algorithmically from a base triad + an optional
+    // sixth/seventh/extension spine + any sequence of alterations / additions / omissions,
+    // rather than enumerating named qualities in a finite lookup table. This makes it
+    // exhaustive over the combinatorial space — "7b13", "maj7#5", "13#9", "m11b5",
+    // "7sus4b9", "C(add#11)" all resolve — instead of silently failing (and dropping the
+    // query to a hallucinating LLM) whenever a symbol is missing from a hand-maintained list.
     private static readonly Dictionary<string, int> Roots = new(StringComparer.OrdinalIgnoreCase)
     {
         ["C"] = 0, ["C#"] = 1, ["Db"] = 1, ["D"] = 2, ["D#"] = 3, ["Eb"] = 3,
@@ -242,8 +197,23 @@ public static class ChordPitchClasses
         ["Ab"] = 8, ["A"] = 9, ["A#"] = 10, ["Bb"] = 10, ["B"] = 11, ["Cb"] = 11,
     };
 
-    /// <summary>Canonical chord-quality suffixes the parser recognizes (after the root letter).</summary>
-    public static IReadOnlyCollection<string> KnownQualities => Qualities.Keys;
+    // Representative suffixes — ADVISORY ONLY (vocabulary hints). The parser is
+    // compositional, so the accepted set is far larger than this list; never treat it as
+    // the exhaustive accepted set.
+    private static readonly string[] RepresentativeQualities =
+    [
+        "", "maj", "m", "dim", "aug", "sus2", "sus4", "5", "6", "m6", "69", "6/9",
+        "7", "maj7", "m7", "m7b5", "dim7", "mmaj7", "7sus4",
+        "9", "maj9", "m9", "11", "m11", "13", "maj13", "m13", "add9", "madd9", "add11",
+        "7b5", "7#5", "7b9", "7#9", "7#11", "7b13", "7alt", "9#11", "13#9", "13b9",
+        "maj7#5", "maj7b5", "maj9#11", "m7#5", "aug7", "+7",
+    ];
+
+    /// <summary>
+    ///     Representative chord-quality suffixes (advisory; the compositional parser accepts
+    ///     far more — any root + base triad + spine + alteration/addition sequence).
+    /// </summary>
+    public static IReadOnlyCollection<string> KnownQualities => RepresentativeQualities;
 
     /// <summary>Canonical root notes (C, C#, Db, D, ... B, Cb) the parser recognizes.</summary>
     public static IReadOnlyCollection<string> KnownRoots => Roots.Keys;
@@ -262,6 +232,7 @@ public static class ChordPitchClasses
         if (!Roots.TryGetValue(rootStr, out var r)) return false;
 
         var qualityStr = symbol[rootLen..];
+
         // Drop slash-BASS suffix (e.g. "Cmaj7/G" → bass G). But keep slash-in-quality
         // like "C6/9" where the token after the slash is a digit — that's an extension,
         // not a bass note.
@@ -273,35 +244,142 @@ public static class ChordPitchClasses
             qualityStr = qualityStr[..slashIdx];
         }
 
-        if (!Qualities.TryGetValue(qualityStr, out var offsets))
-        {
-            // Paren-stripped retry: the user-facing notation `E7(#9)`, `C7(b9)`,
-            // `C(add9)`, `Cm(maj9)` carries parens around the alteration suffix. The
-            // dictionary keys store the canonical paren-less forms ("7#9", "7b9",
-            // "add9"). Without this retry, removing parens from the tokenizer
-            // (companion fix in TypedMusicalQueryExtractor) would regress those
-            // forms — they'd reach TryParse as a single token, fail the lookup,
-            // and be dropped entirely. The only key that genuinely needs parens
-            // is "m(maj7)" which already matches on the first attempt.
-            if (qualityStr.Contains('(') || qualityStr.Contains(')'))
-            {
-                var stripped = qualityStr.Replace("(", "").Replace(")", "");
-                if (Qualities.TryGetValue(stripped, out offsets))
-                {
-                    root = r;
-                    pitchClasses = offsets.Select(o => (r + o) % 12).Distinct().OrderBy(x => x).ToArray();
-                    return true;
-                }
-            }
+        // Parens are cosmetic: "C7(#9)", "Cm(maj7)", "C(add9)" mean the paren-less forms.
+        qualityStr = qualityStr.Replace("(", "").Replace(")", "");
 
-            // Reject unknown qualities — otherwise every english word starting with a letter
-            // A-G (e.g. "and", "fade", "be") parses as a chord and every query carries false
-            // musical structure into retrieval.
-            return false;
-        }
+        if (!TryComputeChordOffsets(qualityStr, out var offsets)) return false;
 
         root = r;
         pitchClasses = offsets.Select(o => (r + o) % 12).Distinct().OrderBy(x => x).ToArray();
         return true;
     }
+
+    /// <summary>
+    ///     Compositional chord-quality → semitone-offsets (from the root). Assembles the
+    ///     interval set from a base triad (major / minor / diminished / augmented /
+    ///     suspended), an optional sixth or seventh/extension spine (6, 7, maj7, 9, 11, 13 —
+    ///     the 7th quality implied by maj/M/△ vs dominant vs diminished), and any sequence of
+    ///     alterations (b5 #5 b9 #9 #11 b13 …), additions (add2/4/6/9/11/13) and omissions
+    ///     (no3/omit5). Returns <see langword="false"/> when the suffix leaves residue it
+    ///     cannot explain, so a root letter followed by ordinary words ("Fade", "Bee") does
+    ///     NOT parse as a chord and inject false structure into retrieval.
+    /// </summary>
+    internal static bool TryComputeChordOffsets(string quality, out int[] offsets)
+    {
+        offsets = [];
+        var w = (quality ?? string.Empty).Trim();
+
+        // ── normalize symbol variants (case matters: 'M7' = major7, 'm' = minor) ──
+        w = Regex.Replace(w, "△|Δ", "maj");
+        w = Regex.Replace(w, "ø|Ø", "m7b5");
+        w = Regex.Replace(w, @"M(?=7|9|11|13|6)", "maj");        // M7 / M9 / M13 → major-7th family
+        w = w.Replace("Maj", "maj").Replace("MAJ", "maj").Replace("Major", "maj").Replace("major", "maj");
+        w = w.Replace("Min", "min").Replace("MIN", "min").Replace("minor", "min");
+        w = w.Replace("M", "maj");                                // any lone uppercase M ⇒ major
+        // The major-7th marker is now canonical, so folding to lower case leaves a residual
+        // 'm' meaning unambiguously minor.
+        w = w.ToLowerInvariant();
+        w = w.Replace("°", "dim").Replace("o7", "dim7");
+
+        if (w.Length == 0) { offsets = [0, 4, 7]; return true; }  // bare root → major triad
+        if (w == "5") { offsets = [0, 7]; return true; }          // power chord
+
+        // Altered dominant (7alt / alt) is a fixed 7-note sonority — 1 3 b7 b9 #9 #11 b13.
+        // It carries BOTH b9 and #9, which a one-value-per-degree map cannot express, so
+        // resolve it directly.
+        if (Regex.IsMatch(w, @"^7?alt$")) { offsets = [0, 1, 3, 4, 6, 8, 10]; return true; }
+
+        var set = new SortedSet<int> { 0 };
+        var explicitDegrees = new Dictionary<int, int>();         // degree (2/4/6/9/11/13) → semitone
+        var omit = new HashSet<int>();                            // chord degrees (3, 5) to drop
+        var noThird = false;
+        var fifth = 7;
+        int? sixth = null;
+        int? seventh = null;
+
+        // additions: add2 add4 add6 add9 add11 add13
+        foreach (Match m in Regex.Matches(w, @"add(2|4|6|9|11|13)"))
+        {
+            var d = int.Parse(m.Groups[1].Value);
+            explicitDegrees[d] = DegreeSemitone(d, '\0');
+        }
+        w = Regex.Replace(w, @"add(2|4|6|9|11|13)", "");
+
+        // alterations: b5 #5 b6 b9 #9 #11 b13 … (sign + degree)
+        foreach (Match m in Regex.Matches(w, @"(b|#)(5|6|9|11|13)"))
+        {
+            var sign = m.Groups[1].Value[0];
+            var deg = int.Parse(m.Groups[2].Value);
+            if (deg == 5) fifth = sign == 'b' ? 6 : 8;
+            else if (deg == 6) sixth = sign == 'b' ? 8 : 10;
+            else explicitDegrees[deg] = DegreeSemitone(deg, sign);
+        }
+        w = Regex.Replace(w, @"(b|#)(5|6|9|11|13)", "");
+
+        // omissions: no3 / no5 / omit3 / omit5
+        foreach (Match m in Regex.Matches(w, @"(omit|no)(3|5)")) omit.Add(int.Parse(m.Groups[2].Value));
+        w = Regex.Replace(w, @"(omit|no)(3|5)", "");
+
+        // ── base triad ──
+        bool thirdMinor;
+        if (w.Contains("sus2")) { noThird = true; explicitDegrees[2] = 2; w = w.Replace("sus2", ""); thirdMinor = false; }
+        else if (w.Contains("sus4") || w.Contains("sus")) { noThird = true; explicitDegrees[4] = 5; w = Regex.Replace(w, "sus4|sus", ""); thirdMinor = false; }
+        else if (w.Contains("dim")) { thirdMinor = true; fifth = 6; }
+        else if (w.Contains("aug") || w.StartsWith("+")) { thirdMinor = false; fifth = 8; w = w.Replace("aug", "").Replace("+", ""); }
+        else if (w.StartsWith("min")) { thirdMinor = true; }
+        else if (w.StartsWith("m") && !w.StartsWith("maj")) { thirdMinor = true; }
+        else thirdMinor = false;
+
+        var majSeventh = w.Contains("maj");
+        var dimBase = w.Contains("dim");
+        w = w.Replace("maj", "").Replace("min", "").Replace("dim", "");
+        if (w.StartsWith("m")) w = w[1..];                        // leading minor 'm'
+
+        // ── sixth / seventh / extension spine ──
+        if (Regex.IsMatch(w, @"6/9|69"))
+        {
+            sixth ??= 9;
+            explicitDegrees[9] = explicitDegrees.GetValueOrDefault(9, 2);
+            w = Regex.Replace(w, @"6/9|69", "");
+        }
+
+        var topExt = 0;
+        if (w.Contains("13")) { topExt = 13; w = w.Replace("13", ""); }
+        else if (w.Contains("11")) { topExt = 11; w = w.Replace("11", ""); }
+        else if (w.Contains("9")) { topExt = 9; w = w.Replace("9", ""); }
+        else if (w.Contains("7")) { topExt = 7; w = w.Replace("7", ""); }
+        else if (w.Contains("6")) { sixth ??= 9; w = w.Replace("6", ""); }
+
+        if (dimBase && topExt >= 7) seventh = 9;                  // dim7 → bb7
+        else if (topExt >= 7) seventh = majSeventh ? 11 : 10;
+
+        // residue check: anything left (besides separators) means it was not a chord symbol.
+        var residue = Regex.Replace(w, @"[\s/()+\-]", "");
+        if (residue.Length > 0) return false;
+
+        // ── assemble ──
+        if (!noThird && !omit.Contains(3)) set.Add(thirdMinor ? 3 : 4);
+        if (!omit.Contains(5)) set.Add(fifth);
+        if (sixth is { } s6) set.Add(s6);
+        if (seventh is { } s7) set.Add(s7);
+        if (topExt >= 9) set.Add(explicitDegrees.GetValueOrDefault(9, 2));
+        if (topExt >= 11) set.Add(explicitDegrees.GetValueOrDefault(11, 5));
+        if (topExt >= 13) set.Add(explicitDegrees.GetValueOrDefault(13, 9));
+        foreach (var kv in explicitDegrees) set.Add(kv.Value);   // adds + altered degrees, regardless of spine
+
+        offsets = set.Select(x => x % 12).Distinct().OrderBy(x => x).ToArray();
+        return true;
+    }
+
+    // Natural (sign='\0') or altered semitone for a chord degree, reduced to one octave.
+    private static int DegreeSemitone(int degree, char sign) => degree switch
+    {
+        2  => 2,
+        4  => 5,
+        6  => sign == 'b' ? 8 : sign == '#' ? 10 : 9,
+        9  => sign == 'b' ? 1 : sign == '#' ? 3 : 2,
+        11 => sign == '#' ? 6 : sign == 'b' ? 4 : 5,
+        13 => sign == 'b' ? 8 : sign == '#' ? 10 : 9,
+        _  => 0
+    };
 }

--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -316,9 +316,10 @@ public static class ChordPitchClasses
         }
         w = Regex.Replace(w, @"(b|#)(5|6|9|11|13)", "");
 
-        // omissions: no3 / no5 / omit3 / omit5
-        foreach (Match m in Regex.Matches(w, @"(omit|no)(3|5)")) omit.Add(int.Parse(m.Groups[2].Value));
-        w = Regex.Replace(w, @"(omit|no)(3|5)", "");
+        // omissions: no3 / no5 / omit5 … and extension omissions (no11 / no9 / omit13).
+        // "13no11" — the standard 13-without-11 voicing — must resolve, not fall through.
+        foreach (Match m in Regex.Matches(w, @"(omit|no)(2|3|4|5|6|9|11|13)")) omit.Add(int.Parse(m.Groups[2].Value));
+        w = Regex.Replace(w, @"(omit|no)(2|3|4|5|6|9|11|13)", "");
 
         // ── base triad ──
         bool thirdMinor;
@@ -360,12 +361,13 @@ public static class ChordPitchClasses
         // ── assemble ──
         if (!noThird && !omit.Contains(3)) set.Add(thirdMinor ? 3 : 4);
         if (!omit.Contains(5)) set.Add(fifth);
-        if (sixth is { } s6) set.Add(s6);
+        if (sixth is { } s6 && !omit.Contains(6)) set.Add(s6);
         if (seventh is { } s7) set.Add(s7);
-        if (topExt >= 9) set.Add(explicitDegrees.GetValueOrDefault(9, 2));
-        if (topExt >= 11) set.Add(explicitDegrees.GetValueOrDefault(11, 5));
-        if (topExt >= 13) set.Add(explicitDegrees.GetValueOrDefault(13, 9));
-        foreach (var kv in explicitDegrees) set.Add(kv.Value);   // adds + altered degrees, regardless of spine
+        if (topExt >= 9 && !omit.Contains(9)) set.Add(explicitDegrees.GetValueOrDefault(9, 2));
+        if (topExt >= 11 && !omit.Contains(11)) set.Add(explicitDegrees.GetValueOrDefault(11, 5));
+        if (topExt >= 13 && !omit.Contains(13)) set.Add(explicitDegrees.GetValueOrDefault(13, 9));
+        foreach (var kv in explicitDegrees)                      // adds + altered degrees, regardless of spine
+            if (!omit.Contains(kv.Key)) set.Add(kv.Value);
 
         offsets = set.Select(x => x % 12).Distinct().OrderBy(x => x).ToArray();
         return true;

--- a/Common/GA.Business.ML/Search/OptickSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/OptickSearchStrategy.cs
@@ -30,6 +30,10 @@ public sealed class OptickSearchStrategy : IVoicingSearchStrategy, IDisposable
     public bool IsAvailable => true;
     public QueryVectorSpace QuerySpace => QueryVectorSpace.OpticCompact112;
 
+    /// <summary>The OPTK index is mmap-loaded in the constructor, so it serves queries
+    /// immediately — no host warmup gating (avoids the cold-start "Service not initialized" race).</summary>
+    public bool RequiresWarmup => false;
+
     public VoicingSearchPerformance Performance => new(
         TimeSpan.FromMilliseconds(20),
         MemoryUsageMb: 0,          // mmap — OS handles paging

--- a/Tests/Common/GA.Business.ML.Tests/Search/ChordPitchClassesCompositionalTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/ChordPitchClassesCompositionalTests.cs
@@ -1,0 +1,124 @@
+namespace GA.Business.ML.Tests.Search;
+
+using System.Linq;
+using GA.Business.ML.Search;
+
+/// <summary>
+/// Exhaustiveness tests for the COMPOSITIONAL chord-symbol parser
+/// (<see cref="ChordPitchClasses.TryParse"/>). The parser builds pitch classes
+/// algorithmically from base triad + spine + alteration/addition/omission tokens,
+/// replacing the old finite quality lookup table. These tests assert it resolves the
+/// full combinatorial space — including the jazz qualities (7b13, add11, maj7#5, 7#11 …)
+/// that previously fell through to a hallucinating LLM fallback.
+/// </summary>
+[TestFixture]
+public class ChordPitchClassesCompositionalTests
+{
+    // All 17 canonical roots the parser accepts.
+    private static readonly string[] Roots =
+        ["C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B"];
+
+    // A broad quality matrix: triads, sixths, sevenths, extensions, suspensions, additions,
+    // and a wide span of altered/extended jazz qualities + notation variants.
+    private static readonly string[] Qualities =
+    [
+        "", "maj", "m", "min", "dim", "aug", "+", "sus2", "sus4", "sus", "5",
+        "6", "m6", "69", "6/9", "m6/9",
+        "7", "maj7", "M7", "△7", "m7", "min7", "m7b5", "ø7", "dim7", "°7", "7sus4", "+7", "aug7",
+        "9", "maj9", "m9", "11", "maj11", "m11", "13", "maj13", "m13",
+        "add9", "madd9", "add11", "add2", "add4", "sus2add11", "sus4add9",
+        "mmaj7", "minmaj7", "m(maj7)",
+        "7b5", "7#5", "7b9", "7#9", "7#11", "7b13", "7sus4b9", "7alt",
+        "9#11", "9b5", "9#5", "13#9", "13b9", "13#11",
+        "maj7#5", "maj7b5", "maj9#11", "m7#5", "m9b5", "m11b5",
+    ];
+
+    [Test]
+    public void EveryRootTimesQuality_ParsesToNonEmptyPitchClasses()
+    {
+        var failures = new List<string>();
+
+        foreach (var root in Roots)
+        foreach (var quality in Qualities)
+        {
+            var symbol = root + quality;
+            if (!ChordPitchClasses.TryParse(symbol, out var r, out var pcs))
+            {
+                failures.Add($"{symbol} → did not parse");
+                continue;
+            }
+
+            if (r is null) failures.Add($"{symbol} → null root");
+            if (pcs.Length < 2) failures.Add($"{symbol} → only {pcs.Length} pitch class(es)");
+            if (pcs.Distinct().Count() != pcs.Length) failures.Add($"{symbol} → duplicate pcs [{string.Join(",", pcs)}]");
+            if (pcs.Any(p => p is < 0 or > 11)) failures.Add($"{symbol} → pc out of range [{string.Join(",", pcs)}]");
+        }
+
+        Assert.That(failures, Is.Empty,
+            $"{failures.Count} symbol(s) failed:\n{string.Join("\n", failures.Take(40))}");
+    }
+
+    // Exact pitch-class sets. Root C ⇒ root pitch class 0, so pitch classes == offsets.
+    [TestCase("C", new[] { 0, 4, 7 })]
+    [TestCase("Cm", new[] { 0, 3, 7 })]
+    [TestCase("Cdim", new[] { 0, 3, 6 })]
+    [TestCase("Caug", new[] { 0, 4, 8 })]
+    [TestCase("C5", new[] { 0, 7 })]
+    [TestCase("Csus2", new[] { 0, 2, 7 })]
+    [TestCase("Csus4", new[] { 0, 5, 7 })]
+    [TestCase("C6", new[] { 0, 4, 7, 9 })]
+    [TestCase("Cm6", new[] { 0, 3, 7, 9 })]
+    [TestCase("C6/9", new[] { 0, 2, 4, 7, 9 })]
+    [TestCase("C7", new[] { 0, 4, 7, 10 })]
+    [TestCase("Cmaj7", new[] { 0, 4, 7, 11 })]
+    [TestCase("CM7", new[] { 0, 4, 7, 11 })]
+    [TestCase("C△7", new[] { 0, 4, 7, 11 })]
+    [TestCase("Cm7", new[] { 0, 3, 7, 10 })]
+    [TestCase("Cm7b5", new[] { 0, 3, 6, 10 })]
+    [TestCase("Cø7", new[] { 0, 3, 6, 10 })]
+    [TestCase("Cdim7", new[] { 0, 3, 6, 9 })]
+    [TestCase("Cmmaj7", new[] { 0, 3, 7, 11 })]
+    [TestCase("Cm(maj7)", new[] { 0, 3, 7, 11 })]
+    [TestCase("C7sus4", new[] { 0, 5, 7, 10 })]
+    [TestCase("C9", new[] { 0, 2, 4, 7, 10 })]
+    [TestCase("Cmaj9", new[] { 0, 2, 4, 7, 11 })]
+    [TestCase("C13", new[] { 0, 2, 4, 5, 7, 9, 10 })]
+    // The previously-broken jazz qualities:
+    [TestCase("C7b13", new[] { 0, 4, 7, 8, 10 })]
+    [TestCase("Cadd11", new[] { 0, 4, 5, 7 })]
+    [TestCase("Cmaj7#5", new[] { 0, 4, 8, 11 })]
+    [TestCase("C7#11", new[] { 0, 4, 6, 7, 10 })]
+    [TestCase("C7#9", new[] { 0, 3, 4, 7, 10 })]
+    [TestCase("C7b9", new[] { 0, 1, 4, 7, 10 })]
+    [TestCase("Cm7#5", new[] { 0, 3, 8, 10 })]
+    [TestCase("Cmadd9", new[] { 0, 2, 3, 7 })]
+    public void ResolvesExactPitchClasses(string symbol, int[] expected)
+    {
+        Assert.That(ChordPitchClasses.TryParse(symbol, out var root, out var pcs), Is.True, $"{symbol} should parse");
+        Assert.That(root, Is.EqualTo(0), $"{symbol} root should be C=0");
+        Assert.That(pcs, Is.EqualTo(expected), $"{symbol} → [{string.Join(",", pcs)}]");
+    }
+
+    // A root letter followed by ordinary words must NOT parse as a chord — otherwise every
+    // English word starting with A–G injects false musical structure into retrieval.
+    [TestCase("Fade")]
+    [TestCase("Bee")]
+    [TestCase("Cab")]
+    [TestCase("Dad")]
+    [TestCase("Gem")]
+    [TestCase("Bed")]
+    [TestCase("Age")]
+    [TestCase("Effect")]
+    [TestCase("Garbage")]
+    public void RejectsOrdinaryWords(string word)
+    {
+        Assert.That(ChordPitchClasses.TryParse(word, out _, out _), Is.False, $"{word} should NOT parse as a chord");
+    }
+
+    [Test]
+    public void SlashBass_IsDroppedFromPitchClasses()
+    {
+        Assert.That(ChordPitchClasses.TryParse("Cmaj7/G", out _, out var pcs), Is.True);
+        Assert.That(pcs, Is.EqualTo(new[] { 0, 4, 7, 11 }), "slash bass note must not add a pitch class");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Search/ChordPitchClassesCompositionalTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/ChordPitchClassesCompositionalTests.cs
@@ -92,6 +92,10 @@ public class ChordPitchClassesCompositionalTests
     [TestCase("C7b9", new[] { 0, 1, 4, 7, 10 })]
     [TestCase("Cm7#5", new[] { 0, 3, 8, 10 })]
     [TestCase("Cmadd9", new[] { 0, 2, 3, 7 })]
+    // Extension omissions — the standard "13 without 11" and friends must resolve:
+    [TestCase("C13no11", new[] { 0, 2, 4, 7, 9, 10 })]
+    [TestCase("C9no3", new[] { 0, 2, 7, 10 })]
+    [TestCase("Cmaj7no5", new[] { 0, 4, 11 })]
     public void ResolvesExactPitchClasses(string symbol, int[] expected)
     {
         Assert.That(ChordPitchClasses.TryParse(symbol, out var root, out var pcs), Is.True, $"{symbol} should parse");


### PR DESCRIPTION
Makes the chatbot return correct guitar voicings for **any** chord query. Three coupled fixes (each layer was masking the next):

## 1. Wrong search strategy → score 0.000

The chatbot was the **only** consumer wired to `CpuVoicingSearchStrategy`; `GaApi` and `GaMcpServer` use `OptickSearchStrategy`. `VoicingAgent` encodes 124-dim OPTK query vectors, but the Cpu strategy scored them against per-voicing 768-dim text embeddings → dimension mismatch → `CosineSimilarity` returned `0.0` for **every** voicing → ranking collapsed to corpus order → wrong chords. Fixed by registering the dimension-clean OPTK mmap index in `GaChatbot.Api` DI (resolved like `GaMcpServer`: `VoicingSearch:OpticIndexPath` / `GA_OPTICK_INDEX_PATH` / walk-up to `state/voicings/optick.index`), CPU fallback only when absent.

## 2. Finite chord vocabulary → jazz chords fell to a hallucinating LLM

`MusicalQueryEncoder`'s chord parser was a **hardcoded quality dictionary** — any symbol not in it (`7b13`, `add11`, `maj7#5`, `7#11`, `m7#5`, `alt`, …) failed to parse, so the query dropped to the 15s LLM path which invented invalid fingerings. Replaced with a **compositional parser**: base triad + sixth/seventh/extension spine + any sequence of alterations (b5 #5 b9 #9 #11 b13 …) / additions (add2/4/6/9/11/13) / omissions (no3/omit5), plus notation variants (△ ø, `M7` vs `m`, parens, slash bass). Exhaustive over the combinatorial space; ordinary words ("Fade","Bee") still rejected so they don't inject false structure.

## 3. Hard ChordName filter → out-of-corpus chords returned nothing

The OPTK index is ranked by pitch-class **geometry**, but `VoicingAgent` also passed a hard `ChordName` filter that rejected every geometric match when the corpus had no voicing *labelled* with that exact symbol (e.g. `G7b13`). Added a geometric fallback: when the name-filtered search returns nothing, retry on geometry alone (keeping instrument/mode/tag filters). Safe **only** because of fix #1 — on the old Cpu strategy this returned score-0.000 garbage (which is why an earlier retry attempt was reverted).

## Verification — generated matrix + live

**Unit (`ChordPitchClassesCompositionalTests`):** 17 roots × 68 qualities all resolve to valid pitch classes; 31 exact pitch-class assertions (incl. `7b13`,`add11`,`maj7#5`,`7#11`,`13`,`mmaj7`,`6/9`,`m(maj7)`); ordinary words rejected; slash-bass dropped. **Full `GA.Business.ML` suite green: 1487 passed, 0 failed.**

**Live (chatbot mode "full", `:5252`)** — all now route to the voicing agent with real, musically-apt scores (previously `fallback-direct` / hallucinated):

| Query | Before | After |
|---|---|---|
| `Dmaj7` | 0.000 wrong | **0.533** correct Dmaj7 |
| `Cadd11` | LLM | **0.512** Cadd11 |
| `C7#11` | LLM | **0.484** C7#11 |
| `G7b13` | LLM | **0.46** (Gaug core) |
| `Amaj7#5` | LLM | **0.55** (Faug) |
| `Galt` | LLM timeout | **0.45** (D♭7♯11 — tritone-sub) |
| `Cmaj7 drop2 jazz` | — | **0.582**, tags honored (no regression) |

## Scope

`GaChatbot.Api/Extensions/ServiceCollectionExtensions.cs` (DI), `GA.Business.ML/Search/MusicalQueryEncoder.cs` (parser), `GA.Business.ML/Agents/VoicingAgent.cs` (retry), + tests. Does **not** touch `ProductionOrchestrator` or routing. Independent of #375 (the `CpuVoicingSearchStrategy` NRE null-guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)