### PR TITLE
feat(governance): one governance gate + opt-in snapshot registry

### DIFF
--- a/.claude/skills/auto-optimize/SKILL.md
+++ b/.claude/skills/auto-optimize/SKILL.md
@@ -94,35 +94,18 @@ if (Test-Path "state/quality/$domain/.STOP") {
     exit 0
 }
 
-# 3. Cross-repo HALT-ALL marker (overseer Phase 1).
-# Opportunistic check: if ~/.demerzel/HALT-ALL exists, every loop in every
-# sibling repo MUST pause. See docs/contracts/2026-05-16-overseer-halt-marker.contract.md
-# for the schema. If the file is unreadable / dir is missing / agent is in
-# exempt_agents, fall through silently — per-repo .loop-halted above is the
-# authoritative offline fallback (D-offline-fallback in the strategic plan).
-$haltMarker = Join-Path $env:USERPROFILE '.demerzel\HALT-ALL'
-if (-not $env:USERPROFILE) { $haltMarker = Join-Path $env:HOME '.demerzel/HALT-ALL' }
-if (Test-Path $haltMarker) {
-    try {
-        $halt = Get-Content $haltMarker -Raw | ConvertFrom-Json
-        $expired = $halt.expires_at -and ([datetime]::Parse($halt.expires_at) -lt (Get-Date).ToUniversalTime())
-        $exempt  = $halt.exempt_agents -and ($halt.exempt_agents -contains 'auto-optimize')
-        $unknownVersion = $halt.schema_version -ne 1
-        if ($unknownVersion) {
-            Write-Host "Cross-repo HALT-ALL marker has unknown schema_version=$($halt.schema_version) — failing closed" -ForegroundColor Red
-            exit 0
-        }
-        if (-not $expired -and -not $exempt -and ($halt.scope -in @($null, 'loops-only', 'loops-and-batch', 'global'))) {
-            Write-Host "Halted by overseer at $($halt.halted_at):" -ForegroundColor Red
-            Write-Host "  reason: $($halt.reason)" -ForegroundColor DarkYellow
-            Write-Host "  halted_by: $($halt.halted_by)" -ForegroundColor DarkYellow
-            Write-Host "  To resume: delete $haltMarker (or wait for expires_at)" -ForegroundColor DarkYellow
-            exit 0
-        }
-    } catch {
-        # Unreadable / unparseable marker → fall through to per-repo halt
-        Write-Host "Cross-repo HALT-ALL marker unreadable; falling back to per-repo killswitch" -ForegroundColor DarkGray
-    }
+# 3. Cross-repo HALT-ALL marker (overseer Phase 1) + per-repo kill switch, via the
+# ONE governance gate. The fail-closed contract parse (schema_version / expires_at /
+# exempt_agents / scope) lives in Scripts/Governance.psm1 — tested in
+# Scripts/Governance.test.ps1 — not copy-pasted here. See
+# docs/contracts/2026-05-16-overseer-halt-marker.contract.md for the obligations.
+Import-Module ./Scripts/Governance.psm1 -Force
+$gate = Test-GovernanceGate -AgentId 'auto-optimize'
+if ($gate.Halted) {
+    Write-Host "Halted ($($gate.Source)): $($gate.Reason)" -ForegroundColor Red
+    if ($gate.HaltedBy) { Write-Host "  halted_by: $($gate.HaltedBy)" -ForegroundColor DarkYellow }
+    Write-Host "  To resume: clear state/.loop-halted or ~/.demerzel/HALT-ALL (or wait for expires_at)" -ForegroundColor DarkYellow
+    exit 0
 }
 
 # 4. Demerzel governance check (only if mcp__demerzel server is wired)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,15 @@ at layer 4, orchestration at 5; never in lower layers.
 - **dev-data middleware** — the `/dev-data/*` Vite endpoints powering the dashboard
   (`demos.guitaralchemist.com/test#dev/...`); dev-server-only (stripped by `vite build`).
 - **Prime Radiant** — the 3D governance/assumption-graph visualization.
+- **Governance gate** — the single authority answering "may this loop/skill/overseer
+  act right now?", owned by `Scripts/Governance.psm1` (`Test-GovernanceGate`). Folds the
+  cross-repo HALT-ALL marker (`~/.demerzel/HALT-ALL`) and the per-repo
+  `state/.loop-halted` kill switch into one fail-closed verdict, honoring every
+  obligation in the overseer-halt-marker contract (unknown `schema_version` →
+  halt; expired → fall through; `exempt_agents`; `scope`). Built on **`Test-Contract`**
+  (same module) — the reusable "validate JSON against `docs/contracts/*.schema.json`"
+  primitive. Consumers (the loop skills, `dev-process-overseer.ps1`) cross this seam
+  rather than re-parsing the marker.
 - **Weighted partition cosine** — the OPTIC-K similarity score: `Σ weight[p]·cosine(a[p], b[p])`
   over the similarity partitions of two **raw** vectors. Owned by `EmbeddingSchema`
   (`WeightedPartitionCosine`); equals the dot product of the two **compact** vectors
@@ -45,6 +54,16 @@ at layer 4, orchestration at 5; never in lower layers.
   *separate* idea — canonicalize by interval-span compactness, which can pick a different rotation than
   minimal id. The elementary id ops (complement, inverse, M5/M7, transpose) also live on
   `PitchClassSetId` — it is the single canonicalization authority; the value types delegate.
+
+- **Quality snapshot envelope** — the canonical dashboard tile shape
+  (`domain`, `emitted_at`, `metric_name`, `metric_value`, `oracle_status`, `summary`;
+  `docs/contracts/quality-snapshot.schema.json`, owned by ix, vendored here). Producers
+  MAY add domain-specific fields. **Snapshot registry**
+  (`state/quality/.snapshot-registry.json`) is the **opt-in** seam declaring which
+  `state/quality/<domain>/` dirs emit envelopes; `Scripts/validate-quality-snapshots.ps1`
+  validates only those (via `Test-Contract`), so baselines, `SCHEMA.json`, SAE artifacts,
+  and lens sidecars are excluded by design rather than false-failing. A `FAIL` is a real
+  producer gap (not yet emitting the envelope), not noise.
 
 ## Conventions
 

--- a/Scripts/Governance.psm1
+++ b/Scripts/Governance.psm1
@@ -1,0 +1,178 @@
+<#
+.SYNOPSIS
+    The Galactic-Protocol governance gate — the single authority for two questions
+    every loop/skill/overseer in this repo asks before it acts:
+
+      1. "Is this JSON valid against its cross-repo contract?"   → Test-Contract
+      2. "Am I allowed to run a cycle right now?"                → Test-GovernanceGate
+
+.DESCRIPTION
+    Before this module, the HALT-ALL marker parse (schema_version / expires_at /
+    exempt_agents / scope, fail-closed on unknown version) was copy-pasted across
+    .claude/skills/auto-optimize, ga-chatbot-afk-harness, and Scripts/
+    dev-process-overseer.ps1 — and the overseer only checked the *local* kill switch,
+    so an operator who set ~/.demerzel/HALT-ALL got "loop eligible" from the very tool
+    meant to be the unified gate. This module concentrates that load-bearing,
+    fail-closed logic in one tested place. Every consumer crosses this seam instead of
+    re-deriving it.
+
+    Architecture decision: serving/ranking stays where it is (ADR-0001); this is
+    governance plumbing, layer-5 orchestration only.
+#>
+
+Set-StrictMode -Version Latest
+
+# ── The contract-validation primitive ────────────────────────────────────────
+
+<#
+.SYNOPSIS
+    Validate a JSON value against a docs/contracts/*.schema.json (draft 2020-12),
+    returning a structured verdict instead of throwing.
+.OUTPUTS
+    [pscustomobject] @{ Valid = [bool]; Errors = [string[]]; Version = [int?] }
+    Version is the object's `schema_version` field if present (for fail-closed checks).
+#>
+function Test-Contract {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $SchemaPath,
+        # JSON string OR an already-parsed object/hashtable.
+        [Parameter(Mandatory)][AllowNull()] $Data
+    )
+
+    if (-not (Test-Path -LiteralPath $SchemaPath)) {
+        return [pscustomobject]@{ Valid = $false; Errors = @("schema not found: $SchemaPath"); Version = $null }
+    }
+
+    $json = if ($Data -is [string]) { $Data } else { $Data | ConvertTo-Json -Depth 32 }
+
+    # schema_version is extracted directly so callers can distinguish "unknown
+    # version" (fail-closed) from other validation failures (malformed → fall through).
+    $version = $null
+    try {
+        $parsed = $json | ConvertFrom-Json -ErrorAction Stop
+        if ($parsed.PSObject.Properties.Name -contains 'schema_version') { $version = [int]$parsed.schema_version }
+    } catch { }
+
+    try {
+        Test-Json -Json $json -SchemaFile $SchemaPath -ErrorAction Stop | Out-Null
+        return [pscustomobject]@{ Valid = $true; Errors = @(); Version = $version }
+    } catch {
+        return [pscustomobject]@{ Valid = $false; Errors = @($_.Exception.Message); Version = $version }
+    }
+}
+
+# ── The HALT-ALL marker location (one definition, was inlined per-consumer) ───
+
+<#
+.SYNOPSIS Resolve the per-user HALT-ALL marker path, cross-platform.
+#>
+function Get-HaltMarkerPath {
+    [CmdletBinding()]
+    param()
+    $home = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+    return (Join-Path $home '.demerzel/HALT-ALL')
+}
+
+# ── The governance gate ──────────────────────────────────────────────────────
+
+<#
+.SYNOPSIS
+    Decide whether the calling agent may run a cycle right now, honoring BOTH the
+    cross-repo HALT-ALL marker and the per-repo state/.loop-halted kill switch.
+    Implements every consumer obligation from the overseer-halt-marker contract:
+    opportunistic read, fail-closed on unknown schema_version, honor expires_at,
+    honor exempt_agents, honor scope, surface the reason.
+.OUTPUTS
+    [pscustomobject] @{
+        Allowed  = [bool]   # $true = may act
+        Halted   = [bool]   # convenience = -not Allowed
+        Source   = 'none' | 'halt-all' | 'loop-halted' | 'unknown-version'
+        Reason   = [string]
+        HaltedBy = [string]
+        Exempt   = [bool]   # agent was exempt from HALT-ALL (a local halt can still apply)
+    }
+#>
+function Test-GovernanceGate {
+    [CmdletBinding()]
+    param(
+        [string] $AgentId   = 'unknown',
+        [string] $RepoRoot  = (Resolve-Path .).Path,
+        # Overridable for tests; defaults to the canonical per-user / per-repo paths.
+        [string] $MarkerPath = (Get-HaltMarkerPath),
+        [string] $LoopHaltedPath = (Join-Path $RepoRoot 'state/.loop-halted'),
+        [string] $SchemaPath = (Join-Path $PSScriptRoot '../docs/contracts/overseer-halt-marker.schema.json')
+    )
+
+    function New-Verdict($allowed, $source, $reason, $haltedBy, $exempt) {
+        [pscustomobject]@{
+            Allowed = [bool]$allowed; Halted = -not [bool]$allowed
+            Source = $source; Reason = $reason; HaltedBy = $haltedBy; Exempt = [bool]$exempt
+        }
+    }
+
+    $localHalted = Test-Path -LiteralPath $LoopHaltedPath
+    $exempt = $false
+
+    # ── Cross-repo HALT-ALL marker (opportunistic) ──
+    if (Test-Path -LiteralPath $MarkerPath) {
+        $raw = $null
+        try { $raw = Get-Content -LiteralPath $MarkerPath -Raw -ErrorAction Stop } catch { }
+
+        if ($raw) {
+            $obj = $null
+            try { $obj = $raw | ConvertFrom-Json -ErrorAction Stop } catch { }
+
+            if ($null -eq $obj) {
+                # Unparseable marker → fall through to the local kill switch (obligation 1).
+            }
+            else {
+                $declaredVersion = if ($obj.PSObject.Properties.Name -contains 'schema_version') { [int]$obj.schema_version } else { $null }
+
+                if ($declaredVersion -ne 1) {
+                    # Obligation 5: unknown schema_version → fail-closed (newer producer than us).
+                    return New-Verdict $false 'unknown-version' "HALT-ALL has unknown schema_version=$declaredVersion (fail-closed)" $null $false
+                }
+
+                $contract = Test-Contract -SchemaPath $SchemaPath -Data $raw
+                if (-not $contract.Valid) {
+                    # Schema-version is fine but the body is malformed → treat as unparseable, fall through.
+                }
+                else {
+                    # Obligation 2: honor expires_at (past → treat as absent).
+                    $expired = $false
+                    if ($obj.PSObject.Properties.Name -contains 'expires_at' -and $obj.expires_at) {
+                        try { $expired = ([datetime]::Parse($obj.expires_at)).ToUniversalTime() -lt (Get-Date).ToUniversalTime() } catch { }
+                    }
+
+                    if (-not $expired) {
+                        # Obligation 3: honor exempt_agents.
+                        $exemptList = @()
+                        if ($obj.PSObject.Properties.Name -contains 'exempt_agents' -and $obj.exempt_agents) { $exemptList = @($obj.exempt_agents) }
+                        $exempt = $exemptList -contains $AgentId
+
+                        # Obligation 4: honor scope (v1 honored set; others reserved = no-act).
+                        $scope = if ($obj.PSObject.Properties.Name -contains 'scope' -and $obj.scope) { $obj.scope } else { 'loops-only' }
+                        $scopeActs = $scope -in @('loops-only', 'loops-and-batch', 'global')
+
+                        if (-not $exempt -and $scopeActs) {
+                            $by = if ($obj.PSObject.Properties.Name -contains 'halted_by') { $obj.halted_by } else { $null }
+                            return New-Verdict $false 'halt-all' $obj.reason $by $false
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    # ── Per-repo kill switch (also blocks an exempt agent) ──
+    if ($localHalted) {
+        $reason = ''
+        try { $reason = (Get-Content -LiteralPath $LoopHaltedPath -Raw -ErrorAction Stop).Trim() } catch { }
+        return New-Verdict $false 'loop-halted' $reason $null $exempt
+    }
+
+    return New-Verdict $true 'none' $null $null $exempt
+}
+
+Export-ModuleMember -Function Test-Contract, Test-GovernanceGate, Get-HaltMarkerPath

--- a/Scripts/Governance.test.ps1
+++ b/Scripts/Governance.test.ps1
@@ -1,0 +1,91 @@
+# Governance.test.ps1 — pins the contract-validation + governance-gate semantics.
+#
+# Run:
+#   pwsh Scripts/Governance.test.ps1
+#
+# Covers the load-bearing, fail-closed behaviours that were previously copy-pasted
+# (and untestable) inside SKILL.md prose:
+#   - Test-Contract: valid passes, bad const fails, missing-required fails.
+#   - Test-GovernanceGate: clean → allowed; local kill switch → halted; valid marker →
+#     halted; expired marker → falls through; exempt agent → not marker-halted;
+#     UNKNOWN schema_version → fail-closed halt; unparseable marker → falls through.
+
+[CmdletBinding()]
+param()
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'Governance.psm1') -Force
+$schema = Join-Path $PSScriptRoot '../docs/contracts/overseer-halt-marker.schema.json'
+
+$failures = @()
+function Assert($cond, $msg) {
+    if (-not $cond) { $script:failures += $msg; Write-Host "  FAIL: $msg" -ForegroundColor Red }
+    else { Write-Host "  ok: $msg" -ForegroundColor Green }
+}
+
+# Isolated sandbox so the test never touches the real ~/.demerzel or state/.
+$sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("gov-test-{0}" -f ([Guid]::NewGuid().ToString('N').Substring(0,8)))
+$repoRoot = Join-Path $sandbox 'repo'
+New-Item -ItemType Directory -Force -Path (Join-Path $repoRoot 'state') | Out-Null
+$marker = Join-Path $sandbox 'HALT-ALL'
+$loopHalted = Join-Path $repoRoot 'state/.loop-halted'
+
+function Gate([string]$agent = 'auto-optimize') {
+    Test-GovernanceGate -AgentId $agent -RepoRoot $repoRoot -MarkerPath $marker -LoopHaltedPath $loopHalted -SchemaPath $schema
+}
+function Set-Marker($obj) { $obj | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $marker -Encoding utf8 }
+function Clear-State { Remove-Item $marker, $loopHalted -ErrorAction SilentlyContinue }
+
+try {
+    Write-Host "Test-Contract:" -ForegroundColor Cyan
+    $valid = @{ schema_version = 1; halted_at = '2026-05-16T16:30:00Z'; reason = 'x' }
+    Assert (Test-Contract -SchemaPath $schema -Data $valid).Valid 'valid marker passes'
+    Assert (-not (Test-Contract -SchemaPath $schema -Data @{ schema_version = 2; halted_at = '2026-05-16T16:30:00Z'; reason = 'x' }).Valid) 'bad const (version 2) fails'
+    Assert (-not (Test-Contract -SchemaPath $schema -Data @{ schema_version = 1; reason = 'no ts' }).Valid) 'missing required (halted_at) fails'
+    Assert ((Test-Contract -SchemaPath $schema -Data $valid).Version -eq 1) 'Version extracted from body'
+
+    Write-Host "Test-GovernanceGate:" -ForegroundColor Cyan
+    Clear-State
+    Assert (Gate).Allowed 'clean (no marker, no kill switch) → allowed'
+
+    Clear-State
+    'cost spike' | Set-Content -LiteralPath $loopHalted -Encoding utf8
+    $v = Gate
+    Assert ((-not $v.Allowed) -and $v.Source -eq 'loop-halted') 'local .loop-halted → halted (loop-halted)'
+
+    Clear-State
+    Set-Marker @{ schema_version = 1; halted_at = '2026-05-16T16:30:00Z'; reason = 'freeze'; scope = 'loops-only'; halted_by = 'operator:test' }
+    $v = Gate
+    Assert ((-not $v.Allowed) -and $v.Source -eq 'halt-all' -and $v.Reason -eq 'freeze') 'valid HALT-ALL → halted (halt-all) with reason'
+
+    Clear-State
+    Set-Marker @{ schema_version = 1; halted_at = '2026-05-16T16:30:00Z'; reason = 'old'; expires_at = '2020-01-01T00:00:00Z' }
+    Assert (Gate).Allowed 'expired marker → falls through → allowed'
+
+    Clear-State
+    Set-Marker @{ schema_version = 1; halted_at = '2026-05-16T16:30:00Z'; reason = 'all but me'; exempt_agents = @('auto-optimize') }
+    $v = Gate 'auto-optimize'
+    Assert ($v.Allowed -and $v.Exempt) 'exempt agent → allowed + Exempt flag'
+    $v = Gate 'some-other-agent'
+    Assert (-not $v.Allowed) 'non-exempt agent still halted by same marker'
+
+    Clear-State
+    Set-Marker @{ schema_version = 99; halted_at = '2026-05-16T16:30:00Z'; reason = 'future' }
+    $v = Gate
+    Assert ((-not $v.Allowed) -and $v.Source -eq 'unknown-version') 'UNKNOWN schema_version → fail-closed halt'
+
+    Clear-State
+    'not json {{{' | Set-Content -LiteralPath $marker -Encoding utf8
+    Assert (Gate).Allowed 'unparseable marker, no kill switch → falls through → allowed'
+    'kill' | Set-Content -LiteralPath $loopHalted -Encoding utf8
+    Assert ((Gate).Source -eq 'loop-halted') 'unparseable marker falls through TO the local kill switch'
+}
+finally {
+    Remove-Item -Recurse -Force $sandbox -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "`n$($failures.Count) failure(s)." -ForegroundColor Red
+    exit 1
+}
+Write-Host "`nAll governance-gate assertions passed." -ForegroundColor Green

--- a/Scripts/dev-process-overseer.ps1
+++ b/Scripts/dev-process-overseer.ps1
@@ -20,6 +20,11 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# The governance gate (HALT-ALL + local kill switch, fail-closed). Single authority —
+# this script previously checked ONLY the local switch and silently ignored a
+# cross-repo HALT-ALL (the divergence the contract flagged as a deferred follow-up).
+Import-Module (Join-Path $PSScriptRoot 'Governance.psm1') -Force
+
 function Add-Finding {
     param(
         [System.Collections.Generic.List[object]]$Findings,
@@ -128,17 +133,25 @@ function Get-DomainFromBaselinePath {
 $findings = [System.Collections.Generic.List[object]]::new()
 $statusEntries = @(Get-GitStatusEntries -RepoRoot $RepoRoot)
 $baselineFiles = @(Get-BaselineFiles -RepoRoot $RepoRoot -Domain $Domain)
-$loopHaltedPath = Join-Path $RepoRoot 'state/.loop-halted'
-
 $branch = ''
 $headSha = ''
 try { $branch = (& git -C $RepoRoot branch --show-current 2>$null) } catch { }
 try { $headSha = (& git -C $RepoRoot rev-parse --short HEAD 2>$null) } catch { }
 
-if (Test-Path -LiteralPath $loopHaltedPath) {
-    Add-Finding $findings 'block' 'global-loop-halted' `
-        'The global loop kill switch is active.' `
-        'Do not start /loop or /goal automation until state/.loop-halted is intentionally cleared.'
+# Cross-repo HALT-ALL + per-repo kill switch, via the one governance gate.
+$gate = Test-GovernanceGate -AgentId 'dev-process-overseer' -RepoRoot $RepoRoot
+if ($gate.Halted) {
+    if ($gate.Source -in @('halt-all', 'unknown-version')) {
+        $detail = if ($gate.Reason) { ": $($gate.Reason)" } else { '' }
+        $who    = if ($gate.HaltedBy) { " (by $($gate.HaltedBy))" } else { '' }
+        Add-Finding $findings 'block' 'overseer-halt-all' `
+            "Cross-repo HALT-ALL is active$detail$who." `
+            'Every loop in every sibling repo must pause until ~/.demerzel/HALT-ALL is cleared (or expires).'
+    } else {
+        Add-Finding $findings 'block' 'global-loop-halted' `
+            'The global loop kill switch is active.' `
+            'Do not start /loop or /goal automation until state/.loop-halted is intentionally cleared.'
+    }
 }
 
 if (-not $baselineFiles) {

--- a/Scripts/validate-quality-snapshots.ps1
+++ b/Scripts/validate-quality-snapshots.ps1
@@ -1,0 +1,77 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+    Validate dashboard-envelope snapshots against the canonical schema — OPT-IN by the
+    snapshot registry, not opt-out by filename. Reuses Test-Contract from Governance.psm1.
+
+.DESCRIPTION
+    The previous validator (PR #370) walked EVERY *.json under state/quality/ and checked
+    it against the envelope schema, skipping only `_`-prefixed names — so 134 of 165 files
+    false-failed because they were baselines, SCHEMA.json, SAE artifacts, and lens sidecars
+    that were never dashboard envelopes. This validator inverts the selection: it reads
+    state/quality/.snapshot-registry.json and validates ONLY the dated snapshot files in the
+    registered envelope domains. Everything else is excluded by design, so a `FAIL` here is a
+    REAL conformance gap (a registered producer that isn't emitting the envelope yet), not noise.
+
+    Self-contained in ga: uses the vendored docs/contracts/quality-snapshot.schema.json — no
+    cross-repo rust build (the old workflow checked out ix and built ix-quality-validate).
+
+.PARAMETER Advisory
+    Exit 0 even when registered snapshots fail (report-only). Default: exit 1 on any failure
+    so the check can be a real merge gate once producers conform.
+#>
+[CmdletBinding()]
+param(
+    [string] $RepoRoot = (Resolve-Path .).Path,
+    [switch] $Advisory
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Import-Module (Join-Path $PSScriptRoot 'Governance.psm1') -Force
+
+$registryPath = Join-Path $RepoRoot 'state/quality/.snapshot-registry.json'
+if (-not (Test-Path $registryPath)) {
+    Write-Host "SNAPSHOT-VALIDATE: no registry at $registryPath" -ForegroundColor Red; exit 2
+}
+$registry = Get-Content $registryPath -Raw | ConvertFrom-Json
+$schemaPath = Join-Path $RepoRoot $registry.envelope_schema
+if (-not (Test-Path $schemaPath)) {
+    Write-Host "SNAPSHOT-VALIDATE: envelope schema missing at $schemaPath" -ForegroundColor Red; exit 2
+}
+
+$pass = 0; $failures = @(); $domainsChecked = 0; $filesChecked = 0
+foreach ($d in $registry.domains) {
+    $dir = Join-Path $RepoRoot $d.dir
+    if (-not (Test-Path $dir)) { continue }
+    $domainsChecked++
+    $files = @(Get-ChildItem -Path $dir -Filter $d.snapshot_glob -File -ErrorAction SilentlyContinue)
+    foreach ($f in $files) {
+        $filesChecked++
+        $res = Test-Contract -SchemaPath $schemaPath -Data (Get-Content $f.FullName -Raw)
+        if ($res.Valid) { $pass++ }
+        else {
+            $rel = [System.IO.Path]::GetRelativePath($RepoRoot, $f.FullName) -replace '\\', '/'
+            $failures += [pscustomobject]@{ domain = $d.domain; file = $rel; error = ($res.Errors -join '; ') }
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Dashboard-envelope snapshots (opt-in via .snapshot-registry.json)" -ForegroundColor Cyan
+Write-Host "  domains registered : $($registry.domains.Count)  (checked: $domainsChecked)"
+Write-Host "  snapshots validated: $filesChecked   pass: $pass   fail: $($failures.Count)"
+if ($failures.Count -gt 0) {
+    Write-Host "  Non-conforming (REAL gap — producer not emitting the envelope yet):" -ForegroundColor Yellow
+    foreach ($x in $failures) {
+        Write-Host ("    FAIL {0,-18} {1}" -f $x.domain, $x.file) -ForegroundColor Yellow
+        Write-Host ("         {0}" -f $x.error) -ForegroundColor DarkGray
+    }
+}
+
+if ($failures.Count -gt 0 -and -not $Advisory) {
+    Write-Host "`nSNAPSHOT-VALIDATE: $($failures.Count) registered snapshot(s) fail the envelope schema." -ForegroundColor Red
+    exit 1
+}
+Write-Host "`nSNAPSHOT-VALIDATE: ok ($filesChecked checked, $($failures.Count) non-conforming$(if($Advisory){' — advisory'}))." -ForegroundColor Green
+exit 0

--- a/docs/contracts/quality-snapshot.schema.json
+++ b/docs/contracts/quality-snapshot.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/ix/contracts/quality-snapshot-v1.json",
+  "title": "Quality Snapshot — Dashboard Envelope",
+  "description": "Canonical envelope for snapshot JSON files written to `state/quality/<domain>/*.json`. The GA dev dashboard (`/test#dev/summary`) reads these required top-level fields to render the per-domain tile. Producers MAY include any number of additional domain-specific fields (e.g. `exemplars`, `fired`, `summary.total`, `repos`); those are passed through unchanged. Established additively in ix#65 (ix-invariant-coverage) and ga#367/#368/#369 (readme-drift-survey, VoicingAnalysisAudit, embeddings-snapshot) on 2026-05-24 after three producers landed without these fields and silently degraded the dashboard. Cross-field rule: when `degraded` is `true`, `degraded_reason` MUST be present (encoded as a draft 2020-12 `if`/`then`/`required` clause below).",
+  "type": "object",
+  "required": [
+    "domain",
+    "emitted_at",
+    "metric_name",
+    "metric_value",
+    "oracle_status",
+    "summary"
+  ],
+  "properties": {
+    "domain": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "description": "Slug identifying the producer (e.g. `ga-harness`, `invariants`, `readme-drift`). Lower-kebab-case."
+    },
+    "emitted_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 UTC timestamp of when the snapshot was emitted."
+    },
+    "metric_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short identifier of the headline metric (e.g. `invariant_pass_ratio`, `harness_ready`, `drift_days_p95`)."
+    },
+    "metric_value": {
+      "type": ["number", "null"],
+      "description": "Headline metric value. `null` is permitted only when the producer ran in degraded mode (`degraded: true`) and no last-known-good value is available."
+    },
+    "oracle_status": {
+      "type": "string",
+      "enum": ["ok", "warn", "error"],
+      "description": "Traffic-light state for the dashboard tile."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-line human-readable summary suitable for display under the metric value."
+    },
+    "degraded": {
+      "type": "boolean",
+      "description": "True when the producer ran in degraded mode (e.g. missing dependency, partial corpus, network unavailable). Pairs with `degraded_reason`."
+    },
+    "degraded_reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Required when `degraded` is `true`. Short machine-friendly reason code or human sentence."
+    },
+    "last_known_good_pass_pct": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "Last-known-good pass percentage carried forward when the producer is degraded."
+    },
+    "last_known_good_source": {
+      "type": "string",
+      "description": "Provenance for `last_known_good_pass_pct` (e.g. `\"baseline\"`, ISO date, snapshot path)."
+    },
+    "last_known_good_date": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 UTC timestamp of when the last-known-good value was originally captured."
+    },
+    "problems": {
+      "type": "array",
+      "maxItems": 50,
+      "description": "Per-problem detail surfaced to the dashboard. Capped at 50 entries to keep snapshots small.",
+      "items": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Stable machine-readable identifier (e.g. `invariant-18`, `orphan`, `missing-readme`)."
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable explanation."
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": true,
+  "if": {
+    "properties": {
+      "degraded": { "const": true }
+    },
+    "required": ["degraded"]
+  },
+  "then": {
+    "required": ["degraded_reason"]
+  }
+}

--- a/state/quality/.snapshot-registry.json
+++ b/state/quality/.snapshot-registry.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "envelope_schema": "docs/contracts/quality-snapshot.schema.json",
+  "description": "Opt-IN registry of dashboard-envelope snapshot producers. ONLY the dirs listed under `domains` are validated against the envelope schema, and only their dated `snapshot_glob` files (so baseline.json / _*.json inside a registered dir are NOT validated). Every other *.json under state/quality/ — baselines, SCHEMA.json, *-artifact.json (own contract), lens sidecars, analysis dirs, loose one-off files — is excluded BY DESIGN. This replaces the opt-OUT (`_`-prefix-only) selection that false-failed 134 of 165 files in PR #370. Add a domain here when it starts emitting the canonical dashboard envelope; do not list sidecar/lens dirs.",
+  "domains": [
+    { "domain": "chatbot-qa",       "dir": "state/quality/chatbot-qa",       "snapshot_glob": "20??-??-??.json" },
+    { "domain": "embeddings",       "dir": "state/quality/embeddings",       "snapshot_glob": "20??-??-??.json" },
+    { "domain": "invariants",       "dir": "state/quality/invariants",       "snapshot_glob": "20??-??-??.json" },
+    { "domain": "readme-drift",     "dir": "state/quality/readme-drift",     "snapshot_glob": "20??-??-??.json" },
+    { "domain": "voicing-analysis", "dir": "state/quality/voicing-analysis", "snapshot_glob": "20??-??-??.json" }
+  ],
+  "excluded_by_design": [
+    "*/baseline.json and *-baseline-*.json — policy contracts, not envelopes (different shape)",
+    "**/SCHEMA.json, _schema.json, _fixtures/** — schema definitions / fixtures",
+    "optick-sae/** — own contract (optick-sae-artifact.schema.json), not the dashboard envelope",
+    "optick-retrieval/, routing-diagnostic/, ga-ix-settheory/, domain-invariants/, query-embeddings/ — lens sidecars (plain arrays / per-row data)",
+    "ai-costs/, council/, test-plans/, sentrux-next-steps/ — config / schema dirs",
+    "loose state/quality/*-2026-*.json one-offs and routing-eval-*.json — not dashboard tiles"
+  ]
+}


