### PR TITLE
feat(router): IEmbeddingGeneratorFactory — decouple routing embedder (Phase 1)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
+++ b/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
@@ -8,9 +8,12 @@ using GA.Business.Core.Orchestration.Trace;
 using GA.Business.ML.Agents;
 using GA.Business.ML.Agents.Intents;
 using GA.Business.ML.Agents.Plugins;
+using GA.Business.ML.Extensions;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 /// <summary>
@@ -102,7 +105,16 @@ public static class ChatbotOrchestrationExtensions
         // Codex CLI 2026-05-08 design call.
         services.TryAddSingleton<IRoutingHintProvider, DefaultRoutingHintProvider>();
 
-        services.AddSingleton<SemanticIntentRouter>();
+        // Routing embedder resolved via the purpose factory (plan #420 Phase 1)
+        // so the routing model can be swapped (AI:Embedding:routing:Model) without
+        // touching the persisted memory store's embedder. Create("routing") returns
+        // the configured override or the global default; the `??` is a safety net
+        // if the factory itself isn't registered.
+        services.AddSingleton<SemanticIntentRouter>(sp => new SemanticIntentRouter(
+            sp.GetService<IEmbeddingGeneratorFactory>()?.Create("routing")
+                ?? sp.GetService<IEmbeddingGenerator<string, Embedding<float>>>(),
+            sp.GetRequiredService<IRoutingHintProvider>(),
+            sp.GetRequiredService<ILogger<SemanticIntentRouter>>()));
         services.AddHostedService<IntentEmbeddingWarmupService>();
         services.AddHostedService<ClosureRegistryStartupCheck>();
         services.AddScoped<TabAnalysisOrchestrationService>();

--- a/Common/GA.Business.ML/Extensions/AiServiceExtensions.cs
+++ b/Common/GA.Business.ML/Extensions/AiServiceExtensions.cs
@@ -208,6 +208,16 @@ public static class AiServiceExtensions
                 throw new ArgumentException($"Unknown embedding provider: {provider}", nameof(provider));
         }
 
+        // Purpose-aware factory (plan #420 Phase 1): lets routing use a different
+        // embedding model from the persisted memory store. Captures `configuration`
+        // so it works without IConfiguration in DI; no override → the default
+        // generator above, so behaviour is unchanged until AI:Embedding:*:Model is set.
+        services.TryAddSingleton<IEmbeddingGeneratorFactory>(sp =>
+            new DefaultEmbeddingGeneratorFactory(
+                configuration,
+                sp.GetService<IEmbeddingGenerator<string, Embedding<float>>>(),
+                sp.GetService<ILoggerFactory>()?.CreateLogger<DefaultEmbeddingGeneratorFactory>()));
+
         return services;
     }
 

