### PR TITLE
fix(chatbot-qa): in-runner Ollama — CI measures a real pass_pct, no operator infra

### DIFF
--- a/.github/workflows/chatbot-qa-snapshot.yml
+++ b/.github/workflows/chatbot-qa-snapshot.yml
@@ -53,7 +53,7 @@ concurrency:
 jobs:
   snapshot:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60   # in-runner Ollama: model pull + ~50 CPU-inference prompts
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,6 +89,34 @@ jobs:
               "OPTICK_INDEX_AUTH=$($env:SECRET_INDEX_AUTH)" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
             }
           }
+
+      # Default backend: run Ollama ON the runner — no secret, no tunnel, no
+      # Cloudflare. Only runs when the remote OLLAMA_BASE_URL secret did NOT set
+      # a backend above, so a remote override still wins if one is ever configured.
+      # Pulls the exact models the chatbot config declares (Apps/GaChatbot.Api/
+      # appsettings.json: ChatModel llama3.2:3b, EmbeddingModel nomic-embed-text) so
+      # the measured pass_pct is comparable to the local baseline (0.94, llama3.2:3b).
+      - name: Install + warm in-runner Ollama (default backend)
+        if: ${{ env.OLLAMA_BASE_URL == '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ollama.com/install.sh | sh
+          nohup ollama serve > /tmp/ollama.log 2>&1 &
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:11434/api/version >/dev/null; then echo "ollama up"; break; fi
+            sleep 1
+          done
+          curl -sf http://localhost:11434/api/version || { echo "ollama did not start:"; cat /tmp/ollama.log; exit 1; }
+          ollama pull nomic-embed-text
+          ollama pull llama3.2:3b
+          ollama list
+          {
+            echo "OLLAMA_BASE_URL=http://localhost:11434"
+            echo "Ollama__BaseUrl=http://localhost:11434"
+            echo "Ollama__Endpoint=http://localhost:11434"
+          } >> "$GITHUB_ENV"
+          echo "Backend: in-runner Ollama warmed (nomic-embed-text + llama3.2:3b)."
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/state/quality/chatbot-qa/2026-06-15.json
+++ b/state/quality/chatbot-qa/2026-06-15.json
@@ -1,11 +1,52 @@
 {
-  "timestamp": "2026-06-15T07:49:11.2786939+00:00",
+  "timestamp": "2026-06-15T19:19:52.7757466+00:00",
   "total_prompts": 52,
-  "pass_pct": null,
-  "degraded": true,
-  "degraded_reason": "backend_unavailable",
-  "note": "Environment degraded: 51/51 failures were HTTP 5xx / network errors. pass_pct omitted — backend (Ollama / OPTIC-K index / deps) was unavailable, not the chatbot itself failing.",
-  "last_known_good_pass_pct": 94.0,
-  "last_known_good_date": "05/16/2026 05:30:00",
-  "last_known_good_source": "carryforward"
+  "pass_pct": 75.0,
+  "degraded": false,
+  "by_category": {
+    "atonal": {
+      "pass_pct": 100.0,
+      "total": 4
+    },
+    "case-variants": {
+      "pass_pct": 50.0,
+      "total": 2
+    },
+    "chord-from-notes": {
+      "pass_pct": 100.0,
+      "total": 4
+    },
+    "extended-chords": {
+      "pass_pct": 100.0,
+      "total": 2
+    },
+    "getting-started": {
+      "pass_pct": 100.0,
+      "total": 1
+    },
+    "modes": {
+      "pass_pct": 100.0,
+      "total": 13
+    },
+    "operations": {
+      "pass_pct": 28.57,
+      "total": 7
+    },
+    "progressions": {
+      "pass_pct": 60.0,
+      "total": 5
+    },
+    "scales-keys": {
+      "pass_pct": 50.0,
+      "total": 8
+    },
+    "theory": {
+      "pass_pct": 100.0,
+      "total": 2
+    },
+    "typo-tolerance": {
+      "pass_pct": 75.0,
+      "total": 4
+    }
+  }
 }


### PR DESCRIPTION
## Why
The daily **chatbot-qa snapshot** has degraded every day since 2026-05-16: the hosted runner has no model, so the oracle can't run and `pass_pct` is null. The existing remote path needed an `OLLAMA_BASE_URL` secret fronted by Cloudflare Access — **operator infrastructure**.

## What
Run **Ollama on the runner itself** — no secret, no tunnel, no Cloudflare:
- Install Ollama, pull the exact models the chatbot declares (`nomic-embed-text` + `llama3.2:3b`, matching the 0.94 baseline), point the app + preflight at `localhost:11434`.
- Gated on `env.OLLAMA_BASE_URL == ''`, so a remote-secret override still wins if ever configured.
- OPTIC-K index already fetched via the public-release `OPTICK_INDEX_URL` secret.
- `timeout-minutes` 30 → 60 for the pull + ~50 CPU-inference prompts.

## Effect
CI produces a **real, non-degraded `pass_pct`** — the signal the autonomous improvement loop gates on. **Removes the operator from the loop** entirely for the chatbot-qa oracle.

Verifying via a `workflow_dispatch` on this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)