### PR TITLE
fix(chatbot): set-theory reliability — deterministic routing + canonical Forte lookup

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Intents/AlgebraIntent.cs
+++ b/Common/GA.Business.Core.Orchestration/Intents/AlgebraIntent.cs
@@ -31,6 +31,20 @@ public sealed class AlgebraIntent(IIxAlgebraService algebraService) : IIntent
         "Are these Z-related: 0136 and 0146?",
         "Set class summary for [0,1,3,7]",
         "Interval-class vector of 014",
+        // Natural-language phrasings real users type. Added 2026-06-16: the
+        // short canonical examples above scored below the router threshold for
+        // verbose questions, so "is the pitch class set 0,1,4,6 z-related to
+        // another set class" fell through to the LLM path and timed out at 15s
+        // instead of reaching this deterministic engine. These are additional
+        // embedding anchors (the semantic-routing lever) — not keyword rules.
+        "Is the pitch class set 0,1,4,6 Z-related to another set class?",
+        "Does the set 0,1,4,6 have a Z-partner, and what is it?",
+        "Which set class has the same interval-class vector as 0,1,4,6?",
+        "Tell me the Forte label and Z-relation of the pitch-class set 0,1,3,7",
+        // NOTE: deliberately NOT adding "what is Forte number 4-Z29" — that is a
+        // reverse Forte-label→set LOOKUP the engine doesn't support yet; routing
+        // it here would extract {2,9} from "29" and answer the wrong question.
+        // Tracked as a missing feature (reverse ForteCatalog lookup).
     ];
 
     public async Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default)

--- a/Common/GA.Business.Core.Orchestration/Intents/AlgebraIntent.cs
+++ b/Common/GA.Business.Core.Orchestration/Intents/AlgebraIntent.cs
@@ -41,10 +41,9 @@ public sealed class AlgebraIntent(IIxAlgebraService algebraService) : IIntent
         "Does the set 0,1,4,6 have a Z-partner, and what is it?",
         "Which set class has the same interval-class vector as 0,1,4,6?",
         "Tell me the Forte label and Z-relation of the pitch-class set 0,1,3,7",
-        // NOTE: deliberately NOT adding "what is Forte number 4-Z29" — that is a
-        // reverse Forte-label→set LOOKUP the engine doesn't support yet; routing
-        // it here would extract {2,9} from "29" and answer the wrong question.
-        // Tracked as a missing feature (reverse ForteCatalog lookup).
+        // Reverse Forte-label lookup (label → set class), e.g. "4-Z29".
+        "What is Forte number 4-Z29?",
+        "Which set class is Forte 3-11?",
     ];
 
     public async Task<IntentResult> ExecuteAsync(string query, CancellationToken cancellationToken = default)

--- a/Common/GA.Business.Core.Orchestration/Services/IxAlgebraService.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/IxAlgebraService.cs
@@ -354,6 +354,28 @@ public sealed partial class IxAlgebraService(
             return results;
         }
 
