### PR TITLE
feat(router): per-query embedding sink (Contract B — ix-duck OOD lens)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,6 +266,11 @@ state/quality/memory-curator/
 # baseline sweep reads, stdout/stderr is debugging-only.
 state/telemetry/
 
+# Per-query embedding sink (Contract B → ix-duck OOD lens). One row per routed
+# query with the full vector (~12KB/row) — bulky runtime telemetry, not a
+# committed artifact. ix-duck reads the working tree cross-repo; no commit needed.
+state/quality/query-embeddings/
+
 # AI-surface handoff notes — working memory between Antigravity native, Claude
 # Code, and remote agents. Notes ARE ignored; the README explaining the
 # protocol is tracked.

--- a/Common/GA.Business.ML/Agents/Intents/QueryEmbeddingLog.cs
+++ b/Common/GA.Business.ML/Agents/Intents/QueryEmbeddingLog.cs
@@ -1,0 +1,134 @@
+namespace GA.Business.ML.Agents.Intents;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+///     Append-only per-day JSONL sink of the EXACT query embedding the
+///     <see cref="SemanticIntentRouter"/> scored with — one row per routed query —
+///     plus the decision it drove. Cross-repo Contract B (GA → ix): the sibling
+///     <c>ix-duck</c> analyst bench reads <c>state/quality/query-embeddings/*.jsonl</c>
+///     and computes mean-top-3 cosine vs an in-domain reference set to flag
+///     out-of-domain queries (the raw-cosine method ix's ROC sweep validated).
+///     <para>
+///         CRITICAL: this persists the vector the router actually routed on — NOT a
+///         re-embed — so the OOD lens analyses real routing decisions. The embedder
+///         + dim are recorded dynamically from the live generator (today
+///         <c>bge-large</c> / 1024-d, per the Phase-2 routing swap), never hardcoded.
+///     </para>
+///     <para>
+///         Mirrors <see cref="RoutingTelemetryLog"/> (daily rotation, write lock,
+///         error swallowing, env disable) so the streams stay operationally
+///         identical. Distinct from telemetry: telemetry keeps the decision; this
+///         keeps the VECTOR (bulky), so it lands under <c>state/quality/</c> and is
+///         gitignored — ix-duck reads the working tree cross-repo, no commit needed.
+///     </para>
+/// </summary>
+public static class QueryEmbeddingLog
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    private static readonly Lock _writeLock = new();
+
+    /// <summary>
+    ///     Set <c>GA_QUERY_EMBEDDING_NO_LOG=1</c> to suppress all writes (test/CI, or
+    ///     deployments that don't want per-query vectors on disk).
+    /// </summary>
+    public const string DisableEnvVar = "GA_QUERY_EMBEDDING_NO_LOG";
+
+    /// <summary>
+    ///     Directory holding the rolling JSONL files. Override via
+    ///     <c>GA_QUERY_EMBEDDING_DIR</c>; default <c>{repo-root}/state/quality/query-embeddings/</c>.
+    /// </summary>
+    public static string ResolveDirectory()
+    {
+        var env = Environment.GetEnvironmentVariable("GA_QUERY_EMBEDDING_DIR");
+        if (!string.IsNullOrWhiteSpace(env)) return env;
+
+        // Walk up from the app base toward the repo root looking for a `state/` sibling.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "state", "quality", "query-embeddings");
+            if (Directory.Exists(Path.Combine(dir.FullName, "state"))) return candidate;
+            dir = dir.Parent;
+        }
+        return Path.Combine(AppContext.BaseDirectory, "state", "quality", "query-embeddings");
+    }
+
+    public static string CurrentDayFile() =>
+        Path.Combine(ResolveDirectory(), $"{DateTime.UtcNow:yyyy-MM-dd}.jsonl");
+
+    /// <summary>
+    ///     Appends a single record. Silently swallows I/O errors — this sink must
+    ///     never break the routing path.
+    /// </summary>
+    public static void Append(QueryEmbeddingRecord record)
+    {
+        if (Environment.GetEnvironmentVariable(DisableEnvVar) == "1") return;
+
+        try
+        {
+            var path = CurrentDayFile();
+            var dir = Path.GetDirectoryName(path);
+            if (dir is not null) Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(record, JsonOpts);
+            lock (_writeLock)
+            {
+                File.AppendAllText(path, json + "\n");
+            }
+        }
+        catch
+        {
+            // sink failure must be invisible to the routing caller
+        }
+    }
+}
+
+/// <summary>
+///     One row per routed query: the decision plus the exact vector that produced
+///     it. Field names match the cross-repo Contract B shape ratified with ix.
+/// </summary>
+public sealed record QueryEmbeddingRecord
+{
+    /// <summary>Stable id for this routed query (correlate with telemetry / traces).</summary>
+    [JsonPropertyName("query_id")]
+    public required string QueryId { get; init; }
+
+    /// <summary>ISO-8601 UTC timestamp.</summary>
+    [JsonPropertyName("ts")]
+    public required string Timestamp { get; init; }
+
+    /// <summary>Raw user query text (GA's own telemetry; the label-able surface).</summary>
+    [JsonPropertyName("query_text")]
+    public required string QueryText { get; init; }
+
+    /// <summary>Chosen intent id, or null if the router declined (below threshold).</summary>
+    [JsonPropertyName("intent")]
+    public string? Intent { get; init; }
+
+    /// <summary>How the query routed: <c>embedding</c> (cleared threshold) or <c>fallback</c> (declined).</summary>
+    [JsonPropertyName("route_method")]
+    public required string RouteMethod { get; init; }
+
+    /// <summary>Final (hint-boosted) confidence of the top candidate — recorded even when declined.</summary>
+    [JsonPropertyName("route_confidence")]
+    public double RouteConfidence { get; init; }
+
+    /// <summary>Embedder model id, resolved live from the generator (e.g. <c>bge-large</c>).</summary>
+    [JsonPropertyName("embedder")]
+    public required string Embedder { get; init; }
+
+    /// <summary>Embedding dimensionality (== <see cref="Embedding"/> length; explicit per contract).</summary>
+    [JsonPropertyName("dim")]
+    public int Dim { get; init; }
+
+    /// <summary>The exact vector the router scored with (NOT a re-embed).</summary>
+    [JsonPropertyName("embedding")]
+    public required IReadOnlyList<float> Embedding { get; init; }
+}

