### PR TITLE
refactor(search): VoicingFilterEngine — shared CPU/GPU filter seam (foundation)

### DIFF
--- a/Common/GA.Business.ML/Search/CpuVoicingSearchStrategy.cs
+++ b/Common/GA.Business.ML/Search/CpuVoicingSearchStrategy.cs
@@ -98,7 +98,7 @@ public class CpuVoicingSearchStrategy : IVoicingSearchStrategy
 
         await Task.Run(() => {
             Parallel.ForEach(voicingList, voicing => {
-                if (MatchesFilters(voicing, filters))
+                if (VoicingFilterEngine.Matches(voicing, filters))
                 {
                     // If target has text embedding, use it for semantic alignment
                     // otherwise fall back to musical embedding
@@ -149,88 +149,6 @@ public class CpuVoicingSearchStrategy : IVoicingSearchStrategy
             CalculateMemoryUsage(),
             _totalSearches > 0 ? TimeSpan.FromTicks(_totalSearchTime.Ticks / _totalSearches) : TimeSpan.Zero,
             _totalSearches);
-
-    private static bool MatchesFilters(VoicingEmbedding voicing, VoicingSearchFilters filters)
-    {
-        // Null-safe: a corpus voicing that lacks the filtered attribute cannot
-        // satisfy a filter on it, so treat null as "does not match" (return
-        // false) — same convention as the StackingType guard below. Before this,
-        // a single voicing with a null VoicingType/ChordName/etc. threw a
-        // NullReferenceException inside the Parallel.ForEach, which collapsed the
-        // ENTIRE voicing search → orchestration error → "error-fallback" to the
-        // LLM for every "<chord> voicing on guitar" query. (Live trace 2026-05-30.)
-        if (filters.Difficulty != null && (voicing.Difficulty == null || !voicing.Difficulty.Equals(filters.Difficulty, StringComparison.OrdinalIgnoreCase))) return false;
-        if (filters.Position != null && (voicing.Position == null || !voicing.Position.Equals(filters.Position, StringComparison.OrdinalIgnoreCase))) return false;
-        if (filters.VoicingType != null && (voicing.VoicingType == null || !voicing.VoicingType.Contains(filters.VoicingType, StringComparison.OrdinalIgnoreCase))) return false;
-        if (filters.Tags != null && filters.Tags.Any() && (voicing.SemanticTags == null || !filters.Tags.All(t => voicing.SemanticTags.Contains(t, StringComparer.OrdinalIgnoreCase)))) return false;
-
-        if (filters.MinFret.HasValue && voicing.MinFret < filters.MinFret.Value) return false;
-        if (filters.MaxFret.HasValue && voicing.MaxFret > filters.MaxFret.Value) return false;
-        if (filters.RequireBarreChord.HasValue && voicing.BarreRequired != filters.RequireBarreChord.Value) return false;
-
-        // Structured Filters
-        if (filters.ChordName != null && (voicing.ChordName == null || !voicing.ChordName.Contains(filters.ChordName, StringComparison.OrdinalIgnoreCase))) return false;
-
-        if (filters.StackingType != null)
-        {
-            // Null check on voicing.StackingType because it's nullable
-            if (voicing.StackingType == null || !voicing.StackingType.Equals(filters.StackingType, StringComparison.OrdinalIgnoreCase)) return false;
-        }
-
-        if (filters.IsSlashChord.HasValue)
-        {
-            var isSlash = (voicing.MidiBassNote % 12) != voicing.RootPitchClass;
-            if (filters.IsSlashChord.Value != isSlash) return false;
-        }
-
-        if (filters.MinMidiPitch.HasValue && voicing.MidiNotes.Length > 0 && voicing.MidiNotes.Min() < filters.MinMidiPitch.Value) return false;
-        if (filters.MaxMidiPitch.HasValue && voicing.MidiNotes.Length > 0 && voicing.MidiNotes.Max() > filters.MaxMidiPitch.Value) return false;
-
-        if (filters.SetClassId != null && (voicing.PrimeFormId == null || !voicing.PrimeFormId.Contains(filters.SetClassId, StringComparison.OrdinalIgnoreCase))) return false;
-
-        // PitchClassSet string looks like "{0,4,7}" or similar.
-        if (filters.RahnPrimeForm != null && !voicing.PitchClassSet.Contains(filters.RahnPrimeForm, StringComparison.OrdinalIgnoreCase)) return false;
-
-        if (filters.FingerCount.HasValue)
-        {
-            // Heuristic: Count non-open, non-muted strings.
-            // Perfect finger count requires fingering analysis which is not in the search index yet.
-            var parts = voicing.Diagram.Contains('-') ? voicing.Diagram.Split('-') : [.. voicing.Diagram.Select(c => c.ToString())];
-            var active = parts.Count(p => p != "x" && p != "m" && p != "0");
-
-            // Adjust for barre: if barre is required, typically reduces finger count by count of barred notes - 1
-            // But without exact data, we test against active strings for now as a proxy.
-            if (active != filters.FingerCount.Value) return false;
-        }
-
-        // Phase 3 Extended Filters
-        if (filters.HarmonicFunction != null && !string.Equals(voicing.HarmonicFunction, filters.HarmonicFunction, StringComparison.OrdinalIgnoreCase)) return false;
-        if (filters.IsNaturallyOccurring.HasValue && voicing.IsNaturallyOccurring != filters.IsNaturallyOccurring.Value) return false;
-        if (filters.IsRootless.HasValue && voicing.IsRootless != filters.IsRootless.Value) return false;
-        if (filters.HasGuideTones.HasValue && voicing.HasGuideTones != filters.HasGuideTones.Value) return false;
-        if (filters.Inversion.HasValue && voicing.Inversion != filters.Inversion.Value) return false;
-        if (filters.MinConsonance.HasValue && voicing.ConsonanceScore < filters.MinConsonance.Value) return false;
-        if (filters.MinBrightness.HasValue && voicing.BrightnessScore < filters.MinBrightness.Value) return false;
-        if (filters.MaxBrightness.HasValue && voicing.BrightnessScore > filters.MaxBrightness.Value) return false;
-        if (filters.MaxBrightness.HasValue && voicing.BrightnessScore > filters.MaxBrightness.Value) return false;
-        if (filters.OmittedTones != null && filters.OmittedTones.Any() &&
-            (voicing.OmittedTones == null || !filters.OmittedTones.All(t => voicing.OmittedTones.Contains(t, StringComparer.OrdinalIgnoreCase)))) return false;
-
-        // Melody Note Filter
-        if (filters.TopPitchClass.HasValue && voicing.TopPitchClass != filters.TopPitchClass.Value) return false;
-
-        // AI Agent Metadata Filters (Phase 4)
-        if (filters.TexturalDescriptionContains != null &&
-            (voicing.TexturalDescription == null || !voicing.TexturalDescription.Contains(filters.TexturalDescriptionContains, StringComparison.OrdinalIgnoreCase))) return false;
-
-        if (filters.DoubledTonesContain != null && filters.DoubledTonesContain.Any() &&
-            (voicing.DoubledTones == null || !filters.DoubledTonesContain.All(t => voicing.DoubledTones.Contains(t, StringComparer.OrdinalIgnoreCase)))) return false;
-
-        if (filters.AlternateNameMatch != null &&
-            (voicing.AlternateNames == null || !voicing.AlternateNames.Any(n => n.Contains(filters.AlternateNameMatch, StringComparison.OrdinalIgnoreCase)))) return false;
-
-        return true;
-    }
 
     private static double CosineSimilarity(double[] v1, double[] v2)
     {

--- a/Common/GA.Business.ML/Search/VoicingFilterEngine.cs
+++ b/Common/GA.Business.ML/Search/VoicingFilterEngine.cs
@@ -1,0 +1,101 @@
+namespace GA.Business.ML.Search;
+
+using GA.Domain.Services.Fretboard.Voicings.Core;
+
+/// <summary>
+///     The single authority for deciding whether a <see cref="VoicingEmbedding"/> satisfies a set of
+///     <see cref="VoicingSearchFilters"/> — the metadata-filter seam the search strategies cross.
+/// </summary>
+/// <remarks>
+///     Lifted verbatim from <see cref="CpuVoicingSearchStrategy"/>'s hardened predicate (the one with the
+///     2026-05-30 null-safety fix and case-insensitive <c>Contains</c> semantics). The GPU strategy
+///     historically carried its OWN, drifted copy — exact <c>==</c> instead of <c>Contains</c>,
+///     case-sensitive, not null-safe, <c>Tags</c> matched ANY instead of ALL, and several metadata
+///     filters (e.g. <c>SetClassId</c>, <c>FingerCount</c>, <c>ChordName</c>) were silently skipped — so
+///     the same filtered query could return different results on CPU vs GPU. This type is the deep
+///     module both adapters delegate to so that can't recur. Analysis-dependent filters (biomechanical
+///     comfort/stretch) need a fingering-analysis service and stay layered in the GPU adapter; this
+///     engine owns only the metadata predicate.
+/// </remarks>
+public static class VoicingFilterEngine
+{
+    /// <summary>
+    ///     True if <paramref name="voicing"/> satisfies every populated filter in <paramref name="filters"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Null-safe by convention: a corpus voicing that lacks the filtered attribute cannot satisfy a
+    ///     filter on it, so a null attribute returns false rather than throwing — before this, a single
+    ///     voicing with a null VoicingType/ChordName/etc. threw inside the search's Parallel.ForEach and
+    ///     collapsed the ENTIRE voicing search → orchestration error → LLM fallback for every
+    ///     "&lt;chord&gt; voicing on guitar" query (live trace 2026-05-30).
+    /// </remarks>
+    public static bool Matches(VoicingEmbedding voicing, VoicingSearchFilters filters)
+    {
+        if (filters.Difficulty != null && (voicing.Difficulty == null || !voicing.Difficulty.Equals(filters.Difficulty, StringComparison.OrdinalIgnoreCase))) return false;
+        if (filters.Position != null && (voicing.Position == null || !voicing.Position.Equals(filters.Position, StringComparison.OrdinalIgnoreCase))) return false;
+        if (filters.VoicingType != null && (voicing.VoicingType == null || !voicing.VoicingType.Contains(filters.VoicingType, StringComparison.OrdinalIgnoreCase))) return false;
+        if (filters.Tags != null && filters.Tags.Any() && (voicing.SemanticTags == null || !filters.Tags.All(t => voicing.SemanticTags.Contains(t, StringComparer.OrdinalIgnoreCase)))) return false;
+
+        if (filters.MinFret.HasValue && voicing.MinFret < filters.MinFret.Value) return false;
+        if (filters.MaxFret.HasValue && voicing.MaxFret > filters.MaxFret.Value) return false;
+        if (filters.RequireBarreChord.HasValue && voicing.BarreRequired != filters.RequireBarreChord.Value) return false;
+
+        // Structured filters
+        if (filters.ChordName != null && (voicing.ChordName == null || !voicing.ChordName.Contains(filters.ChordName, StringComparison.OrdinalIgnoreCase))) return false;
+
+        if (filters.StackingType != null)
+        {
+            if (voicing.StackingType == null || !voicing.StackingType.Equals(filters.StackingType, StringComparison.OrdinalIgnoreCase)) return false;
+        }
+
+        if (filters.IsSlashChord.HasValue)
+        {
+            var isSlash = (voicing.MidiBassNote % 12) != voicing.RootPitchClass;
+            if (filters.IsSlashChord.Value != isSlash) return false;
+        }
+
+        if (filters.MinMidiPitch.HasValue && voicing.MidiNotes.Length > 0 && voicing.MidiNotes.Min() < filters.MinMidiPitch.Value) return false;
+        if (filters.MaxMidiPitch.HasValue && voicing.MidiNotes.Length > 0 && voicing.MidiNotes.Max() > filters.MaxMidiPitch.Value) return false;
+
+        if (filters.SetClassId != null && (voicing.PrimeFormId == null || !voicing.PrimeFormId.Contains(filters.SetClassId, StringComparison.OrdinalIgnoreCase))) return false;
+
+        // PitchClassSet string looks like "{0,4,7}" or similar.
+        if (filters.RahnPrimeForm != null && !voicing.PitchClassSet.Contains(filters.RahnPrimeForm, StringComparison.OrdinalIgnoreCase)) return false;
+
+        if (filters.FingerCount.HasValue)
+        {
+            // Heuristic: count non-open, non-muted strings. Exact finger count needs fingering analysis
+            // which is not in the search index yet, so active strings is the proxy.
+            var parts = voicing.Diagram.Contains('-') ? voicing.Diagram.Split('-') : [.. voicing.Diagram.Select(c => c.ToString())];
+            var active = parts.Count(p => p != "x" && p != "m" && p != "0");
+            if (active != filters.FingerCount.Value) return false;
+        }
+
+        // Phase 3 extended filters
+        if (filters.HarmonicFunction != null && !string.Equals(voicing.HarmonicFunction, filters.HarmonicFunction, StringComparison.OrdinalIgnoreCase)) return false;
+        if (filters.IsNaturallyOccurring.HasValue && voicing.IsNaturallyOccurring != filters.IsNaturallyOccurring.Value) return false;
+        if (filters.IsRootless.HasValue && voicing.IsRootless != filters.IsRootless.Value) return false;
+        if (filters.HasGuideTones.HasValue && voicing.HasGuideTones != filters.HasGuideTones.Value) return false;
+        if (filters.Inversion.HasValue && voicing.Inversion != filters.Inversion.Value) return false;
+        if (filters.MinConsonance.HasValue && voicing.ConsonanceScore < filters.MinConsonance.Value) return false;
+        if (filters.MinBrightness.HasValue && voicing.BrightnessScore < filters.MinBrightness.Value) return false;
+        if (filters.MaxBrightness.HasValue && voicing.BrightnessScore > filters.MaxBrightness.Value) return false;
+        if (filters.OmittedTones != null && filters.OmittedTones.Any() &&
+            (voicing.OmittedTones == null || !filters.OmittedTones.All(t => voicing.OmittedTones.Contains(t, StringComparer.OrdinalIgnoreCase)))) return false;
+
+        // Melody note filter
+        if (filters.TopPitchClass.HasValue && voicing.TopPitchClass != filters.TopPitchClass.Value) return false;
+
+        // AI-agent metadata filters (Phase 4)
+        if (filters.TexturalDescriptionContains != null &&
+            (voicing.TexturalDescription == null || !voicing.TexturalDescription.Contains(filters.TexturalDescriptionContains, StringComparison.OrdinalIgnoreCase))) return false;
+
+        if (filters.DoubledTonesContain != null && filters.DoubledTonesContain.Any() &&
+            (voicing.DoubledTones == null || !filters.DoubledTonesContain.All(t => voicing.DoubledTones.Contains(t, StringComparer.OrdinalIgnoreCase)))) return false;
+
+        if (filters.AlternateNameMatch != null &&
+            (voicing.AlternateNames == null || !voicing.AlternateNames.Any(n => n.Contains(filters.AlternateNameMatch, StringComparison.OrdinalIgnoreCase)))) return false;
+
+        return true;
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/VoicingFilterEngineTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/VoicingFilterEngineTests.cs
@@ -1,0 +1,127 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Search;
+using GA.Domain.Services.Fretboard.Voicings.Core;
+
+/// <summary>
+///     Pins the contract of <see cref="VoicingFilterEngine"/> — the shared metadata-filter seam both
+///     search strategies cross (architecture deepening #2). These cases are exactly the points where the
+///     GPU strategy's old private copy had <b>drifted</b>: null-safety, case-insensitivity, <c>Tags</c>
+///     ALL-match (not ANY), <c>VoicingType</c> <c>Contains</c> (not <c>==</c>), and the metadata filters
+///     the GPU path silently skipped. When the GPU adapter is routed through this engine, these are the
+///     behaviours it must adopt.
+/// </summary>
+[TestFixture]
+public class VoicingFilterEngineTests
+{
+    // A baseline voicing; tests vary just the field under test via `with`.
+    private static VoicingEmbedding Voicing() => new(
+        Id: "v1",
+        ChordName: "Cmaj7",
+        VoicingType: "drop2 closed",
+        Position: "open",
+        Difficulty: "easy",
+        ModeName: null,
+        ModalFamily: null,
+        PossibleKeys: [],
+        SemanticTags: ["jazz", "shell"],
+        PrimeFormId: "4-27",
+        TranslationOffset: 0,
+        Diagram: "x35453",
+        MidiNotes: [48, 52, 55, 59],
+        PitchClassSet: "{0,4,7,11}",
+        IntervalClassVector: "<101220>",
+        MinFret: 3,
+        MaxFret: 5,
+        BarreRequired: false,
+        HandStretch: 2,
+        StackingType: "tertian",
+        RootPitchClass: 0,
+        MidiBassNote: 48,
+        HarmonicFunction: "tonic",
+        IsNaturallyOccurring: true,
+        ConsonanceScore: 0.8,
+        BrightnessScore: 0.5,
+        IsRootless: false,
+        HasGuideTones: true,
+        Inversion: 0,
+        TopPitchClass: 11,
+        TexturalDescription: "warm",
+        DoubledTones: [],
+        AlternateNames: [],
+        OmittedTones: [],
+        CagedShape: "C",
+        Description: "test voicing",
+        Embedding: new double[216],
+        TextEmbedding: null);
+
+    private static VoicingSearchFilters Empty() => new();
+
+    [Test]
+    public void EmptyFilters_MatchEverything()
+    {
+        Assert.That(VoicingFilterEngine.Matches(Voicing(), Empty()), Is.True);
+    }
+
+    [Test]
+    public void NullAttribute_DoesNotThrow_AndDoesNotMatch()
+    {
+        // The 2026-05-30 fix: a voicing with a null VoicingType must not throw when a VoicingType filter
+        // is set; it simply fails the filter. (The GPU path's `v.VoicingType == filters.VoicingType` would
+        // not throw but would also wrongly let a null through on an exact-null compare.)
+        var voicing = Voicing() with { VoicingType = null };
+        var filters = Empty() with { VoicingType = "drop2" };
+
+        Assert.That(() => VoicingFilterEngine.Matches(voicing, filters), Throws.Nothing);
+        Assert.That(VoicingFilterEngine.Matches(voicing, filters), Is.False);
+    }
+
+    [Test]
+    public void VoicingType_Uses_Contains_Not_Exact_Equality()
+    {
+        // CPU semantics: substring, case-insensitive. The GPU copy used exact `==`, so "drop2" would not
+        // have matched "drop2 closed".
+        var filters = Empty() with { VoicingType = "drop2" };
+        Assert.That(VoicingFilterEngine.Matches(Voicing(), filters), Is.True);
+    }
+
+    [Test]
+    public void StringFilters_Are_CaseInsensitive()
+    {
+        var filters = Empty() with { Difficulty = "EASY", Position = "OPEN" };
+        Assert.That(VoicingFilterEngine.Matches(Voicing(), filters), Is.True);
+    }
+
+    [Test]
+    public void Tags_Require_ALL_To_Match_Not_ANY()
+    {
+        var voicing = Voicing(); // SemanticTags = ["jazz","shell"]
+
+        // ALL present → match.
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { Tags = ["jazz", "shell"] }), Is.True);
+        // One missing → no match (the GPU copy used ANY and would have matched this).
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { Tags = ["jazz", "bossa"] }), Is.False);
+    }
+
+    [Test]
+    public void Metadata_Filters_The_Gpu_Skipped_Are_Applied()
+    {
+        var voicing = Voicing(); // PrimeFormId "4-27", TopPitchClass 11
+
+        // SetClassId (substring on PrimeFormId) — GPU never applied this.
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { SetClassId = "4-27" }), Is.True);
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { SetClassId = "3-11" }), Is.False);
+
+        // TopPitchClass (melody-note filter) — GPU never applied this.
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { TopPitchClass = 11 }), Is.True);
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { TopPitchClass = 0 }), Is.False);
+    }
+
+    [Test]
+    public void FretRange_Filters_Boundaries()
+    {
+        var voicing = Voicing(); // MinFret 3, MaxFret 5
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { MinFret = 3, MaxFret = 5 }), Is.True);
+        Assert.That(VoicingFilterEngine.Matches(voicing, Empty() with { MaxFret = 4 }), Is.False, "voicing reaches fret 5");
+    }
+}


