### PR TITLE
feat(quality): DuckDB analytics layer over state/quality artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,12 @@ todos/
 # OPTIC-K generated index (build artifact, ~660MB)
 **/state/voicings/optick.index
 
+# DuckDB quality analytics layer: the .duckdb is a generated binary materialized
+# from the committed JSON snapshots by analytics/build-views.sql — regenerable,
+# never committed. The build script and README are tracked.
+state/quality/analytics/*.duckdb
+state/quality/analytics/*.duckdb.wal
+
 # Baseline diagnostic artifacts (regenerable)
 state/baseline/embedding-clusters-*.json
 state/baseline-phaseE/embedding-clusters-*.json

--- a/AllProjects.slnx
+++ b/AllProjects.slnx
@@ -37,6 +37,7 @@
         <Project Path="Tools/LocalEmbedding/LocalEmbedding.csproj" />
         <Project Path="Tools/MongoImporter/MongoImporter.csproj" />
         <Project Path="Tools/MongoVerify/MongoVerify.csproj" />
+        <Project Path="Tools/QualityLens/QualityLens.csproj" />
         <Project Path="Demos/Performance/VectorSearchBenchmark/VectorSearchBenchmark.csproj" />
 
     </Folder>

--- a/Tools/QualityLens/Program.cs
+++ b/Tools/QualityLens/Program.cs
@@ -1,0 +1,68 @@
+// QualityLens — queries the persisted DuckDB quality analytics layer from .NET.
+//
+// Reads state/quality/analytics/quality.duckdb (built by analytics/build-views.sql)
+// and prints either the quality_latest rollup or a caller-supplied SQL query.
+//
+//   dotnet run --project Tools/QualityLens                       # latest rollup
+//   dotnet run --project Tools/QualityLens -- "SELECT * FROM routing_eval"
+
+using DuckDB.NET.Data;
+using Spectre.Console;
+
+var dbPath = FindQualityDb();
+if (dbPath is null)
+{
+    AnsiConsole.MarkupLine("[red]Could not locate state/quality/analytics/quality.duckdb.[/]");
+    AnsiConsole.MarkupLine("Build it first: [yellow]duckdb analytics/quality.duckdb < analytics/build-views.sql[/] (from state/quality/).");
+    return 1;
+}
+
+var sql = args.Length > 0
+    ? string.Join(' ', args)
+    : "SELECT * FROM quality_latest ORDER BY source";
+
+// READ_ONLY so the tool never contends with a refresh holding the file open.
+using var connection = new DuckDBConnection($"Data Source={dbPath};ACCESS_MODE=READ_ONLY");
+connection.Open();
+
+using var command = connection.CreateCommand();
+command.CommandText = sql;
+
+using var reader = command.ExecuteReader();
+
+var table = new Table().Border(TableBorder.Rounded);
+for (var i = 0; i < reader.FieldCount; i++)
+    table.AddColumn($"[bold]{Markup.Escape(reader.GetName(i))}[/]");
+
+var rows = 0;
+while (reader.Read())
+{
+    var cells = new string[reader.FieldCount];
+    for (var i = 0; i < reader.FieldCount; i++)
+        cells[i] = reader.IsDBNull(i) ? "[grey]NULL[/]" : Markup.Escape(reader.GetValue(i)?.ToString() ?? "");
+    table.AddRow(cells);
+    rows++;
+}
+
+AnsiConsole.MarkupLine($"[grey]{Markup.Escape(dbPath)}[/]");
+AnsiConsole.Write(table);
+AnsiConsole.MarkupLine($"[green]{rows}[/] row(s).");
+return 0;
+
+// Walk up from the executable and the current directory to find the repo-relative DB.
+static string? FindQualityDb()
+{
+    const string relative = "state/quality/analytics/quality.duckdb";
+    foreach (var start in new[] { AppContext.BaseDirectory, Directory.GetCurrentDirectory() })
+    {
+        var dir = new DirectoryInfo(start);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate))
+                return candidate;
+            dir = dir.Parent;
+        }
+    }
+    return null;
+}

--- a/Tools/QualityLens/QualityLens.csproj
+++ b/Tools/QualityLens/QualityLens.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.3.0" />
+    <PackageReference Include="Spectre.Console" Version="0.51.1" />
+  </ItemGroup>
+
+</Project>

--- a/state/quality/analytics/README.md
+++ b/state/quality/analytics/README.md
@@ -29,6 +29,9 @@ duckdb analytics/quality.duckdb < analytics/build-views.sql
 - **`routing_eval`** — semantic intent router accuracy (`accuracy`, `in_scope_accuracy`,
   `oos_decline_rate`).
 - **`voicing_analysis`** — OPTIC-K corpus size + chord-recognition coverage.
+- **`optick_sae`** — OPTIC-K sparse-autoencoder training artifacts (the cross-repo
+  contract output ix produces, consumed here); flattened to mirror ix's columns for
+  producer/consumer parity (`reconstruction_r2`, `dead_features_pct`, `features_alive`).
 - **`pr_grades`** — post-merge grade cards (`/grade-last-pr`); empty until cards land
   (see the commented populate query in `build-views.sql`).
 - **`quality_latest`** (view) — latest value per source.

--- a/state/quality/analytics/README.md
+++ b/state/quality/analytics/README.md
@@ -1,0 +1,43 @@
+# Quality analytics (DuckDB)
+
+A zero-server SQL layer over the file-based quality artifacts under `state/quality/`.
+DuckDB reads the JSON snapshots in place and materializes them into a portable,
+self-contained `quality.duckdb` so trends are queryable across sessions and from
+.NET — without bespoke loaders that silently skip off-pattern files.
+
+## Files
+
+| File | Tracked | Purpose |
+|---|---|---|
+| `build-views.sql` | ✅ | Materializes the snapshots into tables + the `quality_latest` view. |
+| `quality.duckdb` | ❌ (gitignored) | Generated binary; rebuild any time from the script. |
+
+## Rebuild / refresh
+
+Run from `state/quality/` so the relative globs resolve:
+
+```bash
+duckdb analytics/quality.duckdb < analytics/build-views.sql
+```
+
+(`duckdb` CLI: `winget install DuckDB.cli`.)
+
+## Tables
+
+- **`chatbot_qa`** — daily prompt-corpus pass rate (`pass_pct` is NULL when the run
+  was backend-degraded; `degraded` / `degraded_reason` flag why).
+- **`routing_eval`** — semantic intent router accuracy (`accuracy`, `in_scope_accuracy`,
+  `oos_decline_rate`).
+- **`voicing_analysis`** — OPTIC-K corpus size + chord-recognition coverage.
+- **`pr_grades`** — post-merge grade cards (`/grade-last-pr`); empty until cards land
+  (see the commented populate query in `build-views.sql`).
+- **`quality_latest`** (view) — latest value per source.
+
+## Query from .NET
+
+`Tools/QualityLens` opens `quality.duckdb` read-only via `DuckDB.NET.Data.Full`:
+
+```bash
+dotnet run --project Tools/QualityLens                         # latest rollup
+dotnet run --project Tools/QualityLens -- "SELECT * FROM routing_eval ORDER BY day"
+```

--- a/state/quality/analytics/build-views.sql
+++ b/state/quality/analytics/build-views.sql
@@ -57,6 +57,36 @@ SELECT
 FROM read_json_auto('voicing-analysis/*.json', filename = true, union_by_name = true)
 ORDER BY day;
 
+-- optick-sae: OPTIC-K sparse-autoencoder training artifacts (the cross-repo
+-- contract output ix produces; consumed here). Flattened from the nested
+-- artifact so producer (ix) and consumer (GA) expose the same columns.
+-- Committed artifacts only — the gitignored *-local trainer runs are excluded.
+CREATE OR REPLACE TABLE optick_sae AS
+SELECT
+    regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1)        AS day,
+    artifact_id,
+    schema_version,
+    trainer,
+    trainer_version,
+    input.optick_index_sha                                            AS input_optick_index_sha,
+    input.optick_dim                                                  AS input_optick_dim,
+    input.corpus_size                                                 AS input_corpus_size,
+    model.kind                                                        AS model_kind,
+    model.dict_size                                                   AS model_dict_size,
+    model.k_sparse                                                    AS model_k_sparse,
+    model.training.loss_final                                         AS model_loss_final,
+    metrics.reconstruction_mse                                        AS reconstruction_mse,
+    metrics.reconstruction_r2                                         AS reconstruction_r2,
+    metrics.dead_features_pct                                         AS dead_features_pct,
+    metrics.feature_partition_purity_mean                             AS purity_mean,
+    features_summary.total                                            AS features_total,
+    features_summary.alive                                            AS features_alive,
+    links.supersedes                                                  AS links_supersedes
+FROM read_json_auto('optick-sae/*/optick-sae-artifact.json',
+                    filename = true, union_by_name = true)
+WHERE filename NOT LIKE '%-local%'                                    -- exclude local trainer runs
+ORDER BY day;
+
 -- pr-grades: post-merge intent-vs-delivery grade cards (/grade-last-pr).
 -- No grade cards exist yet (only README.md + SCHEMA.json), so this starts as an
 -- explicit empty table. Once <merge-sha>.json cards land, replace the body with
