### PR TITLE
chore(agent-blackbox): bump ref to v0.1.0-beta.2 (case-insensitive harness-audit)

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -11,7 +11,7 @@ permissions:
   checks: write
 
 env:
-  AGENT_BLACKBOX_REF: "v0.1.0-beta.1"
+  AGENT_BLACKBOX_REF: "v0.1.0-beta.2"
   DOTNET_VERSION: "10.0.1xx"
   VERIFY_COMMAND: >-
     dotnet test AllProjects.slnx


### PR DESCRIPTION
Bumps `AGENT_BLACKBOX_REF` `v0.1.0-beta.1` → `v0.1.0-beta.2` to pick up GuitarAlchemist/agent-blackbox#36 (case-insensitive repo-path resolution in `harness-audit`, with backtracking over case variants). Keeps the ecosystem on one agent-blackbox version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)