### PR TITLE
feat(dashboard): business-value scorecard — RICE stars on #dev/summary

### DIFF
--- a/ReactComponents/ga-react-components/src/components/Summary/StarRating.tsx
+++ b/ReactComponents/ga-react-components/src/components/Summary/StarRating.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, Tooltip } from '@mui/material';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+
+// A compact 1–5 star rating. `value` is clamped to [0,5] and rounded; the
+// remaining pips render as outlines so the row always shows five stars.
+// Accessible: the row carries an aria-label and a tooltip with the raw score.
+export interface StarRatingProps {
+  /** Star count 1..5 (the catalog's `stars` field). */
+  value: number;
+  /** Optional continuous score 0..1 (the catalog's `score01`) for the tooltip. */
+  score01?: number;
+  /** Pixel size of each star. */
+  size?: number;
+}
+
+export const StarRating: React.FC<StarRatingProps> = ({ value, score01, size = 16 }) => {
+  const filled = Math.max(0, Math.min(5, Math.round(value)));
+  const label =
+    score01 != null ? `${filled} of 5 stars (score ${score01.toFixed(2)})` : `${filled} of 5 stars`;
+  return (
+    <Tooltip title={label} placement="top" enterDelay={300}>
+      <Box
+        data-testid="star-rating"
+        role="img"
+        aria-label={label}
+        sx={{ display: 'inline-flex', alignItems: 'center', lineHeight: 1, color: 'warning.main' }}
+      >
+        {Array.from({ length: 5 }, (_, i) =>
+          i < filled ? (
+            <StarIcon key={i} sx={{ fontSize: size }} />
+          ) : (
+            <StarBorderIcon key={i} sx={{ fontSize: size, color: 'text.disabled' }} />
+          ),
+        )}
+      </Box>
+    </Tooltip>
+  );
+};

