### PR TITLE
fix(chatbot): force deterministic tool invocation on weak models

### DIFF
--- a/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/SkillMdDrivenSkill.cs
@@ -64,10 +64,65 @@ public sealed class SkillMdDrivenSkill : IOrchestratorSkill
         return _skillMd.Triggers.Any(t => lower.Contains(t.ToLowerInvariant()));
     }
 
+    /// <summary>
+    /// Builds the <see cref="ChatOptions"/> for a skill invocation. When the
+    /// SKILL.md declares <c>allowed-tools</c> (every deterministic GA skill does —
+    /// e.g. <c>[ga_dsl_eval]</c>), the visible tool set is scoped to those tools
+    /// and the tool choice is FORCED, so a weak model (e.g. <c>llama3.2:3b</c> in
+    /// CI) cannot narrate a plausible answer from training instead of running the
+    /// deterministic engine. Conversational skills declare no allowed-tools and
+    /// keep the full tool set with a free <see cref="ChatToolMode.Auto"/> choice.
+    /// </summary>
+    /// <remarks>
+    /// Forcing is loop-safe: <c>FunctionInvokingChatClient</c> resets a required
+    /// <see cref="ChatToolMode"/> to <see langword="null"/> after the first
+    /// iteration (M.E.AI 10.x <c>UpdateOptionsForNextIteration</c>), so the model
+    /// is compelled to call on turn 1 and then synthesizes freely from the real
+    /// tool result rather than being forced to call forever. If the declared
+    /// tool(s) are absent from the provider set (renamed / not wired), we fall
+    /// back to the full set with <see cref="ChatToolMode.Auto"/> rather than
+    /// forcing a nonexistent tool — which would error the call.
+    /// </remarks>
+    private ChatOptions BuildChatOptions(IReadOnlyList<AIFunction> tools)
+    {
+        if (_skillMd.AllowedTools.Count == 0)
+        {
+            return new ChatOptions { Tools = [.. tools] };
+        }
+
+        var allow = new HashSet<string>(_skillMd.AllowedTools, StringComparer.OrdinalIgnoreCase);
+        var scoped = tools.Where(t => allow.Contains(t.Name)).ToList();
+
+        if (scoped.Count == 0)
+        {
+            _logger.LogWarning(
+                "SkillMdDrivenSkill [{Skill}] declares allowed-tools [{Allowed}] but none are present " +
+                "in the provider tool set ({ToolCount} tools); leaving ToolMode=Auto over the full set.",
+                _skillMd.Name, string.Join(", ", _skillMd.AllowedTools), tools.Count);
+            return new ChatOptions { Tools = [.. tools] };
+        }
+
+        var toolMode = scoped.Count == 1
+            ? ChatToolMode.RequireSpecific(scoped[0].Name)
+            : ChatToolMode.RequireAny;
+
+        _logger.LogDebug(
+            "SkillMdDrivenSkill [{Skill}] → forcing tool invocation: mode={Mode}, scoped tools={Scoped}",
+            _skillMd.Name,
+            scoped.Count == 1 ? $"RequireSpecific({scoped[0].Name})" : "RequireAny",
+            string.Join(", ", scoped.Select(t => t.Name)));
+
+        return new ChatOptions
+        {
+            Tools    = [.. scoped],
+            ToolMode = toolMode,
+        };
+    }
+
     public async Task<AgentResponse> ExecuteAsync(string message, CancellationToken ct = default)
     {
         var tools = await _toolsProvider.GetToolsAsync(ct).ConfigureAwait(false);
-        var options = new ChatOptions { Tools = [.. tools] };
+        var options = BuildChatOptions(tools);
 
         ChatMessage[] messages =
         [

--- a/Common/GA.Business.ML/Skills/SkillMd.cs
+++ b/Common/GA.Business.ML/Skills/SkillMd.cs
@@ -19,6 +19,17 @@ public sealed record SkillMd
     public IReadOnlyList<string> Triggers { get; init; } = [];
 
     /// <summary>
+    /// Tool names this skill is permitted to use (from the <c>allowed-tools:</c>
+    /// frontmatter field). For GA's deterministic skills this is the closure/MCP
+    /// tool the skill MUST call (e.g. <c>[ga_dsl_eval]</c>), so <c>SkillMdDrivenSkill</c>
+    /// scopes the visible tool set to these and forces invocation — preventing a
+    /// weak model from narrating a plausible answer from training instead of
+    /// running the deterministic engine. Empty for conversational skills (which
+    /// keep the full tool set and a free <c>Auto</c> tool choice).
+    /// </summary>
+    public IReadOnlyList<string> AllowedTools { get; init; } = [];
+
+    /// <summary>
     /// The markdown body of the SKILL.md file — injected verbatim as the Claude system prompt.
     /// </summary>
     public required string Body { get; init; }

--- a/Common/GA.Business.ML/Skills/SkillMdParser.cs
+++ b/Common/GA.Business.ML/Skills/SkillMdParser.cs
@@ -127,13 +127,22 @@ public static class SkillMdParser
             .ToList()
             ?? [];
 
+        // Allowed tools are matched against AIFunction.Name downstream (the match
+        // there is case-insensitive). Keep the author's exact casing, drop blanks.
+        var allowedTools = frontmatter.AllowedTools?
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .Select(t => t.Trim())
+            .ToList()
+            ?? [];
+
         return new SkillMd
         {
-            Name        = frontmatter.Name.Trim(),
-            Description = frontmatter.Description?.Trim() ?? string.Empty,
-            Triggers    = sanitizedTriggers,
-            Body        = body,
-            FilePath    = filePath,
+            Name         = frontmatter.Name.Trim(),
+            Description  = frontmatter.Description?.Trim() ?? string.Empty,
+            Triggers     = sanitizedTriggers,
+            AllowedTools = allowedTools,
+            Body         = body,
+            FilePath     = filePath,
         };
     }
 
@@ -172,9 +181,10 @@ public static class SkillMdParser
 
         return new SkillMdFrontmatter
         {
-            Name        = name,
-            Description = FirstNonEmpty(pascal?.Description, camel?.Description),
-            Triggers    = FirstNonEmptyList(pascal?.Triggers, camel?.Triggers),
+            Name         = name,
+            Description  = FirstNonEmpty(pascal?.Description, camel?.Description),
+            Triggers     = FirstNonEmptyList(pascal?.Triggers, camel?.Triggers),
+            AllowedTools = FirstNonEmptyList(pascal?.AllowedTools, camel?.AllowedTools),
         };
     }
 