### PR DESCRIPTION
## What

**Approach #2 of 4** (deep-dive on `ga`), foundation slice. The deep-dive found the CPU/GPU voicing-search filters aren't just duplicated — they've **drifted into disagreement**, so the same filtered query returns different results depending on GPU availability:

| | CPU | GPU (old private copy) |
|---|---|---|
| `Tags` | **ALL** must match | **ANY** matches |
| `VoicingType` | `Contains` (substring) | exact `==` |
| null attribute / casing | **null-safe + case-insensitive** (the 2026-05-30 NRE fix) | neither |
| `SetClassId`, `FingerCount`, `ChordName`, MIDI-range, `TopPitchClass`, … | applied | **silently skipped** |

## This PR (safe foundation)

Lifts the CPU's hardened predicate verbatim into **`VoicingFilterEngine.Matches`** and routes the CPU strategy through it — **zero behaviour change for CPU** (same body, relocated). Adds **contract tests** pinning exactly the drift-prone behaviours, i.e. the contract the GPU adapter must adopt.

## Deliberately NOT in this PR

Routing the **GPU** path through the engine is **behaviour-affecting** (it corrects GPU filtering toward these vetted semantics — Tags ANY→ALL, `==`→Contains, null-safety, + applying the skipped filters). Per the agentic-engineering standard (and the multi-LLM-review rule for chatbot-facing search), that lands as its own **parity-tested, reviewed** PR rather than riding in here.

## Tests

```
VoicingFilterEngineTests: 7/7 (null-safety, case-insensitivity, Tags ALL, VoicingType Contains, GPU-skipped metadata filters, fret-range)
Full ML suite: 1108 passed / 7 pre-existing skips
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)