### PR TITLE
feat(prime-radiant): render the IX temporal assumption graph

### DIFF
--- a/Apps/ga-server/GaApi/Controllers/GovernanceController.cs
+++ b/Apps/ga-server/GaApi/Controllers/GovernanceController.cs
@@ -72,6 +72,128 @@ public class GovernanceController(
     }
 
     /// <summary>
+    ///     Get the IX temporal assumption graph adapted to the GovernanceGraph
+    ///     shape, for Prime Radiant. Reads the JSON-on-disk graph emitted by
+    ///     <c>ix-assumption-graph-report --prime-radiant-json</c> in the sibling
+    ///     ix repo (path via config <c>Governance:AssumptionGraphJson</c> or
+    ///     auto-detect). Verdict → healthStatus drives node color;
+    ///     <c>contradicts</c> edges render as red <c>lolli</c> beams.
+    /// </summary>
+    [HttpGet("/api/assumption")]
+    public ActionResult<GovernanceGraph> GetAssumptionGraph()
+    {
+        try
+        {
+            var ixPath = configuration["Governance:AssumptionGraphJson"] ?? FindAssumptionGraphJson();
+            if (ixPath == null || !System.IO.File.Exists(ixPath))
+            {
+                logger.LogWarning("Assumption graph JSON not found; serving empty graph");
+                return Ok(GovernanceGraph.Empty);
+            }
+
+            return Ok(AdaptAssumptionGraph(System.IO.File.ReadAllText(ixPath)));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to load assumption graph");
+            return StatusCode(500, new { error = "Failed to load assumption graph" });
+        }
+    }
+
+    private static string? FindAssumptionGraphJson()
+    {
+        var rel = Path.Combine("state", "assumptions", "prime-radiant.json");
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..", "ix", rel),
+            Path.Combine(Directory.GetCurrentDirectory(), "..", "ix", rel),
+            Path.Combine(@"C:\Users\spare\source\repos\ix", rel),
+        };
+        return candidates.FirstOrDefault(System.IO.File.Exists);
+    }
+
+    // Adapt IX's generic Prime-Radiant envelope ({nodes,edges}) into the
+    // GovernanceGraph shape the 3D renderer consumes. Mirrors the Vite
+    // /dev-data/assumption middleware so dev and prod render identically.
+    private static GovernanceGraph AdaptAssumptionGraph(string ixJson)
+    {
+        var verdictHealth = new Dictionary<string, string>
+        {
+            ["T"] = "healthy", ["P"] = "healthy", ["U"] = "unknown",
+            ["D"] = "warning", ["F"] = "error", ["C"] = "contradictory",
+        };
+        var healthColor = new Dictionary<string, string>
+        {
+            ["error"] = "#FF4444", ["warning"] = "#FFB300", ["healthy"] = "#33CC66",
+            ["unknown"] = "#888888", ["contradictory"] = "#FF44FF",
+        };
+
+        using var doc = JsonDocument.Parse(ixJson);
+        var root = doc.RootElement;
+        string Str(JsonElement el, string prop) =>
+            el.TryGetProperty(prop, out var v) ? v.GetString() ?? "" : "";
+
+        var nodes = new List<GovernanceNode>();
+        if (root.TryGetProperty("nodes", out var nodesEl) && nodesEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var n in nodesEl.EnumerateArray())
+            {
+                var tv = Str(n, "truth_value");
+                if (string.IsNullOrEmpty(tv)) tv = "U";
+                var hs = verdictHealth.GetValueOrDefault(tv, "unknown");
+                var claim = Str(n, "name");
+                nodes.Add(new GovernanceNode
+                {
+                    Id = Str(n, "id"),
+                    Name = claim.Length > 60 ? claim[..57] + "…" : claim,
+                    Type = "schema",
+                    Description = claim,
+                    Color = healthColor[hs],
+                    Domain = Str(n, "type"),
+                    HealthStatus = hs,
+                    FilePath = Str(n, "path"),
+                    Metadata = new Dictionary<string, object> { ["truth_value"] = tv, ["kind"] = Str(n, "kind") },
+                });
+            }
+        }
+
+        var edges = new List<GovernanceEdge>();
+        var contradicts = 0;
+        if (root.TryGetProperty("edges", out var edgesEl) && edgesEl.ValueKind == JsonValueKind.Array)
+        {
+            var i = 0;
+            foreach (var e in edgesEl.EnumerateArray())
+            {
+                var rel = Str(e, "relation");
+                var isC = rel == "contradicts";
+                if (isC) contradicts++;
+                edges.Add(new GovernanceEdge
+                {
+                    Id = $"e{i++}",
+                    Source = Str(e, "source"),
+                    Target = Str(e, "target"),
+                    Type = isC ? "lolli" : "policy-persona",
+                    Label = rel,
+                    Weight = isC ? 1.0 : 0.4,
+                });
+            }
+        }
+
+        var denom = nodes.Count == 0 ? 1 : nodes.Count;
+        return new GovernanceGraph
+        {
+            Nodes = nodes,
+            Edges = edges,
+            GlobalHealth = new HealthMetrics
+            {
+                ResilienceScore = Math.Max(0, 1.0 - (double)contradicts / denom),
+                LolliCount = contradicts,
+                ErgolCount = nodes.Count,
+            },
+        };
+    }
+
+    /// <summary>
     ///     Get Markov prediction data for governance health forecasting.
     /// </summary>
     [HttpGet("predictions")]