@@ -83,4 +113,6 @@ SELECT 'chatbot_qa'       AS source, day, pass_pct          AS metric, 'pass_pct
 UNION ALL
 SELECT 'routing_eval'     AS source, day, accuracy          AS metric, 'accuracy'          AS metric_name FROM routing_eval     QUALIFY row_number() OVER (ORDER BY day DESC) = 1
 UNION ALL
-SELECT 'voicing_analysis' AS source, day, corpus_total      AS metric, 'corpus_total'      AS metric_name FROM voicing_analysis QUALIFY row_number() OVER (ORDER BY day DESC) = 1;
+SELECT 'voicing_analysis' AS source, day, corpus_total      AS metric, 'corpus_total'      AS metric_name FROM voicing_analysis QUALIFY row_number() OVER (ORDER BY day DESC) = 1
+UNION ALL
+SELECT 'optick_sae'       AS source, day, reconstruction_r2  AS metric, 'reconstruction_r2' AS metric_name FROM optick_sae       QUALIFY row_number() OVER (ORDER BY day DESC) = 1;

--- a/state/quality/analytics/build-views.sql
+++ b/state/quality/analytics/build-views.sql
@@ -1,0 +1,86 @@
+-- build-views.sql — DuckDB quality analytics layer for Guitar Alchemist
+--
+-- Materializes the file-based quality artifacts under state/quality/ into a
+-- self-contained quality.duckdb so trends are queryable across sessions and
+-- from .NET (Tools/QualityLens) without depending on JSON glob paths.
+--
+-- Refresh (run from the state/quality/ directory):
+--   duckdb analytics/quality.duckdb < analytics/build-views.sql
+--
+-- Design notes:
+--   * union_by_name=true tolerates the schema drift between snapshots
+--     (e.g. chatbot-qa gained `degraded`/`degraded_reason` on 2026-05-24).
+--   * Tables are materialized (CREATE OR REPLACE TABLE AS) so the .duckdb is
+--     portable; re-run this script to pick up new daily snapshots.
+--   * The day is parsed from the filename, which is the canonical date key
+--     across the quality pipeline (the YYYY-MM-DD stem convention).
+
+-- chatbot-qa: daily prompt-corpus pass rate (NULL when backend was degraded).
+CREATE OR REPLACE TABLE chatbot_qa AS
+SELECT
+    regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1)        AS day,
+    total_prompts,
+    TRY_CAST(pass_pct AS DOUBLE)                                       AS pass_pct,
+    COALESCE(degraded, false)                                          AS degraded,
+    degraded_reason,
+    TRY_CAST(last_known_good_pass_pct AS DOUBLE)                       AS last_known_good_pass_pct
+FROM read_json_auto('chatbot-qa/*.json', filename = true, union_by_name = true)
+WHERE regexp_full_match(
+        regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1),
+        '[0-9]{4}-[0-9]{2}-[0-9]{2}')          -- excludes baseline.json
+ORDER BY day;
+
+-- routing-eval: semantic intent router accuracy over the eval corpus.
+CREATE OR REPLACE TABLE routing_eval AS
+SELECT
+    regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1)        AS day,
+    totalPrompts                                                       AS total_prompts,
+    overall.Total                                                      AS total,
+    overall.Correct                                                    AS correct,
+    overall.Accuracy                                                   AS accuracy,
+    overall.InScopeAccuracy                                            AS in_scope_accuracy,
+    overall.OosDeclineRate                                             AS oos_decline_rate
+FROM read_json_auto('routing-eval-*.json', filename = true, union_by_name = true)
+ORDER BY day;
+
+-- voicing-analysis: OPTIC-K corpus health (size + chord-recognition coverage).
+CREATE OR REPLACE TABLE voicing_analysis AS
+SELECT
+    regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1)        AS day,
+    Corpus.Total                                                       AS corpus_total,
+    Corpus.Guitar                                                      AS corpus_guitar,
+    Corpus.Bass                                                        AS corpus_bass,
+    Corpus.Ukulele                                                     AS corpus_ukulele,
+    ChordRecognition.DistinctChordNames                                AS distinct_chord_names,
+    ChordRecognition.NullChordName.Pct                                 AS null_chord_pct,
+    ChordRecognition.UnknownChordName.Pct                              AS unknown_chord_pct
+FROM read_json_auto('voicing-analysis/*.json', filename = true, union_by_name = true)
+ORDER BY day;
+
+-- pr-grades: post-merge intent-vs-delivery grade cards (/grade-last-pr).
+-- No grade cards exist yet (only README.md + SCHEMA.json), so this starts as an
+-- explicit empty table. Once <merge-sha>.json cards land, replace the body with
+-- the read below and re-run:
+--
+--   CREATE OR REPLACE TABLE pr_grades AS
+--   SELECT pr_number, merge_sha, merged_at, title, alignment, grader, graded_at
+--   FROM read_json_auto('pr-grades/[0-9a-f]*.json', union_by_name = true)
+--   WHERE schema = 'pr-grade-v1';
+CREATE OR REPLACE TABLE pr_grades (
+    pr_number  BIGINT,
+    merge_sha  VARCHAR,
+    merged_at  VARCHAR,
+    title      VARCHAR,
+    alignment  VARCHAR,
+    grader     VARCHAR,
+    graded_at  VARCHAR
+);
+
+-- Unified latest-value-per-source rollup. A view over the materialized tables,
+-- so it carries no JSON path dependency and is safe to query from anywhere.
+CREATE OR REPLACE VIEW quality_latest AS
+SELECT 'chatbot_qa'       AS source, day, pass_pct          AS metric, 'pass_pct'          AS metric_name FROM chatbot_qa       QUALIFY row_number() OVER (ORDER BY day DESC) = 1
+UNION ALL
+SELECT 'routing_eval'     AS source, day, accuracy          AS metric, 'accuracy'          AS metric_name FROM routing_eval     QUALIFY row_number() OVER (ORDER BY day DESC) = 1
+UNION ALL
+SELECT 'voicing_analysis' AS source, day, corpus_total      AS metric, 'corpus_total'      AS metric_name FROM voicing_analysis QUALIFY row_number() OVER (ORDER BY day DESC) = 1;