--- a/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
+++ b/Common/GA.Business.ML/Agents/Intents/SemanticIntentRouter.cs
@@ -53,6 +53,12 @@ public sealed class SemanticIntentRouter(
     private readonly SemaphoreSlim _initLock = new(1, 1);
     private volatile bool _embeddingsReady;
 
+    // Embedder model id for the query-embedding sink (Contract B). Resolved once
+    // from the live generator's metadata so the persisted rows record the ACTUAL
+    // model (e.g. bge-large), never a hardcoded guess. Cached: metadata is static.
+    private string? _embedderModelId;
+    private bool _embedderResolved;
+
     /// <summary>Cosine-similarity threshold above which an intent claims the query.</summary>
     public float MinConfidence { get; init; } = DefaultMinConfidence;
 
@@ -225,6 +231,25 @@ public sealed class SemanticIntentRouter(
             shadow.LogShadow(query, queryVec, prodChosenForShadow);
         }
 
+        // Query-embedding sink (Contract B for ix-duck's out-of-domain lens): persist
+        // the EXACT vector the router scored with — not a re-embed — plus the decision
+        // it drove, so the OOD lens can flag queries far from the in-domain reference
+        // set. One row per routed query, covering both the routed and declined paths.
+        // Error-swallowed + env-gated like the telemetry above; never affects routing.
+        var routed = top.Score >= MinConfidence;
+        QueryEmbeddingLog.Append(new QueryEmbeddingRecord
+        {
+            QueryId         = Guid.NewGuid().ToString("n"),
+            Timestamp       = DateTime.UtcNow.ToString("o"),
+            QueryText       = query,
+            Intent          = routed ? top.Intent.Id : null,
+            RouteMethod     = routed ? "embedding" : "fallback",
+            RouteConfidence = top.Score,
+            Embedder        = ResolveEmbedderModelId(),
+            Dim             = queryVec.Length,
+            Embedding       = queryVec,
+        });
+
         if (top.Score < MinConfidence)
         {
             logger.LogDebug(
@@ -277,6 +302,25 @@ public sealed class SemanticIntentRouter(
         {
             Ranking = routingCandidates,
         };
+    }
+
+    // Best-effort embedder model id from the generator metadata (M.E.AI exposes it
+    // via GetService<EmbeddingGeneratorMetadata>). Falls back to "unknown" if the
+    // provider doesn't surface a model id — never throws into the routing path.
+    private string ResolveEmbedderModelId()
+    {
+        if (_embedderResolved) return _embedderModelId ?? "unknown";
+        _embedderResolved = true;
+        try
+        {
+            var meta = textEmbeddings?.GetService(typeof(EmbeddingGeneratorMetadata)) as EmbeddingGeneratorMetadata;
+            _embedderModelId = meta?.DefaultModelId;
+        }
+        catch
+        {
+            // metadata resolution is best-effort; leave null → "unknown"
+        }
+        return _embedderModelId ?? "unknown";
     }
 
     private static string Trim(string s, int max) =>

--- a/Tests/Common/GA.Business.ML.Tests/Unit/QueryEmbeddingLogTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/QueryEmbeddingLogTests.cs
@@ -1,0 +1,100 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using System.Text.Json;
+using GA.Business.ML.Agents.Intents;
+
+/// <summary>
+/// Pins <see cref="QueryEmbeddingLog"/> (Contract B → ix-duck OOD lens): append →
+/// valid JSONL with the ratified field names, the exact vector round-trips, the
+/// declined-row shape (null intent omitted, route_method=fallback), the env-dir
+/// override, and the disable switch. No router / Ollama needed — exercises the sink
+/// in isolation against a temp directory.
+/// </summary>
+[TestFixture]
+public class QueryEmbeddingLogTests
+{
+    private string _tempDir = "";
+    private string? _priorDisable;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ga-query-embedding-test-" + Guid.NewGuid().ToString("N"));
+        _priorDisable = Environment.GetEnvironmentVariable(QueryEmbeddingLog.DisableEnvVar);
+        Environment.SetEnvironmentVariable("GA_QUERY_EMBEDDING_DIR", _tempDir);
+        Environment.SetEnvironmentVariable(QueryEmbeddingLog.DisableEnvVar, null);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("GA_QUERY_EMBEDDING_DIR", null);
+        Environment.SetEnvironmentVariable(QueryEmbeddingLog.DisableEnvVar, _priorDisable);
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static QueryEmbeddingRecord SampleRouted() => new()
+    {
+        QueryId         = Guid.NewGuid().ToString("n"),
+        Timestamp       = DateTime.UtcNow.ToString("o"),
+        QueryText       = "are 0146 and 0137 z-related?",
+        Intent          = "skill.zrelation",
+        RouteMethod     = "embedding",
+        RouteConfidence = 0.82,
+        Embedder        = "bge-large",
+        Dim             = 4,
+        Embedding       = [0.10f, -0.20f, 0.30f, 0.40f],
+    };
+
+    [Test]
+    public void Append_WritesRatifiedFieldNames_AndRoundTripsVector()
+    {
+        QueryEmbeddingLog.Append(SampleRouted());
+
+        var lines = File.ReadAllLines(QueryEmbeddingLog.CurrentDayFile());
+        Assert.That(lines, Has.Length.EqualTo(1), "one JSONL line per Append");
+
+        using var doc = JsonDocument.Parse(lines[0]);
+        var root = doc.RootElement;
+        // The cross-repo contract is the FIELD NAMES — ix-duck reads these.
+        Assert.Multiple(() =>
+        {
+            Assert.That(root.TryGetProperty("query_id", out _), Is.True);
+            Assert.That(root.GetProperty("query_text").GetString(), Is.EqualTo("are 0146 and 0137 z-related?"));
+            Assert.That(root.GetProperty("intent").GetString(), Is.EqualTo("skill.zrelation"));
+            Assert.That(root.GetProperty("route_method").GetString(), Is.EqualTo("embedding"));
+            Assert.That(root.GetProperty("route_confidence").GetDouble(), Is.EqualTo(0.82).Within(1e-9));
+            Assert.That(root.GetProperty("embedder").GetString(), Is.EqualTo("bge-large"));
+            Assert.That(root.GetProperty("dim").GetInt32(), Is.EqualTo(4));
+        });
+
+        var vec = root.GetProperty("embedding").EnumerateArray().Select(e => e.GetSingle()).ToArray();
+        Assert.That(vec, Is.EqualTo(new[] { 0.10f, -0.20f, 0.30f, 0.40f }).Within(1e-6f),
+            "the EXACT vector the router scored must round-trip — the OOD lens analyses it");
+        Assert.That(vec.Length, Is.EqualTo(root.GetProperty("dim").GetInt32()), "dim must match the vector length");
+    }
+
+    [Test]
+    public void DeclinedRow_OmitsNullIntent_AndMarksFallback()
+    {
+        QueryEmbeddingLog.Append(SampleRouted() with { Intent = null, RouteMethod = "fallback" });
+
+        using var doc = JsonDocument.Parse(File.ReadAllLines(QueryEmbeddingLog.CurrentDayFile())[0]);
+        Assert.Multiple(() =>
+        {
+            Assert.That(doc.RootElement.TryGetProperty("intent", out _), Is.False, "null intent is omitted, not serialized");
+            Assert.That(doc.RootElement.GetProperty("route_method").GetString(), Is.EqualTo("fallback"));
+            // A declined query STILL records its confidence + vector — that's the OOD signal.
+            Assert.That(doc.RootElement.GetProperty("embedding").GetArrayLength(), Is.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public void DisableEnvVar_SuppressesWrites()
+    {
+        Environment.SetEnvironmentVariable(QueryEmbeddingLog.DisableEnvVar, "1");
+        QueryEmbeddingLog.Append(SampleRouted());
+        Assert.That(File.Exists(QueryEmbeddingLog.CurrentDayFile()), Is.False,
+            "GA_QUERY_EMBEDDING_NO_LOG=1 must suppress all writes");
+    }
+}


### PR DESCRIPTION
## What

**Cross-repo Contract B (GA → ix).** Persists the **exact** query vector the router scored with — *not* a re-embed — plus the decision it drove, so the sibling **ix** repo's `ix-duck` out-of-domain lens can flag queries far from the in-domain reference set (raw mean-top-3 cosine, the method ix's ROC sweep validated). JSON-on-disk contract, no runtime coupling.

## Audit finding (build vs wire)

The router **computes** the query vector to route and **logs the decision** (`RoutingTelemetryLog`), but **discards the vector** — no sink persists it. So this is a *new* sink (Contract B = "no writer"), not a re-wire.

## Changes

- **`QueryEmbeddingLog`** — append-only per-day JSONL at `state/quality/query-embeddings/<date>.jsonl`, mirroring `RoutingTelemetryLog` (write lock, error-swallow, `GA_QUERY_EMBEDDING_NO_LOG` disable, `GA_QUERY_EMBEDDING_DIR` override). Ratified field set: `query_id, ts, query_text, intent, route_method (embedding|fallback), route_confidence, embedder, dim, embedding[]`.
- **`SemanticIntentRouter`** — one emit per `RouteAsync`, right after the shadow hook, covering **both** the routed and declined paths with the same vector. `embedder` resolved **live** from generator metadata (`EmbeddingGeneratorMetadata.DefaultModelId`), `dim` from the vector length — never hardcoded. Error-swallowed; never affects routing.
- **Gitignored** — ~12KB/row (full vector) is bulky runtime telemetry, not a committed artifact; ix-duck reads the working tree cross-repo.

## Two corrections vs the brief's draft contract

| field | brief draft | this PR (correct) |
|---|---|---|
| `embedder` | `bge-base-en-v1.5` | **`bge-large`** (the merged Phase-2 routing embedder, #423) |
| `dim` | `768` | **1024** (recorded dynamically from the live generator) |

Recorded dynamically so it stays correct across future embedder swaps.

## Verify

`QueryEmbeddingLogTests` (3) + 10 existing router tests → **13/13 pass**:
- field-name contract (what ix-duck keys on) + **exact-vector round-trip**
- declined-row shape (null `intent` omitted, `route_method=fallback`, vector still recorded — that's the OOD signal)
- env-disable

## Notes

- **Default-on** (mirrors the existing routing telemetry); set `GA_QUERY_EMBEDDING_NO_LOG=1` to suppress. Real rows accrue as the chatbot routes live queries.
- Pairs with **Contract A** (loop ledger, PR #424). ix side: point `ix-duck` at `state/quality/query-embeddings/*.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)