### PR TITLE
ci(docs): docs-health gates + maintenance system (stop doc rot recurring)

### DIFF
--- a/.github/workflows/docs-health.yml
+++ b/.github/workflows/docs-health.yml
@@ -1,0 +1,56 @@
+name: Docs Health
+
+# Stops documentation rot from growing. Two gates on every PR that touches docs:
+#   1. Link gate  — NO broken internal links in any live (non-frozen) doc.
+#   2. Code-ref ratchet — docs the PR *touches* must not reference repo paths
+#      (Apps/..., Common/..., *.cs, ...) that don't exist. The pre-existing
+#      backlog in untouched docs is left to the scheduled content audit; this
+#      gate only stops NEW drift in what you edit.
+#
+# Frozen point-in-time records (docs/archive|plans|reports|solutions|history|
+# brainstorms) are exempt — their decayed references are expected history.
+#
+# See docs/methodology/docs-maintenance.md for the full maintenance system.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'Scripts/audit-doc-links.py'
+      - 'Scripts/audit-doc-code-refs.py'
+      - '.github/workflows/docs-health.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-health-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need the base commit for the changed-docs diff
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Link gate — no broken links in live docs
+        run: python Scripts/audit-doc-links.py HEAD --ci
+
+      - name: Code-reference ratchet — changed docs must cite paths that exist
+        shell: bash
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE" ]; then echo "no base sha (dispatch run) — skipping ratchet"; exit 0; fi
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'docs/**/*.md' | tr '\n' ' ')
+          echo "Changed docs: ${CHANGED:-<none>}"
+          if [ -z "$CHANGED" ]; then echo "No changed docs — nothing to ratchet."; exit 0; fi
+          python Scripts/audit-doc-code-refs.py --files $CHANGED

--- a/Scripts/audit-doc-code-refs.py
+++ b/Scripts/audit-doc-code-refs.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Verify that repo-PATH references in LIVING docs still exist.
+
+Catches doc drift like "Apps/GuitarAlchemistChatbot" or
+"Common/GA.Business.Core/AI/AdaptiveDifficultySystem.cs" when the referenced
+path no longer exists. Conservative on purpose: only flags strings that are
+clearly repo paths (start with a known top dir AND contain '/', or end in a
+code-file extension AND contain '/'), so prose namespaces like
+`GA.Business.Core` are NOT flagged.
+
+Scope: LIVING docs only (skips frozen point-in-time records). Reads from the
+working tree. Exit 1 if any broken path reference is found (use in CI).
+
+Usage: python Scripts/audit-doc-code-refs.py [--report] [--files f1 f2 ...]
+  --report : print findings but always exit 0 (non-gating run)
+  --files  : check only these doc paths (CI ratchet: gate the docs a PR
+             touches, not the whole backlog). Frozen/non-doc paths are ignored.
+"""
+import os, re, sys, posixpath
+
+REPORT_ONLY = "--report" in sys.argv
+EXPLICIT = []
+if "--files" in sys.argv:
+    EXPLICIT = [a.replace("\\", "/") for a in sys.argv[sys.argv.index("--files") + 1:] if not a.startswith("--")]
+FROZEN = ("docs/archive/", "docs/plans/", "docs/reports/", "docs/solutions/",
+          "docs/history/", "docs/brainstorms/")
+TOP_DIRS = ("Apps/", "Common/", "ReactComponents/", "Scripts/", "Tests/",
+            "Experiments/", "mcp-servers/")
+CODE_EXT = (".cs", ".ts", ".tsx", ".csproj", ".ps1", ".ebnf", ".razor", ".fs")
+
+# Build the set of tracked paths (working tree, excluding noise).
+tracked = set()
+for root, dirs, files in os.walk("."):
+    dirs[:] = [d for d in dirs if d not in (".git", "node_modules", "bin", "obj", ".vs")]
+    for f in files:
+        tracked.add(os.path.relpath(os.path.join(root, f), ".").replace("\\", "/"))
+dir_set = set()
+for p in tracked:
+    parts = p.split("/")
+    for i in range(1, len(parts)):
+        dir_set.add("/".join(parts[:i]))
+
+def exists(path):
+    path = path.rstrip("/")
+    return path in tracked or path in dir_set
+
+# Code-ish tokens inside backticks or markdown links.
+BACKTICK = re.compile(r"`([^`\n]+)`")
+LINKTGT = re.compile(r"\]\(\s*([^)\s]+?)\s*(?:\"[^\"]*\")?\)")
+
+def looks_like_path(s):
+    s = s.strip()
+    # exclude prose globs (Tests/**) and placeholders (Apps/..., Apps/<name>)
+    if any(ch in s for ch in (" ", "\t", "*", "<", ">")) or "..." in s:
+        return False
+    if s.startswith(("http", "#", "mailto:")):
+        return False
+    has_dir = "/" in s
+    if has_dir and s.startswith(TOP_DIRS):
+        return True
+    if has_dir and s.lower().endswith(CODE_EXT):
+        return True
+    return False
+
+def candidates(text):
+    out = set()
+    for m in BACKTICK.finditer(text):
+        tok = m.group(1).split("#", 1)[0].split(":")[0].strip().rstrip(".,;)")
+        if looks_like_path(tok):
+            out.add(tok)
+    for m in LINKTGT.finditer(text):
+        tok = m.group(1).split("#", 1)[0].strip()
+        if looks_like_path(tok) and not tok.endswith(".md"):  # .md handled by link auditor
+            out.add(tok)
+    return out
+
+docs = sorted(p for p in tracked if p.startswith("docs/") and p.endswith(".md")
+              and not p.startswith(FROZEN))
+if EXPLICIT:
+    want = set(EXPLICIT)
+    docs = [d for d in docs if d in want]
+    print(f"(ratchet mode: checking {len(docs)} changed living doc(s))")
+broken = {}
+checked = 0
+for d in docs:
+    text = open(d, encoding="utf-8").read()
+    for c in candidates(text):
+        checked += 1
+        norm = c[2:] if c.startswith("./") else c
+        if not exists(norm):
+            broken.setdefault(d, []).append(c)
+
+total = sum(len(v) for v in broken.values())
+print(f"living_docs={len(docs)}  path_refs_checked={checked}  broken={total}  docs_with_broken={len(broken)}")
+for d in sorted(broken):
+    print(f"\n{d}")
+    for c in broken[d]:
+        print(f"    MISSING PATH  {c}")
+
+if total and not REPORT_ONLY:
+    sys.exit(1)

--- a/Scripts/audit-doc-links.py
+++ b/Scripts/audit-doc-links.py
@@ -3,12 +3,18 @@
 
 Reports relative links whose target file does not exist in the tree.
 Reads file content from git (so it audits the ref, not the working copy).
-Usage: python Scripts/audit-doc-links.py [ref]   (default ref: origin/main)
+Usage: python Scripts/audit-doc-links.py [ref] [--ci]
+  ref   : git ref to audit (default: origin/main; in CI use HEAD)
+  --ci  : exit 1 if any LIVE (non-frozen) doc has a broken link (gate mode)
 """
 import subprocess, sys, re, posixpath
 from collections import defaultdict
 