@@ -197,5 +207,15 @@ public static class SkillMdParser
         public string?       Name        { get; set; }
         public string?       Description { get; set; }
         public List<string>? Triggers    { get; set; }  // List<T> for YamlDotNet compatibility
+
+        // `allowed-tools` is kebab-case — neither the PascalCase nor camelCase
+        // naming convention maps to it, so pin the exact YAML key with an alias.
+        // ApplyNamingConventions=false is REQUIRED: otherwise YamlDotNet runs the
+        // active naming convention over the alias too (mangling "allowed-tools"
+        // into "Allowedtools"/"allowedtools"), and the key never matches. This is
+        // the Anthropic Claude Code convention already present in every tool-driven
+        // SKILL.md in this repo.
+        [YamlMember(Alias = "allowed-tools", ApplyNamingConventions = false)]
+        public List<string>? AllowedTools { get; set; }
     }
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdDrivenSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdDrivenSkillTests.cs
@@ -15,14 +15,16 @@ public class SkillMdDrivenSkillTests
         string name = "Test Skill",
         string description = "Test description",
         string[]? triggers = null,
-        string body = "You are a helpful assistant.") =>
+        string body = "You are a helpful assistant.",
+        string[]? allowedTools = null) =>
         new()
         {
-            Name        = name,
-            Description = description,
-            Triggers    = triggers ?? ["test-trigger"],
-            Body        = body,
-            FilePath    = "<test>",
+            Name         = name,
+            Description  = description,
+            Triggers     = triggers ?? ["test-trigger"],
+            Body         = body,
+            AllowedTools = allowedTools ?? [],
+            FilePath     = "<test>",
         };
 
     private static IMcpToolsProvider EmptyToolsProvider()
