### PR TITLE
fix(chatbot): diatonic-chords skill extracts the requested progression, not the full set

### DIFF
--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
@@ -198,13 +198,19 @@ prompts:
   - prompt: "give me a ii-V-I progression in Bb"
     category: progressions
     routes_to: skill.diatonicchords
+    # Progression-SHAPE assertion (SKILL.md progression-selection section): the
+    # ii-V-I in Bb is Cm - F - Bb. A correct answer contains Cm + Bb and must NOT
+    # dump the full diatonic set — Dm (iii) and Gm (vi) appear only if the skill
+    # listed all seven chords instead of extracting the requested degrees. This
+    # is the regression that caught the original gap (#377 routed correctly but
+    # returned the full key inventory).
     contains: ["Cm", "Bb"]
-    not_contains: ["I need a tab", "paste a tab"]
+    not_contains: ["I need a tab", "paste a tab", "Dm", "Gm"]
     forbidden_agent_ids: ["tab.optimize", "tab.analyze"]
     must_not_fallback: true
-    min_length: 50
+    min_length: 30                    # a terse 3-chord progression answer is fine
     max_elapsed_ms: 45000
-    retry: 0                          # deterministic skill — a misroute is a real bug
+    retry: 1                          # routing is deterministic; the progression FORMATTING is LLM — one retry absorbs wording variance
 
   - prompt: "ii-V-I in Bb"
     category: progressions

--- a/skills/diatonic-chords/SKILL.md
+++ b/skills/diatonic-chords/SKILL.md
@@ -64,6 +64,22 @@ Format the answer briefly. Recommended shape:
 
 For minor keys, label with lowercase Roman numerals: i, ii°, III, iv, v, VI, VII (natural minor).
 
+## Progression requests (Roman numerals → select degrees)
+
+If the user asks for a **specific progression by Roman numerals** — e.g. "ii-V-I", "I-IV-V", "I-vi-IV-V" — still call the closure (it gives the correctly-spelled diatonic chords for the key), but then present **only the requested degrees, in the order given**, as the progression. Do **not** list all seven chords in this case.
+
+Map each Roman numeral to its 1-based scale degree and take that chord from the closure's array (array index = degree − 1):
+
+| Roman | I/i | II/ii | III/iii | IV/iv | V/v | VI/vi | VII/vii |
+|---|---|---|---|---|---|---|---|
+| degree | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+
+Use the chord exactly as the closure returned it for that degree — do **not** re-spell it or change its quality. The closure already carries the correct quality per scale degree; the Roman-numeral case (upper/lower) is just the user's notation, not an instruction to alter the chord.
+
+Example: "ii-V-I progression in Bb" → call `domain.diatonicChords(root: Bb, scale: major)` → returns `["Bb","Cm","Dm","Eb","F","Gm","A°"]`; degrees ii=2→`Cm`, V=5→`F`, I=1→`Bb` → answer the progression **Cm – F – Bb** (not the full seven-chord list).
+
+Present it as the progression, e.g. "The **ii–V–I** in **Bb major** is **Cm – F – Bb**." If a Roman numeral falls outside 1–7 or can't be parsed, fall back to listing the full diatonic set and say which numeral you couldn't read.
+
 ## Errors
 
 `closure-not-found` / `arg-coerce-failed` / `closure-runtime-error`: surface the error code and message verbatim. Don't try to "guess" the chords — that's the failure mode this skill exists to prevent.


### PR DESCRIPTION
## Why

Follow-up to #377 (the gap octo flagged on the merge review). #377 routed *"ii-V-I progression in Bb"* to `DiatonicChordsSkill` correctly — but the skill returned **all seven** diatonic chords (the key inventory), not the **3-chord progression** the user asked for. The title promised a progression; the answer was a key dump.

## Fix — grounded, SKILL.md-only (no closure/DSL change)

The chords still come from the deterministic `domain.diatonicChords` closure (correct enharmonic spelling). A new **"Progression requests"** section in `skills/diatonic-chords/SKILL.md` instructs the model to **select only the requested scale degrees** from that grounded array (ii=2, V=5, I=1), in order, and present them as the progression — never the full seven when a Roman-numeral sequence is given. The model only does an index-pick over grounded chords (it has to parse the Roman numerals either way — a closure-arg approach would need the same extraction), so grounding is preserved without DSL surgery.

## Verified LIVE (`:5252`, Mode=full, llama3.2:3b)
| query | result |
|---|---|
| `ii-V-I in Bb` | → `skill.diatonicchords` → **Cm – F – Bb** ✅ |
| `give me a ii-V-I progression in Bb` | → **Cm – F – Bb** ✅ |
| `diatonic chords in C major` (regression) | → all 7 (C Dm Em F G Am B°) ✅ |

## Test
Strengthened the corpus regression prompt to assert **progression-shape**: `contains [Cm, Bb]` AND `not_contains [Dm, Gm]` — `Dm` (iii) / `Gm` (vi) appear only if the full set was dumped, so it catches the exact original gap. `retry: 1` (routing is deterministic; progression *formatting* is LLM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)