### PR TITLE
fix(atonal): emit canonical Allen Forte 1973 numbers (major triad = 3-11)

### DIFF
--- a/Common/GA.Domain.Core/Theory/Atonal/CanonicalForteCatalog.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/CanonicalForteCatalog.cs
@@ -201,6 +201,19 @@ public static class CanonicalForteCatalog
         // index part (may carry a leading Z), e.g. "Z29" or "11".
         var indexPart = label[(dash + 1)..];
 
+        // The trivial classes use synthetic labels (matching TryGetForteLabel): the empty
+        // set is 0-1 and the chromatic aggregate is 12-1. Keep forward/reverse symmetric.
+        if (cardinality == 0)
+        {
+            primeForm = new PitchClassSet(Enumerable.Empty<PitchClass>());
+            return indexPart == "1";
+        }
+        if (cardinality == 12)
+        {
+            primeForm = new PitchClassSet(Enumerable.Range(0, 12).Select(PitchClass.FromValue));
+            return indexPart == "1";
+        }
+
         if (cardinality <= 6)
         {
             return CoreByLabel.TryGetValue(label, out primeForm!);

--- a/Common/GA.Domain.Core/Theory/Atonal/CanonicalForteCatalog.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/CanonicalForteCatalog.cs
@@ -213,4 +213,67 @@ public static class CanonicalForteCatalog
         primeForm = complementSet.Complement.PrimeForm ?? complementSet.Complement;
         return true;
     }
+
+    private static readonly Lazy<IReadOnlyDictionary<PitchClassSetId, string>> _labelByPrimeId =
+        new(BuildReverse, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static IReadOnlyDictionary<PitchClassSetId, string> BuildReverse()
+    {
+        var map = new Dictionary<PitchClassSetId, string>();
+        foreach (var (label, set) in CoreByLabel)
+        {
+            // Key on GA's own prime-form id so callers passing any orbit member resolve.
+            map[(set.PrimeForm ?? set).Id] = label;
+        }
+        return map;
+    }
+
+    /// <summary>
+    ///     Inverse of <see cref="TryGetPrimeForm"/>: resolves a prime form to its
+    ///     canonical Forte label — e.g. {0,3,7} → "3-11", {0,1,3,7} → "4-Z29".
+    ///     Cardinalities 7–11 are derived via the complement rule (same index + Z as
+    ///     the complement); the empty set and chromatic aggregate map to "0-1" / "12-1".
+    ///     Returns false for any input that is not a recognized set class.
+    /// </summary>
+    public static bool TryGetForteLabel(PitchClassSet primeForm, out string? label)
+    {
+        label = null;
+        if (primeForm is null) return false;
+
+        var n = primeForm.Count;
+        if (n == 0) { label = "0-1"; return true; }
+        if (n == 12) { label = "12-1"; return true; }
+
+        var pf = primeForm.PrimeForm ?? primeForm;
+        if (n <= 6)
+        {
+            return _labelByPrimeId.Value.TryGetValue(pf.Id, out label);
+        }
+
+        // Cardinalities 7–11: the set class n-k is the complement of (12−n)-k and
+        // shares its index and Z-status, so look up the complement's label and swap
+        // the cardinality prefix.
+        var complement = pf.Complement;
+        var complementPrime = complement.PrimeForm ?? complement;
+        if (!_labelByPrimeId.Value.TryGetValue(complementPrime.Id, out var complementLabel))
+        {
+            return false;
+        }
+
+        var dash = complementLabel!.IndexOf('-');
+        label = $"{n}-{complementLabel[(dash + 1)..]}";
+        return true;
+    }
+
+    /// <summary>
+    ///     Inverse lookup returning a <see cref="ForteNumber"/> (with its
+    ///     <see cref="ForteNumber.IsZRelated"/> flag set) rather than a string.
+    ///     See <see cref="TryGetForteLabel"/>.
+    /// </summary>
+    public static bool TryGetForteNumber(PitchClassSet primeForm, out ForteNumber forte)
+    {
+        forte = default;
+        return TryGetForteLabel(primeForm, out var label)
+               && ForteNumber.TryParse(label, null, out forte);
+    }
 }

--- a/Common/GA.Domain.Core/Theory/Atonal/ForteCatalog.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/ForteCatalog.cs
@@ -1,12 +1,15 @@
 namespace GA.Domain.Core.Theory.Atonal;
 
 /// <summary>
