### PR TITLE
feat(ci): routing-eval ratchet — Phase 3 mechanical gate

### DIFF
--- a/.github/workflows/routing-eval-gate.yml
+++ b/.github/workflows/routing-eval-gate.yml
@@ -1,0 +1,93 @@
+name: Routing-Eval Ratchet
+
+# Phase 3 CI ratchet (mechanical axis only).
+#
+# Runs the semantic-intent RoutingEvalHarness against an in-runner Ollama
+# embedder (nomic-embed-text — the SAME backend the committed routing-eval
+# baselines were measured with) and FAILS the PR if in-scope routing accuracy
+# or out-of-scope decline rate regressed beyond tolerance vs the newest
+# committed state/quality/routing-eval-*.json baseline.
+#
+# This is the "every passing eval is a one-way door" gate: once the loop
+# lifts routing accuracy and a fresh baseline is committed, no later change
+# may quietly drop it back. Fuzzy answer-quality stays human/tribunal-gated;
+# this gate touches only the deterministic routing-correctness axis.
+#
+# Self-contained: no secrets, no Cloudflare — the embedder runs on the runner.
+
+on:
+  pull_request:
+    paths:
+      - 'Common/GA.Business.ML/Agents/**'
+      - 'Common/GA.Business.ML/Skills/**'
+      - 'Tests/Common/GA.Business.ML.Tests/Eval/**'
+      - 'Tests/Common/GA.Business.ML.Tests/Data/routing-eval-prompts.json'
+      - 'Scripts/routing-eval-gate.ps1'
+      - '.github/workflows/routing-eval-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: routing-eval-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  routing-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install + warm in-runner Ollama (embedder only)
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ollama.com/install.sh | sh
+          nohup ollama serve > /tmp/ollama.log 2>&1 &
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:11434/api/version >/dev/null; then echo "ollama up"; break; fi
+            sleep 1
+          done
+          curl -sf http://localhost:11434/api/version || { echo "ollama did not start:"; cat /tmp/ollama.log; exit 1; }
+          # The routing harness only embeds prompts — no chat model needed.
+          ollama pull nomic-embed-text
+          ollama list
+
+      - name: Restore + build routing-eval test project
+        run: |
+          dotnet restore Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj
+          dotnet build   Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj \
+            --configuration Release --no-restore
+
+      - name: Run RoutingEvalHarness baseline (emits routing-eval-<date>.json)
+        env:
+          GA_EMBED_ENDPOINT: http://localhost:11434
+          GA_EMBED_MODEL: nomic-embed-text
+        run: |
+          dotnet test Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj \
+            --configuration Release --no-build \
+            --filter "FullyQualifiedName~RoutingEvalHarness.RunBaseline_EmitReport" \
+            --logger "console;verbosity=normal"
+
+      - name: Ratchet — fail PR if routing regressed vs committed baseline
+        shell: pwsh
+        run: |
+          $stamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+          $report = "state/quality/routing-eval-$stamp.json"
+          ./Scripts/routing-eval-gate.ps1 -NewReport $report -Tolerance 0.02
+
+      - name: Upload routing-eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: routing-eval-report
+          path: state/quality/routing-eval-*.json
+          if-no-files-found: warn

