### PR TITLE
feat(quality): register maintain-gate verdict snapshot in the dashboard envelope (#445)

### DIFF
--- a/docs/contracts/maintain-gate-snapshot.schema.json
+++ b/docs/contracts/maintain-gate-snapshot.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/ga/contracts/maintain-gate-snapshot-v0.1.json",
+  "title": "Maintain-Gate Verdict Snapshot — GA-readable contract surface",
+  "description": "The fused cross-signal maintain verdict IX emits in scorecard shape, federated into state/quality/maintain-gate/ (producer: ix ix_maintain_snapshot, federation ix#146). It is the canonical GA dashboard envelope (allOf: quality-snapshot.schema.json) PLUS the maintain-specific LOCKED fields below. ADVISORY / non-binding until IX Phase-3b (`advisory: true`); GA surfaces it as the fused verdict GA's per-axis gates (CanonicalSignatureChecker / semantic-regression) individually lack — not another gate. One-way door: the `status` enum and the `signals[].lens` sub-signal keys are the agreed cross-repo contract surface; changing them needs IX+GA coordination once the GovernanceMetricsDashboard tile (ga#446) depends on them. The validator (Scripts/validate-quality-snapshots.ps1) checks registered snapshots against the shared envelope (quality-snapshot.schema.json, additionalProperties:true) — this file documents + tightens the maintain-specific surface that rides along.",
+  "allOf": [
+    { "$ref": "./quality-snapshot.schema.json" }
+  ],
+  "type": "object",
+  "required": [
+    "domain",
+    "emitted_at",
+    "metric_name",
+    "metric_value",
+    "oracle_status",
+    "summary",
+    "advisory",
+    "status",
+    "decision",
+    "signals"
+  ],
+  "properties": {
+    "domain": { "const": "maintain-gate" },
+    "metric_name": { "const": "maintain_yield_delta" },
+    "advisory": {
+      "type": "boolean",
+      "description": "Non-binding marker. `true` until IX Phase-3b makes the verdict gating. GA MUST present the verdict as advisory while this is true."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["T", "P", "U", "D", "F", "C"],
+      "description": "LOCKED. Hexavalent fused verdict: T accept | P accept-with-flags | U escalate (no signal / unverifiable) | D escalate (disputed — oscillating) | F reject | C reject+alarm (reward-hack: metric up while a held capability regressed)."
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["accept", "reject", "escalate"],
+      "description": "Coarse routing of `status`: T/P→accept, F/C→reject, U/D→escalate."
+    },
+    "signals": {
+      "type": "array",
+      "description": "LOCKED sub-signal keys. Per-lens verdict from the maintain fusion. The cross-signal contract surface GA reads.",
+      "items": {
+        "type": "object",
+        "required": ["lens", "status"],
+        "properties": {
+          "lens": {
+            "type": "string",
+            "enum": ["metric", "guardrail", "convergence", "drift", "provenance"],
+            "description": "metric = externally-derived yield delta · guardrail = chatbot held-capability regression gate · convergence = loop-oscillation lens · drift = OOD lens · provenance = iteration commit-verification (present only when scoped to an iteration)."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["ok", "bad", "unknown"],
+            "description": "ok = lens held · bad = lens failed · unknown = no signal (caps the fused verdict at U; never read as green)."
+          },
+          "detail": { "type": "string" }
+        }
+      }
+    },
+    "maintain_trend": {
+      "type": "object",
+      "description": "Convergence rollup over IX's append-only verdict ledger (read side). Advisory trend context for the tile.",
+      "properties": {
+        "total": { "type": "integer" },
+        "accepts": { "type": "integer" },
+        "rejects": { "type": "integer" },
+        "escalates": { "type": "integer" },
+        "reward_hacks": { "type": "integer" },
+        "latest_status": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/state/quality/.snapshot-registry.json
+++ b/state/quality/.snapshot-registry.json
@@ -7,7 +7,8 @@
     { "domain": "embeddings",       "dir": "state/quality/embeddings",       "snapshot_glob": "20??-??-??.json" },
     { "domain": "invariants",       "dir": "state/quality/invariants",       "snapshot_glob": "20??-??-??.json" },
     { "domain": "readme-drift",     "dir": "state/quality/readme-drift",     "snapshot_glob": "20??-??-??.json" },
-    { "domain": "voicing-analysis", "dir": "state/quality/voicing-analysis", "snapshot_glob": "20??-??-??.json" }
+    { "domain": "voicing-analysis", "dir": "state/quality/voicing-analysis", "snapshot_glob": "20??-??-??.json" },
+    { "domain": "maintain-gate",    "dir": "state/quality/maintain-gate",    "snapshot_glob": "20??-??-??.json", "contract": "docs/contracts/maintain-gate-snapshot.schema.json", "advisory": true, "producer": "ix ix_maintain_snapshot (federated, ix#146)" }
   ],
   "excluded_by_design": [
     "*/baseline.json and *-baseline-*.json — policy contracts, not envelopes (different shape)",

--- a/state/quality/maintain-gate/2026-06-20.json
+++ b/state/quality/maintain-gate/2026-06-20.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "maintain-verdict-snapshot.v0.1",
+  "domain": "maintain-gate",
+  "emitted_at": "2026-06-20T22:28:18Z",
+  "metric_name": "maintain_yield_delta",
+  "metric_value": 0.0,
+  "oracle_status": "warn",
+  "summary": "metric evidence missing — cannot decide",
+  "advisory": true,
+  "status": "U",
+  "decision": "escalate",
+  "signals": [
+    { "lens": "metric", "status": "unknown", "detail": "no externally-derived metric evidence" },
+    { "lens": "guardrail", "status": "bad", "detail": "chatbot gate: regression (1 regression(s))" },
+    { "lens": "convergence", "status": "ok", "detail": "loops converging (no oscillation)" },
+    { "lens": "drift", "status": "ok", "detail": "queries in-distribution" }
+  ],
+  "maintain_trend": {
+    "total": 0,
+    "accepts": 0,
+    "rejects": 0,
+    "escalates": 0,
+    "reward_hacks": 0,
+    "by_status": [],
+    "latest_status": null
+  }
+}


### PR DESCRIPTION
## Phase B (schema side) — closes #445

Registers IX's fused hexavalent (T/P/U/D/F/C) **maintain** verdict as an opt-in dashboard-envelope producer, so the GA dashboard/manifest can validate + ingest it. **Not another gate** — GA already gates agent_id/shape/semantic natively (`CanonicalSignatureChecker` / `semantic-regression-chatbot.yml`). This is the **fused cross-signal verdict** GA lacks, surfaced **advisory** (non-binding until IX Phase-3b).

> Note: the issue named `_schema.json`, but that file is a *pin declaration*. The actual opt-in registration surface (added in today's `91f5467c`) is **`.snapshot-registry.json` + `quality-snapshot.schema.json`**, validated by `Scripts/validate-quality-snapshots.ps1`. Registered there instead.

### Changes
- **`.snapshot-registry.json`** — add the `maintain-gate` domain (dated-snapshot glob) with `advisory:true`, a `contract` pointer, and a producer note.
- **`docs/contracts/maintain-gate-snapshot.schema.json`** — the **locked contract surface**: `allOf` the canonical envelope **plus** the maintain-specific fields. **Locked (one-way door, agreed with IX):** the `status` enum `T/P/U/D/F/C` and the `signals[].lens` sub-signal keys **`metric/guardrail/convergence/drift`**(`/provenance`). Changing them needs IX+GA coordination once the tile (#446) depends on them.
- **`state/quality/maintain-gate/2026-06-20.json`** — a **real producer-emitted sample** (from `ix ix_maintain_snapshot` over live GA telemetry), proving the contract.

### Acceptance criteria (all met)
- [x] Envelope describes the maintain-gate snapshot (registry + dedicated contract schema + advisory marker).
- [x] Locked fields agreed with IX (status enum + sub-signal keys; logged as a one-way door in the contract schema).
- [x] A sample snapshot validates — `validate-quality-snapshots.ps1`: maintain-gate **passes** (conforming **34 → 35**).

### Honesty notes
- The validator reports **87 failures, all pre-existing on `main`** (voicing-analysis et al. predate the envelope) — **untouched** here. My sample is the only delta and it passes. (CI must run this `-Advisory` today; out of scope to fix the 87.)
- **Producer alignment landed IX-side** (ix#147): the producer now emits GA's canonical envelope (`domain`/`emitted_at`/`metric_name`) — surfaced by this slice as a tracer-bullet integration fix before merge.
- **Formats-not-coupling**: GA reads an ix-emitted file; no Rust in GA CI.

Parent: ix plan `2026-06-20-001-feat-ga-maintain-verdict-tile-plan.md` (ix#144) · ADR-0002. Pairs with ix#146 (federation producer). Blocks #446 (the tile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)