### PR TITLE
feat(router): structured routing-decision telemetry (JSONL sink)

### DIFF
--- a/Common/GA.Business.ML/Agents/Intents/RoutingTelemetryLog.cs
+++ b/Common/GA.Business.ML/Agents/Intents/RoutingTelemetryLog.cs
@@ -1,0 +1,165 @@
+namespace GA.Business.ML.Agents.Intents;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+///     Append-only per-day JSONL telemetry for <see cref="SemanticIntentRouter"/>
+///     decisions. Shipped 2026-05-31 to close the "we're tuning the router blind"
+///     gap: the regex tie-break hints in <see cref="DefaultRoutingHintProvider"/>
+///     were authored against the fixed 86-prompt eval corpus, so the harness
+///     measures training accuracy, not generalization. This sink captures EVERY
+///     live routing decision (query + the top-3 candidates and their scores +
+///     whether the router fell through) so an UNCONTAMINATED held-out eval set
+///     can be mined from real traffic and hand-labeled — the prerequisite for
+///     trusting any future router change (more hints OR a learned head).
+///     <para>
+///         Mirrors <c>VoicingTelemetryLog</c> exactly (daily rotation, error
+///         swallowing, env disable) so the two telemetry streams stay operationally
+///         identical. One line per <see cref="SemanticIntentRouter.RouteAsync"/>
+///         call that reached the scoring stage.
+///     </para>
+/// </summary>
+public static class RoutingTelemetryLog
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    private static readonly Lock _writeLock = new();
+
+    /// <summary>
+    ///     Environment variable to disable telemetry (e.g. in test/CI runs).
+    ///     Set <c>GA_ROUTING_NO_TELEMETRY=1</c> to suppress all writes.
+    /// </summary>
+    public const string DisableEnvVar = "GA_ROUTING_NO_TELEMETRY";
+
+    /// <summary>
+    ///     Resolves the directory holding the rolling JSONL files. Override via
+    ///     <c>GA_ROUTING_TELEMETRY_DIR</c>; default is
+    ///     <c>{repo-root}/state/telemetry/routing/</c>.
+    /// </summary>
+    public static string ResolveDirectory()
+    {
+        var env = Environment.GetEnvironmentVariable("GA_ROUTING_TELEMETRY_DIR");
+        if (!string.IsNullOrWhiteSpace(env)) return env;
+
+        // Walk up from the app base toward the repo root looking for a `state/` sibling.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "state", "telemetry", "routing");
+            if (Directory.Exists(Path.Combine(dir.FullName, "state"))) return candidate;
+            dir = dir.Parent;
+        }
+        return Path.Combine(AppContext.BaseDirectory, "state", "telemetry", "routing");
+    }
+
+    public static string CurrentDayFile() =>
+        Path.Combine(ResolveDirectory(), $"{DateTime.UtcNow:yyyy-MM-dd}.jsonl");
+
+    /// <summary>
+    ///     Appends a single record. Silently swallows I/O errors — telemetry must
+    ///     never break the routing path.
+    /// </summary>
+    public static void Append(RoutingTelemetryRecord record)
+    {
+        if (Environment.GetEnvironmentVariable(DisableEnvVar) == "1") return;
+
+        try
+        {
+            var path = CurrentDayFile();
+            var dir = Path.GetDirectoryName(path);
+            if (dir is not null) Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(record, JsonOpts);
+            lock (_writeLock)
+            {
+                File.AppendAllText(path, json + "\n");
+            }
+        }
+        catch
+        {
+            // telemetry failure must be invisible to the routing caller
+        }
+    }
+
+    /// <summary>
+    ///     Reads the last <paramref name="limit"/> records from today's file (or a
+    ///     specific <paramref name="day"/>). Convenience for eval-set mining + tests.
+    /// </summary>
+    public static IReadOnlyList<RoutingTelemetryRecord> ReadRecent(int limit = 100, DateOnly? day = null)
+    {
+        var target = day?.ToString("yyyy-MM-dd") ?? DateTime.UtcNow.ToString("yyyy-MM-dd");
+        var path = Path.Combine(ResolveDirectory(), $"{target}.jsonl");
+        if (!File.Exists(path)) return [];
+
+        try
+        {
+            var lines = File.ReadAllLines(path);
+            var slice = lines.Length > limit ? lines[^limit..] : lines;
+            var records = new List<RoutingTelemetryRecord>(slice.Length);
+            foreach (var line in slice)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var rec = JsonSerializer.Deserialize<RoutingTelemetryRecord>(line, JsonOpts);
+                if (rec is not null) records.Add(rec);
+            }
+            return records;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+}
+
+/// <summary>One telemetry record per routing decision. Narrow on purpose: just
+/// what's needed to mine a held-out eval set and study the threshold/margin.</summary>
+public sealed record RoutingTelemetryRecord
+{
+    /// <summary>ISO-8601 UTC timestamp.</summary>
+    [JsonPropertyName("ts")]
+    public required string Timestamp { get; init; }
+
+    /// <summary>Raw user query text (the label-able surface for eval mining).</summary>
+    [JsonPropertyName("q")]
+    public required string Query { get; init; }
+
+    /// <summary>Chosen intent id, or null if the router fell through (below threshold).</summary>
+    [JsonPropertyName("chosen")]
+    public string? Chosen { get; init; }
+
+    /// <summary>Final (hint-boosted) confidence of the winner, or null on fall-through.</summary>
+    [JsonPropertyName("conf")]
+    public double? Confidence { get; init; }
+
+    /// <summary>The MinConfidence threshold in force for this decision.</summary>
+    [JsonPropertyName("threshold")]
+    public double Threshold { get; init; }
+
+    /// <summary>True if no intent cleared the threshold (caller falls through to LLM).</summary>
+    [JsonPropertyName("fell_through")]
+    public bool FellThrough { get; init; }
+
+    /// <summary>Top-1 minus top-2 final score — the escalate-on-ambiguity signal. Null if &lt;2 candidates.</summary>
+    [JsonPropertyName("margin")]
+    public double? Margin { get; init; }
+
+    /// <summary>Top-N candidates (highest first), each with base cosine, hint boost, and final score.</summary>
+    [JsonPropertyName("candidates")]
+    public IReadOnlyList<RoutingTelemetryCandidate>? Candidates { get; init; }
+
+    /// <summary>Routing latency in milliseconds (includes the query embedding call).</summary>
+    [JsonPropertyName("ms")]
+    public double LatencyMs { get; init; }
+}
+
+/// <summary>One candidate intent in a logged routing decision.</summary>
+public sealed record RoutingTelemetryCandidate(
+    [property: JsonPropertyName("id")]    string IntentId,
+    [property: JsonPropertyName("base")]  double BaseScore,
+    [property: JsonPropertyName("boost")] double Boost,
+    [property: JsonPropertyName("final")] double FinalScore);