-///     Forte catalog for mapping pitch-class sets to Forte numbers.
-///     Uses the fully programmatic ProgrammaticForteCatalog for complete coverage.
+///     Maps pitch-class sets to their <b>canonical Allen Forte 1973 number</b>
+///     (e.g. the major triad is 3-11, the all-interval tetrachord is 4-Z29),
+///     backed by <see cref="CanonicalForteCatalog"/>.
 /// </summary>
 /// <remarks>
-///     Uses Rahn ordering (lexicographic by ICV, then by prime form ID) which is
-///     mathematically consistent and complete for all 224 set classes.
+///     For GA's internal Rahn-ordered ordinal (lexicographic by ICV, then prime-form
+///     id) use <see cref="ProgrammaticForteCatalog"/> directly. That ordinal is NOT
+///     Forte's catalog number — it diverges for most set classes — so it must not be
+///     surfaced to users or cross-joined with external Forte-numbered data.
 /// </remarks>
 public static class ForteCatalog
 {
@@ -16,19 +19,29 @@ public static class ForteCatalog
     public static int TotalSetClasses => ProgrammaticForteCatalog.Count;
 
     /// <summary>
-    ///     Attempts to get the Forte number for a given pitch class set.
+    ///     Attempts to get the canonical Forte number for a given prime form.
     /// </summary>
     public static bool TryGetForteNumber(PitchClassSet primeForm, out ForteNumber forte) =>
-        ProgrammaticForteCatalog.TryGetForteNumber(primeForm, out forte);
+        CanonicalForteCatalog.TryGetForteNumber(primeForm, out forte);
 
     /// <summary>
-    ///     Gets the Forte number for a given pitch class set, or null if not found.
+    ///     Gets the canonical Forte number for a given pitch class set, or null if not found.
     /// </summary>
-    public static ForteNumber? GetForteNumber(PitchClassSet set) => ProgrammaticForteCatalog.GetForteNumber(set);
+    public static ForteNumber? GetForteNumber(PitchClassSet set) =>
+        CanonicalForteCatalog.TryGetForteNumber(set.PrimeForm ?? set, out var forte) ? forte : null;
 
     /// <summary>
-    ///     Attempts to get the prime form for a given Forte number.
+    ///     Attempts to get the prime form for a given canonical Forte number.
     /// </summary>
-    public static bool TryGetPrimeForm(ForteNumber forte, out PitchClassSet? primeForm) =>
-        ProgrammaticForteCatalog.TryGetPrimeForm(forte, out primeForm);
+    public static bool TryGetPrimeForm(ForteNumber forte, out PitchClassSet? primeForm)
+    {
+        if (CanonicalForteCatalog.TryGetPrimeForm(forte.ToString(), out var set))
+        {
+            primeForm = set;
+            return true;
+        }
+
+        primeForm = null;
+        return false;
+    }
 }

--- a/Common/GA.Domain.Core/Theory/Atonal/ForteNumber.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/ForteNumber.cs
@@ -64,6 +64,14 @@ public readonly record struct ForteNumber :
     /// </summary>
     public int Index { get; }
 
+    /// <summary>
+    ///     True when this set class is Z-related — its canonical Forte label carries
+    ///     a "Z" marker (e.g. "4-Z29"). Z-related set classes share an interval-class
+    ///     vector with a different set class. Defaults to <c>false</c> (the Rahn-ordered
+    ///     <see cref="ProgrammaticForteCatalog"/> does not model the Z marker).
+    /// </summary>
+    public bool IsZRelated { get; init; }
+
     #region IStaticReadonlyCollection Members
 
     /// <summary>
@@ -75,7 +83,7 @@ public readonly record struct ForteNumber :
     #endregion
 
     /// <inheritdoc />
-    public override string ToString() => $"{Cardinality.Value}-{Index}";
+    public override string ToString() => $"{Cardinality.Value}-{(IsZRelated ? "Z" : "")}{Index}";
 
     #region Innner Classes
 
@@ -132,13 +140,26 @@ public readonly record struct ForteNumber :
         }
 
         var parts = s.Split('-');
