### PR TITLE
feat(loop): self-termination controller — /auto-optimize stops from the ledger (Phase 2)

### DIFF
--- a/.claude/skills/auto-optimize/SKILL.md
+++ b/.claude/skills/auto-optimize/SKILL.md
@@ -50,9 +50,11 @@ error**; see Step 0.
 4. ALWAYS release the .lock on exit (success, failure, or kill).
 5. ALWAYS check state/.loop-halted and the per-domain .STOP marker
    BEFORE every iteration, not just at start.
-6. AUTO-EXIT when the last `plateau_window` cycles all improved the
-   metric by less than `plateau_threshold` (rel. to prior). Plateau
-   exit is not failure — it's the loop's job to know when to stop.
+6. SELF-GOVERN from the ledger via `Scripts/loop-decide.ps1` (Step 3.9):
+   `stop-plateau` → exit; `halt-oscillating` / `halt-misfire` → halt AND
+   emit an algedonic signal (escalate, never silent). The loop decides when
+   to stop from the durable trajectory — not a fixed count, not its own
+   optimism. Stopping at the right time IS the job; it is not failure.
 ```
 
 Memory notes worth honoring (read at session start):
@@ -258,8 +260,31 @@ For each cycle (up to `max_iterations`):
    ```
    Do NOT hand-build the JSON — the writer pins the field set + order to the
    fixture and derives `metric_delta`, so the schema can't drift.
-9. **Plateau check** — track last `plateau_window` cycles' rel. delta.
-   If all are below `plateau_threshold`, exit with status `plateau`.
+9. **Govern from the ledger (self-termination).** Instead of a fixed iteration
+   count or an in-memory plateau guess, ask the controller — it decides from the
+   durable trajectory the cycle just appended in sub-step 8:
+
+   ```powershell
+   $d = (pwsh Scripts/loop-decide.ps1 -Domain $domain -LoopId $loop_id `
+         -PlateauWindow $plateau_window -PlateauThreshold $plateau_threshold) | ConvertFrom-Json
+   switch ($d.decision) {
+     'continue'         { }                                  # → next iteration
+     'stop-plateau'     { $exit_status = 'plateau';     break }
+     'halt-oscillating' { $exit_status = 'oscillating'; break }   # escalate (below)
+     'halt-misfire'     { $exit_status = 'misfire';     break }   # escalate (below)
+   }
+   ```
+
+   On `halt-oscillating` / `halt-misfire`, **escalate, don't exit silently** — emit
+   an algedonic signal so the operator is told the loop stopped itself and why:
+   ```powershell
+   pwsh Scripts/algedonic-emit.ps1 -Severity warn -Repo ga -Source auto-optimize `
+     -Summary "loop($domain) self-halted: $($d.decision)" -Details $d.reason
+   ```
+   `halt-misfire` is the same fail-closed condition as sub-step 2 — the controller
+   just makes it a first-class, ledger-driven decision instead of an ad-hoc exit. The
+   `loop_convergence` view (`SELECT * FROM loop_convergence`) is the post-hoc audit
+   of the same trajectory the controller decided on live.
 
 ### Step 4: Open PR (NOT merge)
 

