### PR TITLE
fix(chatbot): route "ii-V-I progression in <key>" to diatonic chords, not tab.optimize

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
@@ -70,6 +70,15 @@ public class ProductionOrchestrator(
         return blocks.Any(b => b.Slices.Any(s => s.Notes.Any()));
     }
 
+    // A tab-handling intent (tab.optimize / tab.analyze) can only act on a tab in the
+    // message — without one it just replies "paste a tab". The embedding router has no
+    // tab-content signal, so a tabless phrasing whose words overlap a tab example (e.g.
+    // "give me a ii-V-I progression in Bb" matching tab.optimize's example "make this
+    // progression smoother to play") can wrongly win a tab intent. Suppress that pick so
+    // the query falls through to a real handler instead of "I need a tab in the message".
+    private bool IsTabIntentWithoutTab(string intentId, string? message) =>
+        intentId.StartsWith("tab.", StringComparison.Ordinal) && !HasTabContent(message);
+
     // Routing-context enrichment lives in RoutingContextEnricher (2026-05-14
     // extraction) so it can be unit-tested without spinning up the full
     // orchestrator. Behaviour is unchanged from the inlined form.
@@ -400,7 +409,9 @@ public class ProductionOrchestrator(
         // CanHandle foreach. See migration recommendation §"Routing classifiers".
         var intentMatch = await intentRouter.RouteAsync(routingMessage, services, ct);
         EmitRoutingTrace(intentMatch);
-        if (intentMatch is { } pick)
+        // Suppress a tab intent picked for a tabless message (e.g. "give me a ii-V-I
+        // progression in Bb") so it falls through to the LLM agent path below.
+        if (intentMatch is { } pick && !IsTabIntentWithoutTab(pick.Intent.Id, message))
         {
             // OnBeforeSkill hooks (intent.Id replaces the legacy MatchedSkillName).
             var beforeCtx = new ChatHookContext
@@ -801,6 +812,9 @@ public class ProductionOrchestrator(
         var match = await intentRouter.RouteAsync(routingMessage, services, ct);
         EmitRoutingTrace(match);
         if (match is not { } pick) return null;
+
+        // Tab intents cannot act without a tab present — fall through to a real handler.
+        if (IsTabIntentWithoutTab(pick.Intent.Id, executeMessage)) return null;
 
         var result = await pick.Intent.ExecuteAsync(executeMessage, ct);
         return new ChatResponse(

--- a/Common/GA.Business.ML/Agents/Skills/DiatonicChordsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/DiatonicChordsSkill.cs
@@ -61,5 +61,19 @@ public sealed class DiatonicChordsSkill(
         "Diatonic chords in E minor",
         "Show me diatonic chords in F# major",
         "Seven diatonic chords of B major",
+        // PR (2026-05-30) — Roman-numeral "progression in <key>" surface. Live bug:
+        // "give me a ii-V-I progression in Bb" misrouted to tab.optimize because that
+        // intent's example "make this progression smoother to play" was the nearest
+        // centroid (the word "progression" dominated) and this skill had NO progression
+        // example. "ii-V-I in Bb" (terse form) already routed here correctly and returns
+        // Cm F Bb = degrees ii/V/I of domain.diatonicChords. These add the verbose
+        // "progression in <key>" phrasings only — deliberately paired with "in <key>"
+        // (which this skill owns) and NOT bare "ii-V-I" (which collides with the
+        // chord-substitution surface "substitute … in a ii-V-I"). Pairs with a
+        // ProductionOrchestrator guard that suppresses tab intents on tabless queries.
+        "Give me a ii-V-I progression in Bb",
+        "ii-V-I progression in C major",
+        "I-IV-V progression in G",
+        "Give me a I-vi-IV-V progression in C",
     ];
 }

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
@@ -188,6 +188,33 @@ prompts:
     min_length: 100
     max_elapsed_ms: 60000
 
+  # Routing regression (fix/chatbot-progression-routing, 2026-05-30): the verbose
+  # "give me a <Roman-numeral> progression in <key>" phrasing misrouted to tab.optimize
+  # (whose example "make this progression smoother to play" was the cosine attractor),
+  # which then replied "I need a tab in the message". Must route to the diatonic-chords
+  # skill and spell the chords. routes_to + forbidden_agent_ids + not_contains lock the
+  # exact prior failure; the terse "ii-V-I in Bb" guards that the new examples did not
+  # regress the form that already worked.
+  - prompt: "give me a ii-V-I progression in Bb"
+    category: progressions
+    routes_to: skill.diatonicchords
+    contains: ["Cm", "Bb"]
+    not_contains: ["I need a tab", "paste a tab"]
+    forbidden_agent_ids: ["tab.optimize", "tab.analyze"]
+    must_not_fallback: true
+    min_length: 50
+    max_elapsed_ms: 45000
+    retry: 0                          # deterministic skill — a misroute is a real bug
+
+  - prompt: "ii-V-I in Bb"
+    category: progressions
+    routes_to: skill.diatonicchords
+    contains: ["Cm", "Bb"]
+    forbidden_agent_ids: ["tab.optimize"]
+    min_length: 50
+    max_elapsed_ms: 45000
+    retry: 0
+
   # ── beginner / getting started ──────────────────────────────────────────
   - prompt: "Show me some easy beginner chords"
     category: getting-started


### PR DESCRIPTION
## Problem (reproduced live)

- `ii-V-I in Bb` → `skill.diatonicchords` → **correct** (Cm, F, B♭).
- `give me a ii-V-I progression in Bb` → `tab.optimize` → **wrong** ("I need a tab in the message").

The embedding router scores cosine over each intent's Description + ExamplePrompts. `tab.optimize`'s example **"Make this progression smoother to play"** makes the word *progression* its attractor, and `DiatonicChordsSkill` had no progression/Roman-numeral example — so the verbose phrasing lost the cosine race.

## Fix — two coupled changes

Designed via an **octo two-lens design pass** (architecture + adversarial regression review; they disagreed, the disagreement is captured in the commit) and validated by a **16-query live regression battery**.

**1. Tab-content guard (`ProductionOrchestrator`).** A tab intent (`tab.optimize`/`tab.analyze`) can only act on a tab in the message. The router has no tab-content signal, so tabless queries can win a tab intent. Added `IsTabIntentWithoutTab` (reusing the existing `HasTabContent` helper) and gated **both** semantic-dispatch sites so a `tab.*` pick on a tabless message falls through to a real handler.

**2. `DiatonicChordsSkill` examples.** Added four `"<progression> in <key>"` Roman-numeral phrasings so the skill that already answers `ii-V-I in Bb` correctly also wins the verbose form. Deliberately paired with `"in <key>"` (which this skill owns) and **not** bare `"ii-V-I"` (which collides with the chord-substitution surface).

## Verification — 16-query live battery (`:5252`)

Target fixed; **every fragile boundary the reviewer flagged held**:

| Query | Route | |
|---|---|---|
| **give me a ii-V-I progression in Bb** | `skill.diatonicchords` | ✅ was tab.optimize |
| What can I substitute for Cmaj7 in a ii-V-I? | `skill.chordsubstitution` | ✅ highest-risk, held |
| what chord comes next after C G Am? | `skill.progressioncompletion` | ✅ |
| make this progression sound darker | `skill.progressionmood` | ✅ |
| What key is C Am F G in? | `skill.keyidentification` | ✅ |
| Diatonic chords in G major | `skill.diatonicchords` | ✅ prior fix held |
| C major on guitar | `skill.chordvoicings` | ✅ known prior-regression case safe |
| make this progression smoother **+tab** | `tab.optimize` | ✅ legit tab use survives guard |

## Tradeoff (accepted)

A tabless genuine `optimize my tab` (user wants tab help but didn't paste one) now falls to the LLM instead of the fast "paste a tab" prompt. No existing test asserts tabless→tab routing.

## Scope

`ProductionOrchestrator.cs` (guard) + `DiatonicChordsSkill.cs` (examples). Independent of the voicing PRs #375/#376. Routing is validated live (the embedder is the system under test — synthetic unit tests don't exercise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)