-        if (parts.Length != 2 || !int.TryParse(parts[0], out var cardinality) || !int.TryParse(parts[1], out var index))
+        if (parts.Length != 2 || !int.TryParse(parts[0], out var cardinality))
+        {
+            return false; // Failure
+        }
+
+        // The index may carry a leading "Z" marker for Z-related set classes, e.g. "4-Z29".
+        var indexPart = parts[1];
+        var isZRelated = indexPart.StartsWith("Z", StringComparison.OrdinalIgnoreCase);
+        if (isZRelated)
+        {
+            indexPart = indexPart[1..];
+        }
+
+        if (!int.TryParse(indexPart, out var index))
         {
             return false; // Failure
         }
 
         // Success
-        result = new(cardinality, index);
+        result = new ForteNumber(cardinality, index) { IsZRelated = isZRelated };
         return true;
     }
 

--- a/Common/GA.Domain.Core/Theory/Atonal/ForteNumber.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/ForteNumber.cs
@@ -97,32 +97,34 @@ public readonly record struct ForteNumber :
 
         private static IEnumerable<ForteNumber> Collection()
         {
-            var setClassesByCardinality = SetClass.Items
-                .GroupBy(sc => sc.Cardinality)
-                .ToImmutableDictionary(g => g.Key, g => g.Count());
+            // Canonical Forte numbers (Z markers included) for every set class, so display
+            // surfaces such as the GraphQL Forte-number hierarchy render "4-Z29", not the
+            // bare "4-29". Distinct because T/I-equivalent sets share one Forte number.
+            var result = new List<ForteNumber>();
+            var seen = new HashSet<(int Card, int Index, bool Z)>();
 
-            return Enumerable.Range(0, 13)
-                .SelectMany(cardinality =>
-                {
-                    var count = GetIndexCount(cardinality, setClassesByCardinality);
-                    // If there are no set classes for this cardinality, yield none instead of throwing
-                    return count == 0
-                        ? []
-                        : Enumerable.Range(1, count).Select(index => new ForteNumber(cardinality, index));
-                });
-
-            static int GetIndexCount(int cardinality, IReadOnlyDictionary<Cardinality, int> setClassesByCardinality)
+            void TryAdd(ForteNumber f)
             {
-                return cardinality switch
+                if (seen.Add((f.Cardinality.Value, f.Index, f.IsZRelated)))
                 {
-                    // For the empty set, the singleton set, and the full chromatic set we have a single class
-                    0 or 1 or 12 => 1,
-                    // For other cardinalities (2..11), use the number of distinct set classes if available
-                    _ when setClassesByCardinality.TryGetValue(cardinality, out var count) => count,
-                    // If not available, return 0 to avoid blowing up static initialization in test environments
-                    _ => 0
-                };
+                    result.Add(f);
+                }
             }
+
+            foreach (var setClass in SetClass.Items)
+            {
+                if (ForteCatalog.TryGetForteNumber(setClass.PrimeForm, out var forte))
+                {
+                    TryAdd(forte);
+                }
+            }
+
+            // Ensure the trivial classes are present even if SetClass.Items omits them.
+            if (TryParse("0-1", null, out var empty)) TryAdd(empty);
+            if (TryParse("12-1", null, out var chromatic)) TryAdd(chromatic);
+
+            result.Sort();
+            return result;
         }
     }
 

--- a/Common/GA.Domain.Core/Theory/Atonal/SetClassLabelFormatter.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/SetClassLabelFormatter.cs
@@ -1,15 +1,17 @@
 namespace GA.Domain.Core.Theory.Atonal;
 
 /// <summary>
