### PR TITLE
ci(semantic-regression): dispatch-only — stop repo-wide red from model-less runners

### DIFF
--- a/.github/workflows/semantic-regression-chatbot.yml
+++ b/.github/workflows/semantic-regression-chatbot.yml
@@ -44,14 +44,18 @@ name: Semantic Regression — Chatbot Goldens
 #   warns and the user can switch to sampling. See SAMPLE_SIZE input.
 
 on:
-  pull_request:
-    paths:
-      - 'Apps/GaChatbot.Api/**'
-      - 'Apps/ga-server/GaApi/**'
-      - 'Common/GA.Business.ML/**'
-      - 'state/quality/chatbot-qa/golden-traces/**'
-      - 'Scripts/replay-chatbot-goldens.ps1'
-      - '.github/workflows/semantic-regression-chatbot.yml'
+  # Dispatch-only (2026-05-31). This is a LIVE-MODEL integration check: it spins
+  # up GaChatbot.Api and replays golden prompts, which needs Ollama (llama3.2:3b
+  # + nomic-embed) for the chatbot to generate answers. GitHub-hosted runners
+  # have no Ollama, so on `pull_request` the chatbot never became ready
+  # ("Connection refused localhost:11434" in SemanticIntentRouter warmup) and
+  # the job failed on EVERY PR regardless of content — repo-wide red noise, not
+  # a real regression signal. Run it on demand where a model runner exists (a dev
+  # machine or a self-hosted runner with Ollama). The OPENAI_API_KEY secret powers
+  # only the diff-embedding step (text-embedding-3-small), not the chatbot itself
+  # — do NOT point the chatbot at OpenAI in CI, that would invalidate the diff
+  # against the llama3.2-generated golden traces. Re-add a `pull_request` trigger
+  # only once CI provisions a model runner (self-hosted + Ollama service).
   workflow_dispatch:
     inputs:
       sample_size:


### PR DESCRIPTION
## Why
`replay-and-diff` failed on **every PR** repo-wide — not a regression signal, just noise. It's a **live-model integration check**: it boots `GaChatbot.Api` and replays golden prompts, which needs **Ollama** (llama3.2:3b + nomic-embed) for the chatbot to generate answers. GitHub-hosted runners have no Ollama → the chatbot never becomes ready (`Connection refused localhost:11434` in `SemanticIntentRouter` warmup) → the job fails.

Verified today via a `workflow_dispatch` run after configuring the `OPENAI_API_KEY` secret: the `Guard — OPENAI_API_KEY present` step now **passes**, but `Wait for chatbot ready` fails on the missing model runner — so the key was necessary but not sufficient.

## Change
Drop the `pull_request` trigger; keep `workflow_dispatch`. The check still runs **on demand** where a model runner exists (a dev machine or a self-hosted runner with Ollama). The `OPENAI_API_KEY` secret powers only the diff-embedding step (`text-embedding-3-small`), not the chatbot — pointing the chatbot at OpenAI in CI would invalidate the diff against the llama3.2-generated goldens.

Re-add `pull_request` once CI provisions a model runner (self-hosted + Ollama service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)