### PR TITLE
fix(quality): drop 3 non-existent repos from readme-drift survey (clears false red)

### DIFF
--- a/.github/workflows/readme-drift-sensor.yml
+++ b/.github/workflows/readme-drift-sensor.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -e
           # Sibling list mirrors baseline.json tracked_repos. Update both together.
-          for repo in ix Demerzel tars guitaralchemist.github.io mergerisk agent-blackbox demerzel-bot devto-mcp fin ga-godot hari; do
+          for repo in ix Demerzel tars guitaralchemist.github.io agent-blackbox demerzel-bot ga-godot hari; do
             echo "Cloning $repo..."
             if gh repo clone "GuitarAlchemist/$repo" "$repo" -- --depth=50 --no-tags 2>/dev/null; then
               echo "  ok"

--- a/Scripts/readme-drift-survey.ps1
+++ b/Scripts/readme-drift-survey.ps1
@@ -53,11 +53,8 @@ $Repos = @(
     'Demerzel',
     'tars',
     'guitaralchemist.github.io',
-    'mergerisk',
     'agent-blackbox',
     'demerzel-bot',
-    'devto-mcp',
-    'fin',
     'ga-godot',
     'hari'
 )

--- a/state/quality/readme-drift/baseline.json
+++ b/state/quality/readme-drift/baseline.json
@@ -23,11 +23,8 @@
     "Demerzel",
     "tars",
     "guitaralchemist.github.io",
-    "mergerisk",
     "agent-blackbox",
     "demerzel-bot",
-    "devto-mcp",
-    "fin",
     "ga-godot",
     "hari"
   ],


### PR DESCRIPTION
## Summary

The **readme-drift** quality tile was stuck permanently **🔴 red**, not because of stale docs but because the `oracle_status` rule forces `"error"` whenever `absent > 0`, and the survey tracked three repos that **don't exist** under `GuitarAlchemist/*`:

| Repo | `gh repo view` |
|---|---|
| `mergerisk` | **404** |
| `devto-mcp` | **404** |
| `fin` | **404** |

Every weekly run marked them `absent` ("Repo directory not found …"), pinning the tile red regardless of real README freshness and masking the actual signal.

## Change

Remove the three phantoms from all three coordinated sites (the survey comment requires they stay in sync):
- `Scripts/readme-drift-survey.ps1` → `$Repos`
- `state/quality/readme-drift/baseline.json` → `tracked_repos`
- `.github/workflows/readme-drift-sensor.yml` → sibling clone loop

The four genuinely-stale READMEs (`ga`, `demerzel-bot`, `ga-godot`, `hari`) are **left untouched** — they're real doc drift and should stay visible. After this change the tile reads **amber** (`stale>0`), which is the honest state, instead of red. `primary_baseline` (stale_count = 3) is unaffected — phantoms were `absent`, never counted as `stale`.

## Testing
Ran the survey against the real siblings root:
```
oracle_status=warn   metric=0.6667   absent=0
repos surveyed: ga, ix, Demerzel, tars, guitaralchemist.github.io, agent-blackbox, demerzel-bot, ga-godot, hari
```
JSON + YAML re-validated.

## Not in this PR (documented, deliberately deferred)
- **chatbot-qa-sessions** "DEGRADED" is a *staleness* label only — its content passes (0.75 > 0.70 baseline). The fix is a scheduled producer mirroring `chatbot-qa-snapshot.yml` to run `Scripts/run-session-corpus.ps1 -Snapshot`. That's a ~200-line workflow with an Ollama-runner dependency I can't CI-verify from outside; filing as a follow-up rather than shipping a workflow I can't validate (green-but-dead discipline).
- **embeddings 🔴** is working-as-designed (index absent on hosted runner → the artifact is correctly `degraded`/amber; the manifest aggregator coerces it to red). No GA code change needed — that's an aggregator alignment, tracked separately.

## Post-Deploy Monitoring & Validation
- **Watch:** the next `README Drift Sensor` run (Mondays 08:00 UTC, or `workflow_dispatch`).
- **Expected healthy signal:** snapshot `summary.absent == 0`; `oracle_status` ∈ {`ok`,`warn`} (never `error` from phantoms); the readme-drift tile renders amber, not red.
- **Failure signal / rollback:** if `absent > 0` reappears, a tracked repo genuinely failed to clone (PAT access) — investigate the token, don't re-add phantoms. Revert = restore the three names in all three files.
- **Window/owner:** one weekly cycle; operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
