### PR TITLE
refactor(atonal): concentrate prime-form canonicalization on PitchClassSetId

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,14 @@ at layer 4, orchestration at 5; never in lower layers.
   (`WeightedPartitionCosine`); equals the dot product of the two **compact** vectors
   (`ExtractCompact`, per-partition L2 × √weight) by construction — corpus build, query encode,
   and the CPU/GPU scorers all cross these layout operations rather than re-deriving offsets/weights.
+- **Prime form vs normal form (atonal)** — two different canonicalizations, often confused. **Prime
+  form** = the minimal-packed-id representative, owned by `PitchClassSetId`: `PrimeForm` folds in
+  transposition *and* inversion (the OPTIC / set-class representative, what `PitchClassSet.PrimeForm`
+  and `SetClass` use); `TranspositionPrimeForm` folds in transposition only (the OPTC / "Tn-type"
+  representative, what `TranspositionClass` uses). **Normal form** (`PitchClassSet.ToNormalForm`) is a
+  *separate* idea — canonicalize by interval-span compactness, which can pick a different rotation than
+  minimal id. The elementary id ops (complement, inverse, M5/M7, transpose) also live on
+  `PitchClassSetId` — it is the single canonicalization authority; the value types delegate.
 
 ## Conventions
 

--- a/Common/GA.Domain.Core/Theory/Atonal/PitchClassSet.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/PitchClassSet.cs
@@ -149,12 +149,16 @@ public sealed class PitchClassSet : IStaticReadonlyCollection<PitchClassSet>,
     }
 
     /// <summary>
-    ///     Gets the <see cref="Nullable{PitchClassSet}" />
+    ///     Gets the transposition/inversion prime form (the OPTIC / set-class representative).
     /// </summary>
     /// <remarks>
-    ///     By definition, the prime form is the <see cref="PitchClassSet" /> with the most compact representation
+    ///     The canonical member of <see cref="TranspositionsAndInversions" /> — the one with the smallest
+    ///     packed id. Owned by <see cref="PitchClassSetId.PrimeForm" /> (pure id arithmetic); this property
+    ///     just lifts it back to a <see cref="PitchClassSet" />. <b>Not</b> the same as
+    ///     <see cref="ToNormalForm" />, which canonicalises by interval-span compactness rather than minimal
+    ///     id and can return a different rotation.
     /// </remarks>
-    public PitchClassSet? PrimeForm => TranspositionsAndInversions.MinBy(pitchClassSet => pitchClassSet.Id.Value);
+    public PitchClassSet? PrimeForm => Id.PrimeForm.ToPitchClassSet();
 
     /// <summary>
     ///     Gets a flag that indicates whether this pitch class set is it prime form

--- a/Common/GA.Domain.Core/Theory/Atonal/PitchClassSetId.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/PitchClassSetId.cs
@@ -94,6 +94,68 @@ public readonly record struct PitchClassSetId : IStaticReadonlyCollectionFromVal
     }
 
     /// <summary>
+    ///     The transposition-only prime form (the OPTC / "Tn-type" representative): the smallest id among
+    ///     the twelve transpositions. Folds in transposition only, so a major triad and a minor triad have
+    ///     <em>different</em> transposition prime forms but the same <see cref="PrimeForm" />.
+    /// </summary>
+    /// <remarks>
+    ///     The canonicalization authority for <see cref="TranspositionClass" />. Pure id arithmetic — no
+    ///     <see cref="PitchClassSet" /> allocation.
+    /// </remarks>
+    public PitchClassSetId TranspositionPrimeForm
+    {
+        get
+        {
+            var min = Value;
+            for (var i = 1; i < 12; i++)
+            {
+                var t = Transpose(i).Value;
+                if (t < min)
+                {
+                    min = t;
+                }
+            }
+
+            return new(min);
+        }
+    }
+
+    /// <summary>
+    ///     The transposition/inversion prime form (the OPTIC / set-class representative): the smallest id
+    ///     among the twenty-four transposition and inversion forms.
+    /// </summary>
+    /// <remarks>
+    ///     The canonicalization authority that <see cref="PitchClassSet.PrimeForm" /> and
+    ///     <see cref="SetClass" /> are built on. Defined by <b>minimal packed id</b> — this is distinct
+    ///     from <see cref="PitchClassSet.ToNormalForm" />, which canonicalises by interval-span
+    ///     <em>compactness</em>, not minimal id, and can pick a different rotation.
+    /// </remarks>
+    public PitchClassSetId PrimeForm
+    {
+        get
+        {
+            var min = Value;
+            var inverse = Inverse;
+            for (var i = 0; i < 12; i++)
+            {
+                var t = Transpose(i).Value;
+                if (t < min)
+                {
+                    min = t;
+                }
+
+                var ti = inverse.Transpose(i).Value;
+                if (ti < min)
+                {
+                    min = ti;
+                }
+            }
+
+            return new(min);
+        }
+    }
+
+    /// <summary>
     ///     Multiplies every pitch class by <paramref name="multiplier" /> (mod 12). A bijection only when the
     ///     multiplier is coprime to 12 (1, 5, 7, 11): 5 and 7 give the M5 / M7 transforms and 11 is the inversion.
     /// </summary>