-REF = sys.argv[1] if len(sys.argv) > 1 else "origin/main"
+CI = "--ci" in sys.argv
+_pos = [a for a in sys.argv[1:] if not a.startswith("--")]
+REF = _pos[0] if _pos else "origin/main"
+FROZEN = ("docs/archive/", "docs/plans/", "docs/reports/", "docs/solutions/",
+          "docs/history/", "docs/brainstorms/")
 
 def git(*args):
     return subprocess.run(["git", *args], capture_output=True, text=True, encoding="utf-8").stdout
@@ -59,3 +65,11 @@ for doc in sorted(broken):
     print(f"\n{doc}")
     for target, resolved in broken[doc]:
         print(f"    BROKEN  [{target}]  ->  {resolved}")
+
+if CI:
+    live_broken = [d for d in broken if not d.startswith(FROZEN)]
+    if live_broken:
+        print(f"\n::error::{sum(len(broken[d]) for d in live_broken)} broken link(s) in "
+              f"{len(live_broken)} live doc(s). Fix or delinkify before merge.")
+        sys.exit(1)
+    print("\nOK: no broken links in live docs.")

--- a/docs/methodology/docs-maintenance.md
+++ b/docs/methodology/docs-maintenance.md
@@ -1,0 +1,78 @@
+---
+title: Documentation maintenance system
+scope: How GA keeps 400+ docs from rotting — the ephemeral/durable split, CI gates, and scheduled content audit.
+status: authoritative
+last_verified: 2026-06-01
+parent: docs/architecture/README.md
+---
+
+# Documentation maintenance system
+
+Docs rot because code moves and prose doesn't. A 2026-06-01 audit of all 424
+docs found **142 broken internal links** and **50 docs whose content was
+contradicted by the current code** (e.g. references to apps/classes/endpoints
+that were never shipped or had been removed). The biggest single source was a
+generation of `*_COMPLETE.md` / `*_SUMMARY.md` session docs that were written
+to celebrate a moment, then frozen as if they were current reference.
+
+This is a process problem, not a one-time cleanup. The system has four layers.
+
+## 1. Ephemeral vs durable (the structural lever)
+
+Split docs by lifecycle and treat them differently:
+
+- **Durable** — `architecture/`, `guides/`, `methodology/`, `contracts/`,
+  `runbooks/`, `API/`, root-level reference docs. These **must stay current**.
+  They carry frontmatter (`status`, `last_verified`) and are subject to the
+  gates below.
+- **Ephemeral / point-in-time** — `plans/`, `reports/`, `solutions/`,
+  `brainstorms/`, `archive/`, `history/`. These are **append-only history**:
+  dated, never updated, never claimed to be "current". Their links/refs are
+  allowed to decay — that's expected for a record.
+
+**Do not mint new permanent `*_COMPLETE.md` / `*_SUMMARY.md` docs.** "What I did
+this session" belongs in `state/` / the digest system, or in a clearly-dated
+`reports/` file — never as a durable reference doc.
+
+## 2. CI gates — stop new rot in minutes (`.github/workflows/docs-health.yml`)
+
+Run on every PR touching `docs/`:
+
+- **Link gate** (`Scripts/audit-doc-links.py HEAD --ci`) — fails if **any live
+  doc** has a broken internal markdown link. Live docs are kept at zero, so any
+  new break fails the PR.
+- **Code-reference ratchet** (`Scripts/audit-doc-code-refs.py --files <changed>`)
+  — fails if a doc the PR **touches** references a repo path (`Apps/...`,
+  `Common/...`, `*.cs`, …) that doesn't exist. It only checks changed docs, so
+  the pre-existing backlog doesn't block unrelated PRs, but you can't *add*
+  drift to a doc you edit. This is the gate that would have caught the
+  `GuitarAlchemistChatbot` app reference (the app doesn't exist) and the
+  dead-class references found in the audit.
+
+Frozen dirs are exempt in both.
+
+## 3. Scheduled deep audit — bound the backlog
+
+The mechanical gates can't judge "this paragraph describes a workflow that no
+longer exists". For that, a **monthly** content audit (an LLM multi-agent sweep
+— too expensive per-PR) reads each durable doc and verifies its claims against
+the code, producing a dated report under `reports/` and filing issues for STALE
+docs. This is the Cherny-loop pattern; it extends the existing `readme-drift`
+quality signal rather than inventing a new one. (First run:
+`docs/reports/2026-06-01-docs-staleness-audit.md`.)
+
+## 4. Shrink + freeze the surface (ongoing)
+
+Delete docs for never-shipped features; archive done-and-dusted ones; keep one
+canonical index (`docs/README.md`), not several. Fewer, current docs are easier
+to keep current.
+
+## Tooling
+
+| Script | Purpose |
+|---|---|
+| `Scripts/audit-doc-links.py` | broken internal-link scanner (`--ci` to gate live docs) |
+| `Scripts/audit-doc-code-refs.py` | repo-path-reference checker (`--files` to ratchet changed docs; `--report` for a non-gating full scan) |
+| `Scripts/patch-doc-links.py` | bulk fix: redirect or delinkify broken links (skips frozen dirs) |
+| `Scripts/remediate-stale-docs.py` | applies a staleness-audit result (delete/archive/banner) |
+| `Scripts/check-architecture-docs.ps1` | frontmatter + freshness check for `architecture/` docs |