### PR DESCRIPTION
Architecture deepening (candidates **A + C** from the CI / galactic-protocol `/improve-codebase-architecture` review).

## A — One governance gate (`Scripts/Governance.psm1`)
The fail-closed HALT-ALL marker parse was copy-pasted across `auto-optimize`, `ga-chatbot-afk-harness`, and `dev-process-overseer.ps1` — and the overseer **only checked the local kill switch**, silently ignoring a cross-repo `~/.demerzel/HALT-ALL` (the contract's deferred follow-up). Now one tested authority:

- `Test-Contract` — validate any `docs/contracts/*.schema.json` (draft 2020-12, via `Test-Json`) → structured verdict.
- `Test-GovernanceGate` — folds HALT-ALL + `state/.loop-halted` into one fail-closed verdict, honoring every contract obligation (unknown `schema_version` → halt, `expires_at`, `exempt_agents`, `scope`).
- **`dev-process-overseer.ps1` divergence fixed** (now honors HALT-ALL); `auto-optimize/SKILL.md` 24-line copy → 6-line gate call.
- **`Scripts/Governance.test.ps1`: 13/13 green** — the fail-closed semantics are now testable (were untestable SKILL.md prose).

## C — Opt-in snapshot registry
PR #370's validator was **opt-out** (`_`-prefix only) → false-failed 134/165 files. Flipped to **opt-in**:

- `state/quality/.snapshot-registry.json` declares which dirs emit the dashboard envelope; `Scripts/validate-quality-snapshots.ps1` validates only those via `Test-Contract` (vendored `docs/contracts/quality-snapshot.schema.json`).
- Result: **134 false-positives → 0**; **87 real producer-conformance gaps** surfaced honestly (baselines / SCHEMA.json / SAE artifacts / lens sidecars excluded by design).

`Test-Contract` now has two independent consumers (gate + validator) — a real seam.

## Follow-ons (not in this PR)
- Rewire #370's workflow to call `validate-quality-snapshots.ps1` (drops the cross-repo rust build).
- `New-QualitySnapshot` producer module to clear the 87.
- Swap `algedonic-emit.ps1`'s inline validation for `Test-Contract` (3rd consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)