### PR TITLE
fix(atonal): AtonalModalFamiliesGenerator emits canonical Forte (follow-up to #434)

### DIFF
--- a/Demos/AtonalModalFamiliesGenerator/Program.cs
+++ b/Demos/AtonalModalFamiliesGenerator/Program.cs
@@ -180,7 +180,7 @@ internal static class Program
         var forteNumbers = new SortedSet<string>(StringComparer.Ordinal);
         foreach (var mode in family.Modes)
         {
-            var forte = ProgrammaticForteCatalog.GetForteNumber(mode);
+            var forte = ForteCatalog.GetForteNumber(mode);
             if (forte.HasValue) forteNumbers.Add(forte.Value.ToString());
         }
 
@@ -410,7 +410,7 @@ internal static class Program
         sb.Append("# cross-referenced against GA.Business.Config/Modes.yaml for tonal analogs.\n");
         sb.Append("#\n");
         sb.Append("# - Families are keyed by IntervalClassVector (atonal invariant).\n");
-        sb.Append("# - Forte numbers come from ProgrammaticForteCatalog (Rahn ordering).\n");
+        sb.Append("# - Forte numbers come from ForteCatalog (canonical Allen Forte 1973; e.g. major triad = 3-11).\n");
         sb.Append("# - Tonal analogs are imported from Modes.yaml via PitchClassSetId matching\n");
         sb.Append("#   (resilient to ICV string drift in the curated data).\n");
         sb.Append("# - Unnamed families use positional modes (no coined names).\n");


### PR DESCRIPTION
## Summary

Follow-up to #434. That PR retargeted `ForteCatalog` to canonical Allen Forte 1973 numbering, but `AtonalModalFamiliesGenerator` called `ProgrammaticForteCatalog.GetForteNumber` **directly** (Rahn ordinal). So running the deferred-rollout step "regenerate `AtonalModalFamilies.yaml`" would have **reproduced the old mislabels** (e.g. `Family-3-8` instead of canonical `Family-3-5`). One-line retarget closes the gap.

- `Program.cs:183` — `ProgrammaticForteCatalog.GetForteNumber` → `ForteCatalog.GetForteNumber`
- `Program.cs:413` — preamble comment updated (now `ForteCatalog` / canonical)

## Testing
- `dotnet build Demos/AtonalModalFamiliesGenerator` → **0 errors** (the swap typechecks — same signature).
- Ran the generator; spot-checks pass and the output is now canonical:
  - `3-11` (major triad) present
  - Z-markers present (`5-Z12`, `6-Z10`, …) — exercises the `IsZRelated` flag from #434
  - genuine Rahn→canonical relabels: `3-8`→`3-5`, `3-4`→`3-9`

The **regenerated YAML is deliberately not committed here** — this PR is the code fix only.

## Rollout note (operator, separate step)
The actual artifact regen + DB re-index is the coordinated rollout and is **not** in this PR:
1. `dotnet run --project Demos/ScaleCatalogGenerator` (ExtendedScales.yaml — already canonical) + `dotnet run --project Demos/AtonalModalFamiliesGenerator` (now correct with this PR), commit both YAMLs.
2. **Stop `GaApi` + `GaMcpServer`** (release Mongo/mmap locks), then re-index voicings with `--drop` (**destructive — `voicings` collection only**). Verify first on `main` that the live indexer entrypoint isn't the `NotImplementedException` stub and that `EquivalenceInfo.ForteCode` is populated from `ForteCatalog`.
3. `dotnet build GaMcpServer`, restart the MCP client; verify `ga_chord_to_set "C"` → `Forte: 3-11`.

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required: one-off generator code fix; no runtime/service impact. The downstream YAML/DB regen it enables is the operator rollout above, monitored there (verify `ga_chord_to_set "C"` → 3-11 post-rebuild).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