--- a/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
+++ b/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
@@ -88,6 +88,10 @@ public sealed class SemanticIntentRouter(
 
         await EnsureExamplesEmbeddedAsync(candidates, cancellationToken);
 
+        // Per-query routing latency starts AFTER the one-time example-embedding
+        // warmup (that cost belongs to the first request only, not every query).
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
         float[] queryVec;
         try
         {
@@ -195,12 +199,34 @@ public sealed class SemanticIntentRouter(
                 ? $"{r.Intent.Id}={r.Score - r.Boost:F3}+{r.Boost:F3}={r.Score:F3} via {Trim(r.MatchedSource, 40)}"
                 : $"{r.Intent.Id}={r.Score:F3} via {Trim(r.MatchedSource, 40)}")));
 
+        // Routing-decision telemetry (append-only JSONL, error-swallowed). One line
+        // per scored query so an uncontaminated held-out eval set can be mined from
+        // live traffic — the regex hints are tuned against the fixed corpus, so the
+        // harness number is training accuracy; real generalization can only be
+        // measured on traffic the hints never saw. See RoutingTelemetryLog.
+        var telemetryCandidates = topK
+            .Select(r => new RoutingTelemetryCandidate(r.Intent.Id, r.Score - r.Boost, r.Boost, r.Score))
+            .ToList();
+        var margin = topK.Count >= 2 ? (double?)(topK[0].Score - topK[1].Score) : null;
+
         var top = withHints[0];
         if (top.Score < MinConfidence)
         {
             logger.LogDebug(
                 "SemanticIntentRouter: top score {Score:F3} below threshold {Threshold:F2}; falling through",
                 top.Score, MinConfidence);
+            RoutingTelemetryLog.Append(new RoutingTelemetryRecord
+            {
+                Timestamp   = DateTime.UtcNow.ToString("o"),
+                Query       = query,
+                Chosen      = null,
+                Confidence  = null,
+                Threshold   = MinConfidence,
+                FellThrough = true,
+                Margin      = margin,
+                Candidates  = telemetryCandidates,
+                LatencyMs   = sw.Elapsed.TotalMilliseconds,
+            });
             return null;
         }
 
