### PR TITLE
fix(domain): IntervalClassVector.Major decoded to garbage — base-10 literal vs base-12 id

### DIFF
--- a/Apps/ga-server/GaApi/Models/VoicingEntity.cs
+++ b/Apps/ga-server/GaApi/Models/VoicingEntity.cs
@@ -86,7 +86,7 @@ public class VoicingEntity
     public string? ForteCode { get; set; }
 
     /// <summary>
-    /// Interval class vector (e.g., "<254361>")
+    /// Interval class vector in ToString form, e.g. "&lt;2 5 4 3 6 1&gt;" (space-separated counts)
     /// </summary>
     [BsonElement("intervalClassVector")]
     public string? IntervalClassVector { get; set; }

--- a/Common/GA.Domain.Core/Theory/Atonal/IntervalClassVector.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/IntervalClassVector.cs
@@ -18,7 +18,9 @@ using Design.Schema;
 ///     <br />
 ///     Modes from a scale share the same Interval Class Vector - Example:<br />
 ///     <bt />
-///     Major scale => 254361 | Dorian mode => 254361 | etc...
+///     Major scale => &lt;2 5 4 3 6 1&gt; | Dorian mode => &lt;2 5 4 3 6 1&gt; | etc...<br />
+///     (the counts are packed base-12 into the <see cref="IntervalClassVectorId" />,
+///     so the major scale's id is 608761 — NOT the decimal-looking 254361.)
 /// </remarks>
 [PublicAPI]
 [DomainInvariant("Must contain exactly 6 interval class counts", "Count == 6")]