--- a/Common/GA.Business.ML/Extensions/IEmbeddingGeneratorFactory.cs
+++ b/Common/GA.Business.ML/Extensions/IEmbeddingGeneratorFactory.cs
@@ -1,0 +1,78 @@
+namespace GA.Business.ML.Extensions;
+
+using System.Collections.Concurrent;
+using GA.Business.ML.Providers;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// Returns an <see cref="IEmbeddingGenerator{String,Embedding}"/> for a named
+/// purpose, so different consumers can use different embedding models without a
+/// global swap. The text-embedding analogue of <see cref="IChatClientFactory"/>.
+/// </summary>
+/// <remarks>
+/// <para>Motivation (plan <c>docs/plans/2026-06-16-ml-text-embedder-evaluation-plan.md</c>):
+/// routing and the persisted memory store historically shared one global
+/// <see cref="IEmbeddingGenerator{String,Embedding}"/> singleton. A bake-off found
+/// a stronger routing embedder (<c>bge-large</c>), but a global swap would force
+/// re-embedding the memory store + break dimension-coupled call sites. This factory
+/// lets ROUTING use a different model while the store keeps its own — a routing-only,
+/// reversible change.</para>
+/// <para>Defined purposes: <c>routing</c> (semantic intent routing) and
+/// <c>memory</c> / <c>default</c> (persisted retrieval). A purpose with no
+/// configured override transparently uses the default generator, so behaviour is
+/// UNCHANGED until <c>AI:Embedding:&lt;purpose&gt;:Model</c> is set.</para>
+/// </remarks>
+public interface IEmbeddingGeneratorFactory
+{
+    /// <summary>
+    /// Returns the embedding generator for <paramref name="purpose"/>: an
+    /// override built from <c>AI:Embedding:&lt;purpose&gt;:Model</c> if configured,
+    /// otherwise the global default generator (which may be <see langword="null"/>
+    /// when no embedder is registered — callers already treat embeddings as
+    /// optional). Override instances are cached per purpose.
+    /// </summary>
+    IEmbeddingGenerator<string, Embedding<float>>? Create(string purpose);
+}
+
+/// <summary>
+/// Config-driven <see cref="IEmbeddingGeneratorFactory"/>. An override is read from
+/// <c>AI:Embedding:&lt;purpose&gt;:Model</c> and built as an Ollama embedding
+/// generator at <c>Ollama:BaseUrl</c>; absent an override the global default
+/// generator is returned verbatim (zero behaviour change).
+/// </summary>
+public sealed class DefaultEmbeddingGeneratorFactory(
+    IConfiguration configuration,
+    IEmbeddingGenerator<string, Embedding<float>>? defaultGenerator,
+    ILogger<DefaultEmbeddingGeneratorFactory>? logger = null) : IEmbeddingGeneratorFactory
+{
+    private readonly ILogger<DefaultEmbeddingGeneratorFactory> _logger =
+        logger ?? NullLogger<DefaultEmbeddingGeneratorFactory>.Instance;
+
+    // Only override generators are cached; the no-override path returns the shared
+    // default singleton, so there is nothing to cache (and ConcurrentDictionary
+    // cannot store the null-default case).
+    private readonly ConcurrentDictionary<string, IEmbeddingGenerator<string, Embedding<float>>> _overrides = new();
+
+    public IEmbeddingGenerator<string, Embedding<float>>? Create(string purpose)
+    {
+        // Config keys are case-insensitive, so the lowercase purpose matches
+        // "AI:Embedding:Routing:Model" as authored.
+        var model = configuration.GetValue<string>($"AI:Embedding:{purpose}:Model");
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            return defaultGenerator; // exact current behaviour
+        }
+
+        return _overrides.GetOrAdd(purpose, _ =>
+        {
+            var baseUrl = configuration.GetValue<string>("Ollama:BaseUrl") ?? OllamaProvider.DefaultBaseUrl;
+            _logger.LogInformation(
+                "Embedding purpose '{Purpose}' uses override model '{Model}' at {BaseUrl} (decoupled from the default embedder).",
+                purpose, model, baseUrl);
+            return OllamaProvider.CreateEmbeddingGenerator(baseUrl, model);
+        });
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/DefaultEmbeddingGeneratorFactoryTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/DefaultEmbeddingGeneratorFactoryTests.cs
@@ -1,0 +1,77 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Extensions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Moq;
+
+/// <summary>
+/// The purpose factory (plan #420 Phase 1) must leave behaviour UNCHANGED until a
+/// per-purpose model override is configured: no override → the global default
+/// generator; an override → a distinct, cached generator. This is what makes the
+/// bge-large routing swap a routing-only, reversible change.
+/// </summary>
+[TestFixture]
+public class DefaultEmbeddingGeneratorFactoryTests
+{
+    private static IConfiguration Config(params (string Key, string Value)[] kv) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(kv.ToDictionary(x => x.Key, x => (string?)x.Value))
+            .Build();
+
+    private static IEmbeddingGenerator<string, Embedding<float>> StubDefault() =>
+        new Mock<IEmbeddingGenerator<string, Embedding<float>>>().Object;
+
+    [Test]
+    public void Create_NoOverride_ReturnsDefaultGenerator()
+    {
+        var def = StubDefault();
+        var factory = new DefaultEmbeddingGeneratorFactory(Config(), def);
+
+        Assert.That(factory.Create("routing"), Is.SameAs(def),
+            "with no AI:Embedding:routing:Model override, routing must use the default embedder (zero behaviour change)");
+    }
+
+    [Test]
+    public void Create_Override_ReturnsDistinctGenerator_AndCachesPerPurpose()
+    {
+        var def = StubDefault();
+        var factory = new DefaultEmbeddingGeneratorFactory(
+            Config(("AI:Embedding:routing:Model", "bge-large"), ("Ollama:BaseUrl", "http://localhost:11434")),
+            def);
+
+        var a = factory.Create("routing");
+        var b = factory.Create("routing");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a, Is.Not.Null);
+            Assert.That(a, Is.Not.SameAs(def), "an override must NOT be the default generator");
+            Assert.That(b, Is.SameAs(a), "override instances must be cached per purpose");
+        });
+    }
+
+    [Test]
+    public void Create_OverridesOneePurpose_LeavesOthersOnDefault()
+    {
+        var def = StubDefault();
+        var factory = new DefaultEmbeddingGeneratorFactory(
+            Config(("AI:Embedding:routing:Model", "bge-large")), def);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(factory.Create("routing"), Is.Not.SameAs(def), "routing is overridden");
+            Assert.That(factory.Create("memory"), Is.SameAs(def), "memory has no override → default (decoupled)");
+        });
+    }
+
+    [Test]
+    public void Create_NullDefault_NoOverride_ReturnsNull()
+    {
+        // Callers treat embeddings as optional (SemanticIntentRouter.IsAvailable),
+        // so an unconfigured purpose with no default must surface as null, not throw.
+        var factory = new DefaultEmbeddingGeneratorFactory(Config(), defaultGenerator: null);
+
+        Assert.That(factory.Create("routing"), Is.Null);
+    }
+}