@@ -30,6 +32,39 @@ public class SkillMdDrivenSkillTests
         var mock = new Mock<IMcpToolsProvider>();
         mock.Setup(p => p.GetToolsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
+        return mock.Object;
+    }
+
+    /// <summary>
+    /// A real <see cref="AIFunction"/> with a concrete <see cref="AIFunction.Name"/> —
+    /// AIFunctionFactory gives a name we can assert against (a Moq'd AIFunction can't
+    /// set the non-virtual Name reliably).
+    /// </summary>
+    private static AIFunction NamedTool(string name) =>
+        AIFunctionFactory.Create(() => "ok", name);
+
+    private static IMcpToolsProvider ToolsProvider(params AIFunction[] tools)
+    {
+        var mock = new Mock<IMcpToolsProvider>();
+        mock.Setup(p => p.GetToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tools);
+        return mock.Object;
+    }
+
+    /// <summary>
+    /// An <see cref="IChatClient"/> that records the <see cref="ChatOptions"/> it was
+    /// called with via <paramref name="captured"/>, so tests can assert tool scoping
+    /// and forced tool choice.
+    /// </summary>
+    private static IChatClient CapturingClient(Action<ChatOptions?> captured)
+    {
+        var mock = new Mock<IChatClient>();
+        mock.Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>((_, o, _) => captured(o))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
         return mock.Object;
     }
 
@@ -362,5 +397,121 @@ public class SkillMdDrivenSkillTests
 
         factoryMock.Verify(f => f.Create("skill-md"), Times.Once);
         factoryMock.Verify(f => f.Create(It.IsNotIn("skill-md")), Times.Never);
