### PR TITLE
fix(parser): accept accidental-additions (add#11/addb9/add#9) — closes #376 P2

### DIFF
--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -297,13 +297,17 @@ public static class ChordPitchClasses
         int? sixth = null;
         int? seventh = null;
 
-        // additions: add2 add4 add6 add9 add11 add13
-        foreach (Match m in Regex.Matches(w, @"add(2|4|6|9|11|13)"))
+        // additions: add2 add4 add6 add9 add11 add13, AND accidental-additions
+        // add#11 / addb9 / add#9 / addb13 etc. The sign group is optional — must
+        // run BEFORE the alteration pass below, or "add#11" leaves "add" as residue
+        // (the alteration pass eats "#11") and the whole symbol fails to parse.
+        foreach (Match m in Regex.Matches(w, @"add(b|#)?(2|4|6|9|11|13)"))
         {
-            var d = int.Parse(m.Groups[1].Value);
-            explicitDegrees[d] = DegreeSemitone(d, '\0');
+            var sign = m.Groups[1].Value.Length > 0 ? m.Groups[1].Value[0] : '\0';
+            var d = int.Parse(m.Groups[2].Value);
+            explicitDegrees[d] = DegreeSemitone(d, sign);
         }
-        w = Regex.Replace(w, @"add(2|4|6|9|11|13)", "");
+        w = Regex.Replace(w, @"add(b|#)?(2|4|6|9|11|13)", "");
 
         // alterations: b5 #5 b6 b9 #9 #11 b13 … (sign + degree)
         foreach (Match m in Regex.Matches(w, @"(b|#)(5|6|9|11|13)"))

--- a/Tests/Common/GA.Business.ML.Tests/Search/ChordPitchClassesCompositionalTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/ChordPitchClassesCompositionalTests.cs
@@ -96,6 +96,13 @@ public class ChordPitchClassesCompositionalTests
     [TestCase("C13no11", new[] { 0, 2, 4, 7, 9, 10 })]
     [TestCase("C9no3", new[] { 0, 2, 7, 10 })]
     [TestCase("Cmaj7no5", new[] { 0, 4, 11 })]
+    // Accidental-additions (#376 octo P2): the additions pass must accept a sign,
+    // or "add#11" leaves "add" residue (the alteration pass eats "#11") → parse fails.
+    [TestCase("Cadd#11", new[] { 0, 4, 6, 7 })]
+    [TestCase("C(add#11)", new[] { 0, 4, 6, 7 })]
+    [TestCase("Caddb9", new[] { 0, 1, 4, 7 })]
+    [TestCase("Cadd#9", new[] { 0, 3, 4, 7 })]
+    [TestCase("Caddb13", new[] { 0, 4, 7, 8 })]
     public void ResolvesExactPitchClasses(string symbol, int[] expected)
     {
         Assert.That(ChordPitchClasses.TryParse(symbol, out var root, out var pcs), Is.True, $"{symbol} should parse");


### PR DESCRIPTION
## Why
Closes the P2 octo flagged on #376. The compositional chord parser's additions pass matched only `add(2|4|6|9|11|13)` (no sign), so `Cadd#11` / `C(add#11)` left `add` as residue (the alteration pass ate `#11`) → the symbol failed the residue check and fell through to the LLM.

## Fix
Widen the additions regex to `add(b|#)?(2|4|6|9|11|13)` and pass the captured sign to `DegreeSemitone` (already handles signed 6/9/11/13). The additions pass already runs before the alteration pass, so the sign is consumed in the right order.

## Test
`ChordPitchClassesCompositionalTests` 51/51 green, +5 exact-pitch-class cases:
`Cadd#11`→[0,4,6,7] · `C(add#11)`→[0,4,6,7] · `Caddb9`→[0,1,4,7] · `Cadd#9`→[0,3,4,7] · `Caddb13`→[0,4,7,8].

🤖 Generated with [Claude Code](https://claude.com/claude-code)