--- a/ReactComponents/ga-react-components/src/components/PrimeRadiant/DataLoader.ts
+++ b/ReactComponents/ga-react-components/src/components/PrimeRadiant/DataLoader.ts
@@ -137,7 +137,11 @@ export function deriveGovernanceHealthStatus(node: GovernanceNode): GovernanceHe
 // ---------------------------------------------------------------------------
 export function applyHealthColors(graph: GovernanceGraph): GovernanceGraph {
   const coloredNodes = graph.nodes.map(node => {
-    const healthStatus = deriveGovernanceHealthStatus(node);
+    // Honor an explicit healthStatus when the source already set one — e.g.
+    // assumption-graph verdicts, including `contradictory`, which the
+    // metric-based derivation below cannot produce. Governance nodes carry no
+    // healthStatus, so they still derive from health metrics as before.
+    const healthStatus = node.healthStatus ?? deriveGovernanceHealthStatus(node);
     return {
       ...node,
       healthStatus,

--- a/ReactComponents/ga-react-components/src/pages/PrimeRadiantTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/PrimeRadiantTest.tsx
@@ -32,23 +32,40 @@ const PrimeRadiantTest: React.FC = () => {
   return (
     <Container maxWidth={false} disableGutters sx={{ height: '100%', overflow: 'hidden', position: 'relative' }}>
       <CastButton right={64} />
-      <div style={{ position: 'absolute', top: 12, left: 12, zIndex: 20, display: 'flex', gap: 8 }}>
+      {/* Source switcher — top-center, below the metrics HUD bar and clear of
+          the top-left breadcrumb / perf-info panel (which otherwise overlap and
+          intercept clicks). High z-index keeps it clickable above the canvas. */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 56,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 1000,
+          display: 'flex',
+          gap: 0,
+          borderRadius: 8,
+          overflow: 'hidden',
+          border: '1px solid rgba(255,215,0,0.6)',
+          boxShadow: '0 2px 10px rgba(0,0,0,0.5)',
+        }}
+      >
         {(['governance', 'assumption'] as const).map((s) => (
           <button
             key={s}
             onClick={() => setSource(s)}
             style={{
-              padding: '6px 12px',
-              borderRadius: 6,
+              padding: '6px 16px',
               cursor: 'pointer',
               fontFamily: 'monospace',
-              fontSize: 13,
-              background: source === s ? '#FFD700' : 'rgba(0,0,0,0.6)',
+              fontSize: 12,
+              letterSpacing: 0.5,
+              border: 'none',
+              background: source === s ? '#FFD700' : 'rgba(0,0,8,0.72)',
               color: source === s ? '#000' : '#FFD700',
-              border: '1px solid #FFD700',
             }}
           >
-            {s === 'governance' ? 'Governance' : 'Assumptions'}
+            {s === 'governance' ? 'GOVERNANCE' : 'ASSUMPTIONS'}
           </button>
         ))}
       </div>

--- a/ReactComponents/ga-react-components/src/pages/PrimeRadiantTest.tsx
+++ b/ReactComponents/ga-react-components/src/pages/PrimeRadiantTest.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { Container } from '@mui/material';
 import CastButton from '../components/Common/CastButton';
 
@@ -7,8 +7,16 @@ const ForceRadiant = React.lazy(() =>
   import('../components/PrimeRadiant').then(mod => ({ default: mod.ForceRadiant }))
 );
 
+type GraphSource = 'governance' | 'assumption';
+
 const PrimeRadiantTest: React.FC = () => {
   console.log('[PrimeRadiantTest] Rendering ForceRadiant...');
+
+  // Which graph to render: governance (default) or the IX temporal assumption
+  // graph (served by the Vite /dev-data/assumption middleware).
+  const [source, setSource] = useState<GraphSource>('governance');
+  const liveDataUrl = source === 'assumption' ? '/dev-data/assumption' : '/api/governance';
+  const liveHubUrl = source === 'assumption' ? undefined : '/hubs/governance';
 
   // Prevent body scrolling while Prime Radiant is mounted
   useEffect(() => {
@@ -24,6 +32,26 @@ const PrimeRadiantTest: React.FC = () => {
   return (
     <Container maxWidth={false} disableGutters sx={{ height: '100%', overflow: 'hidden', position: 'relative' }}>
       <CastButton right={64} />
+      <div style={{ position: 'absolute', top: 12, left: 12, zIndex: 20, display: 'flex', gap: 8 }}>
+        {(['governance', 'assumption'] as const).map((s) => (
+          <button
+            key={s}
+            onClick={() => setSource(s)}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 6,
+              cursor: 'pointer',
+              fontFamily: 'monospace',
+              fontSize: 13,
+              background: source === s ? '#FFD700' : 'rgba(0,0,0,0.6)',
+              color: source === s ? '#000' : '#FFD700',
+              border: '1px solid #FFD700',
+            }}
+          >
+            {s === 'governance' ? 'Governance' : 'Assumptions'}
+          </button>
+        ))}
+      </div>
       <Suspense fallback={
         <div style={{
           width: '100%',
@@ -40,8 +68,9 @@ const PrimeRadiantTest: React.FC = () => {
         </div>
       }>
         <ForceRadiant
-          liveDataUrl="/api/governance"
-          liveHubUrl="/hubs/governance"
+          key={source}
+          liveDataUrl={liveDataUrl}
+          liveHubUrl={liveHubUrl}
           onNodeSelect={(node) => {
             if (node) {
               console.log('[PrimeRadiant] Selected:', node.name, node.type);

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -1474,6 +1474,69 @@ function devDataPlugin(): Plugin {
                 res.end(JSON.stringify({ generated_at: new Date().toISOString(), docs: gatherArchitecture() }));
             });
 
+            // ── /dev-data/assumption — IX temporal assumption graph ─────────
+            // Reads the Prime-Radiant-format graph emitted by
+            // `ix-assumption-graph-report --prime-radiant-json` (JSON-on-disk
+            // contract from the sibling ix repo) and adapts the generic
+            // {nodes,edges} envelope into the GovernanceGraph shape the 3D
+            // renderer consumes. Verdict → healthStatus drives node color;
+            // `contradicts` edges render as red `lolli` beams.
+            server.middlewares.use('/dev-data/assumption', (req, res, next) => {
+                if (req.method !== 'GET') { next(); return; }
+                const ixRoot = process.env.IX_ROOT || path.resolve(repoRoot, '../ix')
+                const p = path.join(ixRoot, 'state/assumptions/prime-radiant.json')
+                if (!existsSync(p)) {
+                    res.writeHead(404, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({ error: `assumption graph not found at ${p} — run: ix-assumption-graph-report . --prime-radiant-json state/assumptions/prime-radiant.json` }))
+                    return
+                }
+                try {
+                    const ix = JSON.parse(readFileSync(p, 'utf-8'))
+                    const VERDICT_HEALTH: Record<string, string> = { T: 'healthy', P: 'healthy', U: 'unknown', D: 'warning', F: 'error', C: 'contradictory' }
+                    const HEALTH_COLOR: Record<string, string> = { error: '#FF4444', warning: '#FFB300', healthy: '#33CC66', unknown: '#888888', contradictory: '#FF44FF' }
+                    let contradicts = 0
+                    const nodes = (ix.nodes ?? []).map((n: Record<string, unknown>) => {
+                        const tv = String(n.truth_value ?? 'U')
+                        const hs = VERDICT_HEALTH[tv] ?? 'unknown'
+                        const claim = String(n.name ?? '')
+                        return {
+                            id: n.id,
+                            name: claim.length > 60 ? claim.slice(0, 57) + '…' : claim,
+                            type: 'schema',
+                            description: claim,
+                            color: HEALTH_COLOR[hs],
+                            domain: n.type,            // ix node.type is the namespace facet
+                            healthStatus: hs,
+                            filePath: n.path ?? '',
+                            metadata: { truth_value: tv, kind: n.kind, domain: n.domain },
+                        }
+                    })
+                    const edges = (ix.edges ?? []).map((e: Record<string, unknown>, i: number) => {
+                        const isC = e.relation === 'contradicts'
+                        if (isC) contradicts++
+                        return {
+                            id: `e${i}`,
+                            source: e.source,
+                            target: e.target,
+                            type: isC ? 'lolli' : 'policy-persona',
+                            label: e.relation,
+                            weight: isC ? 1.0 : 0.4,
+                        }
+                    })
+                    const denom = nodes.length || 1
+                    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+                    res.end(JSON.stringify({
+                        nodes,
+                        edges,
+                        globalHealth: { resilienceScore: Math.max(0, 1 - contradicts / denom), lolliCount: contradicts, ergolCount: nodes.length, staleness: 0 },
+                        timestamp: new Date().toISOString(),
+                    }))
+                } catch (err) {
+                    res.writeHead(500, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({ error: String(err) }))
+                }
+            });
+
             server.middlewares.use('/dev-data/agents', (req, res, next) => {
                 if (req.method !== 'GET') { next(); return; }
                 res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });


### PR DESCRIPTION
## What

Adds an **"Assumptions"** source to Prime Radiant so it renders the IX temporal assumption graph (from `ix-assumption-graph`) alongside the governance graph — the visualization half of the assumption-graph work (IX side merged via ix#74; emitter ix#75).

**Data path (JSON-on-disk, per ecosystem convention):**
`ix-assumption-graph-report --prime-radiant-json` writes `state/assumptions/prime-radiant.json` in the ix repo → consumed two ways:
- **dev:** Vite `/dev-data/assumption` middleware (no backend needed)
- **prod:** GaApi `GET /api/assumption`

Both adapt IX's generic `{nodes,edges}` envelope into the `GovernanceGraph` shape the existing 3D renderer already consumes — **no render-engine changes**. Verdict → `healthStatus` drives node color (C=contradictory magenta, F=error red, D=warning amber, T/P=healthy green, U=unknown gray); `contradicts` edges render as red `lolli` beams.

## Changes
- `vite.config.ts` — `/dev-data/assumption` middleware (reads ix JSON, adapts).
- `GovernanceController.cs` — `GET /api/assumption` (same adapter in C#).
- `DataLoader.applyHealthColors` — honor an explicit `healthStatus` (so assumption verdicts incl. `contradictory` survive; governance nodes still derive from metrics).
- `PrimeRadiantTest.tsx` — Governance/Assumptions source toggle.

## Verification
- ✅ **Data path verified live**: `GET http://localhost:5176/dev-data/assumption` → 200, **18 nodes, 4 red `lolli` contradiction edges**, verdict-colored nodes, resilience 0.778 (the demo includes a `/deep-research` claim refuting a code invariant).
- ✅ **GaApi compiles**: `dotnet build` succeeded, 0 errors.
- ⚠️ **3D screenshot NOT captured**: the ga SPA currently 500s because **`@mui/material` is not installed** in this workspace (pre-existing, affects all of `main.tsx`, unrelated to this change). Run `npm install` in `ReactComponents/ga-react-components`, then visit `/test/prime-radiant` → "Assumptions" to verify the render.

## Notes
- Frontend dev toggle points at `/dev-data/assumption` (works without GaApi). A prod build should point the assumption source at `/api/assumption`.
- Depends on the ix emitter (ix#75) for the JSON; works with the committed `state/assumptions/prime-radiant.json` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)