--- a/Common/GA.Domain.Core/Theory/Atonal/TranspositionClass.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/TranspositionClass.cs
@@ -21,7 +21,7 @@ public sealed class TranspositionClass : IEquatable<TranspositionClass>
     public TranspositionClass(PitchClassSet pitchClassSet)
     {
         ArgumentNullException.ThrowIfNull(pitchClassSet);
-        PrimeForm = TranspositionPrimeForm(pitchClassSet);
+        PrimeForm = pitchClassSet.Id.TranspositionPrimeForm.ToPitchClassSet();
     }
 
     /// <summary>
@@ -50,28 +50,12 @@ public sealed class TranspositionClass : IEquatable<TranspositionClass>
     ///     triad) pair with a distinct inverted transposition class inside the same <see cref="SetClass" />.
     /// </summary>
     public bool IsInversionallySymmetric =>
-        PrimeForm.Id.Value == TranspositionPrimeForm(PrimeForm.Inverse).Id.Value;
+        PrimeForm.Id.Value == PrimeForm.Inverse.Id.TranspositionPrimeForm.Value;
 
     /// <summary>
     ///     Gets all transposition classes, ordered by prime-form id.
     /// </summary>
     public static IReadOnlyList<TranspositionClass> Items => _lazyItems.Value;
-
-    private static PitchClassSet TranspositionPrimeForm(PitchClassSet pitchClassSet)
-    {
-        var id = pitchClassSet.Id;
-        var min = id.Value;
-        for (var i = 1; i < 12; i++)
-        {
-            var rotated = id.Transpose(i).Value;
-            if (rotated < min)
-            {
-                min = rotated;
-            }
-        }
-
-        return ((PitchClassSetId)min).ToPitchClassSet();
-    }
 
     private static IReadOnlyList<TranspositionClass> Build()
     {

--- a/Tests/Common/GA.Business.Core.Tests/Atonal/PitchClassSetCanonicalizationTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Atonal/PitchClassSetCanonicalizationTests.cs
@@ -1,0 +1,100 @@
+namespace GA.Business.Core.Tests.Atonal;
+
+using GA.Domain.Core.Theory.Atonal;
+
+/// <summary>
+///     Guards the canonicalization deepening (architecture-review candidate #4): the prime-form
+///     reductions moved onto <see cref="PitchClassSetId" /> (the home of the elementary id ops), with
+///     <see cref="PitchClassSet.PrimeForm" /> and <see cref="TranspositionClass" /> delegating. Prime
+///     form feeds set-class enumeration → OPTIC-K, so any drift is a one-way door. These tests verify
+///     the new id-level reductions against an <em>independent</em> min-over-rotations oracle across all
+///     4096 ids, and pin the set-class count, so a behavioural change cannot ship silently.
+/// </summary>
+[TestFixture]
+public class PitchClassSetCanonicalizationTests
+{
+    // Independent oracle: smallest id among the 12 transpositions.
+    private static int MinTransposition(PitchClassSetId id)
+    {
+        var min = id.Value;
+        for (var i = 0; i < 12; i++)
+        {
+            var t = id.Transpose(i).Value;
+            if (t < min)
+            {
+                min = t;
+            }
+        }
+
+        return min;
+    }
+
+    // Independent oracle: smallest id among the 24 transposition + inversion forms.
+    private static int MinTranspositionInversion(PitchClassSetId id) =>
+        Math.Min(MinTransposition(id), MinTransposition(id.Inverse));
+
+    [Test]
+    public void TranspositionPrimeForm_Matches_Independent_Min_Across_All_4096_Ids()
+    {
+        for (var v = 0; v <= 4095; v++)
+        {
+            var id = new PitchClassSetId(v);
+            Assert.That(id.TranspositionPrimeForm.Value, Is.EqualTo(MinTransposition(id)),
+                $"id {v}: TranspositionPrimeForm diverged from the min over 12 transpositions");
+        }
+    }
+
+    [Test]
+    public void PrimeForm_Matches_Independent_Min_Across_All_4096_Ids()
+    {
+        for (var v = 0; v <= 4095; v++)
+        {
+            var id = new PitchClassSetId(v);
+            Assert.That(id.PrimeForm.Value, Is.EqualTo(MinTranspositionInversion(id)),
+                $"id {v}: PrimeForm diverged from the min over 24 T/I forms");
+        }
+    }
+
+    [Test]
+    public void PitchClassSet_PrimeForm_Delegates_To_Id_PrimeForm()
+    {
+        foreach (var pcs in PitchClassSet.Items)
+        {
+            Assert.That(pcs.PrimeForm, Is.Not.Null);
+            Assert.That(pcs.PrimeForm!.Id.Value, Is.EqualTo(pcs.Id.PrimeForm.Value),
+                $"PitchClassSet.PrimeForm must equal Id.PrimeForm for id {pcs.Id.Value}");
+        }
+    }
+
+    [Test]
+    public void SetClass_Count_Is_Unchanged_At_224()
+    {
+        // The set-class enumeration is built on PrimeForm and feeds OPTIC-K. The count is a
+        // one-way-door invariant: a change here means the canonicalization shifted.
+        Assert.That(SetClass.Items.Count, Is.EqualTo(224));
+    }
+
+    [Test]
+    public void TranspositionClass_Count_Matches_Distinct_TranspositionPrimeForms()
+    {
+        var distinct = new HashSet<int>();
+        for (var v = 0; v <= 4095; v++)
+        {
+            distinct.Add(new PitchClassSetId(v).TranspositionPrimeForm.Value);
+        }
+
+        Assert.That(TranspositionClass.Items.Count, Is.EqualTo(distinct.Count));
+    }
+
+    [TestCase("047", "037")]   // C major triad → set-class prime form {0,3,7} (3-11)
+    [TestCase("037", "037")]   // already a prime form
+    [TestCase("0146", "0146")] // all-interval tetrachord 4-Z15 (already prime)
+    public void PrimeForm_Anchors(string input, string expectedPrime)
+    {
+        Assert.That(PitchClassSet.TryParse(input, null, out var pcs), Is.True);
+        Assert.That(PitchClassSet.TryParse(expectedPrime, null, out var expected), Is.True);
+
+        Assert.That(pcs.PrimeForm!.Id.Value, Is.EqualTo(expected.Id.Value),
+            $"prime form of {input} should be {expectedPrime}");
+    }
+}


### PR DESCRIPTION
## What

Architecture-review candidate **#4** — the last open candidate from the 2026-06-19 `/improve-codebase-architecture` sweep.

Prime form was computed in **two** places with their own min-over-rotations loops:
- `PitchClassSet.PrimeForm` (T/I, over the 24-form `TranspositionsAndInversions` collection)
- `TranspositionClass` (T-only, an inline loop)

The elementary equivalence ops (complement, inverse, M5/M7, transpose) already lived in one home — `PitchClassSetId` — so this **completes that module** rather than spawning a separate forwarding canonicalizer (a deliberate deviation from the report's `PitchClassCanonicalizer` shape; putting it on the id keeps `set.Complement` / `id.PrimeForm` as discoverable instance members and avoids a shallow forwarding class).

- `PitchClassSetId` gains **`PrimeForm`** (T/I → OPTIC / set-class representative) and **`TranspositionPrimeForm`** (T-only → OPTC / Tn-type representative) — pure id arithmetic, no `PitchClassSet` allocation.
- `PitchClassSet.PrimeForm` and `TranspositionClass` now **delegate**; the duplicated loop is gone.
- Docs disambiguate the three canonicalizations that had blurred: **prime form** (T/I, minimal id), **transposition prime form** (T-only, minimal id), **normal form** (`ToNormalForm` — interval-span compactness, a *different* idea). `CONTEXT.md` term added.

## Impact / risk

**Behavior-preserving.** Prime form feeds set-class enumeration → OPTIC-K, so a change here is a **one-way door**. Guarded by an exhaustive oracle:
- Across **all 4096 ids**, `Id.PrimeForm` / `Id.TranspositionPrimeForm` equal an *independent* min-over-rotations recomputation.
- `SetClass.Items.Count` stays at **224**.

Tests live in `GA.Business.Core.Tests` (in the slnx / CI), **not** the orphan `GA.Domain.Core.Tests`.

## Test output

```
PitchClassSetCanonicalizationTests + CanonicalForteCatalogTests: Passed 25/25
Broader atonal/set-class/modal/transposition suite: Passed 119/119
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)