### PR DESCRIPTION
## Why

The 2026-06-01 content audit found **142 broken links + 50 content-stale docs**. PRs #392–#395 fixed the backlog (links, two stale index rewrites, 53-doc remediation). This PR makes sure it **can't silently grow back** — the systemic answer to "we have a HUGE maintenance issue over time."

## Two CI gates (`.github/workflows/docs-health.yml`, on every PR touching `docs/`)

1. **Link gate** — `audit-doc-links.py --ci` fails on any broken internal link in a **live** doc. Live docs are at zero today, so any new break fails the PR.
2. **Code-reference ratchet** — `audit-doc-code-refs.py --files <changed>` fails if a doc the PR **touches** cites a repo path (`Apps/…`, `Common/…`, `*.cs`) that doesn't exist. Checks **only changed docs**, so the pre-existing backlog doesn't block unrelated work, but no new drift can be added. *This is the gate that would have caught the `GuitarAlchemistChatbot` / dead-class references the audit found.*

Frozen point-in-time dirs (`archive/`/`plans/`/`reports/`/`solutions/`/`history/`/`brainstorms/`) are exempt in both — their decayed refs are expected history.

## Also

- `Scripts/audit-doc-code-refs.py` — new, conservative path-reference checker (ignores prose globs/placeholders; `--report` full scan, `--files` ratchet).
- `Scripts/audit-doc-links.py` — `--ci` exit-code mode.
- `docs/methodology/docs-maintenance.md` — documents the 4-layer system: **ephemeral vs durable** split (the structural lever — stop minting permanent `*_COMPLETE.md` docs), CI gates, a **monthly scheduled** LLM content audit, and shrink+freeze.

This PR self-tests the gates (it touches docs + the scripts).

## Next (separate)
Wire the monthly content-audit workflow on a schedule; add the ephemeral/durable convention to `CLAUDE.md` + `PROJECT_DOCUMENTATION_STANDARD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)