-///     Display-only label formatter for set-class notation (Forte/Rahn).
-///     Uses the programmatic ForteCatalog for complete coverage.
+///     Display-only label formatter for set-class notation. <see cref="SetClassNotation.Forte"/>
+///     yields the canonical Allen Forte 1973 number (via <see cref="ForteCatalog"/> /
+///     <see cref="CanonicalForteCatalog"/>); <see cref="SetClassNotation.Rahn"/> yields GA's
+///     internal Rahn-ordered ordinal (via <see cref="ProgrammaticForteCatalog"/>).
 /// </summary>
 [PublicAPI]
 public static class SetClassLabelFormatter
 {
     /// <summary>
     ///     Computes a display label for the given <see cref="SetClass"/> in the requested notation.
-    ///     Both Forte and Rahn use the programmatic catalog (Rahn ordering).
+    ///     Forte → canonical 1973 catalog (e.g. major triad "3-11"); Rahn → GA's Rahn ordinal.
     /// </summary>
     public static string ToLabel(SetClass setClass, SetClassNotation notation)
     {
@@ -18,15 +20,22 @@ public static class SetClassLabelFormatter
         switch (notation)
         {
             case SetClassNotation.Forte:
-            case SetClassNotation.Rahn:
             {
-                // Use programmatic catalog for both Forte and Rahn
-                // (Note: This uses Rahn ordering for both, which is mathematically consistent)
+                // Canonical Allen Forte 1973 number, e.g. the major triad is "3-11".
                 if (ForteCatalog.TryGetForteNumber(setClass.PrimeForm, out var forte))
                 {
                     return forte.ToString();
                 }
-                // Fallback: use ICV-based heuristic
+                return $"{n}-{setClass.IntervalClassVector.Id.Value % 100}";
+            }
+
+            case SetClassNotation.Rahn:
+            {
+                // GA's internal Rahn ordering (lexicographic by ICV, then prime-form id).
+                if (ProgrammaticForteCatalog.TryGetForteNumber(setClass.PrimeForm, out var rahn))
+                {
+                    return rahn.ToString();
+                }
                 return $"{n}-{setClass.IntervalClassVector.Id.Value % 100}";
             }
 
@@ -36,12 +45,9 @@ public static class SetClassLabelFormatter
     }
 
     /// <summary>
-    ///     Returns both Forte and Rahn labels for convenience (display-only).
-    ///     Note: Both return the same value since we use a unified ordering.
+    ///     Returns both the canonical Forte label and the Rahn-ordinal label (display-only).
+    ///     These now differ for most set classes (only the Forte label is the standard catalog number).
     /// </summary>
     public static (string forte, string rahn) ToDualLabel(SetClass setClass)
-    {
-        var label = ToLabel(setClass, SetClassNotation.Forte);
-        return (label, label);
-    }
+        => (ToLabel(setClass, SetClassNotation.Forte), ToLabel(setClass, SetClassNotation.Rahn));
 }

--- a/Tests/Common/GA.Business.Core.Tests/Atonal/CanonicalForteCatalogTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Atonal/CanonicalForteCatalogTests.cs
@@ -110,4 +110,54 @@ public class CanonicalForteCatalogTests
         Assert.That((set.PrimeForm ?? set).Cardinality.Value, Is.EqualTo(8));
         Assert.That(set.IsZRelated, Is.True);
     }
+
+    // ── Forward lookup (prime form → canonical Forte label) ─────────────────────
+
+    [TestCase("047", "3-11")]    // major triad
+    [TestCase("037", "3-11")]    // minor triad — same set class
+    [TestCase("07", "2-5")]      // perfect-fifth dyad (the {0,7} → 2-5 case GA got wrong)
+    [TestCase("048", "3-12")]    // augmented triad
+    [TestCase("0137", "4-Z29")]  // all-interval tetrachord (Z marker preserved)
+    [TestCase("0146", "4-Z15")]  // all-interval tetrachord
+    [TestCase("0158", "4-20")]   // major-seventh chord set class
+    public void ForwardLookup_Returns_Canonical_Forte(string pcs, string expected)
+    {
+        Assert.That(PitchClassSet.TryParse(pcs, null, out var set), Is.True);
+        var prime = set.PrimeForm ?? set;
+
+        Assert.That(CanonicalForteCatalog.TryGetForteLabel(prime, out var label), Is.True);
+        Assert.That(label, Is.EqualTo(expected));
+
+        // The public facade must agree (this is what every consumer calls).
+        Assert.That(ForteCatalog.GetForteNumber(set)?.ToString(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ForwardLookup_Derives_Complement_Cardinality_7()
+    {
+        // 7-35 (the diatonic collection) is the complement of 5-35; exercises the 7–11 path.
+        Assert.That(CanonicalForteCatalog.TryGetPrimeForm("7-35", out var diatonic), Is.True);
+        Assert.That(CanonicalForteCatalog.TryGetForteLabel(diatonic.PrimeForm ?? diatonic, out var label), Is.True);
+        Assert.That(label, Is.EqualTo("7-35"));
+    }
+
+    [Test]
+    public void Forward_Then_Reverse_RoundTrips_For_Every_GA_SetClass()
+    {
+        // The strong invariant: for every set class GA knows (cardinalities 1–11),
+        // prime-form → canonical label → prime-form returns the same prime form.
+        foreach (var sc in SetClass.Items)
+        {
+            var prime = sc.PrimeForm;
+            var card = prime.Cardinality.Value;
+            if (card is 0 or 12) continue; // trivial classes use synthetic "0-1"/"12-1" labels
+
+            Assert.That(CanonicalForteCatalog.TryGetForteLabel(prime, out var label), Is.True,
+                $"no canonical label for prime form {prime} (card {card})");
+            Assert.That(CanonicalForteCatalog.TryGetPrimeForm(label, out var back), Is.True,
+                $"canonical label {label} did not resolve back to a prime form");
+            Assert.That((back.PrimeForm ?? back).Id, Is.EqualTo(prime.Id),
+                $"round-trip mismatch: {prime} → {label} → {back}");
+        }
+    }
 }

--- a/Tests/Common/GA.Business.ML.Tests/CoverAllModesIntegrationTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/CoverAllModesIntegrationTests.cs
@@ -82,7 +82,7 @@ public class CoverAllModesIntegrationTests
             "C Major (Ionian)",
             new[] { 0, 2, 4, 5, 7, 9, 11 },
             0,
-            new[] { "Set:7-1", "Flavor:Ionian" },
+            new[] { "Set:7-35", "Flavor:Ionian" }, // 7-35 = canonical Forte for the diatonic collection
             new[] { "Flavor:Lydian" }
         );
 
@@ -90,7 +90,7 @@ public class CoverAllModesIntegrationTests
             "C Altered (Super Locrian)",
             new[] { 0, 1, 3, 4, 6, 8, 10 },
             0,
-            new[] { "Set:7-2", "Flavor:Altered" },
+            new[] { "Set:7-34", "Flavor:Altered" }, // 7-34 = canonical Forte (melodic-minor collection)
             null
         );
 
