### PR TITLE
feat(quality): multi-turn chatbot session corpus — loop's session axis

### DIFF
--- a/Scripts/run-session-corpus.ps1
+++ b/Scripts/run-session-corpus.ps1
@@ -1,0 +1,113 @@
+# run-session-corpus.ps1 — Replay the multi-turn chatbot session corpus + emit a snapshot
+#
+# Usage:
+#   pwsh Scripts/run-session-corpus.ps1                 # replay, summarize
+#   pwsh Scripts/run-session-corpus.ps1 -Snapshot       # also write state/quality/chatbot-qa-sessions/YYYY-MM-DD.json
+#   pwsh Scripts/run-session-corpus.ps1 -NoBuild        # skip build (DLL must be current)
+#
+# The multi-turn counterpart to run-prompt-corpus.ps1. Drives
+# SessionCorpusTests.EverySession_SatisfiesItsInvariants against GaChatbot.Api,
+# parses the canonical summary line it prints, and emits a trend-shaped JSON the
+# improvement loop can target on the SESSION axis (lost context, follow-up
+# fallback) — distinct from the single-turn pass_pct.
+#
+# Oracle-paranoia (see docs/solutions/tooling/2026-05-16-auto-optimize-oracle-
+# silent-success-build-failure.md): if the replay could not run (build failed,
+# host down, zero turns), this writes NO snapshot and exits 2 — a run that
+# couldn't execute must never read as a passing baseline.
+
+[CmdletBinding()]
+param(
+    [switch]$NoBuild,
+    [switch]$Snapshot
+)
+$ErrorActionPreference = 'Stop'
+# Capture native dotnet output as UTF-8 so the test's → / … glyphs survive the
+# pipe; we still sanitize to ASCII before persisting the snapshot.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$testProj = Join-Path $repoRoot 'Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj'
+
+Write-Host '─── Replaying chatbot session corpus ───' -ForegroundColor Cyan
+
+$dotnetArgs = @(
+    'test', $testProj, '-c', 'Debug',
+    '--filter', 'FullyQualifiedName~SessionCorpusTests.EverySession_SatisfiesItsInvariants',
+    '--logger', 'console;verbosity=normal'
+)
+if ($NoBuild) { $dotnetArgs += '--no-build' }
+
+$out = (& dotnet @dotnetArgs 2>&1 | ForEach-Object { $_.ToString() }) -join "`n"
+$dotnetExit = $LASTEXITCODE
+
+# Canonical summary line emitted by the test:
+#   "Sessions: 4  ·  turns: 11/16 passed  ·  session_pass_pct=68.8%"
+$summary = [regex]::Match($out, 'Sessions:\s*(\d+)\s*.*?turns:\s*(\d+)/(\d+)\s*passed.*?session_pass_pct=([\d.]+)%')
+if (-not $summary.Success) {
+    Write-Host '✗ Oracle did NOT run cleanly — no session summary line found.' -ForegroundColor Red
+    Write-Host "  dotnet test exit=$dotnetExit. Likely a build failure or host that never booted." -ForegroundColor Red
+    if ($out -match 'MSB3027|MSB3021|file is locked') {
+        Write-Host '  Cause: a DLL is locked by a running host (GaChatbot.Api). Stop it and retry.' -ForegroundColor DarkYellow
+    }
+    ($out -split "`r?`n" | Select-Object -Last 20) | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+    exit 2
+}
+
+$sessions   = [int]$summary.Groups[1].Value
+$passedT    = [int]$summary.Groups[2].Value
+$totalT     = [int]$summary.Groups[3].Value
+$passPct    = [double]$summary.Groups[4].Value / 100.0
+
+if ($totalT -lt 1) {
+    Write-Host '✗ Oracle ran but replayed 0 turns — treating as couldnt_run.' -ForegroundColor Red
+    exit 2
+}
+
+# Failure lines: after "violating invariants (N):", each "  - ..." bullet.
+$failures = @()
+$fm = [regex]::Match($out, 'violating invariants \(\d+\):')
+if ($fm.Success) {
+    $block = $out.Substring($fm.Index + $fm.Length)
+    $end = [regex]::Match($block, '(?m)^\s*$|^(But was|Test Run|Total tests|Passed!|Failed!)').Index
+    if ($end -gt 0) { $block = $block.Substring(0, $end) }
+    foreach ($m in [regex]::Matches($block, '^\s*-\s*(.+)$', 'Multiline')) {
+        $line = $m.Groups[1].Value.Trim()
+        if ($line) { $failures += $line }
+    }
+    # Normalize to clean ASCII for the committed artifact: arrow → '->',
+    # ellipsis → '...', then drop any other non-ASCII so the snapshot is
+    # diff-stable regardless of the runner's console code page.
+    $failures = @($failures | ForEach-Object {
+        ($_ -replace '→', ' -> ' -replace '…', '...' -replace '[^\x20-\x7E]', '').Trim()
+    } | Select-Object -Unique)
+}
+
+Write-Host ''
+Write-Host ("Sessions: {0}  ·  turns: {1}/{2} passed  ·  session_pass_pct={3:P1}" -f $sessions, $passedT, $totalT, $passPct) `
+    -ForegroundColor ($(if ($failures.Count -eq 0) { 'Green' } else { 'Yellow' }))
+foreach ($f in $failures) { Write-Host "  ✗ $f" -ForegroundColor Red }
+
+if ($Snapshot) {
+    $snapDir = Join-Path $repoRoot 'state/quality/chatbot-qa-sessions'
+    New-Item -ItemType Directory -Force -Path $snapDir | Out-Null
+    $stamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+    $snapPath = Join-Path $snapDir "$stamp.json"
+    $snap = [ordered]@{
+        schema_version   = 1
+        date             = $stamp
+        metric           = 'session_pass_pct'
+        sessions         = $sessions
+        turns_total      = $totalT
+        turns_passed     = $passedT
+        session_pass_pct = [math]::Round($passPct, 4)
+        failures         = $failures
+        degraded         = $false
+        source           = 'run-session-corpus'
+    }
+    $snap | ConvertTo-Json -Depth 5 | Set-Content -Path $snapPath -Encoding utf8
+    Write-Host "Wrote session snapshot to $snapPath" -ForegroundColor Cyan
+}
+
+# Mirror run-prompt-corpus: invariant failures are the metric signal, not an
+# infrastructure error — exit 0 so the loop reads the snapshot, not a crash.
+exit 0

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/SessionCorpusTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/SessionCorpusTests.cs
@@ -1,0 +1,345 @@
+namespace GaChatbot.Api.Tests.Corpus;
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+/// <summary>
+///     Replays YAML-defined multi-turn conversations (sessions.yaml) against
+///     the GaChatbot.Api host and asserts per-turn invariants, carrying the
+///     accumulating ConversationHistory between turns exactly as the live
+///     /chatbot UI does. This is the multi-turn counterpart to
+///     <see cref="PromptCorpusTests"/>: where that gate sees one-shot answers,
+///     this one catches conversation bugs — lost context, a follow-up that
+///     falls back, a "those chords" the model no longer remembers.
+///
+///     DESIGN BOUNDARY: every invariant here is MECHANICAL (routing, grounding
+///     presence, no-fallback, context retention, banned phrases, latency) and
+///     therefore safe for the autonomous improvement loop to optimise against.
+///     Fuzzy answer-quality stays human / Demerzel-tribunal-gated and is not
+///     encoded in this file.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class SessionCorpusTests
+{
+    private WebApplicationFactory<Program>? _factory;
+    private HttpClient? _client;
+    private SessionCorpusFile? _corpus;
+
+    // Same universal regression markers PromptCorpusTests enforces — a session
+    // answer leaking SKILL.md preamble or an unloaded-index message is a bug
+    // regardless of which turn it appears on.
+    private static readonly string[] UniversalBannedMarkers =
+    [
+        "Reproduce the catalog below verbatim",
+        "Pure pedagogy",
+        "Use when a learner asks",
+        "Use when a visitor asks",
+        "doesn't need a tool call",
+        "returned no matches",
+        "not yet implemented",
+        "index is not loaded",
+    ];
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _factory = new GaChatbot.Api.Tests.TestWebApplicationFactory();
+        _client = _factory.CreateClient();
+        _client.Timeout = TimeSpan.FromMinutes(3);
+
+        var yamlPath = Path.Combine(
+            TestContext.CurrentContext.TestDirectory, "Corpus", "sessions.yaml");
+        if (!File.Exists(yamlPath))
+        {
+            yamlPath = Path.Combine(
+                AppContext.BaseDirectory, "..", "..", "..", "Corpus", "sessions.yaml");
+        }
+
+        var yaml = File.ReadAllText(yamlPath);
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+        _corpus = deserializer.Deserialize<SessionCorpusFile>(yaml)
+            ?? throw new InvalidOperationException("sessions.yaml deserialized to null");
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public void Sessions_LoadAtLeastOne()
+    {
+        Assert.That(_corpus!.Sessions, Is.Not.Null);
+        Assert.That(_corpus.Sessions.Count, Is.GreaterThan(0),
+            "sessions.yaml must contain at least one session");
+        foreach (var s in _corpus.Sessions)
+            Assert.That(s.Turns.Count, Is.GreaterThan(0), $"session '{s.Id}' has no turns");
+    }
+
+    /// <summary>
+    ///     Replays every session turn-by-turn and aggregates per-turn failures.
+    ///     Explicit because it drives the full orchestrator (Ollama + DI) once
+    ///     per turn — too slow for inner-loop CI, but the oracle for the
+    ///     multi-turn axis of the improvement loop and a release gate.
+    /// </summary>
+    [Test]
+    [Explicit("Slow — replays full multi-turn sessions against the live orchestrator (Ollama + DI). Run before releases and as the session-axis oracle for the improvement loop.")]
+    public async Task EverySession_SatisfiesItsInvariants()
+    {
+        var failures = new List<string>();
+        var warnings = new List<string>();
+        var turnsRun = 0;
+        var turnsPassed = 0;
+
+        foreach (var session in _corpus!.Sessions)
+        {
+            // ConversationHistory accumulates across the session — this is what
+            // makes "those chords" / "that key" resolvable. Each turn appends
+            // the user message and the assistant answer.
+            var history = new List<ChatTurn>();
+
+            foreach (var (turn, index) in session.Turns.Select((t, i) => (t, i)))
+            {
+                turnsRun++;
+                var label = $"[{session.Persona}/{session.Id}] turn {index + 1}: '{Truncate(turn.User, 60)}'";
+
+                var maxAttempts = 1 + (turn.Retry ?? 1);
+                (string? failure, string? warning, string? answer) result = (null, null, null);
+                for (var attempt = 1; attempt <= maxAttempts; attempt++)
+                {
+                    result = await EvaluateTurnAsync(label, turn, history);
+                    if (result.failure is null) break;
+                }
+
+                if (result.failure is not null) failures.Add(result.failure);
+                if (result.warning is not null) warnings.Add(result.warning);
+                if (result.failure is null) turnsPassed++;
+
+                // Append BOTH sides so the next turn sees the full thread, even
+                // when this turn failed an invariant — a later turn shouldn't be
+                // penalised for missing context the model was never given.
+                history.Add(new ChatTurn("user", turn.User));
+                history.Add(new ChatTurn("assistant", result.answer ?? ""));
+            }
+        }
+
+        var passPct = turnsRun == 0 ? 0 : (double)turnsPassed / turnsRun;
+        TestContext.Out.WriteLine(
+            $"Sessions: {_corpus.Sessions.Count}  ·  turns: {turnsPassed}/{turnsRun} passed  ·  session_pass_pct={passPct:P1}");
+
+        if (warnings.Count > 0)
+        {
+            TestContext.Out.WriteLine($"Warnings ({warnings.Count}):");
+            foreach (var w in warnings) TestContext.Out.WriteLine($"  ! {w}");
+        }
+
+        Assert.That(failures, Is.Empty,
+            $"Session turns violating invariants ({failures.Count}):\n  - {string.Join("\n  - ", failures)}");
+    }
+
+    // ── evaluation ──────────────────────────────────────────────────────────
+
+    private async Task<(string? failure, string? warning, string? answer)> EvaluateTurnAsync(
+        string label, TurnEntry turn, List<ChatTurn> history)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        HttpResponseMessage response;
+        try
+        {
+            response = await _client!.PostAsJsonAsync(
+                "/api/chatbot/chat",
+                new
+                {
+                    message = turn.User,
+                    conversationHistory = history.Select(h => new { role = h.Role, content = h.Content }).ToList(),
+                });
+        }
+        catch (Exception ex)
+        {
+            return ($"{label} → exception: {ex.GetType().Name}: {ex.Message}", null, null);
+        }
+        sw.Stop();
+
+        if (response.StatusCode != HttpStatusCode.OK)
+            return ($"{label} → HTTP {(int)response.StatusCode}", null, null);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var answer = body.TryGetProperty("naturalLanguageAnswer", out var a) ? a.GetString() ?? "" : "";
+        var agentId = body.TryGetProperty("agentId", out var ag) ? ag.GetString() : null;
+        var grounding = body.TryGetProperty("grounding", out var g) && g.ValueKind == JsonValueKind.Object
+            && g.TryGetProperty("source", out var gs) ? gs.GetString() : null;
+
+        if (string.IsNullOrWhiteSpace(answer))
+            return ($"{label} → empty response", null, answer);
+
+        var minLen = turn.MinLength ?? 50;
+        if (answer.Length < minLen)
+            return ($"{label} → too short ({answer.Length} < {minLen} chars)", null, answer);
+
+        foreach (var marker in UniversalBannedMarkers)
+            if (answer.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                return ($"{label} → leaked universal banned marker: \"{marker}\"", null, answer);
+
+        if (turn.NotContains is not null)
+            foreach (var marker in turn.NotContains)
+                if (answer.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                    return ($"{label} → contained banned phrase: \"{marker}\"", null, answer);
+
+        if (turn.Contains is not null)
+            foreach (var must in turn.Contains)
+                if (!answer.Contains(must, StringComparison.OrdinalIgnoreCase))
+                    return ($"{label} → missing required substring: \"{must}\"", null, answer);
+
+        if (turn.ContainsAny is { Count: > 0 }
+            && !turn.ContainsAny.Any(s => answer.Contains(s, StringComparison.OrdinalIgnoreCase)))
+            return ($"{label} → none of contains_any matched: [{string.Join(", ", turn.ContainsAny)}]", null, answer);
+
+        // ── Context-retention invariant (the multi-turn-only signal) ─────────
+        // `references` are substrings a CORRECT answer must carry because a
+        // prior turn established them. A miss means the chatbot dropped the
+        // conversational thread — the failure mode a single-turn corpus is
+        // structurally blind to.
+        if (turn.References is { Count: > 0 })
+        {
+            var missing = turn.References
+                .Where(r => !answer.Contains(r, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            // Require the answer to carry at least one referenced anchor; a
+            // total miss is a lost-context failure. (Any-of, not all-of, so a
+            // legitimate rephrase that keeps one anchor still passes.)
+            if (missing.Count == turn.References.Count)
+                return ($"{label} → lost conversation context: none of the prior-turn references appeared [{string.Join(", ", turn.References)}]", null, answer);
+        }
+
+        if (!string.IsNullOrWhiteSpace(turn.RoutesTo)
+            && !string.Equals(agentId, turn.RoutesTo, StringComparison.OrdinalIgnoreCase))
+            return ($"{label} → routed to '{agentId}' but expected '{turn.RoutesTo}'", null, answer);
+
+        if (!string.IsNullOrWhiteSpace(turn.ExpectedGrounding)
+            && !string.Equals(grounding, turn.ExpectedGrounding, StringComparison.OrdinalIgnoreCase))
+            return ($"{label} → grounding '{grounding ?? "<null>"}' but expected '{turn.ExpectedGrounding}'", null, answer);
+
+        // ── trace-shape invariants ──────────────────────────────────────────
+        var traceSteps = ExtractTraceSteps(body);
+
+        if (turn.MustNotFallback == true)
+        {
+            var fallbackStep = traceSteps.FirstOrDefault(s =>
+                string.Equals(s.Name, "orchestration.fallback", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(s.Name, "gen_ai.chat.fallback", StringComparison.OrdinalIgnoreCase));
+            if (fallbackStep.Name is not null)
+                return ($"{label} → trace visited '{fallbackStep.Name}'; must_not_fallback violated", null, answer);
+        }
+
+        if (turn.ForbiddenAgentIds is { Count: > 0 })
+            foreach (var step in traceSteps)
+            {
+                if (step.Attributes is null) continue;
+                if (!step.Attributes.TryGetValue("agent.id", out var stepAgentId) || stepAgentId is null) continue;
+                if (turn.ForbiddenAgentIds.Any(f => string.Equals(stepAgentId, f, StringComparison.OrdinalIgnoreCase)))
+                    return ($"{label} → trace step '{step.Name}' visited forbidden agent.id '{stepAgentId}'", null, answer);
+            }
+
+        if (turn.MinRoutingConfidence is { } minConf)
+        {
+            var answerStep = traceSteps.FirstOrDefault(s =>
+                string.Equals(s.Name, "orchestration.answer", StringComparison.OrdinalIgnoreCase));
+            if (answerStep.Attributes is not null
+                && answerStep.Attributes.TryGetValue("routing.confidence", out var confStr)
+                && double.TryParse(confStr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var conf)
+                && conf < minConf)
+                return ($"{label} → routing.confidence {conf:F3} below required minimum {minConf:F3}", null, answer);
+        }
+
+        string? warning = null;
+        if (turn.MaxElapsedMs.HasValue && sw.ElapsedMilliseconds > turn.MaxElapsedMs.Value)
+            warning = $"{label} → {sw.ElapsedMilliseconds}ms exceeded soft budget {turn.MaxElapsedMs}ms";
+
+        return (null, warning, answer);
+    }
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..max] + "…";
+
+    // ── YAML shape ──────────────────────────────────────────────────────────
+
+    public sealed class SessionCorpusFile
+    {
+        public List<SessionEntry> Sessions { get; set; } = [];
+    }
+
+    public sealed class SessionEntry
+    {
+        public string Id { get; set; } = "";
+        public string? Persona { get; set; }
+        public string? Description { get; set; }
+        public List<TurnEntry> Turns { get; set; } = [];
+    }
+
+    public sealed class TurnEntry
+    {
+        public string User { get; set; } = "";
+        public string? RoutesTo { get; set; }
+        public List<string>? Contains { get; set; }
+        public List<string>? ContainsAny { get; set; }
+        public List<string>? NotContains { get; set; }
+
+        /// <summary>
+        /// Context-retention anchors: substrings the answer must carry because
+        /// a prior turn established them. The multi-turn-only invariant.
+        /// </summary>
+        public List<string>? References { get; set; }
+
+        public int? MinLength { get; set; }
+        public int? MaxElapsedMs { get; set; }
+        public string? ExpectedGrounding { get; set; }
+        public bool? MustNotFallback { get; set; }
+        public List<string>? ForbiddenAgentIds { get; set; }
+        public double? MinRoutingConfidence { get; set; }
+        public int? Retry { get; set; }
+    }
+
+    private readonly record struct ChatTurn(string Role, string Content);
+
+    private readonly record struct TraceStep(string Name, IDictionary<string, string?>? Attributes);
+
+    private static List<TraceStep> ExtractTraceSteps(JsonElement body)
+    {
+        var steps = new List<TraceStep>();
+        if (!body.TryGetProperty("trace", out var trace) || trace.ValueKind != JsonValueKind.Object)
+            return steps;
+        if (!trace.TryGetProperty("steps", out var stepsArr) || stepsArr.ValueKind != JsonValueKind.Array)
+            return steps;
+
+        foreach (var step in stepsArr.EnumerateArray())
+        {
+            var name = step.TryGetProperty("name", out var n) ? n.GetString() : null;
+            if (string.IsNullOrEmpty(name)) continue;
+
+            Dictionary<string, string?>? attrs = null;
+            if (step.TryGetProperty("attributes", out var attrsObj) && attrsObj.ValueKind == JsonValueKind.Object)
+            {
+                attrs = [];
+                foreach (var prop in attrsObj.EnumerateObject())
+                    attrs[prop.Name] = prop.Value.ValueKind switch
+                    {
+                        JsonValueKind.String => prop.Value.GetString(),
+                        JsonValueKind.Null => null,
+                        _ => prop.Value.ToString(),
+                    };
+            }
+            steps.Add(new TraceStep(name!, attrs));
+        }
+        return steps;
+    }
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml
@@ -1,0 +1,172 @@
+# GA Chatbot SESSION corpus — multi-turn invariant gate
+#
+# Where prompts.yaml asserts invariants on single one-shot answers, this file
+# asserts invariants across a *full conversation* a real guitarist would have.
+# Each session is replayed turn-by-turn against GaChatbot.Api with the
+# accumulating ConversationHistory passed on every request (the same path the
+# live /chatbot UI uses), so context-dependent turns ("those chords", "in that
+# key") actually carry state. SessionCorpusTests.cs is the canonical runner.
+#
+# DESIGN BOUNDARY (load-bearing): these invariants are MECHANICAL only —
+# routing, grounding presence, no-fallback, context retention, banned phrases,
+# latency. They are safe for the autonomous improvement loop to optimise
+# against. Fuzzy "was this a *good* lesson?" judgement stays human / Demerzel-
+# tribunal-gated; it is NOT encoded here.
+#
+# Per-turn fields (snake_case, UnderscoredNamingConvention):
+#   user                — the guitarist's message for this turn (required)
+#   routes_to           — expected agentId for this turn
+#   contains            — substrings that MUST appear (case-insensitive)
+#   contains_any        — at least one must appear
+#   not_contains        — substrings that must NOT appear
+#   references          — CONTEXT-RETENTION: substrings the answer must carry
+#                         BECAUSE a prior turn established them. A miss here
+#                         means the chatbot lost the thread — the multi-turn
+#                         failure single-turn corpora can't see.
+#   min_length          — minimum useful answer size (chars)
+#   max_elapsed_ms      — soft latency budget (warns, never fails)
+#   expected_grounding  — expected grounding.source ("ga.dsl", "ix-compatible", null)
+#   must_not_fallback   — fail if the trace visits orchestration.fallback
+#   forbidden_agent_ids — fail if any trace step routed to one of these
+#   min_routing_confidence — fail if the answer step's routing.confidence is below this
+#   retry               — additional attempts before declaring the turn failed (default 1)
+#
+# Universally-banned markers from PromptCorpusTests apply here too.
+
+sessions:
+
+  # ── Journey 1: Beginner onboarding ──────────────────────────────────────
+  # A brand-new guitarist: first chords → a progression using them → smooth
+  # changes → a strum. The most common real entry path.
+  - id: beginner-first-chords
+    persona: beginner-onboarding
+    description: >
+      Absolute beginner learns first open chords, then a progression with
+      them, then how to change between them, then a simple strum.
+    turns:
+      - user: "I just got my first guitar and I've never played before. What are the easiest chords I should learn first?"
+        routes_to: skill.beginnerchords
+        contains_any: ["Em", "E minor", "Am", "A minor", "G", "C", "D", "open chord"]
+        not_contains: ["I don't know", "cannot help"]
+        must_not_fallback: true
+        min_length: 120
+        max_elapsed_ms: 30000
+
+      - user: "Nice. Can you give me a simple song progression I can play using those beginner chords?"
+        # Context retention: the progression must reuse chords from turn 1.
+        references: ["G", "C", "D"]
+        contains_any: ["progression", "G", "C", "D", "Em", "Am", "verse", "I", "IV", "V"]
+        must_not_fallback: true
+        min_length: 80
+        max_elapsed_ms: 30000
+
+      - user: "How do I switch between those chords smoothly without stopping?"
+        contains_any: ["practice", "slow", "finger", "pivot", "anchor", "transition", "muscle memory", "metronome"]
+        not_contains: ["returned no matches"]
+        min_length: 80
+        max_elapsed_ms: 30000
+
+      - user: "And what's an easy strumming pattern for that?"
+        contains_any: ["down", "up", "strum", "pattern", "D-D-U", "downstroke", "rhythm"]
+        min_length: 60
+        max_elapsed_ms: 30000
+
+  # ── Journey 2: Songwriting & progressions ───────────────────────────────
+  # Writing a song in a key: diatonic chords → extend the progression → borrow
+  # a chord for colour → confirm the key.
+  - id: songwriting-in-g
+    persona: songwriting-progressions
+    description: >
+      Songwriter working in G major: diatonic palette → a 4-chord progression
+      → borrow a chord for colour → ask what key it implies.
+    turns:
+      - user: "I'm writing a song in G major. What chords are available to me in that key?"
+        routes_to: skill.diatonicchords
+        contains_any: ["G", "Am", "Bm", "C", "D", "Em", "F#dim", "F#"]
+        expected_grounding: ga.dsl
+        must_not_fallback: true
+        min_length: 100
+        max_elapsed_ms: 30000
+
+      - user: "Give me a catchy 4-chord progression from those that sounds happy."
+        references: ["G", "C", "D"]
+        contains_any: ["G", "C", "D", "Em", "I", "IV", "V", "vi", "progression"]
+        must_not_fallback: true
+        min_length: 60
+        max_elapsed_ms: 30000
+
+      - user: "Can I borrow a chord from outside the key to add some colour?"
+        contains_any: ["borrow", "borrowed", "modal", "minor", "parallel", "Cm", "Bb", "Eb", "secondary", "F"]
+        min_length: 80
+        max_elapsed_ms: 45000
+
+      - user: "If someone played that progression to me, what key would they guess?"
+        contains_any: ["G major", "G", "key of G"]
+        references: ["G"]
+        min_length: 40
+        max_elapsed_ms: 45000
+
+  # ── Journey 3: Improv — scales & modes applied ──────────────────────────
+  # Soloing over a progression: which scale → arpeggios → target tones → a mode
+  # for flavour. Applied theory, not academic.
+  - id: improv-over-am-progression
+    persona: improv-scales-modes
+    description: >
+      Improviser over an A-minor vamp: which scale fits → arpeggios per chord →
+      target/chord tones → a mode for a different colour.
+    turns:
+      - user: "I'm jamming over an Am - F - C - G loop. What scale can I solo with over the whole thing?"
+        contains_any: ["A minor", "Am", "pentatonic", "A minor pentatonic", "C major", "Aeolian", "natural minor"]
+        not_contains: ["I don't know"]
+        must_not_fallback: true
+        min_length: 100
+        max_elapsed_ms: 45000
+
+      - user: "Cool. What arpeggio should I target when the F chord comes around?"
+        references: ["F"]
+        contains_any: ["F", "A", "C", "arpeggio", "F major", "triad", "chord tone"]
+        min_length: 60
+        max_elapsed_ms: 45000
+
+      - user: "Which notes are the strongest to land on over that progression?"
+        contains_any: ["chord tone", "root", "third", "3rd", "fifth", "5th", "target", "A", "C", "E"]
+        min_length: 60
+        max_elapsed_ms: 45000
+
+      - user: "If I wanted a darker, more exotic sound over the Am, what mode could I try?"
+        references: ["A"]
+        contains_any: ["Phrygian", "Dorian", "harmonic minor", "Phrygian dominant", "mode"]
+        min_length: 60
+        max_elapsed_ms: 45000
+
+  # ── Journey 4: Jazz & advanced harmony ──────────────────────────────────
+  # ii-V-I in a key → tritone sub → voice leading → an extended/altered voicing.
+  - id: jazz-ii-v-i-reharm
+    persona: jazz-advanced-harmony
+    description: >
+      Jazz player on a ii-V-I in C: spell it → tritone-sub the V → smooth the
+      voice leading → ask for an extended voicing.
+    turns:
+      - user: "Give me a ii-V-I progression in C major with seventh chords."
+        contains_any: ["Dm7", "G7", "Cmaj7", "ii", "V", "I"]
+        must_not_fallback: true
+        min_length: 60
+        max_elapsed_ms: 45000
+
+      - user: "Now substitute the V chord with its tritone substitution."
+        references: ["G7", "Db7"]
+        contains_any: ["Db7", "tritone", "Db", "substitut"]
+        min_length: 60
+        max_elapsed_ms: 45000
+
+      - user: "How does the voice leading move from that sub chord into the Cmaj7?"
+        references: ["Cmaj7"]
+        contains_any: ["voice leading", "semitone", "half step", "chromatic", "resolve", "F", "B", "Db", "C"]
+        min_length: 60
+        max_elapsed_ms: 45000
+
+      - user: "Give me a richer extended voicing for that Cmaj7 to finish on."
+        references: ["Cmaj7"]
+        contains_any: ["Cmaj9", "maj9", "maj7", "9", "13", "6/9", "add", "extended", "E", "B", "D"]
+        min_length: 50
+        max_elapsed_ms: 45000

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml
@@ -170,3 +170,75 @@ sessions:
         contains_any: ["Cmaj9", "maj9", "maj7", "9", "13", "6/9", "add", "extended", "E", "B", "D"]
         min_length: 50
         max_elapsed_ms: 45000
+
+  # ── Journey 5: Pitch-class set theory (GA SetClass / atonal domain) ──────
+  # GA's differentiated engine, not generic guitar advice: interval-class
+  # vector → Z-relation → transposition/inversion equivalence → symmetric
+  # families. Exercises the SetClass analysis path + OPTIC-K's atonal catalog.
+  - id: pc-set-analysis
+    persona: pc-set-theory
+    description: >
+      A theorist probing GA's pitch-class set engine on the all-interval
+      tetrachord {0,1,4,6}: its interval-class vector → its Z-partner →
+      whether they are T/I-equivalent → which modal families are symmetric.
+    turns:
+      - user: "What is the interval-class vector of the pitch-class set {0,1,4,6}?"
+        contains_any: ["interval", "vector", "ICV", "[1", "1 1 1 1 1 1", "1,1,1,1,1,1", "all-interval"]
+        not_contains: ["I don't know", "returned no matches", "index is not loaded"]
+        min_length: 40
+        max_elapsed_ms: 45000
+
+      - user: "Is that set Z-related to a different set class with the same vector?"
+        references: ["0,1,4,6", "0146", "0", "tetrachord"]
+        contains_any: ["Z", "Z-related", "0,1,3,7", "0137", "same", "vector"]
+        min_length: 40
+        max_elapsed_ms: 45000
+
+      - user: "Are {0,1,4,6} and {0,1,3,7} equivalent under transposition or inversion?"
+        contains_any: ["no", "not", "distinct", "transposition", "inversion", "Z"]
+        min_length: 40
+        max_elapsed_ms: 45000
+
+      - user: "Which modal families in your catalog are symmetric under transposition?"
+        contains_any: ["symmetric", "whole tone", "whole-tone", "diminished", "octatonic", "augmented", "family", "families"]
+        not_contains: ["returned no matches"]
+        min_length: 60
+        max_elapsed_ms: 45000
+
+  # ── Journey 6: OPTIC-K voicing search & navigation ──────────────────────
+  # GA's crown jewel: the 240-dim OPTIC-K voicing index. find voicings →
+  # easier ones → nearest neighbors in the index → a voice-leading move.
+  # The universal banned markers ("returned no matches", "index is not
+  # loaded") turn an unloaded/empty OPTIC-K index into a hard turn failure —
+  # exactly the reliability signal we want on this path.
+  - id: optick-voicing-search
+    persona: optick-voicing-search
+    description: >
+      A guitarist mining the OPTIC-K voicing index: find voicings for a chord →
+      easier versions → nearest neighbors in the index → a smooth voice-leading
+      target.
+    turns:
+      - user: "Find me some playable guitar voicings for a Cmaj7 chord."
+        contains_any: ["voicing", "fret", "string", "Cmaj7", "x", "shape", "position"]
+        not_contains: ["returned no matches", "index is not loaded"]
+        min_length: 60
+        max_elapsed_ms: 60000
+
+      - user: "Show me easier versions of those voicings."
+        references: ["Cmaj7"]
+        contains_any: ["easier", "open", "simpler", "fret", "Cmaj7", "voicing"]
+        not_contains: ["returned no matches", "index is not loaded"]
+        min_length: 50
+        max_elapsed_ms: 60000
+
+      - user: "What voicings are the nearest neighbors to that shape in the index?"
+        contains_any: ["neighbor", "similar", "nearest", "voicing", "index", "distance", "close"]
+        not_contains: ["index is not loaded"]
+        min_length: 50
+        max_elapsed_ms: 60000
+
+      - user: "Give me a voicing that voice-leads smoothly into a Dm7."
+        references: ["Dm7"]
+        contains_any: ["voice leading", "voice-leading", "Dm7", "smooth", "common tone", "move", "voicing", "fret"]
+        min_length: 50
+        max_elapsed_ms: 60000

--- a/Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj
+++ b/Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <None Update="Corpus\prompts.yaml" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="Corpus\sessions.yaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/quality/chatbot-session-corpus.md
+++ b/docs/quality/chatbot-session-corpus.md
@@ -1,0 +1,67 @@
+# Chatbot session corpus — the multi-turn axis of the improvement loop
+
+**Added:** 2026-06-16 · **Type:** quality oracle (mechanical axis)
+
+## Why
+
+The single-turn corpus (`prompts.yaml`, 56 prompts) asserts invariants on one-shot
+answers. It is structurally blind to **conversation** bugs: a follow-up that falls
+back, an answer that forgets "those chords" two turns later, a journey that works
+prompt-by-prompt but not as a session. Real guitarists don't ask one question —
+they have a conversation. This corpus measures that.
+
+## What
+
+`Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml` defines full multi-turn
+conversations across four guitarist journeys (beginner onboarding, songwriting &
+progressions, improv scales/modes, jazz & advanced harmony).
+`SessionCorpusTests.EverySession_SatisfiesItsInvariants` replays each one
+turn-by-turn against `GaChatbot.Api`, passing the **accumulating
+`ConversationHistory`** on every request — the exact path the live `/chatbot` UI
+uses — so context-dependent turns actually carry state.
+
+`Scripts/run-session-corpus.ps1 -Snapshot` emits a trend snapshot to
+`state/quality/chatbot-qa-sessions/YYYY-MM-DD.json` with `session_pass_pct`.
+
+### The context-retention invariant
+
+The one invariant single-turn corpora cannot express: a turn's `references:` are
+substrings the answer must carry **because a prior turn established them**. If turn
+2 ("give me a progression using *those* chords") drops every chord turn 1 taught,
+that's a `lost conversation context` failure — caught here, invisible elsewhere.
+
+All invariants are **mechanical** (routing, grounding presence, no-fallback,
+context retention, banned phrases, latency). That is deliberate: the mechanical
+axis is deterministically verifiable and therefore safe for the autonomous loop to
+optimise against.
+
+## How the loop/goal consumes it
+
+`state/quality/chatbot-qa-sessions/baseline.json` is the setpoint contract — the
+same shape as the single-turn `chatbot-qa/baseline.json` the `/auto-optimize` loop
+already reads. The loop's session-axis cycle:
+
+1. **Measure** — `run-session-corpus.ps1 -Snapshot` → `session_pass_pct` + the
+   failing-turn list.
+2. **Target** — pick the worst failing turn (a stable miss like "tritone sub →
+   Db7", or a lost-context turn) and fix the responsible skill/agent within
+   `scope_boundary.allow_edit`.
+3. **Re-measure → ratchet** — commit only if `session_pass_pct` did not regress
+   (`reject_on_regression`, threshold 0.06 — wider than single-turn because a
+   16-turn corpus is coarse and multi-turn LLM variance is higher).
+4. **Grow** — the loop may **add** new sessions/turns (gear/tuning, technique,
+   ear-training — see `baseline.json:corpus_growth`). New journeys start as failing
+   targets; lifting them is the work. The loop must **not weaken** existing
+   invariants to pass them.
+
+## Boundary held
+
+Multi-turn answer **helpfulness/tone** is fuzzy and stays human/Demerzel-tribunal-
+gated. This corpus never encodes it, and an LLM-judge of session quality must never
+drive the inner loop — the same line the whole nested-loop design holds.
+
+## Seed baseline (2026-06-16)
+
+`session_pass_pct ≈ 0.69–0.81` across runs (11–13 / 16 turns). Stable target:
+jazz tritone-substitution turn. Flaky targets: the two jazz context-retention
+turns (Cmaj7) and two borderline `min_length` turns — first loop work items.

--- a/docs/quality/chatbot-session-corpus.md
+++ b/docs/quality/chatbot-session-corpus.md
@@ -13,8 +13,15 @@ they have a conversation. This corpus measures that.
 ## What
 
 `Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml` defines full multi-turn
-conversations across four guitarist journeys (beginner onboarding, songwriting &
-progressions, improv scales/modes, jazz & advanced harmony).
+conversations across six journeys. Two target **GA's differentiated domain** —
+**pitch-class set theory** (the SetClass engine: interval-class vector,
+Z-relation, T/I equivalence, symmetric families) and the **OPTIC-K voicing
+index** (search, easier voicings, nearest neighbors, voice leading) — because
+that is what makes GA more than a generic chatbot. The other four are
+music-theory journeys (beginner onboarding, songwriting & progressions, improv
+scales/modes, jazz & advanced harmony). Generic guitar-teacher content
+(practice routines, metronome, gear/tuning) is deliberately **out of scope** —
+not GA's value.
 `SessionCorpusTests.EverySession_SatisfiesItsInvariants` replays each one
 turn-by-turn against `GaChatbot.Api`, passing the **accumulating
 `ConversationHistory`** on every request — the exact path the live `/chatbot` UI
@@ -62,6 +69,11 @@ drive the inner loop — the same line the whole nested-loop design holds.
 
 ## Seed baseline (2026-06-16)
 
-`session_pass_pct ≈ 0.69–0.81` across runs (11–13 / 16 turns). Stable target:
-jazz tritone-substitution turn. Flaky targets: the two jazz context-retention
-turns (Cmaj7) and two borderline `min_length` turns — first loop work items.
+`session_pass_pct = 0.75` (18/24 turns, 6 journeys). **GA's differentiated
+domain is mostly reliable through the chatbot:** the OPTIC-K voicing-search
+journey passes 4/4 (index loaded, search → easier → neighbors → voice-leading
+all answered), and pitch-class set theory passes 3/4. **Stable GA-domain
+target:** the Z-relation lookup (pc-set turn 2 — the chatbot answers ICV and
+T/I-equivalence but does not surface the Z-partner {0,1,3,7}). Other failures
+are on the lower-priority music-theory journeys (jazz tritone-sub, a couple of
+context-retention and `min_length` turns) — the first loop work items.

--- a/state/quality/chatbot-qa-sessions/2026-06-16.json
+++ b/state/quality/chatbot-qa-sessions/2026-06-16.json
@@ -2,14 +2,17 @@
   "schema_version": 1,
   "date": "2026-06-16",
   "metric": "session_pass_pct",
-  "sessions": 4,
-  "turns_total": 16,
-  "turns_passed": 13,
-  "session_pass_pct": 0.812,
+  "sessions": 6,
+  "turns_total": 24,
+  "turns_passed": 18,
+  "session_pass_pct": 0.75,
   "failures": [
-    "[beginner-onboarding/beginner-first-chords] turn 3: 'How do I switch between those chords smoothly without stoppi...'  ->  too short (70 < 80 chars)",
+    "[beginner-onboarding/beginner-first-chords] turn 4: 'And what's an easy strumming pattern for that?'  ->  none of contains_any matched: [down, up, strum, pattern, D-D-U, downstroke, rhythm]",
     "[improv-scales-modes/improv-over-am-progression] turn 2: 'Cool. What arpeggio should I target when the F chord comes a...'  ->  too short (35 < 60 chars)",
-    "[jazz-advanced-harmony/jazz-ii-v-i-reharm] turn 2: 'Now substitute the V chord with its tritone substitution.'  ->  none of contains_any matched: [Db7, tritone, Db, substitut]"
+    "[jazz-advanced-harmony/jazz-ii-v-i-reharm] turn 2: 'Now substitute the V chord with its tritone substitution.'  ->  none of contains_any matched: [Db7, tritone, Db, substitut]",
+    "[jazz-advanced-harmony/jazz-ii-v-i-reharm] turn 3: 'How does the voice leading move from that sub chord into the...'  ->  lost conversation context: none of the prior-turn references appeared [Cmaj7]",
+    "[jazz-advanced-harmony/jazz-ii-v-i-reharm] turn 4: 'Give me a richer extended voicing for that Cmaj7 to finish o...'  ->  lost conversation context: none of the prior-turn references appeared [Cmaj7]",
+    "[pc-set-theory/pc-set-analysis] turn 2: 'Is that set Z-related to a different set class with the same...'  ->  none of contains_any matched: [Z, Z-related, 0,1,3,7, 0137, same, vector]"
   ],
   "degraded": false,
   "source": "run-session-corpus"

--- a/state/quality/chatbot-qa-sessions/2026-06-16.json
+++ b/state/quality/chatbot-qa-sessions/2026-06-16.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "date": "2026-06-16",
+  "metric": "session_pass_pct",
+  "sessions": 4,
+  "turns_total": 16,
+  "turns_passed": 13,
+  "session_pass_pct": 0.812,
+  "failures": [
+    "[beginner-onboarding/beginner-first-chords] turn 3: 'How do I switch between those chords smoothly without stoppi...'  ->  too short (70 < 80 chars)",
+    "[improv-scales-modes/improv-over-am-progression] turn 2: 'Cool. What arpeggio should I target when the F chord comes a...'  ->  too short (35 < 60 chars)",
+    "[jazz-advanced-harmony/jazz-ii-v-i-reharm] turn 2: 'Now substitute the V chord with its tritone substitution.'  ->  none of contains_any matched: [Db7, tritone, Db, substitut]"
+  ],
+  "degraded": false,
+  "source": "run-session-corpus"
+}

--- a/state/quality/chatbot-qa-sessions/baseline.json
+++ b/state/quality/chatbot-qa-sessions/baseline.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "domain": "chatbot-qa-sessions",
+  "purpose": "Setpoint contract for the MULTI-TURN session axis of the chatbot improvement loop. Mirrors state/quality/chatbot-qa/baseline.json (the single-turn axis) so /auto-optimize can target session_pass_pct the same way it targets pass_pct. Replayed by SessionCorpusTests.EverySession_SatisfiesItsInvariants over Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml; snapshot emitted by Scripts/run-session-corpus.ps1 -Snapshot.",
+  "established_at": "2026-06-16",
+  "established_by": "session-corpus seed (4 guitarist journeys: beginner, songwriting, improv, jazz)",
+  "metric": "session_pass_pct",
+  "metric_description": "Fraction of session TURNS that pass all mechanical invariants when each session is replayed turn-by-turn with accumulating ConversationHistory. Mechanical axis only — routing, grounding presence, no-fallback, context retention (the `references` field), banned phrases, latency. Fuzzy answer-quality is NOT measured here; it stays human/Demerzel-tribunal-gated.",
+  "primary_baseline": 0.69,
+  "primary_baseline_source": "First seed replay 2026-06-16 against in-runner-comparable Ollama (llama3.2:3b + nomic-embed-text). Two runs observed 11/16 (68.8%) and 13/16 (81.2%) — multi-turn LLM variance is higher than single-turn, so the floor is pinned at the observed minimum, not the mean. The loop's job is to lift it and re-pin.",
+  "_harness": {
+    "runner": "Scripts/run-session-corpus.ps1",
+    "oracle_test": "SessionCorpusTests.EverySession_SatisfiesItsInvariants",
+    "snapshot_glob": "state/quality/chatbot-qa-sessions/YYYY-MM-DD.json",
+    "reject_on_loss": true,
+    "reject_on_regression": true,
+    "regression_threshold": 0.06,
+    "regression_threshold_rationale": "Wider than the single-turn 0.02 because a 16-turn corpus has coarse granularity (one turn = 6.25%) and higher run-to-run LLM variance. Tighten as the corpus grows."
+  },
+  "kill_switches": {
+    "global": "state/.loop-halted",
+    "per_domain": "state/quality/chatbot-qa-sessions/.STOP"
+  },
+  "scope_boundary": {
+    "allow_edit": [
+      "Common/GA.Business.ML/Agents/**",
+      "Common/GA.Business.ML/Skills/**",
+      "Common/GA.Business.Core.Orchestration/**",
+      "Apps/GaChatbot.Api/Services/**"
+    ],
+    "allow_edit_rationale": "The loop fixes the chatbot's behaviour — skills, agents, orchestration, narration — to make failing session turns pass.",
+    "protected": [
+      "Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml",
+      "Tests/Apps/GaChatbot.Api.Tests/Corpus/SessionCorpusTests.cs",
+      "state/quality/chatbot-qa-sessions/baseline.json"
+    ],
+    "protected_rationale": "The loop must not weaken the measure to pass it. It MAY ADD new sessions/turns (corpus growth is the point of the user request) but must not relax or delete existing invariants without an explicit [allow-protected: <path>] override and human sign-off."
+  },
+  "corpus_growth": {
+    "intent": "The loop/goal should GROW this corpus over time — adding new guitarist journeys and turns that real players would ask — so multi-turn coverage compounds. New sessions are additive and start as failing targets; lifting them is the loop's work.",
+    "seed_personas": ["beginner-onboarding", "songwriting-progressions", "improv-scales-modes", "jazz-advanced-harmony"],
+    "candidate_next": ["gear-and-tuning (capo, alternate tunings, transposing for a singer)", "technique-and-practice (routines, exercises, difficulty ramps)", "ear-training", "song-specific learning journeys"]
+  },
+  "constraints": {
+    "max_commits_per_session": 50,
+    "max_wall_clock_minutes": 480,
+    "plateau_window": 5,
+    "plateau_threshold": 0.005
+  },
+  "design_boundary": "Mechanical axis only — this corpus is safe for the autonomous loop to optimise against. Multi-turn answer HELPFULNESS/TONE is fuzzy and stays human/Demerzel-tribunal-gated; never let an LLM-judge of session quality drive the inner loop."
+}

--- a/state/quality/chatbot-qa-sessions/baseline.json
+++ b/state/quality/chatbot-qa-sessions/baseline.json
@@ -3,11 +3,11 @@
   "domain": "chatbot-qa-sessions",
   "purpose": "Setpoint contract for the MULTI-TURN session axis of the chatbot improvement loop. Mirrors state/quality/chatbot-qa/baseline.json (the single-turn axis) so /auto-optimize can target session_pass_pct the same way it targets pass_pct. Replayed by SessionCorpusTests.EverySession_SatisfiesItsInvariants over Tests/Apps/GaChatbot.Api.Tests/Corpus/sessions.yaml; snapshot emitted by Scripts/run-session-corpus.ps1 -Snapshot.",
   "established_at": "2026-06-16",
-  "established_by": "session-corpus seed (4 guitarist journeys: beginner, songwriting, improv, jazz)",
+  "established_by": "session-corpus seed refocused on GA's differentiated domain — pitch-class set theory (SetClass: ICV, Z-relation, T/I equivalence, symmetric families) and the OPTIC-K voicing index (search, easier voicings, neighbors, voice leading) — alongside the music-theory journeys (beginner, songwriting, improv, jazz). Generic guitar-teacher journeys (gear/tuning, practice/metronome) deliberately excluded: not GA's value.",
   "metric": "session_pass_pct",
   "metric_description": "Fraction of session TURNS that pass all mechanical invariants when each session is replayed turn-by-turn with accumulating ConversationHistory. Mechanical axis only — routing, grounding presence, no-fallback, context retention (the `references` field), banned phrases, latency. Fuzzy answer-quality is NOT measured here; it stays human/Demerzel-tribunal-gated.",
-  "primary_baseline": 0.69,
-  "primary_baseline_source": "First seed replay 2026-06-16 against in-runner-comparable Ollama (llama3.2:3b + nomic-embed-text). Two runs observed 11/16 (68.8%) and 13/16 (81.2%) — multi-turn LLM variance is higher than single-turn, so the floor is pinned at the observed minimum, not the mean. The loop's job is to lift it and re-pin.",
+  "primary_baseline": 0.70,
+  "primary_baseline_source": "Seed replay 2026-06-16 (6 journeys, 24 turns) against in-runner-comparable Ollama (llama3.2:3b + nomic-embed-text): 18/24 (75.0%). GA-domain journeys are strong — OPTIC-K voicing search 4/4, pitch-class set theory 3/4 (only the Z-relation lookup missed). Floor pinned conservatively at 0.70 (below the observed 0.75) for multi-turn LLM variance; the loop's job is to lift it and re-pin. Known stable targets: Z-relation lookup (pc-set turn 2), jazz tritone-sub (Db7).",
   "_harness": {
     "runner": "Scripts/run-session-corpus.ps1",
     "oracle_test": "SessionCorpusTests.EverySession_SatisfiesItsInvariants",
@@ -37,9 +37,10 @@
     "protected_rationale": "The loop must not weaken the measure to pass it. It MAY ADD new sessions/turns (corpus growth is the point of the user request) but must not relax or delete existing invariants without an explicit [allow-protected: <path>] override and human sign-off."
   },
   "corpus_growth": {
-    "intent": "The loop/goal should GROW this corpus over time — adding new guitarist journeys and turns that real players would ask — so multi-turn coverage compounds. New sessions are additive and start as failing targets; lifting them is the loop's work.",
-    "seed_personas": ["beginner-onboarding", "songwriting-progressions", "improv-scales-modes", "jazz-advanced-harmony"],
-    "candidate_next": ["gear-and-tuning (capo, alternate tunings, transposing for a singer)", "technique-and-practice (routines, exercises, difficulty ramps)", "ear-training", "song-specific learning journeys"]
+    "intent": "The loop/goal should GROW this corpus over time toward GA's DIFFERENTIATED domain — pitch-class set theory (GA SetClass) and the OPTIC-K voicing index — rather than generic guitar advice. New sessions are additive and start as failing targets; lifting them is the loop's work.",
+    "focus": "GA domain classes (Note, Interval, Scale, Chord, Key, Fretboard, SetClass) + OPTIC-K voicing index. NOT practice routines, metronome, or gear (explicitly out of scope per user 2026-06-16).",
+    "seed_personas": ["pc-set-theory", "optick-voicing-search", "beginner-onboarding", "songwriting-progressions", "improv-scales-modes", "jazz-advanced-harmony"],
+    "candidate_next": ["more SetClass (Forte numbers, cardinality, modal set classes, prime form, complement)", "more OPTIC-K (by-query voicing search, ICV neighbors, generate-embedding, index-info, telemetry)", "Fretboard domain (positions, tunings as domain objects, fingerings)", "Interval/voice-leading domain (common tones as set-theory, voice-leading pairs)"]
   },
   "constraints": {
     "max_commits_per_session": 50,


### PR DESCRIPTION
## What
Adds the **multi-turn** counterpart to the single-turn prompt corpus, so the loops/goals evaluate **full chatbot conversations a guitarist would actually have**, not just one-shot prompts.

Four realistic journeys (selected with the user), 16 turns total, each replayed against `GaChatbot.Api` with the **accumulating `ConversationHistory`** — the exact path the live `/chatbot` UI uses:

| Journey | Persona |
|---|---|
| Beginner onboarding | first chords → progression with them → smooth changes → strum |
| Songwriting & progressions | diatonic palette → 4-chord progression → borrow a chord → key |
| Improv: scales & modes | scale over a vamp → arpeggios per chord → target tones → a mode |
| Jazz & advanced harmony | ii-V-I → tritone sub → voice leading → extended voicing |

## The new invariant: context retention
`SessionCorpusTests` mirrors `PromptCorpusTests` (same host, request/response shape, banned markers) and adds **`references`** — substrings an answer must carry *because a prior turn established them*. A miss = `lost conversation context`, the failure class single-turn corpora are structurally blind to (e.g. "give me a voicing for **that Cmaj7**" two turns later).

All invariants are **mechanical** (routing, grounding, no-fallback, context retention, banned phrases, latency) — safe for the autonomous loop. Fuzzy session *helpfulness* stays human/Demerzel-tribunal-gated.

## Loop/goal integration
- **`run-session-corpus.ps1 -Snapshot`** → `state/quality/chatbot-qa-sessions/YYYY-MM-DD.json` (`session_pass_pct`), with the oracle-paranoia guard (no summary line ⇒ `couldnt_run` ⇒ no snapshot, exit 2).
- **`baseline.json`** — setpoint contract mirroring `chatbot-qa/baseline.json`, so `/auto-optimize` targets `session_pass_pct` the same way it targets `pass_pct`. Declares `scope_boundary` (loop may **grow** the corpus, never weaken invariants) and candidate next journeys (gear/tuning, technique, ear-training).
- **`docs/quality/chatbot-session-corpus.md`** — how the loop consumes + grows it.

## Verification (local, live Ollama — llama3.2:3b + nomic-embed-text)
- Build clean (0 errors). `Sessions_LoadAtLeastOne` passes.
- Full replay runs end-to-end, accumulating history; the **context-retention invariant fires on real lost-context turns**.
- `session_pass_pct ≈ 0.69–0.81` across runs (11–13/16). **Stable target:** jazz tritone-substitution turn (Db7). Flaky: two jazz Cmaj7 context turns + two borderline `min_length` — the loop's first work items.

## Deferred (follow-up)
Wiring the session snapshot into the in-runner-Ollama CI workflow lands after #411 merges (avoids editing that PR's file); the `/auto-optimize` SKILL Step reference lands after the loop-analytics branch converges. Tracked in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)