--- a/Scripts/routing-eval-gate.ps1
+++ b/Scripts/routing-eval-gate.ps1
@@ -1,0 +1,118 @@
+#!/usr/bin/env pwsh
+# routing-eval-gate.ps1 — Phase 3 CI ratchet for semantic-intent routing.
+#
+# Compares a freshly-emitted routing-eval report (from
+# RoutingEvalHarness.RunBaseline_EmitReport) against the newest *committed*
+# routing-eval baseline and FAILS (exit 1) if in-scope routing accuracy — or
+# the out-of-scope decline rate — regressed beyond tolerance.
+#
+# The routing harness measures with the embedder + threshold pinned in the
+# report's routerConfig (nomic-embed-text @ minConfidence 0.55), which is the
+# SAME backend in-runner Ollama provides in CI — so the comparison is
+# apples-to-apples (unlike chatbot-qa pass_pct, where CPU vs cloud differ).
+#
+# Paranoia rule (see feedback_auto_optimize_oracle_paranoia): a report that
+# could not run (missing file, zero prompts) is a FAILURE, never a silent pass.
+#
+#   pwsh Scripts/routing-eval-gate.ps1 -NewReport state/quality/routing-eval-2026-06-15.json
+#
+[CmdletBinding()]
+param(
+    # The report just emitted by the harness this CI run.
+    [Parameter(Mandatory)] [string] $NewReport,
+    # Floor to compare against. Default: newest committed routing-eval-*.json
+    # that is NOT $NewReport.
+    [string] $Baseline,
+    # Allowed drop before the gate fails (matches baseline.json regression_threshold).
+    [double] $Tolerance = 0.02,
+    # Emits a one-line gate-ledger row alongside the human report when set.
+    [string] $LedgerPath
+)
+$ErrorActionPreference = 'Stop'
+
+function Read-Overall([string]$path) {
+    if (-not (Test-Path $path)) {
+        throw "GATE FAIL (couldnt_run): report not found at '$path'. " +
+              "The harness did not produce output — treat as failure, never a pass."
+    }
+    $doc = Get-Content -Raw $path | ConvertFrom-Json
+    $o = $doc.overall
+    if ($null -eq $o -or [int]$o.Total -le 0) {
+        throw "GATE FAIL (couldnt_run): '$path' has no scored prompts (Total<=0). " +
+              "Backend likely unavailable — treat as failure."
+    }
+    return $o
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+if (-not (Test-Path $NewReport)) {
+    Write-Host ("GATE FAIL (couldnt_run): report not found at '{0}'. " -f $NewReport) -ForegroundColor Red
+    Write-Host "The harness did not produce output — treat as failure, never a pass." -ForegroundColor Red
+    exit 1
+}
+$newPath  = Resolve-Path $NewReport
+$new      = Read-Overall $newPath
+
+# Resolve the baseline floor.
+if (-not $Baseline) {
+    $candidates = Get-ChildItem (Join-Path $repoRoot 'state/quality') -Filter 'routing-eval-*.json' |
+        Where-Object { $_.FullName -ne $newPath.Path } |
+        Sort-Object Name -Descending
+    if (-not $candidates) {
+        Write-Host "GATE SKIP: no prior routing-eval baseline committed — recording only, nothing to ratchet against." -ForegroundColor Yellow
+        exit 0
+    }
+    $Baseline = $candidates[0].FullName
+}
+$base = Read-Overall $Baseline
+
+$baseName = Split-Path $Baseline -Leaf
+$dInScope = [math]::Round($new.InScopeAccuracy - $base.InScopeAccuracy, 4)
+$dOos     = [math]::Round($new.OosDeclineRate  - $base.OosDeclineRate,  4)
+
+Write-Host ""
+Write-Host "─── Routing-eval ratchet ───────────────────────────────" -ForegroundColor Cyan
+Write-Host ("  baseline      : {0}" -f $baseName)
+Write-Host ("  in-scope acc  : {0:P1} -> {1:P1}  (Δ {2:+0.0%;-0.0%;0.0%})" -f $base.InScopeAccuracy, $new.InScopeAccuracy, $dInScope)
+Write-Host ("  OOS decline   : {0:P1} -> {1:P1}  (Δ {2:+0.0%;-0.0%;0.0%})" -f $base.OosDeclineRate, $new.OosDeclineRate, $dOos)
+Write-Host ("  tolerance     : {0:P1}" -f $Tolerance)
+
+$reasons = @()
+if ($new.InScopeAccuracy -lt ($base.InScopeAccuracy - $Tolerance)) {
+    $reasons += ("in-scope accuracy {0:P1} below floor {1:P1} (baseline {2:P1} − tol {3:P1})" -f `
+        $new.InScopeAccuracy, ($base.InScopeAccuracy - $Tolerance), $base.InScopeAccuracy, $Tolerance)
+}
+if ($new.OosDeclineRate -lt ($base.OosDeclineRate - $Tolerance)) {
+    $reasons += ("OOS-decline rate {0:P1} below floor {1:P1} — router is over-accepting out-of-scope prompts" -f `
+        $new.OosDeclineRate, ($base.OosDeclineRate - $Tolerance))
+}
+
+$decision = if ($reasons.Count -gt 0) { 'fail' } else { 'pass' }
+
+if ($LedgerPath) {
+    $row = [ordered]@{
+        ts            = (Get-Date).ToUniversalTime().ToString('o')
+        source        = 'routing-eval-gate'
+        domain        = 'routing'
+        decision      = $decision
+        metric        = 'inScopeAccuracy'
+        metric_value  = $new.InScopeAccuracy
+        baseline      = $baseName
+        baseline_value= $base.InScopeAccuracy
+        delta         = $dInScope
+        tolerance     = $Tolerance
+    } | ConvertTo-Json -Compress
+    Add-Content -Path $LedgerPath -Value $row
+}
+
+if ($decision -eq 'fail') {
+    Write-Host ""
+    foreach ($r in $reasons) { Write-Host "  ✗ $r" -ForegroundColor Red }
+    Write-Host "GATE FAIL: routing regressed beyond tolerance." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "  ✓ routing held at or above the committed floor." -ForegroundColor Green
+Write-Host "GATE PASS." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## What
Wires the semantic-intent **RoutingEvalHarness** as a PR gate — the mechanical-axis half of the nested-loop **ratchet** (every passing eval becomes a one-way door). This is **Phase 3** of the loop-autonomy design (`docs/research/2026-06-15-nested-loop-chatbot-development-duckdb.md`), unblocked now that in-runner Ollama gives CI a real backend (PR #411).

## How
- **`.github/workflows/routing-eval-gate.yml`** (PR-triggered on agent/skill/router/eval paths + `workflow_dispatch`): warms an in-runner Ollama **embedder** (`nomic-embed-text` — the *exact* backend the committed `routing-eval-*.json` baselines were measured with), runs the harness, then runs the gate.
- **`Scripts/routing-eval-gate.ps1`**: fails the PR if **in-scope routing accuracy** or **out-of-scope decline rate** drops more than `0.02` below the newest committed baseline. Apples-to-apples because the embedder + threshold (0.55) match the baseline's `routerConfig`.

## Verification (local, live Ollama)
- `[Explicit]` harness runs via `--filter` ("Explicit run" mode), emits `routing-eval-<date>.json`.
- Reproduces the committed **2026-05-31** baseline **exactly**: in-scope **93.4%**, OOS-decline **87.5%**, 162/174 → gate **PASS** at Δ0.
- Regression path (−4.2pt) → exit 1 with reason; couldn't-run path (missing report) → exit 1 (**paranoia rule**: a run that couldn't execute is never a silent pass).

## Boundaries held
- Self-contained: **no secrets, no Cloudflare** — embedder runs on the runner.
- Routing only embeds prompts → **no chat model pulled** (fast, ~embedder-only warm).
- **Fuzzy answer-quality stays human/Demerzel-tribunal-gated**; this gate touches only the deterministic routing-correctness axis.

## Deliberately deferred
The **flight-recorder gate** (`ix-duck --features duck`) is *not* included: GA's `golden-traces/run-*.json` are static May-16 fixtures — `run-prompt-corpus.ps1` doesn't regenerate them — so a check over them would be a fixture self-consistency guard, not a live per-PR regression gate. Making it live needs trace-regeneration plumbing in the C# corpus runner first. Tracked as Phase 3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)