@@ -98,7 +98,7 @@ public class CoverAllModesIntegrationTests
             "Whole Tone",
             new[] { 0, 2, 4, 6, 8, 10 },
             0,
-            new[] { "Set:6-1", "Flavor:Whole-tone" },
+            new[] { "Set:6-35", "Flavor:Whole-tone" }, // 6-35 = canonical Forte for the whole-tone scale
             null
         );
 
@@ -106,7 +106,7 @@ public class CoverAllModesIntegrationTests
             "Vienna Trichord",
             new[] { 0, 1, 6 },
             0,
-            new[] { "Set:3-8" },
+            new[] { "Set:3-5" }, // {0,1,6} Viennese trichord = canonical Forte 3-5
             new[] { "Flavor:Ionian", "Flavor:Major" }
         );
 
@@ -122,7 +122,7 @@ public class CoverAllModesIntegrationTests
             "Chromatic Cluster",
             new[] { 0, 1, 2 },
             0,
-            new[] { "Set:3-12" },
+            new[] { "Set:3-1" }, // {0,1,2} chromatic cluster = canonical Forte 3-1
             new[] { "Flavor:Ionian", "Flavor:Major", "Flavor:Dorian" }
         );
 
@@ -130,7 +130,7 @@ public class CoverAllModesIntegrationTests
             "Pentatonic Major",
             new[] { 0, 2, 4, 7, 9 },
             0,
-            new[] { "Set:5-1" },
+            new[] { "Set:5-35" }, // {0,2,4,7,9} major pentatonic = canonical Forte 5-35
             null // Accepts both Pentatonic Major and Ionian
         );
 
@@ -138,7 +138,7 @@ public class CoverAllModesIntegrationTests
             "Power Chord (Sparse)",
             new[] { 0, 7 },
             0,
-            new[] { "Power Chord", "Set:2-2" },
+            new[] { "Power Chord", "Set:2-5" }, // {0,7}→prime {0,5} = canonical Forte 2-5
             new[] { "Flavor:Altered", "Flavor:Locrian" }
         );
     }

--- a/Tests/Common/GA.Business.ML.Tests/ExhaustiveCoverageTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/ExhaustiveCoverageTests.cs
@@ -63,14 +63,20 @@ public class ExhaustiveCoverageTests
 
     public static IEnumerable<TestCaseData> GetForteTestCases()
     {
+        // AutoTagging emits the CANONICAL Forte label (ForteCatalog → CanonicalForteCatalog),
+        // so the expected tag is the canonical number, not the programmatic Rahn ordinal.
+        // Enumerate every prime form GA knows and pair it with its canonical label.
         foreach (var kvp in ProgrammaticForteCatalog.ForteByPrimeFormId)
         {
-            var forteNumber = kvp.Value.ToString();
             var pcs = ProgrammaticForteCatalog.PrimeFormByForte[kvp.Value];
-            var pcArray = pcs.Select(p => p.Value).ToArray();
+            if (!CanonicalForteCatalog.TryGetForteLabel(pcs.PrimeForm ?? pcs, out var canonical) || canonical is null)
+            {
+                continue;
+            }
 
-            yield return new TestCaseData(kvp.Key.ToString(), forteNumber, pcArray)
-                .SetName($"Forte_{forteNumber}");
+            var pcArray = pcs.Select(p => p.Value).ToArray();
+            yield return new TestCaseData(kvp.Key.ToString(), canonical, pcArray)
+                .SetName($"Forte_{canonical}");
         }
     }
 


