### PR TITLE
tune(router): scaleinfo precision 0.67→0.80 (keyid + progressionmood hints)

### DIFF
--- a/Common/GA.Business.ML/Agents/Intents/DefaultRoutingHintProvider.cs
+++ b/Common/GA.Business.ML/Agents/Intents/DefaultRoutingHintProvider.cs
@@ -55,8 +55,11 @@ public sealed class DefaultRoutingHintProvider : IRoutingHintProvider
             RegexOptions.IgnoreCase | RegexOptions.Compiled),
             "skill.chordsubstitution"),
 
-        // Key identification — "what key is X in", "key of <progression>"
-        (new Regex(@"\b(what\s+key|key\s+is|identify\s+the\s+key)\b",
+        // Key identification — "what key is X in", "key of <progression>".
+        // Added 2026-05-31: "tonal cent(er|re)" and "home key" — ki-8 ("figure
+        // out the tonal center of E A B E") was lost to scaleinfo because the
+        // original anchors miss those synonyms; "home key" reinforces ki-10.
+        (new Regex(@"\b(what\s+key|key\s+is|identify\s+the\s+key|tonal\s+cent(?:er|re)|home\s+key)\b",
             RegexOptions.IgnoreCase | RegexOptions.Compiled),
             "skill.keyidentification"),
 
@@ -174,6 +177,17 @@ public sealed class DefaultRoutingHintProvider : IRoutingHintProvider
         (new Regex(@"\b(?:common|shared|overlapping|pivot|mutual)\s+(?:notes?|tones?|pitches?)\b|\b(?:notes?|tones?|pitches?)\b[^.?!]{0,40}?\b(?:shared?|in\s+common)\b|\bintersection\s+of\b",
             RegexOptions.IgnoreCase | RegexOptions.Compiled),
             "skill.commontones"),
+
+        // Progression mood (transform) — added 2026-05-31. progressionmood had
+        // NO hint rule, so mood-transform queries like "lift the mood of D minor"
+        // (pm-9) were stolen by scaleinfo on the "D minor" centroid. The
+        // discriminator is the emotional-transform vocabulary (darken/brighten/
+        // sadder/melancholy/cinematic/"lift the mood"/"add tension") — this is a
+        // TRANSFORM intent ("make it sound X"), unambiguous in a music context and
+        // absent from descriptive scale/chord queries.
+        (new Regex(@"\b(?:dark(?:er|en\w*)|bright(?:er|en\w*)|sadder|happier|melanchol\w*|moodier|gloomier|cinematic)\b|\blift\s+the\s+mood\b|\badd\s+tension\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled),
+            "skill.progressionmood"),
 
         // Capo — added 2026-05-14 to close BACKLOG dealbreaker #3. Anchored on
         // the literal "capo" token (music-unambiguous — no English homonyms

--- a/Tests/Common/GA.Business.ML.Tests/Unit/DefaultRoutingHintProviderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/DefaultRoutingHintProviderTests.cs
@@ -146,6 +146,53 @@ public class DefaultRoutingHintProviderTests
             $"Got deltas: {string.Join(", ", deltas.Select(kv => $"{kv.Key}={kv.Value}"))}");
     }
 
+    // Key-identification synonyms — "tonal center/centre" and "home key" were
+    // added 2026-05-31 to close ki-8 ("figure out the tonal center of E A B E"),
+    // which scaleinfo was stealing. The original what-key/key-is anchors miss them.
+    [TestCase("figure out the tonal center of E A B E")]
+    [TestCase("what is the tonal centre of this progression")]
+    [TestCase("what's the home key for F C G Am")]
+    [TestCase("what key is this progression")]
+    public void KeyIdentification_PositiveExamples_BoostKeyIdIntent(string query)
+    {
+        var deltas = _hints.GetDeltas(query);
+        Assert.That(deltas.ContainsKey("skill.keyidentification"), Is.True,
+            $"Expected skill.keyidentification boost for: \"{query}\". Got: {string.Join(", ", deltas.Keys)}");
+    }
+
+    // Progression-mood (transform) — added 2026-05-31. progressionmood had no
+    // hint rule; mood-transform queries leaked to scaleinfo/others on the
+    // chord/key centroid. pm-9 ("lift the mood of D minor") is the target.
+    [TestCase("lift the mood of D minor")]
+    [TestCase("make C G Am F sound darker")]
+    [TestCase("brighten up a minor key tune")]
+    [TestCase("give this progression a sadder feel")]
+    [TestCase("make my chords feel more melancholy")]
+    [TestCase("make these chords sound more cinematic")]
+    [TestCase("techniques to add tension to a happy progression")]
+    [TestCase("darken a vi-IV-I-V progression")]
+    public void ProgressionMood_PositiveExamples_BoostMoodIntent(string query)
+    {
+        var deltas = _hints.GetDeltas(query);
+        Assert.That(deltas.ContainsKey("skill.progressionmood"), Is.True,
+            $"Expected skill.progressionmood boost for: \"{query}\". Got: {string.Join(", ", deltas.Keys)}");
+        Assert.That(deltas["skill.progressionmood"], Is.EqualTo(DefaultRoutingHintProvider.BoostMagnitude));
+    }
+
+    // False-positive guards for the two new rules — descriptive scale/chord
+    // queries must NOT boost keyidentification or progressionmood.
+    [TestCase("notes in C major scale")]
+    [TestCase("what notes are in Cmaj7")]
+    [TestCase("diatonic chords in C major")]
+    public void KeyIdAndMood_FalsePositiveGuards_DoNotBoost(string query)
+    {
+        var deltas = _hints.GetDeltas(query);
+        Assert.That(deltas.ContainsKey("skill.keyidentification"), Is.False,
+            $"keyidentification should NOT fire for: \"{query}\". Got: {string.Join(", ", deltas.Keys)}");
+        Assert.That(deltas.ContainsKey("skill.progressionmood"), Is.False,
+            $"progressionmood should NOT fire for: \"{query}\". Got: {string.Join(", ", deltas.Keys)}");
+    }
+
     [Test]
     public void EmptyQuery_ReturnsNoDeltas()
     {

--- a/state/quality/routing-eval-2026-05-31.json
+++ b/state/quality/routing-eval-2026-05-31.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "0.1",
-  "generatedAt": "2026-05-31T15:00:18.3440214Z",
+  "generatedAt": "2026-05-31T15:31:26.0985948Z",
   "routerConfig": {
     "minConfidence": 0.55,
     "embedder": "nomic-embed-text"
@@ -8,16 +8,16 @@
   "totalPrompts": 174,
   "overall": {
     "Total": 174,
-    "Correct": 158,
+    "Correct": 160,
     "UnmatchedFallthrough": 7,
-    "Accuracy": 0.9080459770114943,
+    "Accuracy": 0.9195402298850575,
     "InScopeTotal": 166,
-    "InScopeCorrect": 151,
-    "InScopeAccuracy": 0.9096385542168675,
+    "InScopeCorrect": 153,
+    "InScopeAccuracy": 0.9216867469879518,
     "OosTotal": 8,
     "OosCorrectlyDeclined": 7,
     "OosDeclineRate": 0.875,
-    "MeanInScopeMargin": 0.17279280434889965
+    "MeanInScopeMargin": 0.17660415370062174
   },
   "perIntent": {
     "skill.chordinfo": {
@@ -33,11 +33,11 @@
     "skill.scaleinfo": {
       "Support": 10,
       "TruePositives": 8,
-      "FalsePositives": 4,
+      "FalsePositives": 2,
       "FalseNegatives": 2,
-      "Precision": 0.6666666666666666,
+      "Precision": 0.8,
       "Recall": 0.8,
-      "F1": 0.7272727272727272,
+      "F1": 0.8000000000000002,
       "Status": "measured"
     },
     "skill.modes": {
@@ -82,12 +82,12 @@
     },
     "skill.progressionmood": {
       "Support": 14,
-      "TruePositives": 13,
+      "TruePositives": 14,
       "FalsePositives": 0,
-      "FalseNegatives": 1,
+      "FalseNegatives": 0,
       "Precision": 1,
-      "Recall": 0.9285714285714286,
-      "F1": 0.962962962962963,
+      "Recall": 1,
+      "F1": 1,
       "Status": "measured"
     },
     "skill.circleoffifths": {
@@ -162,12 +162,12 @@
     },
     "skill.keyidentification": {
       "Support": 10,
-      "TruePositives": 9,
+      "TruePositives": 10,
       "FalsePositives": 1,
-      "FalseNegatives": 1,
-      "Precision": 0.9,
-      "Recall": 0.9,
-      "F1": 0.9,
+      "FalseNegatives": 0,
+      "Precision": 0.9090909090909091,
+      "Recall": 1,
+      "F1": 0.9523809523809523,
       "Status": "measured"
     },
     "skill.progressioncompletion": {
@@ -982,8 +982,8 @@
       "Prompt": "how do I make this minor progression sound brighter",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.8658892,
-      "Margin": 0.19232094,
+      "Confidence": 0.9258892,
+      "Margin": 0.25232095,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -996,8 +996,8 @@
       "Prompt": "make C G Am F sound darker",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.7167444,
-      "Margin": 0.011623621,
+      "Confidence": 0.7767444,
+      "Margin": 0.07162362,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -1010,8 +1010,8 @@
       "Prompt": "darken a vi-IV-I-V progression",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.77972984,
-      "Margin": 0.05320877,
+      "Confidence": 0.83972985,
+      "Margin": 0.11320877,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -1037,8 +1037,8 @@
       "Prompt": "give this progression a sadder feel",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.78865415,
-      "Margin": 0.093838274,
+      "Confidence": 0.84865415,
+      "Margin": 0.15383828,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -1050,8 +1050,8 @@
       "Prompt": "make my chords feel more melancholy",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.85780317,
-      "Margin": 0.17611551,
+      "Confidence": 0.91780317,
+      "Margin": 0.23611552,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -1063,8 +1063,8 @@
       "Prompt": "techniques to add tension to a happy progression",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.82564807,
-      "Margin": 0.1608252,
+      "Confidence": 0.8856481,
+      "Margin": 0.2208252,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -1076,8 +1076,8 @@
       "Prompt": "how do I make these chords sound more cinematic",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.7985515,
-      "Margin": 0.17192346,
+      "Confidence": 0.8585515,
+      "Margin": 0.23192346,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -1089,10 +1089,10 @@
       "Id": "pm-9",
       "Prompt": "lift the mood of D minor",
       "Expected": "skill.progressionmood",
-      "Chosen": "skill.scaleinfo",
-      "Confidence": 0.8394926,
-      "Margin": 0.021165013,
-      "Correct": false,
+      "Chosen": "skill.progressionmood",
+      "Confidence": 0.8647192,
+      "Margin": 0.025226593,
+      "Correct": true,
       "IsOos": false,
       "Tags": [
         "v0.5-paraphrase"
@@ -1103,8 +1103,8 @@
       "Prompt": "what borrowed chord makes things darker",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.79894584,
-      "Margin": 0.062186837,
+      "Confidence": 0.85894585,
+      "Margin": 0.12218684,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -2135,10 +2135,10 @@
       "Id": "ki-8",
       "Prompt": "figure out the tonal center of E A B E",
       "Expected": "skill.keyidentification",
-      "Chosen": "skill.scaleinfo",
-      "Confidence": 0.72565466,
-      "Margin": 0.038852513,
-      "Correct": false,
+      "Chosen": "skill.keyidentification",
+      "Confidence": 0.7306429,
+      "Margin": 0.004988253,
+      "Correct": true,
       "IsOos": false,
       "Tags": [
         "v0.5-paraphrase"
@@ -2162,8 +2162,8 @@
       "Prompt": "what\u0027s the home key for F C G Am",
       "Expected": "skill.keyidentification",
       "Chosen": "skill.keyidentification",
-      "Confidence": 0.8263936,
-      "Margin": 0.18222028,
+      "Confidence": 0.8863936,
+      "Margin": 0.24222028,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -2309,8 +2309,8 @@
       "Prompt": "borrow from Phrygian to darken C G F",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.8250383,
-      "Margin": 0.028517365,
+      "Confidence": 0.8850383,
+      "Margin": 0.08851737,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -2337,8 +2337,8 @@
       "Prompt": "use Aeolian modal interchange to make it sound sadder",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.6839727,
-      "Margin": 0.0335328,
+      "Confidence": 0.7439727,
+      "Margin": 0.0935328,
       "Correct": true,
       "IsOos": false,
       "Tags": [
@@ -2351,8 +2351,8 @@
       "Prompt": "how does Mixolydian flavor brighten rock progressions",
       "Expected": "skill.progressionmood",
       "Chosen": "skill.progressionmood",
-      "Confidence": 0.99751335,
-      "Margin": 0.2073096,
+      "Confidence": 1,
+      "Margin": 0.20979625,
       "Correct": true,
       "IsOos": false,
       "Tags": [


### PR DESCRIPTION
## What

Second **tuning** pass. `scaleinfo`'s weakness was **precision (0.67)**, not recall — it was *stealing* prompts from neighbors that lacked hint coverage for their paraphrases. Since `DefaultRoutingHintProvider` is **additive-only**, the fix helps the stolen-from intents win their own prompts back rather than touching scaleinfo.

**Stacks on #380 → #378.** Retarget down the chain as each parent merges.

## Diagnosis (from the post-commontones baseline)
| FP prompt | stolen by | expected | fix |
|---|---|---|---|
| "figure out the **tonal center** of E A B E" | scaleinfo | keyidentification | broaden keyid hint |
| "**lift the mood** of D minor" | scaleinfo | progressionmood | new mood hint |
| "**harmonized** A minor scale" | scaleinfo | diatonicchords | *not fixed* — scaleinfo's own hint over-fires; additive hints can't suppress it |

## Changes
- **keyidentification**: + `tonal cent(er|re)` + `home key`.
- **progressionmood**: **new** rule on emotional-transform vocab (`darken`/`brighten`/`sadder`/`melancholy`/`cinematic`/`lift the mood`/`add tension`) — it had no hint at all.

## Result (verified, `routing-eval-2026-05-31` cumulative)
| intent | before | after |
|---|---|---|
| scaleinfo F1 | 0.73 | **0.80** (prec 0.67→0.80) |
| keyidentification F1 | 0.90 | **0.95** (recall →1.00) |
| progressionmood F1 | 0.96 | **1.00** (recall →1.00) |
| overall in-scope | 91.0% | **92.2%** |

`commontones` held at 0.90 → **zero regression**. Cumulative across both tuning PRs: **89.2% → 92.2%** (+3.0 pts).

## Not fixed (documented follow-ups)
- `dc-8` scaleinfo over-fire — needs a scaleinfo-regex negative condition, not an additive hint.
- scaleinfo recall (`si-2`/`si-5`: keyless "harmonic minor scale", "spell C natural minor") — broadening scaleinfo risks new FPs; needs care.

## Tests
15 unit cases (positives incl. ki-8/pm-9 + false-positive guards proving descriptive scale/chord prompts don't boost keyid or mood). Fast, no Ollama. 60/60 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)