--- a/ReactComponents/ga-react-components/src/components/Summary/ValueScorecard.tsx
+++ b/ReactComponents/ga-react-components/src/components/Summary/ValueScorecard.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Chip, CircularProgress, Divider, Paper, Stack, Tooltip, Typography } from '@mui/material';
+import StarRateIcon from '@mui/icons-material/StarRate';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { StarRating } from './StarRating';
+import type { ValueRecord } from '../../dev-data/parsers';
+
+// Business-value scorecard — the "expose" surface for the federated RICE→stars
+// catalog (ix-value, sibling ix repo). Self-fetching like MissionControl /
+// InFlightCard: no props, reads /dev-data/value (served by the Vite dev-data
+// middleware over IX_ROOT/state/value/catalog.jsonl).
+//
+// Layout: repo leaderboard (rollup rows) on top, demo leaderboard below — both
+// sorted by score by the server. Stars are the headline; the continuous score
+// and rationale ride in the tooltip.
+
+interface ValuePayload {
+  generated_at: string;
+  records: ValueRecord[];
+  demos: ValueRecord[];
+  repos: ValueRecord[];
+}
+
+const ScoreRow: React.FC<{ rec: ValueRecord; showRepo?: boolean }> = ({ rec, showRepo }) => (
+  <Stack
+    direction="row"
+    spacing={1}
+    alignItems="center"
+    data-testid="value-row"
+    sx={{ py: 0.5, '&:hover': { bgcolor: 'action.hover' }, borderRadius: 0.5 }}
+  >
+    <StarRating value={rec.stars} score01={rec.score01} />
+    <Typography variant="body2" sx={{ fontWeight: 600, minWidth: 0, flexShrink: 1 }} noWrap>
+      {rec.title}
+    </Typography>
+    {showRepo && (
+      <Chip label={rec.repo} size="small" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
+    )}
+    <Box sx={{ flex: 1 }} />
+    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+      {rec.score01.toFixed(2)}
+    </Typography>
+    {rec.rationale && (
+      <Tooltip title={rec.rationale} placement="top-end" enterDelay={300}>
+        <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+      </Tooltip>
+    )}
+  </Stack>
+);
+
+export const ValueScorecard: React.FC = () => {
+  const [payload, setPayload] = useState<ValuePayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/dev-data/value', { cache: 'no-store' })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`/dev-data/value → ${r.status}`);
+        return r.json() as Promise<ValuePayload>;
+      })
+      .then((d) => { if (!cancelled) setPayload(d); })
+      .catch((e) => { if (!cancelled) setError(String(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Absent catalog (404) or fetch error — render a quiet hint, never blank the
+  // dashboard. This is the expected state until ix-value runs in this checkout.
+  if (error) {
+    return (
+      <Paper data-testid="value-scorecard" sx={{ p: 2 }}>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+          <StarRateIcon sx={{ color: 'warning.main' }} />
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>Business Value</Typography>
+        </Stack>
+        <Typography variant="caption" color="text.secondary">
+          Value catalog unavailable — run <code>cargo run -p ix-value -- catalog</code> in the sibling ix repo.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  if (!payload) {
+    return (
+      <Paper data-testid="value-scorecard" sx={{ p: 2, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress size={20} />
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper data-testid="value-scorecard" sx={{ p: 2 }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+        <StarRateIcon sx={{ color: 'warning.main' }} />
+        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>Business Value</Typography>
+        <Tooltip
+          title="RICE → stars (geometric mean of Reach·Impact·Confidence, so the weakest axis caps the score). Federated across repos by ix-value."
+          placement="top"
+          enterDelay={300}
+        >
+          <InfoOutlinedIcon sx={{ fontSize: 15, color: 'text.disabled' }} />
+        </Tooltip>
+        <Box sx={{ flex: 1 }} />
+        <Chip label={`${payload.demos.length} demos · ${payload.repos.length} repos`} size="small" sx={{ height: 20 }} />
+      </Stack>
+
+      {payload.repos.length > 0 && (
+        <>
+          <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Repos
+          </Typography>
+          <Box data-testid="value-repos" sx={{ mb: 1.5 }}>
+            {payload.repos.map((r) => (
+              <ScoreRow key={`repo:${r.id}`} rec={r} />
+            ))}
+          </Box>
+          <Divider sx={{ mb: 1 }} />
+        </>
+      )}
+
+      <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        Demos
+      </Typography>
+      <Box data-testid="value-demos">
+        {payload.demos.length === 0 ? (
+          <Typography variant="caption" color="text.secondary">No demo items in the catalog yet.</Typography>
+        ) : (
+          payload.demos.map((d) => <ScoreRow key={`demo:${d.repo}:${d.id}`} rec={d} showRepo />)
+        )}
+      </Box>
+    </Paper>
+  );
+};

--- a/ReactComponents/ga-react-components/src/dev-data/parsers.test.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.test.ts
@@ -12,6 +12,7 @@ import {
     projectLoopsGoals,
     extractPrRefs,
     extractDocRefs,
+    parseValueCatalog,
 } from './parsers';
 
 describe('categorize', () => {
@@ -474,5 +475,35 @@ describe('projectLoopsGoals', () => {
         const p = projectLoopsGoals([paused], now);
         expect(p.active_goals.length).toBe(1);
         expect(p.active_goals[0].status).toBe('paused');
+    });
+});
+
+describe('parseValueCatalog', () => {
+    const sample = [
+        '{"schema_version":"0.1.0","id":"crate/ix-agent","repo":"ix","kind":"demo","title":"ix-agent","reach":4,"impact":4,"confidence":3,"stars":4,"score01":0.7268,"rationale":"r"}',
+        '{"schema_version":"0.1.0","id":"ix","repo":"ix","kind":"repo","title":"ix","reach":4,"impact":5,"confidence":3,"stars":4,"score01":0.78}',
+    ].join('\n');
+
+    it('parses one record per non-empty line', () => {
+        const recs = parseValueCatalog(sample);
+        expect(recs).toHaveLength(2);
+        expect(recs[0].id).toBe('crate/ix-agent');
+        expect(recs[0].stars).toBe(4);
+        expect(recs[1].kind).toBe('repo');
+    });
+
+    it('ignores blank lines and trailing newline', () => {
+        expect(parseValueCatalog(`\n${sample}\n\n`)).toHaveLength(2);
+    });
+
+    it('skips malformed lines without throwing (one bad line ≠ blank scorecard)', () => {
+        const withGarbage = `${sample}\n{ this is not json\n{"id":"x"}`; // last is valid JSON but missing kind/stars
+        const recs = parseValueCatalog(withGarbage);
+        expect(recs).toHaveLength(2); // the two good records survive
+        expect(recs.every((r) => typeof r.stars === 'number')).toBe(true);
+    });
+
+    it('returns empty array for empty input', () => {
+        expect(parseValueCatalog('')).toEqual([]);
     });
 });

--- a/ReactComponents/ga-react-components/src/dev-data/parsers.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.ts
@@ -375,3 +375,51 @@ export function projectLoopsGoals(
         total_records: totalRecords,
     };
 }
+
+// ── Business-value scorecard ────────────────────────────────────────────
+// Parses the federated value catalog (state/value/catalog.jsonl, emitted by
+// the sibling ix repo's `ix-value` generator — a RICE→stars rollup across
+// repos). One JSON object per line; malformed lines are skipped, never fatal
+// (mirrors the tolerant ingest on the ix side). See:
+//   ix/crates/ix-value, ix/docs/contracts/business-value.contract.md
+
+export interface ValueRecord {
+    schema_version: string;
+    /** Item id (authored) or repo name (for rollup rows). */
+    id: string;
+    repo: string;
+    /** 'demo' / 'epic' for items; 'repo' for the generated rollup row. */
+    kind: 'demo' | 'repo' | 'epic';
+    title: string;
+    reach: number;
+    impact: number;
+    confidence: number;
+    /** round(geomean(R,I,C)) clamped to 1..=5. */
+    stars: number;
+    /** geomean(R,I,C) / 5 ∈ (0,1] — the sortable continuous score. */
+    score01: number;
+    rationale?: string;
+}
+
+/**
+ * Parse the value catalog JSONL into records. Tolerant: blank lines are
+ * ignored and a line that is not a well-formed record (bad JSON, or missing
+ * the load-bearing `kind`/`stars` fields) is dropped rather than throwing —
+ * a single corrupt line must not blank the whole scorecard.
+ */
+export function parseValueCatalog(content: string): ValueRecord[] {
+    const out: ValueRecord[] = [];
+    for (const line of content.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+            const r = JSON.parse(trimmed) as Partial<ValueRecord>;
+            if (typeof r.id !== 'string' || typeof r.kind !== 'string') continue;
+            if (typeof r.stars !== 'number' || typeof r.score01 !== 'number') continue;
+            out.push(r as ValueRecord);
+        } catch {
+            // skip malformed line
+        }
+    }
+    return out;
+}

--- a/ReactComponents/ga-react-components/src/pages/OverviewSection.tsx
+++ b/ReactComponents/ga-react-components/src/pages/OverviewSection.tsx
@@ -29,6 +29,7 @@ import {
 } from '../components/Algedonic/AlgedonicCard';
 import { InFlightCard } from '../components/Summary/InFlightCard';
 import { MissionControl } from '../components/Summary/MissionControl';
+import { ValueScorecard } from '../components/Summary/ValueScorecard';
 import { deriveTileStatus, type QualitySnapshotLike } from '../utils/qualityStatus';
 
 interface BacklogItem {
@@ -543,6 +544,11 @@ export const OverviewSection: React.FC = () => {
           Sits right after Heartbeat because operators' first question is "what's
           happening right now," not "what's the trend." */}
       <InFlightCard />
+
+      {/* Business Value — RICE→stars scorecard across demos + repos, federated
+          from the sibling ix repo (ix-value). Answers "what's worth the most"
+          right after "what's in flight." */}
+      <ValueScorecard />
 
       {/* Top stat tiles */}
       <Grid container spacing={2}>

--- a/ReactComponents/ga-react-components/tests/dashboard/value-scorecard.spec.ts
+++ b/ReactComponents/ga-react-components/tests/dashboard/value-scorecard.spec.ts
@@ -1,0 +1,61 @@
+// ValueScorecard spec — verifies /test#dev/summary renders the business-value
+// scorecard, fed by the Vite middleware at /dev-data/value (which reads the
+// federated RICE→stars catalog from the sibling ix repo).
+//
+// Catches:
+//   - the /dev-data/value endpoint disappearing or changing shape
+//   - the card vanishing from OverviewSection (regression on the wiring point)
+//   - the star rating not rendering for the top demo
+//
+// Runs against the LIVE dashboard URL (see playwright.dashboard.config.ts).
+// Uses the crossover-skip idiom (matches mission-control.spec.ts) so the test
+// passes on the current deploy until the new card lands — then enforces the
+// contract once visible.
+//
+// See:
+//   src/components/Summary/ValueScorecard.tsx
+//   src/components/Summary/StarRating.tsx
+//   src/pages/OverviewSection.tsx (wiring point after InFlightCard)
+import { test, expect } from '@playwright/test';
+
+test.describe('ValueScorecard (/test#dev/summary)', () => {
+  test('renders the scorecard with stars once deployed', async ({ page }) => {
+    await page.goto('/test#dev/summary', { waitUntil: 'domcontentloaded' });
+
+    // Crossover-skip: until the deploy picks up ValueScorecard the wrapper
+    // won't exist. Wait briefly then skip — same pattern as the other
+    // dashboard specs. The /dev-data/value check below is the load-bearing
+    // assertion that runs unconditionally.
+    const card = page.getByTestId('value-scorecard');
+    const appeared = await card.first()
+      .waitFor({ state: 'visible', timeout: 20_000 })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!appeared, 'ValueScorecard not yet on live deploy — skipping until #dev/summary rebuilds');
+
+    await expect(card.getByText('Business Value', { exact: true })).toBeVisible();
+    // At least one star rating renders (the top demo row), unless the catalog
+    // is genuinely empty — in which case the empty-state copy shows instead.
+    const stars = card.getByTestId('star-rating');
+    const empty = card.getByText(/No demo items in the catalog yet/i);
+    const hasStars = await stars.first().isVisible().catch(() => false);
+    const isEmpty = await empty.isVisible().catch(() => false);
+    expect(hasStars || isEmpty, 'either star rows or the empty-state copy must render').toBe(true);
+  });
+
+  test('the /dev-data/value endpoint responds with the catalog shape', async ({ page }) => {
+    const resp = await page.request.get('/dev-data/value');
+    // 404 is acceptable when the sibling ix catalog is absent in this checkout
+    // (e.g. the live deploy has no ix sibling); the contract is "never 500".
+    expect(resp.status(), '/dev-data/value should not 500').not.toBe(500);
+    if (resp.status() >= 400) return; // absent catalog — nothing more to assert
+    const payload = await resp.json();
+    expect(Array.isArray(payload.records), 'payload.records should be an array').toBe(true);
+    expect(Array.isArray(payload.demos), 'payload.demos should be an array').toBe(true);
+    expect(Array.isArray(payload.repos), 'payload.repos should be an array').toBe(true);
+    // demos sorted by score descending (server-side contract)
+    for (let i = 1; i < payload.demos.length; i++) {
+      expect(payload.demos[i - 1].score01).toBeGreaterThanOrEqual(payload.demos[i].score01);
+    }
+  });
+});

--- a/ReactComponents/ga-react-components/tests/dashboard/value-scorecard.spec.ts
+++ b/ReactComponents/ga-react-components/tests/dashboard/value-scorecard.spec.ts
@@ -34,13 +34,22 @@ test.describe('ValueScorecard (/test#dev/summary)', () => {
     test.skip(!appeared, 'ValueScorecard not yet on live deploy — skipping until #dev/summary rebuilds');
 
     await expect(card.getByText('Business Value', { exact: true })).toBeVisible();
-    // At least one star rating renders (the top demo row), unless the catalog
-    // is genuinely empty — in which case the empty-state copy shows instead.
+    // The card has three valid terminal states once mounted:
+    //   1. star rows render (the catalog has demos),
+    //   2. the empty-state copy ("No demo items…") when the catalog is empty,
+    //   3. the "Value catalog unavailable" hint when /dev-data/value 404s
+    //      because the sibling ix catalog is absent (the live deploy may have
+    //      no ix sibling — documented as acceptable graceful degrade).
     const stars = card.getByTestId('star-rating');
     const empty = card.getByText(/No demo items in the catalog yet/i);
+    const unavailable = card.getByText(/Value catalog unavailable/i);
     const hasStars = await stars.first().isVisible().catch(() => false);
     const isEmpty = await empty.isVisible().catch(() => false);
-    expect(hasStars || isEmpty, 'either star rows or the empty-state copy must render').toBe(true);
+    const isUnavailable = await unavailable.isVisible().catch(() => false);
+    expect(
+      hasStars || isEmpty || isUnavailable,
+      'stars, the empty-state copy, or the unavailable hint must render',
+    ).toBe(true);
   });
 
   test('the /dev-data/value endpoint responds with the catalog shape', async ({ page }) => {

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import { createReadStream, existsSync, statSync, readFileSync, readdirSync, appendFileSync } from 'fs'
 import { execFileSync, spawn } from 'child_process'
 import type { Plugin } from 'vite'
-import { parseBacklog, extractDocTitle, binActivityByDay, projectLoopsGoals } from './src/dev-data/parsers'
+import { parseBacklog, extractDocTitle, binActivityByDay, projectLoopsGoals, parseValueCatalog } from './src/dev-data/parsers'
 import type { BacklogPayload, LoopsGoalsProjection } from './src/dev-data/parsers'
 
 // Load ALL env vars (not just VITE_*) from .env.local for proxy auth injection
@@ -1594,6 +1594,33 @@ function devDataPlugin(): Plugin {
                 if (req.method !== 'GET') { next(); return; }
                 res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
                 res.end(JSON.stringify({ generated_at: new Date().toISOString(), docs: gatherArchitecture() }));
+            });
+
+            // ── /dev-data/value — business-value scorecard ──────────────────
+            // Reads the federated RICE→stars catalog emitted by the sibling ix
+            // repo's `ix-value` generator (JSON-on-disk contract). Returns the
+            // parsed records plus a precomputed split (demo leaderboard sorted
+            // by score, repo rollups) so the card stays dumb. Never 500s on a
+            // corrupt line — parseValueCatalog drops bad lines.
+            server.middlewares.use('/dev-data/value', (req, res, next) => {
+                if (req.method !== 'GET') { next(); return; }
+                const ixRoot = process.env.IX_ROOT || path.resolve(repoRoot, '../ix')
+                const p = path.join(ixRoot, 'state/value/catalog.jsonl')
+                if (!existsSync(p)) {
+                    res.writeHead(404, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({ error: `value catalog not found at ${p} — run: cargo run -p ix-value -- catalog` }))
+                    return
+                }
+                try {
+                    const records = parseValueCatalog(readFileSync(p, 'utf-8'))
+                    const demos = records.filter((r) => r.kind === 'demo').sort((a, b) => b.score01 - a.score01)
+                    const repos = records.filter((r) => r.kind === 'repo').sort((a, b) => b.score01 - a.score01)
+                    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+                    res.end(JSON.stringify({ generated_at: new Date().toISOString(), records, demos, repos }))
+                } catch (err) {
+                    res.writeHead(500, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({ error: String(err) }))
+                }
             });
 
             server.middlewares.use('/dev-data/agents', (req, res, next) => {

--- a/state/value/manifest.json
+++ b/state/value/manifest.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "0.1.0",
+  "repo": "ga",
+  "items": [
+    {
+      "id": "demo/ecosystem-roadmap",
+      "kind": "demo",
+      "title": "Ecosystem Roadmap",
+      "reach": 3,
+      "impact": 3,
+      "confidence": 3,
+      "rationale": "Dev-facing overview of ecosystem direction; useful for steering, modest external reach."
+    },
+    {
+      "id": "demo/prime-radiant",
+      "kind": "demo",
+      "title": "Prime Radiant",
+      "reach": 4,
+      "impact": 5,
+      "confidence": 3,
+      "rationale": "Flagship governance/assumption-graph 3D viz; high impact, no usage telemetry yet."
+    },
+    {
+      "id": "demo/ga-chat",
+      "kind": "demo",
+      "title": "GA Chat (music-theory chatbot)",
+      "reach": 5,
+      "impact": 4,
+      "confidence": 3,
+      "rationale": "Broadest user-facing surface (grounded music-theory Q&A); reach high, quality still stabilizing."
+    },
+    {
+      "id": "demo/grothendieck-dsl",
+      "kind": "demo",
+      "title": "Grothendieck DSL",
+      "reach": 2,
+      "impact": 4,
+      "confidence": 2,
+      "rationale": "Powerful categorical composition DSL; niche audience and speculative adoption."
+    }
+  ],
+  "repo_score": {
+    "reach": 4,
+    "impact": 4,
+    "confidence": 3,
+    "rationale": "Music-theory engine + demos are the ecosystem's user-facing front door; reach high, value mostly declared not yet measured."
+  }
+}


### PR DESCRIPTION
## Summary

Renders the **business-value scorecard** on the dev dashboard (`/test#dev/summary`) — the "expose" half of the RICE→stars business-value loop. The ix side (catalog generator + federated `catalog.jsonl`) shipped in `GuitarAlchemist/ix#104`; this PR is the UI that makes the stars visible.

- **`/dev-data/value`** Vite middleware reads `IX_ROOT/state/value/catalog.jsonl` (federated by the sibling ix repo's `ix-value`), parses it, and returns records + a server-side split (demo leaderboard sorted by score, repo rollups). Mirrors the existing `/dev-data/assumption` pattern. **404s (never 500s)** when the catalog is absent.
- **`parseValueCatalog`** (pure, in `dev-data/parsers.ts`) — tolerant JSONL parse that drops malformed lines so one corrupt row never blanks the whole scorecard.
- **`<StarRating>`** — accessible 1–5 star row (filled + outline pips), raw score in the tooltip.
- **`<ValueScorecard>`** — self-fetching card (same shape as `MissionControl`/`InFlightCard`), repo leaderboard above demo leaderboard, wired into `OverviewSection` right after `InFlightCard`. Quiet hint state when the catalog is unavailable.
- **`state/value/manifest.json`** — ga's hand-authored RICE source (4 demos + a `repo_score`) that `ix-value` federates.

## Why

The original ask: *assess business value per demo, present a score + stars in the UI, and score each repo the same way.* The scoring/federation landed on the ix side; this surfaces it where operators already look.

## Testing

- `vitest run src/dev-data/parsers.test.ts` → **58 passed** (incl. 4 new `parseValueCatalog` cases: per-line parse, blank-line tolerance, malformed-line skip, empty input).
- `eslint` clean on all changed files.
- `tsc -b` → no type errors in the new files (pre-existing BSP/AI errors are unrelated and present on `main`).
- `value-scorecard.spec.ts` — crossover-skip Playwright (passes on the current deploy, enforces the contract once the card ships), plus an unconditional `/dev-data/value` shape + never-500 + sort-order assertion.

## Post-Deploy Monitoring & Validation

- **What to watch:** the `value-scorecard` card on `https://demos.guitaralchemist.com/test#dev/summary` after the deploy rebuilds.
- **Validation:** `curl -s localhost:5176/dev-data/value | jq '.demos[0]'` → top demo with `stars`/`score01`; the Playwright `value-scorecard.spec.ts` flips from skipped → asserting once live.
- **Expected healthy:** card renders repo + demo rows with stars; endpoint 2xx (or 404 if no ix sibling on the host — by design).
- **Failure signal / rollback:** endpoint 500, or the card blanks the dashboard. Trigger: revert this PR (the card is additive and isolated to `OverviewSection`).
- **Window & owner:** first deploy after merge; owner @spareilleux.

## Note

Stars depend on the ix sibling's `state/value/catalog.jsonl` (committed in ix#104). On hosts without an ix sibling the endpoint 404s and the card shows the quiet "run `ix-value`" hint — intentional graceful degrade.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)
