### PR TITLE
docs: rewrite stale docs/README.md as a lean accurate index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,281 +1,50 @@
-# Guitar Alchemist - Documentation Index
-
-Welcome to the Guitar Alchemist documentation! This folder contains comprehensive guides for all features and capabilities.
-
----
-
-## 📚 **Quick Navigation**
-
-### **Start Here**
-- **[ACHIEVEMENT_SUMMARY.md](ACHIEVEMENT_SUMMARY.md)** - Complete overview of all work completed
-- **[FINAL_SUMMARY.md](FINAL_SUMMARY.md)** - Detailed summary with performance metrics
-
-### **GPU Acceleration**
-- **[GPU_ACCELERATION_COMPLETE.md](GPU_ACCELERATION_COMPLETE.md)** - Complete GPU acceleration guide
-  - SIMD acceleration (10-20x speedup, active now!)
-  - ILGPU cross-platform GPU support
-  - Benchmark results and usage examples
-
-### **Advanced Mathematical Techniques**
-- **[ADVANCED_TECHNIQUES_GUIDE.md](ADVANCED_TECHNIQUES_GUIDE.md)** - Complete usage guide for all 9 frameworks
-  - Spectral Graph Theory
-  - Information Theory & Entropy
-  - Category Theory (Functors & Monads)
-  - Topological Data Analysis
-  - Differential Geometry (Voice Leading)
-  - Dynamical Systems
-  - Tensor Analysis
-  - Optimal Transport
-  - Progression Optimization
-
-### **Intelligent BSP and AI Systems**
-- **[INTELLIGENT_BSP_AND_AI_GUIDE.md](INTELLIGENT_BSP_AND_AI_GUIDE.md)** - AI-powered level generation and adaptive difficulty
-  - Intelligent BSP Generator (uses ALL 9 techniques!)
-  - Adaptive Difficulty System
-  - Real-time learning rate measurement
-  - Flow zone optimization
-  - Personalized practice sequences
-
-### **Memory Optimization** 🆕
-- **[MEMORY_OPTIMIZATION_COMPLETE.md](MEMORY_OPTIMIZATION_COMPLETE.md)** - Complete memory optimization guide
-  - 50-70% less memory allocations
-  - 30-40% faster execution
-  - SIMD-accelerated calculations
-  - ImmutableArray, FrozenDictionary, ArrayPool, Span<T>
-  - Lazy<T> memoization, ValueTask, readonly struct
-- **[MEMORY_OPTIMIZATION_GUIDE.md](MEMORY_OPTIMIZATION_GUIDE.md)** - Detailed optimization techniques
-- **[MEMORY_OPTIMIZATION_COMPARISON.md](MEMORY_OPTIMIZATION_COMPARISON.md)** - Before/after comparison
-
-### **Advanced Optimization Opportunities** 🆕
-- **[ADVANCED_OPTIMIZATION_OPPORTUNITIES.md](ADVANCED_OPTIMIZATION_OPPORTUNITIES.md)** - Comprehensive analysis
-  - 23 high-impact optimization opportunities identified
-  - Channels, TPL Dataflow, Reactive Extensions (Rx)
-  - Frozen Collections, Backpressure handling
-  - 40-60% GC pressure reduction potential
-  - 30-50% performance improvement potential
-
-### **Development Guides**
-- **[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)** - Complete developer guide
-- **[DOCKER_DEPLOYMENT.md](DOCKER_DEPLOYMENT.md)** - Docker deployment guide
-- **[DEVOPS_COMPLETE.md](DEVOPS_COMPLETE.md)** - DevOps summary
-
----
-
-## 🚀 **Quick Start**
-
-### 1. GPU-Accelerated Shape Graph
-
-```csharp
-using GA.Business.Core.Fretboard.Shapes;
-using Microsoft.Extensions.Logging;
-
-var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-var gpuBuilder = new GpuShapeGraphBuilder(loggerFactory);
-
-var pitchClassSets = new[]
-{
-    PitchClassSet.Parse("047"),  // C major
-    PitchClassSet.Parse("0479"), // Cmaj7
-    PitchClassSet.Parse("0258")  // C7
-};
-
-var graph = await gpuBuilder.BuildGraphAsync(pitchClassSets, new ShapeGraphOptions
-{
-    MaxDistance = 5.0,
-    IncludeTransitions = true
-});
-
-Console.WriteLine($"Built graph with {graph.Nodes.Count} nodes and {graph.Edges.Count} edges");
-```
-
-### 2. Generate Optimal Progression (Uses ALL 9 Techniques!)
-
-```csharp
-using GA.Business.Core.Fretboard.Shapes.Applications;
-
-var optimizer = new ProgressionOptimizer(loggerFactory);
-
-var progression = optimizer.GeneratePracticeProgression(graph, new ProgressionConstraints
-{
-    Strategy = OptimizationStrategy.Balanced,  // Combines all techniques!
-    TargetLength = 8,
-    PreferCentralShapes = true
-});
-
-Console.WriteLine($"Generated progression:");
-Console.WriteLine($"  Quality: {progression.Quality:F2}");
-Console.WriteLine($"  Entropy: {progression.Entropy:F2} bits");
-Console.WriteLine($"  Complexity: {progression.Complexity:F2}");
-Console.WriteLine($"  Diversity: {progression.Diversity:F2}");
-```
-
-### 3. Comprehensive Harmonic Analysis
-
-```csharp
-using GA.Business.Core.Fretboard.Shapes.Applications;
-
-var engine = new HarmonicAnalysisEngine(loggerFactory);
-
-var report = await engine.AnalyzeAsync(graph, new HarmonicAnalysisOptions
-{
-    IncludeSpectralAnalysis = true,      // Spectral graph theory
-    IncludeDynamicalAnalysis = true,     // Dynamical systems
-    IncludeTopologicalAnalysis = true,   // Topological data analysis
-    ClusterCount = 3,
-    TopCentralShapes = 5
-});
-
-Console.WriteLine($"Analysis results:");
-Console.WriteLine($"  Chord families: {report.ChordFamilies.Count}");
-Console.WriteLine($"  Central shapes: {report.CentralShapes.Count}");
-Console.WriteLine($"  Attractors: {report.Dynamics.Attractors.Count}");
-Console.WriteLine($"  Limit cycles: {report.Dynamics.LimitCycles.Count}");
-Console.WriteLine($"  Betti numbers: H0={report.Topology.BettiNumbers[0]}, H1={report.Topology.BettiNumbers[1]}");
-```
-
----
-
-## 📊 **Performance**
-
-### Current Performance (Verified on NVIDIA RTX 3070)
-
-| Operation | Dataset Size | CPU Time | GPU/SIMD Time | Speedup | Status |
-|-----------|--------------|----------|---------------|---------|--------|
-| **ICV Computation** | 1,000 sets | 31ms | **SIMD Active** | **10-20x** | ✅ **ACTIVE NOW!** |
-| **Batch ICV** | 10,000 sets | 255ms | 196ms | 1.3x | ✅ Working |
-| **Batch Delta** | 5,000 pairs | 48ms | 49ms | 1.0x | ✅ Working |
-
-### Expected Performance (Large Datasets)
-
-| Operation | Dataset Size | Expected Speedup |
-|-----------|--------------|------------------|
-| **Batch ICV** | 100K+ sets | **50-100x** |
-| **Batch Delta** | 100K+ pairs | **50-100x** |
-| **Shape Graph** | 10K+ shapes | **60-300x** |
-
----
-
-## 🔧 **Advanced Techniques**
-
-### 9 Mathematical Frameworks
-
-1. **Spectral Graph Theory** - Chord families, bridge chords, PageRank
-2. **Information Theory** - Entropy, complexity, information gain
-3. **Category Theory** - Functors, monads, transformations
-4. **Topological Data Analysis** - Clusters, cycles, invariants
-5. **Differential Geometry** - Voice leading, geodesics, curvature
-6. **Dynamical Systems** - Attractors, limit cycles, stability
-7. **Tensor Analysis** - Riemann curvature, parallel transport
-8. **Optimal Transport** - Wasserstein distance, optimal plans
-9. **Progression Optimization** - **Combines ALL 8 techniques!**
-
-### Optimization Strategies
-
-- `MaximizeInformationGain` - Information-theoretic optimization
-- `MinimizeVoiceLeading` - Differential geometry optimization
-- `ExploreFamilies` - Spectral clustering optimization
-- `FollowAttractors` - Dynamical systems optimization
-- **`Balanced` - Multi-objective optimization (RECOMMENDED)**
-
----
-
-## 📖 **Documentation Structure**
-
-```
-docs/
-├── README.md                           # This file - documentation index
-├── ACHIEVEMENT_SUMMARY.md              # Complete achievement summary
-├── FINAL_SUMMARY.md                    # Detailed summary with metrics
-├── GPU_ACCELERATION_COMPLETE.md        # GPU acceleration guide
-├── ADVANCED_TECHNIQUES_GUIDE.md        # Advanced techniques usage guide
-├── DEVELOPER_GUIDE.md                  # Developer guide
-├── DOCKER_DEPLOYMENT.md                # Docker deployment guide
-└── DEVOPS_COMPLETE.md                  # DevOps summary
-```
-
----
-
-## 🎯 **Key Features**
-
-### GPU Acceleration ✅
-- **10-20x SIMD speedup** (active now!)
-- **50-300x GPU speedup** potential for large datasets
-- Cross-platform support (NVIDIA, AMD, Intel, Apple)
-- Automatic CPU fallback
-
-### Advanced Mathematics ✅
-- **9 major frameworks** integrated and working
-- **5 optimization strategies** for different goals
-- Comprehensive harmonic analysis
-- Multi-objective optimization
-
-### Production Ready ✅
-- **0 compilation errors** in GPU code
-- Comprehensive test coverage
-- Excellent documentation
-- Verified on real hardware
-
----
-
-## 🚀 **Getting Started**
-
-1. **Read the Achievement Summary**
-   - Start with [ACHIEVEMENT_SUMMARY.md](ACHIEVEMENT_SUMMARY.md)
-   - Understand what's been accomplished
-
-2. **Learn GPU Acceleration**
-   - Read [GPU_ACCELERATION_COMPLETE.md](GPU_ACCELERATION_COMPLETE.md)
-   - See benchmark results and usage examples
-
-3. **Explore Advanced Techniques**
-   - Read [ADVANCED_TECHNIQUES_GUIDE.md](ADVANCED_TECHNIQUES_GUIDE.md)
-   - Learn how to use all 9 mathematical frameworks
-
-4. **Start Coding**
-   - Use the quick start examples above
-   - Refer to the detailed guides as needed
-
----
-
-## 📝 **Additional Resources**
-
-### In-Code Documentation
-- `Common/GA.Business.Core/Fretboard/Shapes/ADVANCED_MATHEMATICS.md` - Mathematical framework details
-- XML documentation comments throughout the codebase
-
-### Test Examples
-- `Tests/Common/GA.Business.Core.Tests/Atonal/Grothendieck/GpuGrothendieckServiceTests.cs` - GPU tests
-- `Tests/Common/GA.Business.Core.Tests/Fretboard/Shapes/Applications/ProgressionOptimizerTests.cs` - Optimization tests
-- `Tests/Common/GA.Business.Core.Tests/Fretboard/Shapes/Applications/HarmonicAnalysisEngineTests.cs` - Analysis tests
-
-### Scripts
-- `Scripts/setup-dev-environment.ps1` - One-command environment setup
-- `Scripts/start-all.ps1` - Start all services
-- `Scripts/run-all-tests.ps1` - Run all tests
-- `Scripts/health-check.ps1` - Verify service health
-
----
-
-## 🎉 **Summary**
-
-**The Guitar Alchemist application is production-ready with:**
-
-- ✅ **GPU acceleration** (10-20x speedup active now!)
-- ✅ **9 advanced mathematical frameworks** working together
-- ✅ **Comprehensive testing** and documentation
-- ✅ **Excellent performance** and scalability
-
-**Start with the quick start examples above, then dive into the detailed guides!** 🚀
-
----
-
-## 📧 **Support**
-
-For questions or issues:
-1. Check the relevant documentation guide
-2. Review the test examples
-3. Consult the in-code XML documentation
-4. Refer to the ADVANCED_MATHEMATICS.md file
-
-**Happy coding!** 🎸⚡
-
+# Guitar Alchemist — Documentation Index
+
+Entry point for the GA documentation tree. Browse by area below; each
+directory has its own docs.
+
+> **Note (2026-05-31):** this index was rebuilt after a sweep found that the
+> previous version linked to a generation of `*_COMPLETE.md` / `*_SUMMARY.md`
+> docs that have since been deleted (every link 404'd). It now points only to
+> directories and files that exist. Run `python Scripts/audit-doc-links.py`
+> from the repo root to re-check `docs/` for broken internal links.
+> (`INDEX.md` is an older, stale second index pending the same treatment — use
+> this file as the canonical entry point.)
+
+## Start here
+
+- [QUICK_START.md](QUICK_START.md) — prerequisites, install, run the stack.
+- [AGENTS.md](AGENTS.md) — repository guidelines for humans and coding agents.
+- [architecture/README.md](architecture/README.md) — **authoritative architecture index**: what runs, what stores data, what serves chat, and the five-layer model.
+
+## Browse by area
+
+| Area | Directory | What's there |
+|---|---|---|
+| Architecture | [architecture/](architecture/) | System design, chat surfaces, app/process inventory, audit |
+| Guides | [Guides/](Guides/) | How-to guides and feature walkthroughs |
+| API | [API/](API/) | API documentation |
+| Configuration | [Configuration/](Configuration/) | Config and settings docs |
+| Testing | [Testing/](Testing/) | Test strategy and guides |
+| Integration | [Integration/](Integration/) | Service/MCP integration docs |
+| Performance | [Performance/](Performance/) | Performance and optimization notes |
+| Chatbot | [chatbot/](chatbot/) | Chatbot runtime + roadmap |
+| Contracts | [contracts/](contracts/) | Cross-repo JSON-on-disk contracts |
+| Methodology | [methodology/](methodology/) | Invariants and methodology |
+| Runbooks | [runbooks/](runbooks/) | Operational runbooks |
+| Solutions | [solutions/](solutions/) | Compounded solution write-ups (dated records) |
+| Plans | [plans/](plans/) | Dated implementation plans (point-in-time) |
+| Reports | [reports/](reports/) | Dated reports (point-in-time) |
+| References | [References/](References/) | Reference material |
+| Archive | [archive/](archive/) | Retired docs and historical tracks |
+
+## Conventions
+
+- **Canonical docs use kebab-case** (`chat-surfaces.md`). Many root-level
+  `SCREAMING_SNAKE.md` files are legacy and pending an archival sweep; prefer
+  the kebab-case docs and the `architecture/` index when they overlap.
+- **Dated records** (`plans/`, `reports/`, `solutions/`, `archive/`,
+  `brainstorms/`) are point-in-time — read them as history, not current state.
+- See [PROJECT_DOCUMENTATION_STANDARD.md](PROJECT_DOCUMENTATION_STANDARD.md)
+  for the documentation standard and [architecture/README.md](architecture/README.md#conventions)
+  for the per-doc frontmatter convention.


### PR DESCRIPTION
## Problem

`docs/README.md` (the docs front door) was a 281-line achievement-showcase relic. Its entire navigation linked a **deleted generation** of `*_COMPLETE.md` / `*_SUMMARY.md` docs (`ACHIEVEMENT_SUMMARY`, `FINAL_SUMMARY`, `GPU_ACCELERATION_COMPLETE`, `MEMORY_OPTIMIZATION_*`, `DEVELOPER_GUIDE`, …) — **every link 404'd** — plus stale RTX-3070 benchmarks and code samples for an old shape-graph framework.

Part 2 of the docs-link cleanup (after #392).

## Fix

Replaced it with a **lean index that links only directories and files that exist** — verified **20/20 link targets resolve**. Organized by area (Architecture, Guides, API, Testing, Integration, …), points to `architecture/README.md` as the authoritative architecture entry, and clearly marks dated dirs (`plans/`, `reports/`, `solutions/`, `archive/`) as point-in-time history and root-level SCREAMING_SNAKE docs as legacy pending sweep.

Deliberately does **not** link the equally-stale `INDEX.md` (flagged in-doc as pending the same treatment) to avoid propagating broken navigation.

## Follow-ups
- `docs/INDEX.md` — second stale index, same relic pattern (rewrite or remove).
- SCREAMING_SNAKE cohort under `Guides/`/`Implementation/`/`Performance/` — archival sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)