### PR DESCRIPTION
## Problem

GA''s `ForteCatalog` returned `ProgrammaticForteCatalog`''s **Rahn ordinal** (set classes numbered `1..n` per cardinality, sorted by ICV id then prime-form id) and labelled it "Forte". That ordinal is **not** Allen Forte''s 1973 catalog number — it diverges for most set classes:

| set | GA emitted | canonical Forte |
|---|---|---|
| major triad {0,4,7} | `3-2` | **`3-11`** |
| perfect fifth {0,7} | `2-2` | **`2-5`** |
| diminished {0,3,6} | `3-3` | **`3-10`** |
| augmented {0,4,8} | `3-1` | **`3-12`** |

Measured impact: against the IX canonical catalog, GA''s `forteCode` agreed on only **0.7%** of real voicings (ICV agreed 100%). So GA''s Forte number was un-joinable with any external Forte-numbered data (the `ix-bracelet`/`ix-duck` set-theory UDFs, textbooks, other software).

## Fix

GA already shipped the canonical table (`CanonicalForteCatalog`, hand-transcribed + test-verified Forte 1973) but only wired it label→prime-form. This adds the inverse and puts it on the forward path:

- **`CanonicalForteCatalog`** — `TryGetForteLabel` / `TryGetForteNumber` (prime-form → canonical label incl. the `Z` marker; cardinalities 7–11 via the complement rule; 0/12 → `0-1`/`12-1`).
- **`ForteNumber`** — carries an `IsZRelated` flag so `4-Z29` round-trips through `ToString`/`TryParse` (defaults `false`; the Rahn ordinal has no Z).
- **`ForteCatalog`** — `TryGetForteNumber`/`GetForteNumber`/`TryGetPrimeForm` now delegate to `CanonicalForteCatalog`. Every consumer (`ga_chord_to_set`, chatbot/`IxAlgebraService`, GraphQL, RAG `forteCode`, `AutoTaggingService`, CLI, tab analysis) becomes canonical at one point.
- **`SetClassLabelFormatter`** — the `Forte` vs `Rahn` split is now real: `Forte` → canonical catalog, `Rahn` → `ProgrammaticForteCatalog` (the ordinal, correctly named).

`ProgrammaticForteCatalog` is unchanged and remains GA''s Rahn catalog.

## Not affected — no corpus rebuild
The OPTIC-K embedding encodes ICV / cardinality / prime-form bitmask, **not** the Forte ordinal string, so **no schema-hash bump and no corpus vector rebuild** are required.

## Deferred (separate operator step — one-way doors)
Not in this PR (they rewrite persisted/generated data): regenerate `AtonalModalFamilies.yaml` & `ExtendedScales.yaml`, and re-index the MongoDB `forteCode` field (`--drop`). Until then, persisted voicing documents still carry the old Rahn labels even though the engine now computes canonical ones.

## Testing
- New forward-lookup cases (`{0,4,7}`→`3-11`, `{0,7}`→`2-5`, `{0,1,3,7}`→`4-Z29`, `{0,1,4,6}`→`4-Z15`, `{0,1,5,8}`→`4-20`) + a full forward→reverse round-trip over **every** GA set class via the engine.
- Full `GA.Business.Core.Tests`: **843 passed, 0 failed, 5 skipped.**

## Post-Deploy Monitoring & Validation
After merge + GA MCP/server rebuild, verify live: `ga_chord_to_set "C"` should report `Forte: 3-11` (was `3-2`). Watch chatbot Forte-lookup traces and GraphQL `forte` metadata. Rollback = revert (no data migrated by this PR). Re-index MongoDB + regenerate the two YAMLs as the follow-up rollout before relying on persisted `forteCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)