### PR DESCRIPTION
Phase 1 of the text-embedder evaluation ([plan #420](https://github.com/GuitarAlchemist/ga/pull/420)). The enabling code change that turns the validated `bge-large` finding ([#421](https://github.com/GuitarAlchemist/ga/pull/421): in-scope 0.946 vs nomic 0.934, OOS-decline 1.000 at the recalibrated 0.64 threshold) into a **routing-only, reversible** swap.

## Problem
Routing and the persisted `MemoryStore` shared **one global `IEmbeddingGenerator` singleton**, so a model swap would force re-embedding the memory store and break dimension-coupled call sites (`GpuAcceleratedEmbeddingService`, MongoDB index). OPTIC-K is unaffected (separate musical embedding).

## What ships
- **`IEmbeddingGeneratorFactory` + `DefaultEmbeddingGeneratorFactory`** — the text-embedding analogue of `IChatClientFactory`. `Create(purpose)` returns a per-purpose override built from `AI:Embedding:<purpose>:Model`, else the **global default generator**. Override instances cached per purpose; captures `IConfiguration` so it works without it in DI.
- Registered in `AddTextEmbeddings`.
- `SemanticIntentRouter` now resolves its embedder via `Create("routing")` with a safety-net fallback to the default.

## Behaviour unchanged until configured
With no `AI:Embedding:routing:Model` override, routing uses the exact same default embedder — **zero behaviour change**. Phase 2 (the actual `bge-large` swap + the embedder-specific `MinConfidence` recalibration to ~0.64) then becomes config + a threshold constant, no further wiring.

## Verification
- 4 factory tests: no-override → default (same instance), override → distinct + cached, per-purpose independence, null-default → null (callers treat embeddings as optional).
- Existing registration + router fast tests green; orchestration + test projects build clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)