### PR DESCRIPTION
## Impact
Adds a zero-server SQL analytics layer over the file-based quality artifacts under `state/quality/`. DuckDB reads the JSON snapshots in place and materializes them into a portable, self-contained `quality.duckdb`, so quality trends survive across sessions and are queryable from .NET — replacing bespoke loaders that silently skip off-pattern files (the documented `ix-quality-trend` silent-skip class).

## What's included
- **`state/quality/analytics/build-views.sql`** — materializes `chatbot_qa`, `routing_eval`, `voicing_analysis` tables + a `quality_latest` rollup view. `union_by_name` tolerates snapshot schema drift; the date key is parsed from the filename (the canonical `YYYY-MM-DD` stem convention).
- **`Tools/QualityLens/`** — .NET 10 console tool (`DuckDB.NET.Data.Full 1.3.0`) that opens the DB read-only and prints the rollup or any supplied SQL. Registered in `AllProjects.slnx`.
- **`state/quality/analytics/README.md`** — refresh + schema docs.
- `quality.duckdb` is gitignored (regenerable binary); the SQL + README are tracked.

## Verification
- `dotnet build Tools/QualityLens/QualityLens.csproj` → **0 warnings, 0 errors**.
- `dotnet run --project Tools/QualityLens` → prints `quality_latest` (16 chatbot_qa + 4 routing_eval + 27 voicing_analysis rows materialized).
- Custom query path verified: `... -- "SELECT day, accuracy FROM routing_eval ORDER BY day"`.

## Surfaced (data, now visible as queries)
- `chatbot_qa.pass_pct` is **NULL across 05-16..05-31** — backend-degraded runs, not real signal.
- `routing_eval.in_scope_accuracy` only exists **from 05-30 on** (older snapshots predate the field).

Both are producer-side gaps the analytics layer just made visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)