--- a/Scripts/loop-decide.ps1
+++ b/Scripts/loop-decide.ps1
@@ -1,0 +1,74 @@
+#!/usr/bin/env pwsh
+# loop-decide.ps1 — the self-termination controller for /auto-optimize (Phase 2).
+#
+# Reads the per-cycle ledger the loop is writing (state/quality/loops/<domain>.iterations.jsonl)
+# for the CURRENT run (loop_id) and returns a governance decision so the loop stops
+# from the *durable trajectory*, not a fixed iteration count or its own optimism:
+#
+#   continue          — still improving / not enough signal to stop
+#   stop-plateau      — last <PlateauWindow> cycles all moved the metric < <PlateauThreshold>
+#   halt-oscillating  — >= 2 regressed cycles this run (the fix-A-breaks-B thrash)
+#   halt-misfire      — the oracle couldn't run (verdict=couldnt_run) — NEVER treat as progress
+#
+# Precedence: misfire > oscillating > plateau > continue (oracle-broken is most urgent).
+# This mirrors the loop_convergence view's `shape` (build-views.sql) but adds the
+# recent-window plateau check the in-loop decision needs. Emits a JSON decision to
+# stdout and always exits 0 (success = "decision computed"); the caller reads .decision.
+#
+#   pwsh Scripts/loop-decide.ps1 -Domain chatbot-qa -LoopId chatbot-qa-20260615T1830Z
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string]$Domain,
+    [Parameter(Mandatory)] [string]$LoopId,
+    [int]$PlateauWindow = 5,
+    [double]$PlateauThreshold = 0.005,
+    [int]$OscillationRegressions = 2,
+    # Override the ledger path (tests point this at a fixture).
+    [string]$LedgerPath = ''
+)
+$ErrorActionPreference = 'Stop'
+if (-not $LedgerPath) { $LedgerPath = "state/quality/loops/$Domain.iterations.jsonl" }
+
+$rows = @()
+if (Test-Path $LedgerPath) {
+    $rows = Get-Content $LedgerPath |
+        Where-Object { $_.Trim() } |
+        ForEach-Object { $_ | ConvertFrom-Json } |
+        Where-Object { $_.loop_id -eq $LoopId } |
+        Sort-Object iteration
+}
+
+$iterations  = @($rows).Count
+$misfires    = @($rows | Where-Object { $_.verdict -eq 'couldnt_run' }).Count
+$regressions = @($rows | Where-Object { $_.verdict -eq 'regressed' }).Count
+
+# Recent-window plateau: the last PlateauWindow cycles that actually ran (delta not null)
+# all moved the metric by less than the threshold (absolute, matching loop_convergence).
+$ran     = @($rows | Where-Object { $_.metric_delta -ne $null })
+$recent  = @($ran | Select-Object -Last $PlateauWindow)
+$recentDeltas = @($recent | ForEach-Object { [double]$_.metric_delta })
+$isPlateau = ($recent.Count -ge $PlateauWindow) -and
+             (@($recentDeltas | Where-Object { [math]::Abs($_) -ge $PlateauThreshold }).Count -eq 0)
+
+$decision, $reason =
+    if ($misfires -gt 0) {
+        'halt-misfire', "oracle misfired on $misfires cycle(s) — verdict=couldnt_run; refusing to treat a non-run as progress"
+    } elseif ($regressions -ge $OscillationRegressions) {
+        'halt-oscillating', "$regressions regressed cycles (>= $OscillationRegressions) — loop is thrashing; escalate for human/next-layer work"
+    } elseif ($isPlateau) {
+        'stop-plateau', "last $PlateauWindow cycles all moved $($recent[0].metric_name) by < $PlateauThreshold — metric stopped responding to this toolbox"
+    } else {
+        'continue', "still improving or insufficient signal to stop ($iterations cycle(s), $regressions regression(s))"
+    }
+
+[pscustomobject]@{
+    decision      = $decision
+    reason        = $reason
+    loop_id       = $LoopId
+    domain        = $Domain
+    iterations    = $iterations
+    regressions   = $regressions
+    misfires      = $misfires
+    recent_deltas = $recentDeltas
+} | ConvertTo-Json -Compress
+exit 0