@@ -218,6 +244,19 @@ public sealed class SemanticIntentRouter(
                 FinalScore:   r.Score,
                 MatchedSource: r.MatchedSource))
             .ToList();
+
+        RoutingTelemetryLog.Append(new RoutingTelemetryRecord
+        {
+            Timestamp   = DateTime.UtcNow.ToString("o"),
+            Query       = query,
+            Chosen      = top.Intent.Id,
+            Confidence  = top.Score,
+            Threshold   = MinConfidence,
+            FellThrough = false,
+            Margin      = margin,
+            Candidates  = telemetryCandidates,
+            LatencyMs   = sw.Elapsed.TotalMilliseconds,
+        });
 
         return new IntentMatch(top.Intent, top.Score, top.MatchedSource)
         {

--- a/Tests/Apps/GaChatbot.Api.Tests/TelemetrySuppressionSetUpFixture.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/TelemetrySuppressionSetUpFixture.cs
@@ -1,0 +1,31 @@
+// Assembly-wide test setup (global namespace → applies to every fixture in
+// GaChatbot.Api.Tests). Suppresses routing telemetry for the whole test run.
+//
+// Why: the in-process orchestrator host (TestWebApplicationFactory) drives
+// SemanticIntentRouter.RouteAsync for every corpus prompt (PromptCorpusTests),
+// which appends a RoutingTelemetryRecord (PR #383). Without this gate those
+// fixed-corpus prompts would land in the real repo state/telemetry/routing/
+// stream and contaminate the held-out eval set the sink exists to create
+// (Codex P1 on #383). GA_ROUTING_NO_TELEMETRY=1 makes RoutingTelemetryLog.Append
+// a no-op (it re-reads the env var on every call).
+
+using NUnit.Framework;
+
+[SetUpFixture]
+public sealed class TelemetrySuppressionSetUpFixture
+{
+    private string? _prior;
+
+    [OneTimeSetUp]
+    public void DisableRoutingTelemetry()
+    {
+        _prior = Environment.GetEnvironmentVariable("GA_ROUTING_NO_TELEMETRY");
+        Environment.SetEnvironmentVariable("GA_ROUTING_NO_TELEMETRY", "1");
+    }
+
+    [OneTimeTearDown]
+    public void RestoreRoutingTelemetry()
+    {
+        Environment.SetEnvironmentVariable("GA_ROUTING_NO_TELEMETRY", _prior);
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/TelemetrySuppressionSetUpFixture.cs
+++ b/Tests/Common/GA.Business.ML.Tests/TelemetrySuppressionSetUpFixture.cs
@@ -1,0 +1,35 @@
+// Assembly-wide test setup (global namespace → applies to every fixture in
+// GA.Business.ML.Tests). Suppresses routing telemetry for the whole test run.
+//
+// Why: SemanticIntentRouter.RouteAsync appends one RoutingTelemetryRecord per
+// scored query (PR #383). Non-explicit tests (SemanticIntentRouterTests,
+// AgentInfrastructureTests) and the [Explicit] RoutingEvalHarness drive that
+// path with synthetic / fixed-corpus prompts — without this gate they write
+// those records into the real repo state/telemetry/routing/ stream, which is
+// exactly the eval-corpus contamination the telemetry sink exists to avoid
+// (Codex P1 on #383). GA_ROUTING_NO_TELEMETRY=1 makes RoutingTelemetryLog.Append
+// a no-op for the duration of the test process.
+//
+// RoutingTelemetryLogTests overrides this per-test (it sets GA_ROUTING_TELEMETRY_DIR
+// to a temp dir and re-enables writes) so it can still exercise the sink directly.
+
+using NUnit.Framework;
+
+[SetUpFixture]
+public sealed class TelemetrySuppressionSetUpFixture
+{
+    private string? _prior;
+
+    [OneTimeSetUp]
+    public void DisableRoutingTelemetry()
+    {
+        _prior = Environment.GetEnvironmentVariable("GA_ROUTING_NO_TELEMETRY");
+        Environment.SetEnvironmentVariable("GA_ROUTING_NO_TELEMETRY", "1");
+    }
+
+    [OneTimeTearDown]
+    public void RestoreRoutingTelemetry()
+    {
+        Environment.SetEnvironmentVariable("GA_ROUTING_NO_TELEMETRY", _prior);
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/RoutingTelemetryLogTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/RoutingTelemetryLogTests.cs
@@ -1,0 +1,92 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Text.Json;
+using GA.Business.ML.Agents.Intents;
+
+/// <summary>
+/// Pins <see cref="RoutingTelemetryLog"/>: append → valid JSONL → read-back, the
+/// env-dir override, and the disable switch. No router / Ollama needed — exercises
+/// the sink in isolation against a temp directory.
+/// </summary>
+[TestFixture]
+public class RoutingTelemetryLogTests
+{
+    private string _tempDir = "";
+    private string? _priorDisable;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ga-routing-telemetry-test-" + Guid.NewGuid().ToString("N"));
+        _priorDisable = Environment.GetEnvironmentVariable(RoutingTelemetryLog.DisableEnvVar);
+        Environment.SetEnvironmentVariable("GA_ROUTING_TELEMETRY_DIR", _tempDir);
+        Environment.SetEnvironmentVariable(RoutingTelemetryLog.DisableEnvVar, null);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("GA_ROUTING_TELEMETRY_DIR", null);
+        Environment.SetEnvironmentVariable(RoutingTelemetryLog.DisableEnvVar, _priorDisable);
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static RoutingTelemetryRecord SampleMatch() => new()
+    {
+        Timestamp   = DateTime.UtcNow.ToString("o"),
+        Query       = "common notes between F major and D minor",
+        Chosen      = "skill.commontones",
+        Confidence  = 0.88,
+        Threshold   = 0.55,
+        FellThrough = false,
+        Margin      = 0.04,
+        Candidates  =
+        [
+            new RoutingTelemetryCandidate("skill.commontones", 0.82, 0.06, 0.88),
+            new RoutingTelemetryCandidate("skill.relativekey", 0.84, 0.0, 0.84),
+        ],
+        LatencyMs = 12.3,
+    };
+
+    [Test]
+    public void Append_ThenReadRecent_RoundTripsRecord()
+    {
+        RoutingTelemetryLog.Append(SampleMatch());
+
+        var read = RoutingTelemetryLog.ReadRecent();
+        Assert.That(read, Has.Count.EqualTo(1));
+        var r = read[0];
+        Assert.That(r.Chosen, Is.EqualTo("skill.commontones"));
+        Assert.That(r.FellThrough, Is.False);
+        Assert.That(r.Confidence, Is.EqualTo(0.88).Within(1e-9));
+        Assert.That(r.Candidates, Has.Count.EqualTo(2));
+        Assert.That(r.Candidates![0].IntentId, Is.EqualTo("skill.commontones"));
+        Assert.That(r.Candidates[0].Boost, Is.EqualTo(0.06).Within(1e-9));
+    }
+
+    [Test]
+    public void Append_WritesExactlyOneJsonLinePerRecord()
+    {
+        RoutingTelemetryLog.Append(SampleMatch());
+        RoutingTelemetryLog.Append(SampleMatch() with { Chosen = null, FellThrough = true, Confidence = null });
+
+        var lines = File.ReadAllLines(RoutingTelemetryLog.CurrentDayFile());
+        Assert.That(lines, Has.Length.EqualTo(2), "one JSONL line per Append");
+        foreach (var line in lines)
+        {
+            Assert.DoesNotThrow(() => JsonDocument.Parse(line), $"each line must be valid JSON: {line}");
+        }
+        // Fall-through record omits null conf/chosen (WhenWritingNull) but keeps the flag.
+        using var doc = JsonDocument.Parse(lines[1]);
+        Assert.That(doc.RootElement.GetProperty("fell_through").GetBoolean(), Is.True);
+        Assert.That(doc.RootElement.TryGetProperty("chosen", out _), Is.False, "null chosen is omitted, not serialized");
+    }
+
+    [Test]
+    public void DisableEnvVar_SuppressesWrites()
+    {
+        Environment.SetEnvironmentVariable(RoutingTelemetryLog.DisableEnvVar, "1");
+        RoutingTelemetryLog.Append(SampleMatch());
+        Assert.That(RoutingTelemetryLog.ReadRecent(), Is.Empty, "GA_ROUTING_NO_TELEMETRY=1 must suppress all writes");
+    }
+}


### PR DESCRIPTION
## Why

The panel's #1 ML finding: the `DefaultRoutingHintProvider` regex hints were authored against (and cite by id) the fixed 86-prompt eval corpus, so `RoutingEvalHarness` measures **training accuracy** (the 93.x% number), not generalization. The prerequisite for trusting *any* future router change — more hints **or** a learned head — is an **uncontaminated held-out eval set mined from live traffic** the hints never saw. This PR adds the capture layer that makes that possible.

## What

`RoutingTelemetryLog` mirrors the proven `VoicingTelemetryLog` exactly:
- append-only per-day JSONL under `state/telemetry/routing/`, daily rotation
- error-swallowed (telemetry can never break routing), `GA_ROUTING_NO_TELEMETRY=1` disable, `GA_ROUTING_TELEMETRY_DIR` override, `ReadRecent` for mining/tests

`SemanticIntentRouter.RouteAsync` appends one record per **scored** query at both decision exits (below-threshold fall-through **and** a match): `q`, `chosen` (null on fall-through), boosted `conf`, `threshold`, `fell_through`, top1–top2 `margin`, the top-3 `candidates` (base/boost/final), and per-query latency.

## Verification
- 3 unit tests (round-trip, one-JSON-line-per-append + valid JSON, disable switch). No router/Ollama needed.
- **End-to-end:** a live `RunBaseline` run wrote **166 well-formed records** to a temp dir (one per corpus query), each with the full candidate ranking + scores. Example line:
  ```json
  {"ts":"2026-05-31T16:00:07Z","q":"what notes are in Cmaj7?","chosen":"skill.chordinfo","conf":0.993,"threshold":0.55,"fell_through":false,"margin":0.112,"candidates":[{"id":"skill.chordinfo","base":0.993,"boost":0,"final":0.993}, ...],"ms":120}
  ```

## Notes
- **No behavior change to routing** — purely additive logging on a swallowed path.
- **Next:** once live records accumulate, mine a held-out eval set → re-baseline hints (and the OOS gate) honestly against traffic.
- **Follow-up:** have the `[Explicit]` eval harness set `GA_ROUTING_NO_TELEMETRY=1` so eval runs don't pollute the live stream (the verification run above used a temp dir to avoid exactly this). Left out here to avoid conflicting with the in-flight router-eval stack (#378/#380/#381/#382).

🤖 Generated with [Claude Code](https://claude.com/claude-code)