### PR TITLE
fix(quality): correct chatbot_qa degraded classification + stale fallback

### DIFF
--- a/state/quality/analytics/build-views.sql
+++ b/state/quality/analytics/build-views.sql
@@ -15,14 +15,22 @@
 --   * The day is parsed from the filename, which is the canonical date key
 --     across the quality pipeline (the YYYY-MM-DD stem convention).
 
--- chatbot-qa: daily prompt-corpus pass rate (NULL when backend was degraded).
+-- chatbot-qa: daily prompt-corpus pass rate (NULL when the QA backend — Ollama /
+-- OPTIC-K index / chatbot deps — was unavailable, so no real measurement ran).
+-- Two snapshot formats coexist: the pre-2026-05-24 format recorded degradation
+-- only in free-text `note` (no structured flag); the newer one sets
+-- `degraded`/`degraded_reason`. We reconcile both so degraded days are never
+-- mislabelled "clean": a missing flag with an absent pass_pct IS a degraded day.
 CREATE OR REPLACE TABLE chatbot_qa AS
 SELECT
     regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1)        AS day,
     total_prompts,
     TRY_CAST(pass_pct AS DOUBLE)                                       AS pass_pct,
-    COALESCE(degraded, false)                                          AS degraded,
-    degraded_reason,
+    COALESCE(degraded, pass_pct IS NULL)                               AS degraded,
+    COALESCE(
+        degraded_reason,
+        CASE WHEN pass_pct IS NULL AND note IS NOT NULL
+             THEN 'backend_unavailable' END)                          AS degraded_reason,
     TRY_CAST(last_known_good_pass_pct AS DOUBLE)                       AS last_known_good_pass_pct
 FROM read_json_auto('chatbot-qa/*.json', filename = true, union_by_name = true)
 WHERE regexp_full_match(
@@ -109,7 +117,14 @@ CREATE OR REPLACE TABLE pr_grades (
 -- Unified latest-value-per-source rollup. A view over the materialized tables,
 -- so it carries no JSON path dependency and is safe to query from anywhere.
 CREATE OR REPLACE VIEW quality_latest AS
-SELECT 'chatbot_qa'       AS source, day, pass_pct          AS metric, 'pass_pct'          AS metric_name FROM chatbot_qa       QUALIFY row_number() OVER (ORDER BY day DESC) = 1
+-- chatbot_qa falls back to last-known-good when the latest run was degraded, so
+-- the rollup shows the last real number with a staleness marker, not bare NULL.
+SELECT 'chatbot_qa'       AS source, day,
+       COALESCE(pass_pct, last_known_good_pass_pct)                                  AS metric,
+       CASE WHEN pass_pct IS NOT NULL                  THEN 'pass_pct'
+            WHEN last_known_good_pass_pct IS NOT NULL   THEN 'pass_pct (stale: last_known_good)'
+            ELSE 'pass_pct (no data)' END                                            AS metric_name
+FROM chatbot_qa       QUALIFY row_number() OVER (ORDER BY day DESC) = 1
 UNION ALL
 SELECT 'routing_eval'     AS source, day, accuracy          AS metric, 'accuracy'          AS metric_name FROM routing_eval     QUALIFY row_number() OVER (ORDER BY day DESC) = 1
 UNION ALL


### PR DESCRIPTION
## Problem (surfaced by the DuckDB analytics layer)

Querying `quality.duckdb` showed `chatbot_qa.pass_pct` NULL for **all 16** snapshots, and a `GROUP BY degraded` reported **8 days as `degraded=false`** (clean) — yet those clean days *also* had NULL pass rates. That's contradictory.

Root cause: two snapshot formats coexist.
- **pre-2026-05-24**: degradation recorded only in free-text `note` (`"Environment degraded: 50/50 failures were HTTP 5xx … backend (Ollama / OPTIC-K index / deps) unavailable"`), no structured flag.
- **2026-05-24+**: structured `degraded=true, degraded_reason=backend_unavailable, last_known_good=94.0`.

`COALESCE(degraded, false)` mapped the early null-flag rows to **false**, so 8 genuinely-degraded days showed as passing. Every run in the window was actually degraded — the QA backend has been unavailable, so no real measurement ran. **The producer is correct** (it omits pass_pct rather than faking it); this is purely a read-side mislabel.

## Fix (read-side only, `build-views.sql`)

- `degraded := COALESCE(degraded, pass_pct IS NULL)` — missing flag + no pass_pct ⇒ degraded.
- Recover `degraded_reason` from `note` for the early format.
- `quality_latest`: fall back to `last_known_good_pass_pct` with a staleness marker, so the rollup shows `94.0 (stale: last_known_good)` instead of bare NULL.

No producer/schema change. `optick_sae` and all other tables untouched.

## Verified

\`\`\`
-- before: GROUP BY degraded -> 8 false / 8 true, all avg NULL  (misleading)
-- after:  all 16 -> degraded=true, 0 with pass_pct, 16 with a reason
SELECT * FROM quality_latest;
  chatbot_qa        94.0    pass_pct (stale: last_known_good)
  optick_sae        0.9996  reconstruction_r2
  routing_eval      0.931   accuracy
  voicing_analysis  313047  corpus_total
\`\`\`

## Note — the real (operational) issue this exposes

The chatbot-QA backend (Ollama / OPTIC-K index / chatbot deps) has been unavailable for **every scheduled run since 2026-05-16** — ~4 weeks with no real pass-rate measurement. This PR only makes the reporting honest; bringing the QA stack up + re-running `Scripts/run-prompt-corpus.ps1 -Snapshot` is a separate operational follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)