--- a/docs/plans/2026-06-15-feat-loop-observability-duckdb-ledger-plan.md
+++ b/docs/plans/2026-06-15-feat-loop-observability-duckdb-ledger-plan.md
@@ -1,0 +1,121 @@
+# Plan: loop observability — persist the per-iteration ledger into DuckDB
+
+**Date:** 2026-06-15
+**Type:** feat (instrumentation — **zero behavior change** to the loop's decisions)
+**Status:** IMPLEMENTED 2026-06-15 (steps 1–3; dashboard strip deferred). See **As built** at the end.
+**Parent research:** `docs/research/2026-06-15-nested-loop-chatbot-development-duckdb.md` (Phase 1)
+**Reversibility:** two-way door — purely additive (new JSONL files, new tables/view, additive SKILL edits). Nothing existing is removed or re-decided.
+
+## 1. Problem / who is in pain
+
+We run autonomous improvement loops (`/auto-optimize`) against the chatbot, but **we can't see whether a loop is converging, plateauing, or spinning** — the one question the research says must be a *query, not a vibe*. Concretely:
+
+- `auto-optimize` **Step 5** persists a *per-run* summary to `state/quality/<domain>/loop-history.jsonl` (`cycles_ran`, `metric_before/after`, `exit_status`).
+- **Step 3** computes each cycle's `metric_before → after` delta and the plateau window **in memory only** — it is never written. So the *trajectory inside a run* (the thing that reveals oscillation, slow climb, or a stuck loop) is lost the moment the run ends.
+- Nothing about loops reaches `quality.duckdb`, so the dashboard/`QualityLens` can't answer "are our loops working?".
+
+**What changes for the operator:** after this, `SELECT * FROM loop_convergence` answers "is this loop run improving / plateaued / oscillating / misfiring?" across every domain, and it surfaces on the dev dashboard. The loop's *behavior* is unchanged — we only record what it already computes.
+
+## 2. Design
+
+### 2a. A run identity to join on
+Generate a `loop_id` once at run start (Step 1) — `"{domain}-{utc:yyyyMMddTHHmmssZ}"`. Both ledgers carry it so per-iteration rows join to their run.
+
+### 2b. Per-iteration ledger (NEW) — `state/quality/<domain>/loop-iterations.jsonl`
+Append one line per cycle inside Step 3 (after the oracle + roundtrip + commit/revert decision is known):
+
+```jsonc
+{ "loop_id": "chatbot-qa-20260615T1830Z", "domain": "chatbot-qa", "iteration": 3,
+  "ts": "2026-06-15T18:34:02Z",
+  "oracle_status": "ok",                     // ok | couldnt_run | error
+  "metric_name": "pass_pct",
+  "metric_before": 0.90, "metric_after": 0.92, "metric_delta": 0.02,
+  "verdict": "improved",                     // improved | regressed | plateau | error | couldnt_run
+  "worst_item": "voice-leading-tritone-sub",
+  "artifact_edited": "Common/GA.Business.ML/Agents/Skills/VoiceLeadingSkill.cs",
+  "commit_sha": "a1b2c3d", "roundtrip_passed": true }
+```
+
+Critical: when the oracle's `oracle_status != "ok"` (the fail-closed contract in Step 3.2), the row is written with `verdict = "couldnt_run"` and `metric_after = null` — **a misfire is never recorded as progress** (the documented `auto-optimize` paranoia rule, now durable + queryable).
+
+### 2c. Per-run ledger (KEEP) — `state/quality/<domain>/loop-history.jsonl`
+Already written in Step 5; add `loop_id` so it joins. No other change.
+
+### 2d. DuckDB views — append to `state/quality/analytics/build-views.sql`
+```sql
+-- One row per loop RUN (Step 5 summary).
+CREATE OR REPLACE TABLE loop_run AS
+SELECT loop_id, domain,
+       TRY_CAST(metric_before AS DOUBLE) AS metric_before,
+       TRY_CAST(metric_after  AS DOUBLE) AS metric_after,
+       cycles_ran, exit_status, pr_url, timestamp AS ran_at
+FROM read_json_auto('*/loop-history.jsonl', filename = true, union_by_name = true);
+
+-- One row per loop ITERATION (Step 3 cycle).
+CREATE OR REPLACE TABLE loop_iteration AS
+SELECT loop_id, domain, iteration, ts,
+       oracle_status, metric_name,
+       TRY_CAST(metric_before AS DOUBLE) AS metric_before,
+       TRY_CAST(metric_after  AS DOUBLE) AS metric_after,
+       TRY_CAST(metric_delta  AS DOUBLE) AS metric_delta,
+       verdict, worst_item, artifact_edited, commit_sha, roundtrip_passed
+FROM read_json_auto('*/loop-iterations.jsonl', filename = true, union_by_name = true)
+ORDER BY loop_id, iteration;
+
+-- Convergence per run: the "improving / plateaued / oscillating / misfiring?" query.
+CREATE OR REPLACE VIEW loop_convergence AS
+SELECT loop_id, domain,
+       count(*)                                              AS iterations,
+       max(metric_after) - min(metric_before)               AS total_gain,
+       round(avg(metric_delta), 4)                          AS mean_delta,
+       sum(CASE WHEN abs(metric_delta) < 0.005 THEN 1 ELSE 0 END) AS plateau_iters,
+       sum(CASE WHEN verdict = 'regressed'   THEN 1 ELSE 0 END)   AS regressions,
+       sum(CASE WHEN verdict = 'couldnt_run' THEN 1 ELSE 0 END)   AS oracle_misfires,
+       CASE
+         WHEN sum(CASE WHEN verdict='couldnt_run' THEN 1 ELSE 0 END) > 0 THEN 'misfiring'
+         WHEN sum(CASE WHEN verdict='regressed'  THEN 1 ELSE 0 END) >= 2 THEN 'oscillating'
+         WHEN max(metric_after) - min(metric_before) > 0.01              THEN 'improving'
+         ELSE 'plateaued'
+       END                                                  AS shape
+FROM loop_iteration GROUP BY loop_id, domain;
+```
+(The `chatbot-qa/*` glob already lives under `state/quality/`; the script runs from there, so `*/loop-iterations.jsonl` picks up every domain.)
+
+### 2e. Surface it (small)
+- `QualityLens` already runs arbitrary SQL read-only → `SELECT * FROM loop_convergence ORDER BY ran_at DESC` works day one, no code.
+- Dashboard (stretch, optional this phase): a "Loop convergence" strip on the **Harness** tab (`LoopsGoalsCard` neighbour) reading a new `/dev-data/loop-convergence` middleware query, colour by `shape` (improving=green, plateaued=grey, oscillating/misfiring=red).
+
+## 3. Steps
+
+1. **SKILL.md edits** (`.claude/skills/auto-optimize/SKILL.md`): emit `loop_id` at Step 1; append the per-iteration record in Step 3 (incl. the `couldnt_run` branch tied to the existing fail-closed contract in 3.2); add `loop_id` to the Step 5 record. *Spec-only change to the executor; no new behavior, just a write.*
+2. **`build-views.sql`**: append the `loop_run` + `loop_iteration` tables and `loop_convergence` view (§2d).
+3. **Fixture + verify** (the proof this phase works without running a real multi-hour loop): commit a tiny `state/quality/_fixtures/loop-iterations.sample.jsonl` with a known improving run, an oscillating run, and a misfire run; a test asserts `loop_convergence.shape` classifies all three correctly via `duckdb < build-views.sql` over the fixture. (Keeps fixtures out of the real `chatbot-qa/` glob.)
+4. **Dashboard strip** (optional/stretch): `/dev-data/loop-convergence` + a Harness-tab card.
+
+## 4. Success criteria (mechanizable)
+
+- After a loop run (or against the fixture), `SELECT shape, count(*) FROM loop_convergence GROUP BY shape` returns rows, and the three fixture runs classify as `improving` / `oscillating` / `misfiring` respectively.
+- A run whose oracle never executed shows `oracle_misfires > 0` and `shape = 'misfiring'` — **never** `improving` (regression-guards the paranoia rule).
+- `dotnet`/frontend builds unaffected; `quality.duckdb` rebuilds clean; existing `quality_latest` unchanged.
+
+## 5. One-way doors / guardrails
+
+- None. Additive only. If unwanted, delete the two JSONL globs + the three SQL objects; the loop reverts to its current (silent) behavior.
+- Does **not** touch the loop's decision logic, scope_boundary, kill switches, or merge gates — observability only. Changing the loop to *act on* `loop_convergence` (self-termination) is **Phase 2**, explicitly out of scope here.
+
+## 6. Effort
+
+~2–3h: SKILL edits + the SQL block + the fixture test. Dashboard strip is another ~1h if taken this phase.
+
+## As built (2026-06-15)
+
+Two refinements vs. the design above, both simplifications:
+
+- **Single seeded ledger dir.** Ledgers live in `state/quality/loops/<domain>.iterations.jsonl` (one dir, not per-domain snapshot dirs). A committed sentinel `loops/__seed__.iterations.jsonl` keeps the `loops/*.iterations.jsonl` glob non-empty — verified that a **zero-match glob errors** in DuckDB, an empty file does not. The views filter `loop_id <> '__seed__'`. `loops/README.md` documents it.
+- **`loop_run` dropped for Phase 1.** `loop_convergence` already groups by `loop_id`, so it *is* the per-run rollup — no separate `loop_run` table, no second glob, and **Step 5 is untouched** (the existing per-run `loop-history.jsonl` write stays). A `loop_run` with `exit_status`/`pr_url` can join in later if the dashboard wants it.
+
+**Files:** `state/quality/analytics/build-views.sql` (+`loop_iteration` table, `loop_convergence` view), `.claude/skills/auto-optimize/SKILL.md` (Step 1 `loop_id`, Step 3 step 9 ledger append incl. the `couldnt_run` branch), `state/quality/loops/{__seed__.iterations.jsonl,README.md}`, `state/quality/_fixtures/{loop-iterations.sample.jsonl,verify-loop-convergence.ps1}`.
+
+**Verified:** `verify-loop-convergence.ps1` runs the real `build-views.sql` with the fixture dropped into the glob and asserts all four shapes — `improving / oscillating / misfiring / plateaued` — classify correctly (incl. a misfiring run that must **not** read as improving). PASS. Confirms the full analytics layer still builds with the new objects.
+
+**Out of scope (Phase 2):** the loop *acting on* `loop_convergence` (self-termination from the trajectory) and the dashboard strip.

--- a/docs/research/2026-06-15-nested-loop-chatbot-development-duckdb.md
+++ b/docs/research/2026-06-15-nested-loop-chatbot-development-duckdb.md
@@ -1,0 +1,125 @@
+# Nested-loop development for the GA chatbot, with DuckDB as the state backbone
+
+**Date:** 2026-06-15
+**Type:** research + design synthesis (not a commitment to build)
+**Question:** Can we structure the *development* of the GA chatbot as **nested loops** — in the spirit of Claude Code `/loop` and `/goal` — using **DuckDB as the durable backbone**?
+
+## TL;DR
+
+**Yes — and you've already built ~80% of it.** The pattern (fast inner loop + slow outer loop, each gated by a verifier, convergence tracked in a durable store) is well-established and now first-class in Claude Code. GA already has the oracles (chatbot-qa corpus, RoutingEvalHarness, the ix-duck flight recorder), the loop executor (`/auto-optimize`), the DuckDB analytics layer (`quality.duckdb`), and a loop/goal tracker. What's missing is **the connective tissue that makes "is the loop converging?" a SQL query**: a per-iteration loop ledger, plateau detection, and wiring the flight-recorder gate into CI.
+
+**The one hard caveat:** the load-bearing part of any dev loop is the **oracle, not the loop**. GA's *mechanical* quality (routing correctness, canonical-trace stability, invariant pass-rate) is deterministically verifiable → safe to loop. GA's *fuzzy* quality (answer helpfulness, tone, NL correctness) is only LLM-judgeable → keep a human or the Demerzel tribunal on that gate. Don't let a fuzzy judge drive an autonomous inner loop; that's where loops produce "locally successful, globally wrong" output.
+
+---
+
+## 1. The model: two loops, two oracle classes
+
+The consensus decomposition (Anthropic's "gather context → act → verify → repeat", OODA's nested short/long cycles, closed-loop control with the goal as setpoint):
+
+| | **Inner loop** (tactical) | **Outer loop** (strategic) |
+|---|---|---|
+| Cycle | per change, seconds–minutes | per goal, hours–days |
+| Drives | edit → build → test → eval-one | "is the capability good enough to ship?" |
+| Oracle | **deterministic** (build, unit tests, routing match, canonical-trace diff, invariant pass) | **eval suite + human/tribunal** on fuzzy quality |
+| Claude primitive | `/goal` (condition-based autonomy w/ independent checker) | `/loop` watchdog + human review gate |
+| Exit | success condition verified, or stop on stagnation/ambiguity | metric ≥ target on the corpus AND tribunal pass |
+
+**The ratchet is the highest-leverage guardrail:** every passing eval becomes a one-way door — CI auto-blocks any change that regresses it. GA already has the polarity-aware roundtrip validators to enforce this.
+
+**Convergence is a query, not a vibe.** The inner loop's continue/stop/escalate decision should read the metric trajectory from DuckDB (improving → continue; plateau → stop & report; oscillating/regressing → halt & escalate), *not* the agent's self-assessment (agents are systematically optimistic about completion).
+
+## 2. How the nesting maps onto GA
+
+```
+OUTER GOAL LOOP  (daily eval + human/tribunal, ratcheted in CI)
+  goal: chatbot-qa pass_pct ≥ 0.94  AND  routing accuracy ≥ baseline  AND  no canonical-trace regressions
+  oracle: state/quality/chatbot-qa/*.json (corpus) + routing-eval + ix-duck flight recorder
+  │
+  └── INNER TASK LOOP  (/auto-optimize, per-change, deterministic oracle)
+        pick worst failing prompt → edit Agents/**/*.cs (scope-bounded) → run oracle →
+        roundtrip-validate → commit if improved, revert if regressed → repeat to plateau
+        │
+        └── TACTICAL LOOP  (/goal or the edit-build-test inner loop on a single fix)
+              build + targeted test until the one prompt's invariants pass
+```
+
+Existing components already playing each role:
+
+- **Outer oracle:** `Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml` (50-prompt invariant suite) via `Scripts/run-prompt-corpus.ps1 -Snapshot`; `RoutingEvalHarness.cs`; `ix/crates/ix-duck/src/chatbot.rs` flight recorder (hard signal = routed `agent_id` vs `_signature.json` canonical).
+- **Outer contract / setpoint:** `state/quality/chatbot-qa/baseline.json` (metric=`pass_pct`, primary_baseline=0.94, scope_boundary, plateau_window=5, plateau_threshold=0.005, kill switches).
+- **Inner executor:** `.claude/skills/auto-optimize/SKILL.md` (lock → iterate → oracle → revert/commit → plateau exit) + `docs/runbooks/chatbot-improvement-loop.md` patterns A/B/C.
+- **Loop/goal runtime state:** `.claude/hooks/loops-goals-tracker.ps1` → `state/.runtime-loops-goals.jsonl` → `/dev-data/runtime-loops-goals` → `LoopsGoalsCard`.
+- **Escalation channel:** `state/algedonic/inbox.jsonl` (severity/ack/supersedes) — the loop's "pain signal".
+
+## 3. DuckDB as the backbone
+
+**Why DuckDB specifically:** convergence and regression questions are *analytical aggregations over many runs* — columnar, fast, reads JSONL/Parquet directly. The right split (per the durable-execution literature): **JSONL/SQLite = per-run append-only journal (resumability), DuckDB = cross-run trajectory analytics (convergence)**. GA's `quality.duckdb` + `GaDuckLens`/`QualityLens` already *is* the analytics half; the daily `chatbot_qa` table is the **outer** loop's trajectory. What's missing is the **inner** loop's per-iteration trajectory.
+
+Proposed additions to `state/quality/analytics/build-views.sql` (materialized from a new `loop-history.jsonl` the executor writes):
+
+```sql
+-- One row per inner-loop iteration (written by /auto-optimize).
+CREATE OR REPLACE TABLE loop_iteration AS
+SELECT day, domain, loop_id, iteration, oracle_name,
+       metric_name, TRY_CAST(metric_value AS DOUBLE) AS metric_value,
+       TRY_CAST(metric_delta AS DOUBLE) AS metric_delta,
+       verdict,                       -- improved | regressed | plateau | error | couldnt_run
+       artifact_edited, commit_sha, started_at
+FROM read_json_auto('chatbot-qa/loop-history.jsonl', union_by_name = true);
+
+-- Convergence view: is each loop run improving, plateaued, or diverging?
+CREATE OR REPLACE VIEW loop_convergence AS
+SELECT loop_id, domain,
+       count(*)                                  AS iterations,
+       max(metric_value) - min(metric_value)     AS total_gain,
+       avg(metric_delta)                         AS mean_delta,
+       sum(CASE WHEN abs(metric_delta) < 0.005 THEN 1 ELSE 0 END) AS plateau_iters,
+       sum(CASE WHEN verdict='regressed' THEN 1 ELSE 0 END)       AS regressions,
+       sum(CASE WHEN verdict='couldnt_run' THEN 1 ELSE 0 END)     AS oracle_misfires
+FROM loop_iteration GROUP BY loop_id, domain;
+```
+
+The executor then makes its stop decision by **querying its own ledger** (`plateau_iters >= plateau_window` → stop; `oracle_misfires > 0` → halt, never count a misfire as "passed" — the documented auto-optimize paranoia rule). `ix.duckdb_extension`'s `ix_pca_project`/`ix_silhouette` can additionally cluster failure embeddings to pick which failure family to attack next.
+
+## 4. What exists vs. the gaps
+
+| Need | Status | Where |
+|---|---|---|
+| Outer oracle (corpus, routing, traces) | ✅ built | `prompts.yaml`, `RoutingEvalHarness.cs`, `ix-duck/src/chatbot.rs` |
+| Setpoint contract (baseline + scope + plateau params) | ✅ built | `state/quality/chatbot-qa/baseline.json` |
+| Inner loop executor | ✅ built | `.claude/skills/auto-optimize/SKILL.md` |
+| DuckDB analytics + read lenses | ✅ built | `quality.duckdb`, `build-views.sql`, `QualityLens`, `GaDuckLens` |
+| Loop/goal runtime state | ✅ built | `loops-goals-tracker.ps1` → JSONL → dashboard |
+| Vector ops in DuckDB (cluster failures) | ✅ built | `ix.duckdb_extension` (merged) |
+| **Per-iteration loop ledger** (`loop-history.jsonl` writer) | ❌ gap | `/auto-optimize` declares `history_file` but doesn't write it |
+| **Plateau detection from trajectory** | ❌ gap | contract has params; executor doesn't compute delta-window |
+| **Flight-recorder gate in CI** | ❌ gap | `chatbot.rs` done; no `--features duck` CI step |
+| **Live eval backend in CI** (real metric, not `degraded`) | 🟡 in flight | chatbot-qa CI thread; PR #409 (CF-Access Ollama) open |
+| **Convergence-as-a-query view** | ❌ gap | proposed §3 |
+
+## 5. Failure modes & guardrails (and GA's existing answers)
+
+| Failure mode | GA mitigation (existing or to-add) |
+|---|---|
+| Non-termination | hard `max_iterations` + `max_wall_clock_minutes` in baseline contract ✅ |
+| Oscillation / regression | revert-on-regress + ratchet; add oscillation halt from `loop_iteration` ❌ |
+| Reward hacking (edits tests, hardcodes) | scope_boundary protects corpus/oracle/baseline ✅; diff-scoped edits ✅ |
+| Silent oracle failure ("passed" but couldn't run) | gate verdict on process exit code; `verdict='couldnt_run'` ❌ (documented paranoia rule, not yet enforced in ledger) |
+| Cost runaway | iteration/commit caps ✅; add token budget |
+| Fuzzy-quality drift | keep human/Demerzel tribunal on the outer gate ✅; never let LLM-judge drive the inner loop |
+| Kill switch | `state/.loop-halted`, `state/quality/<domain>/.STOP`, `~/.demerzel/HALT-ALL` ✅ |
+
+## 6. Feasibility verdict & phased recommendation
+
+**Feasible and low-risk to start, because the oracle and the store already exist.** This is *closing a loop*, not building one. Suggested phasing (each independently shippable, reversible):
+
+- **Phase 1 — Make the loop observable.** `/auto-optimize` writes `loop-history.jsonl` per iteration; add `loop_iteration` + `loop_convergence` to `build-views.sql`; surface on the dashboard. *No behavior change — just instrumentation.* This alone answers "are our improvement loops actually converging or spinning?".
+- **Phase 2 — Make the loop self-terminating.** ✅ **DONE 2026-06-15.** `Scripts/loop-decide.ps1` reads the per-cycle ledger for the current run and returns `continue / stop-plateau / halt-oscillating / halt-misfire` (precedence: misfire > oscillating > plateau > continue). `/auto-optimize` Step 3.9 calls it instead of a fixed count, and escalates via `algedonic-emit.ps1` on a self-halt. `couldnt_run ≠ passed` is enforced (misfire checked first). Verified: `state/quality/_fixtures/verify-loop-decide.ps1` — all four decisions correct.
+- **Phase 3 — Ratchet in CI.** Wire the ix-duck flight-recorder gate (`--features duck`) as a required check; make routing-eval a gate once the live backend lands (PR #409). Now the outer loop's ratchet is mechanical.
+- **Phase 4 — Compound the process.** ✅ **DONE 2026-06-15.** `/auto-optimize` Step 6: after a run, pull its `loop_convergence` trajectory + edited artifacts, invoke `/learnings` (records what worked / what thrashed into `docs/solutions/`) + `/digest`. Step 3.4 must consult those solutions before editing, so the loop never re-walks a thrashing path. This is the meta-loop that makes each run start smarter.
+
+**Hold the line at:** the outer fuzzy-quality judgment stays human/tribunal-gated; autonomous cycles stay branch-only/never-merge (the existing afk-harness rule); OPTIC-K/schema/pricing remain one-way doors needing sign-off.
+
+## Sources
+
+External synthesis (full source list in the research thread): Anthropic *Building effective agents* / *Building agents with the Claude Agent SDK* / *Effective harnesses for long-running agents*; eval-driven development (Braintrust, evaldriven.org, Red Hat); compound engineering (Every.to); OODA & control-loop framings; "SQLite is becoming the agent black box"; the Ralph Wiggum loop failure catalog; Claude Code `/goal` `/loop` `/batch` `/background` writeups. Internal inventory: see the component paths cited inline.

--- a/state/quality/_fixtures/verify-loop-convergence.ps1
+++ b/state/quality/_fixtures/verify-loop-convergence.ps1
@@ -1,0 +1,54 @@
+#!/usr/bin/env pwsh
+# verify-loop-convergence.ps1 — proves build-views.sql's loop_convergence view
+# classifies improving / oscillating / misfiring / plateaued runs correctly,
+# WITHOUT running a real multi-hour loop.
+#
+# Method: drop the fixture into the production glob as loops/__test__.iterations.jsonl,
+# run the REAL analytics/build-views.sql (no duplicated SQL), query loop_convergence
+# for the __test__ domain, assert the four shapes, then clean up.
+#
+#   pwsh state/quality/_fixtures/verify-loop-convergence.ps1
+[CmdletBinding()]
+param()
+$ErrorActionPreference = 'Stop'
+$qualityDir = Split-Path $PSScriptRoot -Parent          # state/quality
+$fixture    = Join-Path $PSScriptRoot 'loop-iterations.sample.jsonl'
+$testFile   = Join-Path $qualityDir 'loops/__test__.iterations.jsonl'
+$expected   = @{
+    'test-improving'   = 'improving'
+    'test-oscillating' = 'oscillating'
+    'test-misfiring'   = 'misfiring'
+    'test-plateaued'   = 'plateaued'
+}
+
+Copy-Item $fixture $testFile -Force
+try {
+    Push-Location $qualityDir
+    try {
+        $sql = (Get-Content 'analytics/build-views.sql' -Raw) +
+               "`nSELECT loop_id || '=' || shape FROM loop_convergence WHERE domain = '__test__' ORDER BY loop_id;`n"
+        $out = $sql | duckdb -noheader -list
+    } finally { Pop-Location }
+
+    $got = @{}
+    foreach ($line in ($out -split "`r?`n" | Where-Object { $_ -match '=' })) {
+        $k, $v = $line.Trim() -split '=', 2
+        $got[$k] = $v
+    }
+
+    $fail = $false
+    foreach ($id in $expected.Keys) {
+        $want = $expected[$id]; $have = $got[$id]
+        if ($have -eq $want) {
+            Write-Host "  PASS  $id -> $have" -ForegroundColor Green
+        } else {
+            Write-Host "  FAIL  $id -> expected '$want', got '$have'" -ForegroundColor Red
+            $fail = $true
+        }
+    }
+    if ($fail) { throw 'loop_convergence classification mismatch' }
+    Write-Host 'OK: loop_convergence classifies all four shapes correctly.' -ForegroundColor Green
+}
+finally {
+    Remove-Item $testFile -ErrorAction SilentlyContinue
+}

--- a/state/quality/_fixtures/verify-loop-decide.ps1
+++ b/state/quality/_fixtures/verify-loop-decide.ps1
@@ -1,0 +1,33 @@
+#!/usr/bin/env pwsh
+# verify-loop-decide.ps1 — proves Scripts/loop-decide.ps1 returns the right
+# governance decision for each run shape, using the shared fixture.
+#
+#   pwsh state/quality/_fixtures/verify-loop-decide.ps1
+[CmdletBinding()]
+param()
+$ErrorActionPreference = 'Stop'
+$repo    = Resolve-Path (Join-Path $PSScriptRoot '../../..')
+$decide  = Join-Path $repo 'Scripts/loop-decide.ps1'
+$fixture = Join-Path $PSScriptRoot 'loop-iterations.sample.jsonl'
+
+# PlateauWindow=3 because the fixture's plateaued run has 3 cycles.
+$expected = @{
+    'test-improving'   = 'continue'
+    'test-oscillating' = 'halt-oscillating'
+    'test-misfiring'   = 'halt-misfire'
+    'test-plateaued'   = 'stop-plateau'
+}
+
+$fail = $false
+foreach ($id in $expected.Keys) {
+    $out = & $decide -Domain '__test__' -LoopId $id -LedgerPath $fixture -PlateauWindow 3 | ConvertFrom-Json
+    $want = $expected[$id]
+    if ($out.decision -eq $want) {
+        Write-Host "  PASS  $id -> $($out.decision)" -ForegroundColor Green
+    } else {
+        Write-Host "  FAIL  $id -> expected '$want', got '$($out.decision)' ($($out.reason))" -ForegroundColor Red
+        $fail = $true
+    }
+}
+if ($fail) { throw 'loop-decide decision mismatch' }
+Write-Host 'OK: loop-decide governs all four run shapes correctly.' -ForegroundColor Green

--- a/state/quality/analytics/build-views.sql
+++ b/state/quality/analytics/build-views.sql
@@ -131,3 +131,38 @@ UNION ALL
 SELECT 'voicing_analysis' AS source, day, corpus_total      AS metric, 'corpus_total'      AS metric_name FROM voicing_analysis QUALIFY row_number() OVER (ORDER BY day DESC) = 1
 UNION ALL
 SELECT 'optick_sae'       AS source, day, reconstruction_r2  AS metric, 'reconstruction_r2' AS metric_name FROM optick_sae       QUALIFY row_number() OVER (ORDER BY day DESC) = 1;
+
+-- loop_iteration / loop_convergence — per-cycle telemetry from the /auto-optimize
+-- loop, so "is this loop run improving / plateaued / oscillating / misfiring?" is a
+-- query, not a vibe. The loop appends one JSON line per cycle to
+-- loops/<domain>.iterations.jsonl (see .claude/skills/auto-optimize/SKILL.md Step 3).
+-- A committed sentinel (loops/__seed__.iterations.jsonl) keeps the glob non-empty
+-- before any loop has run — a zero-match glob is an error — and is filtered out below.
+CREATE OR REPLACE TABLE loop_iteration AS
+SELECT loop_id, domain, iteration, ts, oracle_status, metric_name,
+       TRY_CAST(metric_before AS DOUBLE) AS metric_before,
+       TRY_CAST(metric_after  AS DOUBLE) AS metric_after,
+       TRY_CAST(metric_delta  AS DOUBLE) AS metric_delta,
+       verdict, worst_item, artifact_edited, commit_sha, roundtrip_passed
+FROM read_json_auto('loops/*.iterations.jsonl', filename = true, union_by_name = true)
+WHERE loop_id <> '__seed__'
+ORDER BY loop_id, iteration;
+
+-- Per-run convergence rollup (one row per loop_id). `shape` is the operator's
+-- at-a-glance verdict; misfires are checked FIRST so an oracle that never ran can
+-- never read as 'improving' (the /auto-optimize fail-closed / paranoia rule).
+CREATE OR REPLACE VIEW loop_convergence AS
+SELECT loop_id, domain,
+       count(*)                                                    AS iterations,
+       max(metric_after) - min(metric_before)                     AS total_gain,
+       round(avg(metric_delta), 4)                                AS mean_delta,
+       sum(CASE WHEN abs(metric_delta) < 0.005 THEN 1 ELSE 0 END)  AS plateau_iters,
+       sum(CASE WHEN verdict = 'regressed'   THEN 1 ELSE 0 END)    AS regressions,
+       sum(CASE WHEN verdict = 'couldnt_run' THEN 1 ELSE 0 END)    AS oracle_misfires,
+       CASE
+         WHEN sum(CASE WHEN verdict = 'couldnt_run' THEN 1 ELSE 0 END) > 0  THEN 'misfiring'
+         WHEN sum(CASE WHEN verdict = 'regressed'  THEN 1 ELSE 0 END) >= 2  THEN 'oscillating'
+         WHEN max(metric_after) - min(metric_before) > 0.01                 THEN 'improving'
+         ELSE 'plateaued'
+       END                                                         AS shape
+FROM loop_iteration GROUP BY loop_id, domain;


### PR DESCRIPTION
## Impact

Completes **Phase 2** of the nested-loop plan. Contract A (the per-cycle loop-iteration ledger *writer*) merged in #424; this adds the **consumer** so the loop decides when to stop from its own durable trajectory instead of a fixed iteration count or an in-memory plateau guess.

## What's here

- **`Scripts/loop-decide.ps1`** — reads `state/quality/loops/<domain>.iterations.jsonl` for the current `loop_id` and returns `continue` / `stop-plateau` / `halt-oscillating` / `halt-misfire`. Precedence is **misfire > oscillating > plateau > continue**, so an oracle that couldn't run (`couldnt_run`) can never read as progress — the fail-closed paranoia rule.
- **`build-views.sql`** — appends the `loop_iteration` table + `loop_convergence` view (the post-hoc audit of the same trajectory). Added *after* the existing `optick_sae` table, which is **preserved** (this is a surgical append onto main's current file, not a copy of the stale branch version).
- **`auto-optimize` SKILL.md** — Step 3.9 calls the controller and escalates a self-halt via `algedonic-emit.ps1`; Iron Law 6 reworded from AUTO-EXIT to SELF-GOVERN. **Step 3.8's `loop-record.ps1` writer (from #424) is left untouched.**
- **`verify-loop-decide.ps1` / `verify-loop-convergence.ps1`** — fixture-driven self-tests.

## Test output

Both verifies pass **4/4** locally:
```
verify-loop-decide:      misfiring→halt-misfire, improving→continue, oscillating→halt-oscillating, plateaued→stop-plateau  ✓
verify-loop-convergence: plateaued, misfiring, oscillating, improving all classified correctly  ✓
```
`algedonic-emit.ps1` (referenced by the self-halt escalation) confirmed present on main.

## Provenance

Extracted cleanly off `main` from the stale `feat/duckdb-quality-analytics` checkpoint branch — only the self-termination slice, reconciled against #424's already-merged writer wiring and the `optick_sae` table that landed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)