+        // Comma/space-separated bare pitch-class lists WITHOUT brackets, e.g.
+        // "0,1,4,6" or "0 1 4 6". Without this, the bracketed pass misses and
+        // the contiguous pass below splits "0,1,4,6" into single rejected
+        // digits, so a perfectly well-formed set-theory question extracts
+        // nothing and the deterministic engine never runs (it fell through to
+        // the LLM and timed out). Require >= 3 tokens so prose like "bars 2, 4"
+        // or an interval "0, 7" can't be mistaken for a pc-set. This is data
+        // extraction, not query routing.
+        foreach (Match match in SeparatedSetRegex().Matches(query))
+        {
+            var candidate = string.Concat(TokenRegex().Matches(match.Value).Select(m => NormalizeToken(m.Value)));
+            if (TryParsePitchClassSet(candidate, out var set))
+            {
+                results.Add(set);
+            }
+        }
+
+        if (results.Count > 0)
+        {
+            return results;
+        }
+
         foreach (Match match in CompactSetRegex().Matches(query))
         {
             if (TryParsePitchClassSet(match.Value, out var set))
@@ -412,6 +434,13 @@ public sealed partial class IxAlgebraService(
 
     [GeneratedRegex(@"[\[\{][^\]\}]+[\]\}]", RegexOptions.CultureInvariant)]
     private static partial Regex BracketedSetRegex();
+
+    // A run of >= 3 pitch-class tokens separated by commas/spaces, e.g.
+    // "0,1,4,6" or "0 1 4 6 9". Used only to pull a set out of a query the
+    // router already classified as set-theory; the >= 3 floor avoids matching
+    // ordinary number pairs in prose.
+    [GeneratedRegex(@"\b(?:10|11|[0-9TEte])(?:\s*,\s*|\s+)(?:10|11|[0-9TEte])(?:(?:\s*,\s*|\s+)(?:10|11|[0-9TEte]))+\b", RegexOptions.CultureInvariant)]
+    private static partial Regex SeparatedSetRegex();
 
     [GeneratedRegex(@"\b(?:10|11|[0-9]|[TEAB])+\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex CompactSetRegex();

--- a/Common/GA.Business.Core.Orchestration/Services/IxAlgebraService.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/IxAlgebraService.cs
@@ -152,13 +152,25 @@ public sealed partial class IxAlgebraService(
 
     private IxAlgebraAnswer? TryAnswerInternally(string query)
     {
+        var normalized = query.ToLowerInvariant();
+
+        // Reverse Forte-label lookup: "what is Forte number 4-Z29" → prime form.
+        // Must run BEFORE set extraction, otherwise "4-Z29" gets mis-parsed as a
+        // pitch-class set ("29" → {2,9}) and answered as the wrong question.
+        if (normalized.Contains("forte"))
+        {
+            var reverse = TryAnswerForteLookup(query);
+            if (reverse is not null)
+            {
+                return reverse;
+            }
+        }
+
         var sets = ExtractPitchClassSets(query);
         if (sets.Count == 0)
         {
             return null;
         }
-
-        var normalized = query.ToLowerInvariant();
 
         if (normalized.Contains("z-related") || normalized.Contains("z relation") || normalized.Contains("z-pair"))
         {
@@ -235,6 +247,35 @@ public sealed partial class IxAlgebraService(
                 ? $"The Forte label for {FormatSet(set)} is {forteText}."
                 : $"I could compute the prime form for {FormatSet(set)}, but no Forte label was available.",
             "forte",
+            facts);
+    }
+
+    // Reverse direction of AnswerForte: a canonical Forte label (e.g. "4-Z29")
+    // → the set class it names, using Allen Forte's 1973 numbering
+    // (CanonicalForteCatalog) — NOT GA's internal Rahn ordering, because a user
+    // typing "4-Z29" means the canonical [0,1,3,7], not Rahn index 29. Returns
+    // null when the query carries no Forte-label token or the label isn't in the
+    // canonical catalog, so the caller falls through to the set-extraction path.
+    private IxAlgebraAnswer? TryAnswerForteLookup(string query)
+    {
+        var match = ForteLabelRegex().Match(query);
+        if (!match.Success || !CanonicalForteCatalog.TryGetPrimeForm(match.Value, out var primeForm))
+        {
+            return null;
+        }
+
+        var facts = new Dictionary<string, string>
+        {
+            ["forte"] = match.Value,
+            ["primeForm"] = FormatSet(primeForm),
+            ["intervalClassVector"] = primeForm.IntervalClassVector.ToString(),
+            ["catalog"] = "forte-1973"
+        };
+
+        return CreateAnswer(
+            $"Forte {match.Value} is the set class with prime form {FormatSet(primeForm)} " +
+            $"(interval-class vector {primeForm.IntervalClassVector}).",
+            "forte-lookup",
             facts);
     }
 
@@ -434,6 +475,11 @@ public sealed partial class IxAlgebraService(
 
     [GeneratedRegex(@"[\[\{][^\]\}]+[\]\}]", RegexOptions.CultureInvariant)]
     private static partial Regex BracketedSetRegex();
+
+    // A Forte label: cardinality-index with an optional Z marker on the index,
+    // e.g. "4-Z29", "4-z15", "3-11". Used for reverse lookup (label → set).
+    [GeneratedRegex(@"\b\d{1,2}-Z?\d{1,2}\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ForteLabelRegex();
 
     // A run of >= 3 pitch-class tokens separated by commas/spaces, e.g.
     // "0,1,4,6" or "0 1 4 6 9". Used only to pull a set out of a query the

--- a/Common/GA.Domain.Core/Theory/Atonal/CanonicalForteCatalog.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/CanonicalForteCatalog.cs
@@ -1,0 +1,216 @@
+namespace GA.Domain.Core.Theory.Atonal;
+
+/// <summary>
+///     Allen Forte's canonical 1973 set-class catalog (<c>The Structure of
+///     Atonal Music</c>) — label → prime form. This is the STANDARD numbering a
+///     user means when they type "4-Z29", and it differs from GA's internal
+///     <see cref="ProgrammaticForteCatalog"/> (which uses Rahn ordering and does
+///     not model the Z marker). Use this for human-facing Forte-label lookups;
+///     use the programmatic catalog for GA's internal Rahn-consistent work.
+/// </summary>
+/// <remarks>
+///     Only cardinalities 0–6 are stored. Cardinalities 7–12 are derived at
+///     lookup time via Forte's complement rule: for n ≠ 6, the set class
+///     <c>n-k</c> and its complement <c>(12−n)-k</c> share the same index and
+///     Z-status, so e.g. "8-Z15" resolves to the complement of "4-Z15". The
+///     stored prime forms are the standard Forte-column values from the
+///     canonical catalog; <c>CanonicalForteCatalogTests</c> verifies every entry
+///     against GA's own engine (bijection with <see cref="SetClass.Items"/>,
+///     per-cardinality counts, and Z-marker ⇔ <see cref="PitchClassSet.IsZRelated"/>).
+/// </remarks>
+public static class CanonicalForteCatalog
+{
+    // Pitch classes: 0-9, T=10, E=11. One "label primeForm" pair per line,
+    // cardinalities 0-6 only. Z marker is part of the label.
+    private const string CoreData = """
+        1-1 0
+        2-1 01
+        2-2 02
+        2-3 03
+        2-4 04
+        2-5 05
+        2-6 06
+        3-1 012
+        3-2 013
+        3-3 014
+        3-4 015
+        3-5 016
+        3-6 024
+        3-7 025
+        3-8 026
+        3-9 027
+        3-10 036
+        3-11 037
+        3-12 048
+        4-1 0123
+        4-2 0124
+        4-3 0134
+        4-4 0125
+        4-5 0126
+        4-6 0127
+        4-7 0145
+        4-8 0156
+        4-9 0167
+        4-10 0235
+        4-11 0135
+        4-12 0236
+        4-13 0136
+        4-14 0237
+        4-Z15 0146
+        4-16 0157
+        4-17 0347
+        4-18 0147
+        4-19 0148
+        4-20 0158
+        4-21 0246
+        4-22 0247
+        4-23 0257
+        4-24 0248
+        4-25 0268
+        4-26 0358
+        4-27 0258
+        4-28 0369
+        4-Z29 0137
+        5-1 01234
+        5-2 01235
+        5-3 01245
+        5-4 01236
+        5-5 01237
+        5-6 01256
+        5-7 01267
+        5-8 02346
+        5-9 01246
+        5-10 01346
+        5-11 02347
+        5-Z12 01356
+        5-13 01248
+        5-14 01257
+        5-15 01268
+        5-16 01347
+        5-Z17 01348
+        5-Z18 01457
+        5-19 01367
+        5-20 01568
+        5-21 01458
+        5-22 01478
+        5-23 02357
+        5-24 01357
+        5-25 02358
+        5-26 02458
+        5-27 01358
+        5-28 02368
+        5-29 01368
+        5-30 01468
+        5-31 01369
+        5-32 01469
+        5-33 02468
+        5-34 02469
+        5-35 02479
+        5-Z36 01247
+        5-Z37 03458
+        5-Z38 01258
+        6-1 012345
+        6-2 012346
+        6-Z3 012356
+        6-Z4 012456
+        6-5 012367
+        6-Z6 012567
+        6-7 012678
+        6-8 023457
+        6-9 012357
+        6-Z10 013457
+        6-Z11 012457
+        6-Z12 012467
+        6-Z13 013467
+        6-14 013458
+        6-15 012458
+        6-16 014568
+        6-Z17 012478
+        6-18 012578
+        6-Z19 013478
+        6-20 014589
+        6-21 023468
+        6-22 012468
+        6-Z23 023568
+        6-Z24 013468
+        6-Z25 013568
+        6-Z26 013578
+        6-27 013469
+        6-Z28 013569
+        6-Z29 023679
+        6-30 013679
+        6-31 014579
+        6-32 024579
+        6-33 023579
+        6-34 013579
+        6-35 02468T
+        6-Z36 012347
+        6-Z37 012348
+        6-Z38 012378
+        6-Z39 023458
+        6-Z40 012358
+        6-Z41 012368
+        6-Z42 012369
+        6-Z43 012568
+        6-Z44 012569
+        6-Z45 023469
+        6-Z46 012469
+        6-Z47 012479
+        6-Z48 012579
+        6-Z49 013479
+        6-Z50 014679
+        """;
+
+    private static readonly Lazy<IReadOnlyDictionary<string, PitchClassSet>> _coreByLabel =
+        new(BuildCore, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static IReadOnlyDictionary<string, PitchClassSet> BuildCore()
+    {
+        var map = new Dictionary<string, PitchClassSet>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in CoreData.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 2) continue;
+            if (PitchClassSet.TryParse(parts[1], null, out var set))
+            {
+                map[parts[0]] = set;
+            }
+        }
+        return map;
+    }
+
+    /// <summary>All stored (cardinality 0–6) canonical Forte labels.</summary>
+    public static IReadOnlyDictionary<string, PitchClassSet> CoreByLabel => _coreByLabel.Value;
+
+    /// <summary>
+    ///     Resolves a canonical Forte label (e.g. "4-Z29", "8-Z15", "3-11") to
+    ///     its prime form. Cardinalities 7–12 are derived from the stored
+    ///     complement. Returns false for malformed labels or labels not in the
+    ///     canonical catalog.
+    /// </summary>
+    public static bool TryGetPrimeForm(string? forteLabel, out PitchClassSet primeForm)
+    {
+        primeForm = default!;
+        if (string.IsNullOrWhiteSpace(forteLabel)) return false;
+
+        var label = forteLabel.Trim().ToUpperInvariant();
+        var dash = label.IndexOf('-');
+        if (dash <= 0 || dash == label.Length - 1) return false;
+        if (!int.TryParse(label[..dash], out var cardinality) || cardinality is < 0 or > 12) return false;
+
+        // index part (may carry a leading Z), e.g. "Z29" or "11".
+        var indexPart = label[(dash + 1)..];
+
+        if (cardinality <= 6)
+        {
+            return CoreByLabel.TryGetValue(label, out primeForm!);
+        }
+
+        // Derive cardinality 7–12 from the complement (12−n)-k (same index + Z).
+        var complementLabel = $"{12 - cardinality}-{indexPart}";
+        if (!CoreByLabel.TryGetValue(complementLabel, out var complementSet)) return false;
+
+        primeForm = complementSet.Complement.PrimeForm ?? complementSet.Complement;
+        return true;
+    }
+}

--- a/Tests/Common/GA.Business.Core.Tests/Atonal/CanonicalForteCatalogTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Atonal/CanonicalForteCatalogTests.cs
@@ -1,0 +1,113 @@
+namespace GA.Business.Core.Tests.Atonal;
+
+using GA.Domain.Core.Theory.Atonal;
+
+/// <summary>
+///     Proves the hand-transcribed canonical Forte 1973 catalog
+///     (<see cref="CanonicalForteCatalog"/>) against GA's own atonal engine, so
+///     a transcription error can't ship silently. Four independent constraints:
+///     (1) every stored prime form is a real GA set class, (2) per-cardinality
+///     counts match GA exactly, (3) the catalog is a bijection onto GA's set
+///     classes for cardinalities 1–11, and (4) the Z marker on a label agrees
+///     with GA's computed <see cref="PitchClassSet.IsZRelated"/>.
+/// </summary>
+[TestFixture]
+public class CanonicalForteCatalogTests
+{
+    // GA set classes keyed by canonical (GA) prime-form id, per cardinality.
+    private static Dictionary<int, HashSet<int>> GaSetClassIdsByCardinality()
+    {
+        var byCard = new Dictionary<int, HashSet<int>>();
+        foreach (var sc in SetClass.Items)
+        {
+            var card = sc.PrimeForm.Cardinality.Value;
+            (byCard.TryGetValue(card, out var bucket) ? bucket : byCard[card] = []).Add(sc.PrimeForm.Id.Value);
+        }
+        return byCard;
+    }
+
+    private static int GaPrimeId(PitchClassSet set) => (set.PrimeForm ?? set).Id.Value;
+
+    [Test]
+    public void Core_Counts_Match_GA_Engine_Per_Cardinality()
+    {
+        var ga = GaSetClassIdsByCardinality();
+        var byCard = CanonicalForteCatalog.CoreByLabel
+            .GroupBy(kv => (kv.Value.PrimeForm ?? kv.Value).Cardinality.Value)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        foreach (var card in new[] { 1, 2, 3, 4, 5, 6 })
+        {
+            Assert.That(byCard.GetValueOrDefault(card), Is.EqualTo(ga[card].Count),
+                $"cardinality {card}: canonical catalog has {byCard.GetValueOrDefault(card)} labels but GA has {ga[card].Count} set classes");
+        }
+    }
+
+    [Test]
+    public void Catalog_Is_Bijection_Onto_GA_SetClasses_Cardinalities_1_To_11()
+    {
+        var ga = GaSetClassIdsByCardinality();
+
+        // Build the full canonical id-set: stored cards 1–6 + derived 7–11.
+        var canonical = new Dictionary<int, HashSet<int>>();
+        void Add(int card, int primeId)
+        {
+            var ok = (canonical.TryGetValue(card, out var b) ? b : canonical[card] = []).Add(primeId);
+            Assert.That(ok, Is.True, $"duplicate canonical set class in cardinality {card} (id {primeId})");
+        }
+
+        foreach (var (_, set) in CanonicalForteCatalog.CoreByLabel)
+            Add((set.PrimeForm ?? set).Cardinality.Value, GaPrimeId(set));
+
+        // Derived cardinalities 7–11 via the complement labels.
+        foreach (var (label, set) in CanonicalForteCatalog.CoreByLabel)
+        {
+            var card = (set.PrimeForm ?? set).Cardinality.Value;
+            if (card is < 1 or > 5) continue; // complement lands in 7..11
+            var dash = label.IndexOf('-');
+            var derivedLabel = $"{12 - card}-{label[(dash + 1)..]}";
+            Assert.That(CanonicalForteCatalog.TryGetPrimeForm(derivedLabel, out var derived), Is.True,
+                $"derived label {derivedLabel} failed to resolve");
+            Add((derived.PrimeForm ?? derived).Cardinality.Value, GaPrimeId(derived));
+        }
+
+        foreach (var card in new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 })
+        {
+            Assert.That(canonical.GetValueOrDefault(card) ?? [], Is.EquivalentTo(ga[card]),
+                $"cardinality {card}: canonical set-class ids do not match GA's set classes exactly");
+        }
+    }
+
+    [Test]
+    public void ZMarker_Agrees_With_GA_IsZRelated()
+    {
+        foreach (var (label, set) in CanonicalForteCatalog.CoreByLabel)
+        {
+            var labelSaysZ = label.Contains('Z', StringComparison.OrdinalIgnoreCase);
+            Assert.That(set.IsZRelated, Is.EqualTo(labelSaysZ),
+                $"{label}: label Z-marker={labelSaysZ} but GA IsZRelated={set.IsZRelated}");
+        }
+    }
+
+    [TestCase("4-Z29", "[0,1,3,7]")]
+    [TestCase("4-Z15", "[0,1,4,6]")]
+    [TestCase("3-11", "[0,3,7]")]
+    [TestCase("5-Z12", "[0,1,3,5,6]")]
+    public void ReverseLookup_Returns_Expected_PrimeForm(string label, string expected)
+    {
+        Assert.That(CanonicalForteCatalog.TryGetPrimeForm(label, out var set), Is.True);
+        var prime = set.PrimeForm ?? set;
+        var formatted = "[" + string.Join(",", prime.OrderBy(pc => pc.Value).Select(pc => pc.Value)) + "]";
+        Assert.That(formatted, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ReverseLookup_Derives_Complement_Cardinality_8()
+    {
+        // 8-Z15 is the complement of 4-Z15 = [0,1,4,6]; it must resolve and be
+        // an 8-note set that is itself Z-related.
+        Assert.That(CanonicalForteCatalog.TryGetPrimeForm("8-Z15", out var set), Is.True);
+        Assert.That((set.PrimeForm ?? set).Cardinality.Value, Is.EqualTo(8));
+        Assert.That(set.IsZRelated, Is.True);
+    }
+}

--- a/Tests/Common/GA.Business.Core.Tests/Orchestration/IxAlgebraServiceTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Orchestration/IxAlgebraServiceTests.cs
@@ -61,6 +61,48 @@ public class IxAlgebraServiceTests
     }
 
     [Test]
+    public async Task ZRelation_Query_Accepts_CommaSeparated_Set_Without_Brackets()
+    {
+        // Regression guard (2026-06-16): "0,1,4,6" (comma-separated, no
+        // brackets) is the most natural way a user types a pitch-class set, but
+        // ExtractPitchClassSets used to split it into single rejected digits, so
+        // the deterministic engine never ran and the chatbot fell through to the
+        // LLM and timed out. This locks the comma/space-separated extraction.
+        var service = CreateService(new Dictionary<string, string?>
+        {
+            ["IX:Revision"] = "7b02a56",
+            ["IX:Source"] = "ix-compatible",
+            ["IX:External:Enabled"] = "false"
+        });
+
+        var answer = await service.TryAnswerAsync(
+            "Is the pitch class set 0,1,4,6 Z-related to another set class?");
+
+        Assert.That(answer, Is.Not.Null, "comma-separated set must be extracted and answered deterministically");
+        Assert.That(answer!.QueryType, Is.EqualTo("z-relation"));
+        Assert.That(answer.Facts["isZRelated"], Is.EqualTo(bool.TrueString));
+        // The all-interval tetrachord {0,1,4,6} has a single Z-partner {0,1,3,7}.
+        Assert.That(answer.Facts["partner"], Is.EqualTo("[0,1,3,7]"));
+        Assert.That(answer.Grounding.Source, Is.EqualTo("ix-compatible"));
+    }
+
+    [Test]
+    public async Task SetClass_Query_Accepts_SpaceSeparated_Set()
+    {
+        var service = CreateService(new Dictionary<string, string?>
+        {
+            ["IX:Revision"] = "7b02a56",
+            ["IX:Source"] = "ix-compatible",
+            ["IX:External:Enabled"] = "false"
+        });
+
+        var answer = await service.TryAnswerAsync("set class summary for 0 2 4 7");
+
+        Assert.That(answer, Is.Not.Null, "space-separated set must be extracted");
+        Assert.That(answer!.QueryType, Is.EqualTo("set-class-summary"));
+    }
+
+    [Test]
     public async Task External_Process_Response_Takes_Precedence_When_Configured()
     {
         var scriptPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"ix-algebra-{Guid.NewGuid():N}.ps1");

--- a/Tests/Common/GA.Business.Core.Tests/Orchestration/IxAlgebraServiceTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Orchestration/IxAlgebraServiceTests.cs
@@ -87,6 +87,27 @@ public class IxAlgebraServiceTests
     }
 
     [Test]
+    public async Task ForteLabel_ReverseLookup_Returns_SetClass()
+    {
+        // Feature (2026-06-16): "what is Forte number 4-Z29" is a reverse lookup
+        // (label → set class). 4-Z29 is one of the two all-interval tetrachords;
+        // its prime form is [0,1,3,7]. Must NOT be mis-parsed as the set {2,9}.
+        var service = CreateService(new Dictionary<string, string?>
+        {
+            ["IX:Revision"] = "7b02a56",
+            ["IX:Source"] = "ix-compatible",
+            ["IX:External:Enabled"] = "false"
+        });
+
+        var answer = await service.TryAnswerAsync("What is Forte number 4-Z29?");
+
+        Assert.That(answer, Is.Not.Null);
+        Assert.That(answer!.QueryType, Is.EqualTo("forte-lookup"));
+        Assert.That(answer.Facts["primeForm"], Is.EqualTo("[0,1,3,7]"));
+        Assert.That(answer.NaturalLanguageAnswer, Does.Contain("[0,1,3,7]"));
+    }
+
+    [Test]
     public async Task SetClass_Query_Accepts_SpaceSeparated_Set()
     {
         var service = CreateService(new Dictionary<string, string?>

--- a/state/quality/chatbot-qa/golden-traces/what-is-forte-number-4-z29/_signature.json
+++ b/state/quality/chatbot-qa/golden-traces/what-is-forte-number-4-z29/_signature.json
@@ -12,17 +12,17 @@
     {
       "name": "orchestration.answer",
       "status": "completed",
-      "agentId": "skill.modes"
+      "agentId": "algebra"
     },
     {
       "name": "orchestration.route",
       "status": "completed",
-      "agentId": "skill.modes"
+      "agentId": "algebra"
     },
     {
       "name": "agent.semantic_result",
       "status": "completed",
-      "agentId": "skill.modes"
+      "agentId": "algebra"
     },
     {
       "name": "notation.vextab",


### PR DESCRIPTION
GA's own set-theory domain is now reliable through the chatbot. Two related fixes.

## 1. Comma-separated set queries reach the deterministic engine
"Is the pitch class set **0,1,4,6** Z-related…" extracted **zero sets** — the parser only took `[0,1,4,6]` or `0146`, so the natural comma form split into rejected digits → engine returned null → **15s LLM timeout**. Fixed by accepting comma/space-separated sets (`≥3` tokens). The engine already computed the Z-partner; it just never got the set.
```
"Is 0,1,4,6 Z-related to another set class"
  → algebra / ix-compatible / "[0,1,4,6] is Z-related. One partner is [0,1,3,7]..."
```

## 2. Canonical Forte-label lookup (the "missing feature")
"What is Forte number **4-Z29**" had no handler. The subtlety: GA's internal catalog uses **Rahn ordering** (its `4-29` = `[0,1,2,3]`), not canonical Forte (`4-Z29 = [0,1,3,7]`). Rather than mislabel Rahn indices, added the **canonical Allen Forte 1973 catalog**:
- `CanonicalForteCatalog` (GA.Domain.Core): label → prime form, cardinalities 0–6 stored, **7–12 derived by Forte's complement rule** (`n-k ↔ (12−n)-k`).
- `IxAlgebraService` reverse-lookup branch (before set extraction) + `AlgebraIntent` example prompts for semantic routing.
```
"What is Forte number 4-Z29"
  → algebra / ix-compatible / "Forte 4-Z29 is the set class with prime form [0,1,3,7] (ICV <1 1 1 1 1 1>)."
```

## Correctness is proven, not asserted
- **`CanonicalForteCatalogTests`** verifies all 136 stored entries against GA's own engine: bijection onto `SetClass.Items` (cardinalities 1–11), per-cardinality counts (12/29/38/50…), and **every Z marker agrees with GA's computed `IsZRelated`**. A transcription typo cannot pass.
- Deterministic service tests (comma/space extraction, reverse lookup) — **no Ollama needed**, CI-catchable.
- **Full prompt corpus: all prompts pass** (updated one stale golden signature that encoded the old `skill.modes` misroute).

## Approach note (per feedback)
No keyword/regex routing — that was tried and reverted as "cheating." Routing is fixed via semantic example-embeddings; parsing pitch-class sets / Forte labels from text is data extraction, not routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)