@@ -31,7 +33,19 @@ public sealed class IntervalClassVector(IntervalClassVectorId id) :
     IComparable<IntervalClassVector>,
     IEquatable<IntervalClassVector>
 {
-    public static readonly IntervalClassVector Major = new(new IntervalClassVectorId(254361));
+    // Derived from the canonical major-scale interval-class counts <2 5 4 3 6 1> via the
+    // counts ctor — NOT a hardcoded id — so it stays consistent with the base-12
+    // IntervalClassVectorId encoding. A prior base-10 literal (254361) silently decoded to
+    // <1 0 3 2 4 9> once the id encoding moved to base-12. See IntervalClassVectorId.ToValue.
+    public static readonly IntervalClassVector Major = new(new Dictionary<IntervalClass, int>
+    {
+        [IntervalClass.FromValue(1)] = 2,
+        [IntervalClass.FromValue(2)] = 5,
+        [IntervalClass.FromValue(3)] = 4,
+        [IntervalClass.FromValue(4)] = 3,
+        [IntervalClass.FromValue(5)] = 6,
+        [IntervalClass.FromValue(6)] = 1,
+    });
 
     /// <summary>
     ///     Constructs an Interval Class Vector from the number of occurrences for each Interval Class

--- a/Common/GA.Domain.Core/Theory/Atonal/IntervalClassVectorId.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/IntervalClassVectorId.cs
@@ -4,7 +4,14 @@ namespace GA.Domain.Core.Theory.Atonal;
 ///     Uniquely identifies an Interval Class Vector as a base-12 integer
 /// </summary>
 /// <remarks>
-///     e.g. &lt;2, 5, 4, 3, 6, 1&gt; Interval Class Vector (From major scale or its modes) => 254361
+///     e.g. the &lt;2 5 4 3 6 1&gt; interval-class vector (major scale or its modes) packs
+///     base-12 to Value = 608761 (2·12⁵ + 5·12⁴ + 4·12³ + 3·12² + 6·12 + 1). Base-12 (not
+///     base-10) is used so each count digit holds 0–11 — base-10 corrupts any count ≥ 10,
+///     which occurs for sets of cardinality ≥ 11.
+///     KNOWN LIMITATION: a single count of exactly 12 still overflows a base-12 digit, so the
+///     full chromatic aggregate &lt;12 12 12 12 12 6&gt; does NOT round-trip (decodes to
+///     &lt;1 1 1 1 0 6&gt;). Every set of cardinality ≤ 11 is safe; revisit (base-13 or a
+///     6-field record) only if the 12-note aggregate ever needs a faithful id.
 /// </remarks>
 /// <param name="Value">The base-12 <see cref="int" /> value</param>
 public readonly record struct IntervalClassVectorId(int Value) : IComparable<IntervalClassVectorId>
@@ -61,7 +68,8 @@ public readonly record struct IntervalClassVectorId(int Value) : IComparable<Int
     {
         // Normalize: ensure all interval classes [1..6] are present with default value 0
         // Accumulate weights starting from IC6 (least significant digit) up to IC1 (most significant)
-        // to match GetVector() decomposition and the documented encoding (e.g., 254361).
+        // to match GetVector() decomposition and the documented encoding (major scale
+        // <2 5 4 3 6 1> => 608761 in base 12).
         var value = 0;
         var weight = 1;
 

--- a/GA.Data.MongoDB/Models/VoicingEntity.cs
+++ b/GA.Data.MongoDB/Models/VoicingEntity.cs
@@ -88,7 +88,7 @@ public class VoicingEntity
     public string? ForteCode { get; set; }
 
     /// <summary>
-    /// Interval class vector (e.g., "<254361>")
+    /// Interval class vector in ToString form, e.g. "&lt;2 5 4 3 6 1&gt;" (space-separated counts)
     /// </summary>
     [BsonElement("intervalClassVector")]
     public string? IntervalClassVector { get; set; }

--- a/Tests/Common/GA.Business.Core.Tests/Atonal/IntervalClassVectorTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Atonal/IntervalClassVectorTests.cs
@@ -1,0 +1,84 @@
+namespace GA.Business.Core.Tests.Atonal;
+
+using NUnit.Framework;
+using Domain.Core.Theory.Atonal;
+
+[TestFixture]
+public class IntervalClassVectorTests
+{
+    // Regression guard: IntervalClassVector.Major must be the *actual* major-scale ICV
+    // <2 5 4 3 6 1>, packed base-12 to id 608761. A prior hardcoded base-10 literal
+    // (254361) silently decoded to <1 0 3 2 4 9> once the id encoding became base-12.
+    [Test]
+    public void Major_HasCanonicalMajorScaleVector()
+    {
+        Assert.That(IntervalClassVector.Major.Vector.Values, Is.EqualTo(new[] { 2, 5, 4, 3, 6, 1 }));
+    }
+
+    [Test]
+    public void Major_PacksToBase12Id_608761_NotDecimal254361()
+    {
+        Assert.That(IntervalClassVector.Major.Id.Value, Is.EqualTo(608761),
+            "Major must encode base-12; 254361 is the stale base-10 literal that decodes to <1 0 3 2 4 9>.");
+    }
+
+    [Test]
+    public void Major_RoundTripsFromCounts()
+    {
+        var fromCounts = new IntervalClassVector(new Dictionary<IntervalClass, int>
+        {
+            [IntervalClass.FromValue(1)] = 2,
+            [IntervalClass.FromValue(2)] = 5,
+            [IntervalClass.FromValue(3)] = 4,
+            [IntervalClass.FromValue(4)] = 3,
+            [IntervalClass.FromValue(5)] = 6,
+            [IntervalClass.FromValue(6)] = 1,
+        });
+
+        Assert.That(fromCounts, Is.EqualTo(IntervalClassVector.Major));
+    }
+
+    // Base-12 (vs base-10) exists so counts up to 11 survive a round-trip — they occur for
+    // sets of cardinality >= 11. Pins that guarantee and catches a base regression
+    // (base-10 corrupts any count >= 10).
+    [Test]
+    public void CountsUpTo11_RoundTrip_UnderBase12()
+    {
+        var counts = new Dictionary<IntervalClass, int>
+        {
+            [IntervalClass.FromValue(1)] = 11,
+            [IntervalClass.FromValue(2)] = 11,
+            [IntervalClass.FromValue(3)] = 11,
+            [IntervalClass.FromValue(4)] = 11,
+            [IntervalClass.FromValue(5)] = 11,
+            [IntervalClass.FromValue(6)] = 5,
+        };
+
+        var icv = new IntervalClassVector(counts);
+
+        Assert.That(icv.Vector.Values, Is.EqualTo(new[] { 11, 11, 11, 11, 11, 5 }));
+    }
+
+    // Documented limitation: a single count of exactly 12 (only the full chromatic aggregate)
+    // overflows a base-12 digit and does NOT round-trip. Pins the KNOWN behavior so it can't
+    // change silently; to make it faithful, move to base-13 or a 6-field record
+    // (see IntervalClassVectorId remarks).
+    [Test]
+    public void ChromaticAggregate_Count12_IsLossy_KnownLimitation()
+    {
+        var counts = new Dictionary<IntervalClass, int>
+        {
+            [IntervalClass.FromValue(1)] = 12,
+            [IntervalClass.FromValue(2)] = 12,
+            [IntervalClass.FromValue(3)] = 12,
+            [IntervalClass.FromValue(4)] = 12,
+            [IntervalClass.FromValue(5)] = 12,
+            [IntervalClass.FromValue(6)] = 6,
+        };
+
+        var icv = new IntervalClassVector(counts);
+
+        Assert.That(icv.Vector.Values, Is.Not.EqualTo(new[] { 12, 12, 12, 12, 12, 6 }),
+            "count=12 overflows base-12; if this starts passing, the encoding was widened — update the docs.");
+    }
+}


### PR DESCRIPTION
## The bug (surfaced while writing a domain-model teaching course)

`IntervalClassVector.Major` was `new(new IntervalClassVectorId(254361))`. But the id encoding is **base-12** (a count digit must hold 0–11; base-10 corrupts any count ≥ 10, which happens for sets of cardinality ≥ 11). So the decimal-looking literal `254361` decodes in base-12 to the nonsense vector **`<1 0 3 2 4 9>`** (9 tritones in a 7-note scale) instead of the major scale's **`<2 5 4 3 6 1>`** (correct base-12 id **608761**).

Classic stale-constant-after-a-base-change: the encode/decode moved to base-12 but the `Major` literal + every doc example stayed base-10. `Major` is currently unreferenced in logic, so nothing live broke — but it's a loaded trap, and the docs actively misled (they misled the course).

## Fix
- **Derive `Major` from its counts** via the dictionary ctor (`CreateFrom` → base-12) so it can never drift from the encoding again — no magic id literal.
- Correct the misleading docs in `IntervalClassVector` / `IntervalClassVectorId` and the two `VoicingEntity` examples (`"<254361>"` was neither the id nor the `ToString` form `"<2 5 4 3 6 1>"`).
- **Document a deeper latent limitation:** even base-12 can't hold a count of **12**, so the full chromatic aggregate `<12 12 12 12 12 6>` is lossy (decodes `<1 1 1 1 0 6>`). Safe for cardinality ≤ 11; revisit (base-13 / 6-field record) only if the 12-note aggregate ever needs a faithful id.
- **Regression test** (`Tests/Common/GA.Business.Core.Tests/Atonal/IntervalClassVectorTests.cs` — placed in the in-solution project): pins `Major` = `<2 5 4 3 6 1>` / id 608761, the ≤11 round-trip, and the count-12 limitation.

## Verification
- `dotnet build GA.Domain.Core -c Debug`: **0 errors, 0 warnings.**
- Encoding arithmetic independently verified; test compiles (local execution blocked only by a running GaApi holding DLL locks — CI runs it).

## Side findings (not fixed here, flagged for triage)
- **`GA.Domain.Core.Tests` is in no solution** (`AllProjects.slnx`) — it doesn't build/run in CI, which is why its pre-existing `Chord.FromSymbol` compile break went unnoticed. (Why this test went into `GA.Business.Core.Tests` instead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)