+    }
+
+    // ── allowed-tools → forced, scoped tool invocation ────────────────────────
+    //
+    // The whole point of these tests: a weak model (llama3.2:3b in CI) tends to
+    // narrate a plausible answer from training instead of calling the deterministic
+    // GA tool, which drops content + grounding. When a SKILL.md declares
+    // `allowed-tools`, the skill must (a) scope the visible tool set to those tools
+    // and (b) FORCE the tool choice, so the model can't skip the deterministic path.
+
+    [Test]
+    public async Task ExecuteAsync_NoAllowedTools_LeavesToolChoiceFree_OverFullSet()
+    {
+        ChatOptions? captured = null;
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(allowedTools: null),
+            ToolsProvider(NamedTool("ga_dsl_eval"), NamedTool("ga_chord_info")),
+            FactoryFor(CapturingClient(o => captured = o)),
+            NullLogger<SkillMdDrivenSkill>.Instance);
+
+        await skill.ExecuteAsync("test");
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            // Conversational skills declare no allowed-tools: full set, free choice.
+            Assert.That(captured!.Tools!, Has.Count.EqualTo(2));
+            Assert.That(captured.ToolMode, Is.Null, "no allowed-tools → ToolMode must stay unset (Auto)");
+        });
+    }
+
+    [Test]
+    public async Task ExecuteAsync_SingleAllowedTool_ForcesRequireSpecific_AndScopesToIt()
+    {
+        ChatOptions? captured = null;
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(allowedTools: ["ga_dsl_eval"]),
+            ToolsProvider(NamedTool("ga_dsl_eval"), NamedTool("ga_chord_info"), NamedTool("ga_scale_get_notes")),
+            FactoryFor(CapturingClient(o => captured = o)),
+            NullLogger<SkillMdDrivenSkill>.Instance);
+
+        await skill.ExecuteAsync("transpose Cmaj7 up a fourth");
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(captured!.Tools!, Has.Count.EqualTo(1), "tool set must be scoped to the single allowed tool");
+            Assert.That(captured.Tools![0].Name, Is.EqualTo("ga_dsl_eval"));
+            Assert.That(captured.ToolMode, Is.InstanceOf<RequiredChatToolMode>());
+            Assert.That(((RequiredChatToolMode)captured.ToolMode!).RequiredFunctionName,
+                Is.EqualTo("ga_dsl_eval"), "must force the specific deterministic tool");
+        });
+    }
+
+    [Test]
+    public async Task ExecuteAsync_AllowedToolMatch_IsCaseInsensitive()
+    {
+        ChatOptions? captured = null;
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(allowedTools: ["GA_DSL_EVAL"]),
+            ToolsProvider(NamedTool("ga_dsl_eval"), NamedTool("ga_chord_info")),
+            FactoryFor(CapturingClient(o => captured = o)),
+            NullLogger<SkillMdDrivenSkill>.Instance);
+
+        await skill.ExecuteAsync("test");
+
+        Assert.That(captured!.Tools!, Has.Count.EqualTo(1));
+        Assert.That(((RequiredChatToolMode)captured.ToolMode!).RequiredFunctionName, Is.EqualTo("ga_dsl_eval"));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_MultipleAllowedTools_ForcesRequireAny_AndScopesToThem()
+    {
+        ChatOptions? captured = null;
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(allowedTools: ["ga_chord_substitutions", "ga_chord_compare"]),
+            ToolsProvider(
+                NamedTool("ga_chord_substitutions"),
+                NamedTool("ga_chord_compare"),
+                NamedTool("ga_dsl_eval")),
+            FactoryFor(CapturingClient(o => captured = o)),
+            NullLogger<SkillMdDrivenSkill>.Instance);
+
+        await skill.ExecuteAsync("substitutes for Cmaj7");
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(captured!.Tools!, Has.Count.EqualTo(2), "scoped to the two allowed tools");
+            Assert.That(captured.ToolMode, Is.InstanceOf<RequiredChatToolMode>());
+            // RequireAny forces *some* tool call but names none.
+            Assert.That(((RequiredChatToolMode)captured.ToolMode!).RequiredFunctionName, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task ExecuteAsync_AllowedToolAbsentFromProvider_FallsBackToFreeChoice_FullSet()
+    {
+        // Declared tool renamed / not wired in the provider set: forcing
+        // RequireSpecific on a nonexistent tool would error the call, so the
+        // skill must degrade to the full set with a free tool choice.
+        ChatOptions? captured = null;
+        var skill = new SkillMdDrivenSkill(
+            MakeSkillMd(allowedTools: ["ga_does_not_exist"]),
+            ToolsProvider(NamedTool("ga_dsl_eval"), NamedTool("ga_chord_info")),
+            FactoryFor(CapturingClient(o => captured = o)),
+            NullLogger<SkillMdDrivenSkill>.Instance);
+
+        await skill.ExecuteAsync("test");
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(captured!.Tools!, Has.Count.EqualTo(2), "fall back to the full provider set");
+            Assert.That(captured.ToolMode, Is.Null, "absent tool → do NOT force; leave ToolMode unset");
+        });
     }
 }

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdParserTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillMdParserTests.cs
@@ -477,4 +477,90 @@ public class SkillMdParserTests
         Assert.That(result!.Triggers, Is.Empty,
             "if all triggers are short, the survivor list is empty (downstream filter handles registration)");
     }
+
+    // ── allowed-tools (kebab-case, Claude Code convention) ────────────────────
+
+    [Test]
+    public void TryParseContent_AllowedTools_ParsedFromKebabCaseKey()
+    {
+        // Every deterministic GA SKILL.md declares `allowed-tools` (kebab-case).
+        // Neither the PascalCase nor camelCase naming convention maps to that key,
+        // so the parser pins it with an explicit YamlMember alias.
+        const string content = """
+            ---
+            name: "transpose"
+            description: "Transpose a chord"
+            triggers:
+              - "transpose"
+            allowed-tools:
+              - ga_dsl_eval
+            ---
+            Call ga_dsl_eval.
+            """;
+
+        var result = SkillMdParser.TryParseContent(content);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.AllowedTools, Is.EqualTo(new[] { "ga_dsl_eval" }));
+    }
+
+    [Test]
+    public void TryParseContent_AllowedTools_MultipleEntriesPreserved()
+    {
+        const string content = """
+            ---
+            name: "chord-substitution"
+            triggers:
+              - "substitute"
+            allowed-tools:
+              - ga_chord_substitutions
+              - ga_chord_compare
+            ---
+            body
+            """;
+
+        var result = SkillMdParser.TryParseContent(content);
+
+        Assert.That(result!.AllowedTools, Is.EqualTo(new[] { "ga_chord_substitutions", "ga_chord_compare" }));
+    }
+
+    [Test]
+    public void TryParseContent_NoAllowedTools_DefaultsToEmpty()
+    {
+        // Conversational skills declare no allowed-tools — must surface as an
+        // empty list (not null), so downstream callers can branch on Count.
+        const string content = """
+            ---
+            name: "what-can-you-do"
+            triggers:
+              - "what can you do"
+            ---
+            body
+            """;
+
+        var result = SkillMdParser.TryParseContent(content);
+
+        Assert.That(result!.AllowedTools, Is.Not.Null);
+        Assert.That(result.AllowedTools, Is.Empty);
+    }
+
+    [Test]
+    public void TryParseContent_AllowedTools_BlankEntriesDropped()
+    {
+        const string content = """
+            ---
+            name: "x"
+            triggers:
+              - "xyz"
+            allowed-tools:
+              - ga_dsl_eval
+              - ""
+            ---
+            body
+            """;
+
+        var result = SkillMdParser.TryParseContent(content);
+
+        Assert.That(result!.AllowedTools, Is.EqualTo(new[] { "ga_dsl_eval" }));
+    }
 }


### PR DESCRIPTION
## Problem

SkillMd-driven skills handed the SKILL.md body + the **full** tool set to the chat client with `ToolMode=Auto`, leaving it to the model to *choose* to call the deterministic GA tool. Capable models do; a weak model (`llama3.2:3b` on CPU in CI) **narrates a plausible answer from training instead** — so `ga_dsl_eval` never runs, no grounding attaches, confidence is floored, and the answer can be wrong. That weak-model narration is the chatbot-qa **CI pass_pct floor**.

This is the "SkillMd weak-model tool-invocation fidelity" item that drops content/grounding on `llama3.2:3b`.

## Fix

Honor the `allowed-tools` frontmatter that **every deterministic SKILL.md already declares** (e.g. `[ga_dsl_eval]`). When present:
- **Scope** `ChatOptions.Tools` to those tools (a 3B model reasons better over 1 tool than 100), and
- **Force** the tool choice — `RequireSpecific` for one tool, `RequireAny` for several.

The model can no longer skip the deterministic path. Conversational skills declare no `allowed-tools` and keep the full set + free `Auto` choice — untouched.

**Loop-safe:** `FunctionInvokingChatClient` resets a required `ToolMode` to `null` after the first iteration (M.E.AI 10.x `UpdateOptionsForNextIteration`), so the model is compelled to call on turn 1, then synthesizes freely from the **real tool result**. If a declared tool is absent from the in-process provider (e.g. `qa-architect`'s `qa_*` tools live in Demerzel), it falls back to the full set + `Auto` rather than forcing a nonexistent tool (which would error the call).

**Not a routing change.** Routing already happened semantically; this constrains tool *execution* once routed. No regex/keyword rules.

## Blast radius

| Forced now (tool in-process) | Unchanged |
|---|---|
| transpose, diatonic-chords, common-tones → `ga_dsl_eval` | 7 conversational skills (no `allowed-tools`) |
| chord-info, chord-substitution, fret-span, interval, key-identification, progression-completion, scale-info → their `ga_*` tools | qa-architect (`qa_*` not in-process → safe fallback) |

10 deterministic GA-domain skills now invoke their tool deterministically even on the CI's weak model.

## Changes
- `SkillMd`: add `AllowedTools` (parsed from `allowed-tools`)
- `SkillMdParser`: pin the kebab key with `[YamlMember(Alias = "allowed-tools", ApplyNamingConventions = false)]` — without `ApplyNamingConventions=false`, YamlDotNet mangles the alias through the active naming convention and the key never matches
- `SkillMdDrivenSkill`: `BuildChatOptions` scopes + forces when `allowed-tools` present; falls back otherwise
- Tests: 5 forcing/scoping cases (RequireSpecific / RequireAny / case-insensitive / absent-tool fallback / no-allowed-tools) + 4 parser cases

## Verification
- `GA.Business.ML` + `GaChatbot.Api`: build clean (0 errors)
- New tests: **46/46 green** in `SkillMdDrivenSkillTests` + `SkillMdParserTests`
- Broader skill/loader/wrapper suite: **170 passed, 7 skipped (Explicit/Ollama-gated), 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)