### PR TITLE
feat(dashboard): maintain-gate advisory verdict tile (Phase C, ga#446)

### DIFF
--- a/ReactComponents/ga-react-components/src/components/Summary/MaintainGateCard.test.tsx
+++ b/ReactComponents/ga-react-components/src/components/Summary/MaintainGateCard.test.tsx
@@ -1,0 +1,79 @@
+// MaintainGateCard.test — renders the advisory maintain-gate tile (ga#446)
+// against the real federated snapshot shape. Asserts the four things the issue
+// requires: hexavalent status chip, advisory badge, per-signal breakdown, and
+// an honest freshness/stale read (never a fake green).
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MaintainGateCard } from './MaintainGateCard';
+
+const SNAPSHOT = {
+  schema_version: 'maintain-verdict-snapshot.v0.1',
+  domain: 'maintain-gate',
+  emitted_at: '2026-06-21T00:41:51.122362635+00:00',
+  metric_name: 'maintain_yield_delta',
+  metric_value: 0.0,
+  oracle_status: 'warn',
+  summary: 'metric evidence missing — cannot decide',
+  advisory: true,
+  status: 'U',
+  decision: 'escalate',
+  signals: [
+    { lens: 'metric', status: 'unknown', detail: 'no externally-derived metric evidence' },
+    { lens: 'guardrail', status: 'unknown', detail: 'chatbot gate: skipped (0 regression(s))' },
+    { lens: 'convergence', status: 'unknown', detail: 'no loop data (advisory)' },
+    { lens: 'drift', status: 'unknown', detail: 'no query embeddings (advisory)' },
+  ],
+  maintain_trend: { total: 0, accepts: 0, rejects: 0, escalates: 0, reward_hacks: 0, latest_status: null },
+};
+
+function mockFetch(body: unknown, ok = true) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 404,
+    json: async () => body,
+  }));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('MaintainGateCard', () => {
+  it('renders the hexavalent status chip, advisory badge, summary, and per-signal breakdown', async () => {
+    mockFetch({ generated_at: '2026-06-21T01:00:00Z', snapshot: SNAPSHOT, source: 'live', age_hours: 0.3, stale: false });
+    render(<MaintainGateCard />);
+
+    const chip = await screen.findByTestId('maintain-status-chip');
+    expect(chip.textContent).toContain('U');
+    expect(chip.textContent).toMatch(/escalate/i);
+
+    expect(screen.getByTestId('maintain-advisory-badge').textContent).toMatch(/advisory/i);
+    expect(screen.getByText('metric evidence missing — cannot decide')).toBeInTheDocument();
+
+    // All four sub-signals present.
+    for (const lens of ['metric', 'guardrail', 'convergence', 'drift']) {
+      expect(screen.getByTestId(`maintain-signal-${lens}`)).toBeInTheDocument();
+    }
+
+    // Oracle traffic light reflects warn.
+    expect(screen.getByTestId('maintain-oracle-dot').getAttribute('data-oracle')).toBe('warn');
+  });
+
+  it('surfaces STALE rather than a fake green when the snapshot is old', async () => {
+    mockFetch({ generated_at: '2026-06-21T01:00:00Z', snapshot: SNAPSHOT, source: 'live', age_hours: 72, stale: true });
+    render(<MaintainGateCard />);
+    const badge = await screen.findByTestId('maintain-freshness-badge');
+    expect(badge.textContent).toMatch(/stale/i);
+  });
+
+  it('renders a quiet hint (not blank, not green) on fetch error', async () => {
+    mockFetch({ error: 'not found' }, false);
+    render(<MaintainGateCard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('maintain-gate-card').textContent).toMatch(/no maintain verdict yet/i);
+    });
+    expect(screen.queryByTestId('maintain-status-chip')).toBeNull();
+  });
+});

--- a/ReactComponents/ga-react-components/src/components/Summary/MaintainGateCard.tsx
+++ b/ReactComponents/ga-react-components/src/components/Summary/MaintainGateCard.tsx
@@ -1,0 +1,244 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Chip, CircularProgress, Divider, Paper, Stack, Tooltip, Typography } from '@mui/material';
+import GavelIcon from '@mui/icons-material/Gavel';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import type {
+  MaintainVerdictSnapshot,
+  MaintainSignal,
+  MaintainSignalStatus,
+  MaintainStatus,
+} from '../../dev-data/parsers';
+
+// Maintain-gate advisory verdict tile (ga#446 / Phase C).
+//
+// Renders IX's fused, cross-signal hexavalent (T/P/U/D/F/C) maintain verdict
+// federated into state/quality/maintain-gate/last.json (producer ix#146,
+// schema ga#445). Self-fetching like ValueScorecard / MissionControl: no
+// props, reads /dev-data/maintain-gate (served by the Vite dev-data
+// middleware, which computes age_hours + stale server-side).
+//
+// IMPORTANT: this is ADVISORY / non-binding until IX Phase-3b — it is the
+// fused verdict GA's per-axis gates (CanonicalSignatureChecker, semantic-
+// regression) individually lack, NOT another pass/fail gate. The tile makes
+// that explicit (advisory badge) and never reads a missing/old snapshot as a
+// fake green (stale badge + traffic-light honesty — `unknown` ≠ green).
+
+interface MaintainPayload {
+  generated_at: string;
+  snapshot: MaintainVerdictSnapshot | null;
+  source: 'live' | 'fixture';
+  age_hours: number | null;
+  stale: boolean;
+  note?: string;
+}
+
+// Hexavalent legend — the cross-repo LOCKED status enum.
+const STATUS_LEGEND: Record<MaintainStatus, { label: string; meaning: string; color: 'success' | 'warning' | 'error' | 'default' }> = {
+  T: { label: 'T', meaning: 'accept', color: 'success' },
+  P: { label: 'P', meaning: 'accept (with flags)', color: 'success' },
+  U: { label: 'U', meaning: 'escalate (no / unverifiable signal)', color: 'warning' },
+  D: { label: 'D', meaning: 'escalate (disputed — oscillating)', color: 'warning' },
+  F: { label: 'F', meaning: 'reject', color: 'error' },
+  C: { label: 'C', meaning: 'reject + alarm (reward-hack)', color: 'error' },
+};
+
+// oracle_status → MUI traffic-light color.
+function oracleColor(oracle: string): 'success' | 'warning' | 'error' | 'default' {
+  if (oracle === 'ok') return 'success';
+  if (oracle === 'warn') return 'warning';
+  if (oracle === 'error') return 'error';
+  return 'default';
+}
+
+// per-signal status → color + glyph. `unknown` is deliberately neutral (never
+// green) so a no-signal lens caps the read honestly.
+const SIGNAL_VIS: Record<MaintainSignalStatus, { color: 'success' | 'error' | 'default'; glyph: string }> = {
+  ok: { color: 'success', glyph: '✓' },
+  bad: { color: 'error', glyph: '✗' },
+  unknown: { color: 'default', glyph: '—' },
+};
+
+function formatAge(ageHours: number | null): string {
+  if (ageHours == null) return 'unknown age';
+  if (ageHours < 1) return `${Math.round(ageHours * 60)}m ago`;
+  if (ageHours < 48) return `${Math.round(ageHours)}h ago`;
+  return `${Math.round(ageHours / 24)}d ago`;
+}
+
+const SignalChip: React.FC<{ sig: MaintainSignal }> = ({ sig }) => {
+  const vis = SIGNAL_VIS[sig.status] ?? SIGNAL_VIS.unknown;
+  return (
+    <Tooltip title={`${sig.lens}: ${sig.status}${sig.detail ? ` — ${sig.detail}` : ''}`} placement="top">
+      <Chip
+        label={`${vis.glyph} ${sig.lens}`}
+        color={vis.color}
+        size="small"
+        variant={sig.status === 'ok' ? 'filled' : 'outlined'}
+        sx={{ fontSize: '0.7rem' }}
+        data-testid={`maintain-signal-${sig.lens}`}
+        data-signal-status={sig.status}
+      />
+    </Tooltip>
+  );
+};
+
+const Header: React.FC = () => (
+  <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+    <GavelIcon sx={{ color: 'text.secondary' }} />
+    <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>Maintain Gate</Typography>
+    <Tooltip
+      title="IX's fused cross-signal maintain verdict (metric · guardrail · convergence · drift), rolled up to a single hexavalent status. The verdict GA's per-axis gates individually lack. Federated daily from ix (ix_maintain_snapshot)."
+      placement="top"
+      enterDelay={300}
+    >
+      <InfoOutlinedIcon sx={{ fontSize: 15, color: 'text.disabled' }} />
+    </Tooltip>
+  </Stack>
+);
+
+export const MaintainGateCard: React.FC = () => {
+  const [payload, setPayload] = useState<MaintainPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/dev-data/maintain-gate', { cache: 'no-store' })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`/dev-data/maintain-gate → ${r.status}`);
+        return r.json() as Promise<MaintainPayload>;
+      })
+      .then((d) => { if (!cancelled) setPayload(d); })
+      .catch((e) => { if (!cancelled) setError(String(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Absent snapshot (404) or fetch error — quiet hint, never blank or fake green.
+  if (error) {
+    return (
+      <Paper data-testid="maintain-gate-card" sx={{ p: 2 }}>
+        <Header />
+        <Typography variant="caption" color="text.secondary">
+          No maintain verdict yet — federated from the sibling ix repo
+          (<code>ix_maintain_snapshot</code>, ix#146) into
+          <code> state/quality/maintain-gate/last.json</code>.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  if (!payload) {
+    return (
+      <Paper data-testid="maintain-gate-card" sx={{ p: 2, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress size={20} />
+      </Paper>
+    );
+  }
+
+  const snap = payload.snapshot;
+  if (!snap) {
+    return (
+      <Paper data-testid="maintain-gate-card" sx={{ p: 2 }}>
+        <Header />
+        <Typography variant="caption" color="text.secondary">
+          {payload.note ?? 'Snapshot unparseable — treated as stale (no fake green).'}
+        </Typography>
+      </Paper>
+    );
+  }
+
+  const legend = STATUS_LEGEND[snap.status as MaintainStatus];
+  const statusColor = legend?.color ?? 'default';
+  const statusMeaning = legend?.meaning ?? snap.decision;
+  const oracle = oracleColor(snap.oracle_status);
+
+  return (
+    <Paper data-testid="maintain-gate-card" data-maintain-status={snap.status} data-maintain-stale={payload.stale} sx={{ p: 2 }}>
+      <Header />
+
+      {/* Verdict row: hexavalent status chip (color by value) + decision +
+          oracle traffic-light dot + freshness + advisory/stale badges. */}
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+        <Tooltip title={`Hexavalent verdict ${snap.status} — ${statusMeaning}`} placement="top">
+          <Chip
+            label={`${snap.status} · ${statusMeaning}`}
+            color={statusColor}
+            size="small"
+            sx={{ fontWeight: 700 }}
+            data-testid="maintain-status-chip"
+          />
+        </Tooltip>
+
+        {/* Oracle traffic light. */}
+        <Tooltip title={`oracle_status: ${snap.oracle_status}`} placement="top">
+          <Box
+            data-testid="maintain-oracle-dot"
+            data-oracle={snap.oracle_status}
+            sx={{
+              width: 12, height: 12, borderRadius: '50%',
+              bgcolor: oracle === 'default' ? 'text.disabled' : `${oracle}.main`,
+            }}
+          />
+        </Tooltip>
+
+        <Box sx={{ flex: 1 }} />
+
+        {snap.advisory && (
+          <Tooltip title="Non-binding marker — this verdict is informational until IX Phase-3b makes it gating. GA presents it as advisory, not pass/fail." placement="top">
+            <Chip
+              label="ADVISORY — non-binding until IX Phase-3b"
+              size="small"
+              variant="outlined"
+              color="info"
+              sx={{ fontSize: '0.65rem', height: 20 }}
+              data-testid="maintain-advisory-badge"
+            />
+          </Tooltip>
+        )}
+
+        <Tooltip title={`emitted ${snap.emitted_at}${payload.source === 'fixture' ? ' (dev fixture — no live snapshot)' : ''}`} placement="top">
+          <Chip
+            label={payload.stale ? `STALE · ${formatAge(payload.age_hours)}` : formatAge(payload.age_hours)}
+            size="small"
+            variant="outlined"
+            color={payload.stale ? 'warning' : 'default'}
+            sx={{ fontSize: '0.65rem', height: 20 }}
+            data-testid="maintain-freshness-badge"
+          />
+        </Tooltip>
+      </Stack>
+
+      {/* One-line summary. */}
+      <Typography variant="body2" sx={{ mb: 1 }}>{snap.summary}</Typography>
+
+      <Divider sx={{ mb: 1 }} />
+
+      {/* Per-signal breakdown. */}
+      <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        Sub-signals
+      </Typography>
+      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap data-testid="maintain-signals" sx={{ mt: 0.5 }}>
+        {snap.signals.length === 0 ? (
+          <Typography variant="caption" color="text.secondary">no sub-signals reported</Typography>
+        ) : (
+          snap.signals.map((sig) => <SignalChip key={sig.lens} sig={sig} />)
+        )}
+      </Stack>
+
+      {/* Trend rollup (advisory context). */}
+      {snap.maintain_trend && (snap.maintain_trend.total ?? 0) > 0 && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          trend: {snap.maintain_trend.total} verdicts · {snap.maintain_trend.accepts ?? 0} accept ·{' '}
+          {snap.maintain_trend.rejects ?? 0} reject · {snap.maintain_trend.escalates ?? 0} escalate
+          {(snap.maintain_trend.reward_hacks ?? 0) > 0 && ` · ${snap.maintain_trend.reward_hacks} reward-hack`}
+        </Typography>
+      )}
+
+      {/* Hexavalent legend so the chip is self-explanatory. */}
+      <Typography variant="caption" color="text.disabled" sx={{ display: 'block', mt: 1, fontSize: '0.65rem' }}>
+        T accept · P accept-w/-flags · U escalate · D disputed · F reject · C reward-hack
+      </Typography>
+    </Paper>
+  );
+};
+
+export default MaintainGateCard;

--- a/ReactComponents/ga-react-components/src/dev-data/fixtures/maintain-gate.last.json
+++ b/ReactComponents/ga-react-components/src/dev-data/fixtures/maintain-gate.last.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "maintain-verdict-snapshot.v0.1",
+  "domain": "maintain-gate",
+  "emitted_at": "2026-06-21T00:41:51.122362635+00:00",
+  "metric_name": "maintain_yield_delta",
+  "metric_value": 0.0,
+  "oracle_status": "warn",
+  "summary": "metric evidence missing — cannot decide",
+  "advisory": true,
+  "status": "U",
+  "decision": "escalate",
+  "signals": [
+    {
+      "lens": "metric",
+      "status": "unknown",
+      "detail": "no externally-derived metric evidence"
+    },
+    {
+      "lens": "guardrail",
+      "status": "unknown",
+      "detail": "chatbot gate: skipped (0 regression(s))"
+    },
+    {
+      "lens": "convergence",
+      "status": "unknown",
+      "detail": "no loop data (advisory)"
+    },
+    {
+      "lens": "drift",
+      "status": "unknown",
+      "detail": "no query embeddings (advisory)"
+    }
+  ],
+  "maintain_trend": {
+    "total": 0,
+    "accepts": 0,
+    "rejects": 0,
+    "escalates": 0,
+    "reward_hacks": 0,
+    "by_status": [],
+    "latest_status": null
+  }
+}

--- a/ReactComponents/ga-react-components/src/dev-data/maintainGate.test.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/maintainGate.test.ts
@@ -1,0 +1,74 @@
+// maintainGate.test — covers the pure parser + freshness derivation the
+// maintain-gate tile (ga#446) relies on. These are the green-but-dead guards:
+// a missing/old/unparseable snapshot must NEVER read as fresh-green.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { parseMaintainGate, maintainAgeHours, isMaintainStale } from './parsers';
+
+// The real federated snapshot committed to the repo — proves the parser
+// matches the production envelope shape, not a synthetic input.
+const LIVE = readFileSync(
+  path.resolve(__dirname, '../../../../state/quality/maintain-gate/last.json'),
+  'utf-8',
+);
+
+describe('parseMaintainGate', () => {
+  it('parses the real federated last.json snapshot', () => {
+    const snap = parseMaintainGate(LIVE);
+    expect(snap).not.toBeNull();
+    expect(snap!.domain).toBe('maintain-gate');
+    expect(snap!.status).toBe('U');
+    expect(snap!.decision).toBe('escalate');
+    expect(snap!.advisory).toBe(true);
+    expect(snap!.oracle_status).toBe('warn');
+    expect(snap!.signals.map((s) => s.lens)).toEqual(['metric', 'guardrail', 'convergence', 'drift']);
+    expect(snap!.signals.every((s) => s.status === 'unknown')).toBe(true);
+  });
+
+  it('returns null on malformed JSON (no throw)', () => {
+    expect(parseMaintainGate('{not json')).toBeNull();
+  });
+
+  it('returns null when the load-bearing contract fields are absent', () => {
+    expect(parseMaintainGate(JSON.stringify({ foo: 1 }))).toBeNull();
+  });
+
+  it('defaults advisory to true (fail-safe to non-binding) when omitted', () => {
+    const snap = parseMaintainGate(JSON.stringify({
+      status: 'T', emitted_at: '2026-06-21T00:00:00Z', oracle_status: 'ok',
+    }));
+    expect(snap!.advisory).toBe(true);
+  });
+
+  it('honors advisory:false when the producer marks it gating', () => {
+    const snap = parseMaintainGate(JSON.stringify({
+      status: 'T', emitted_at: '2026-06-21T00:00:00Z', oracle_status: 'ok', advisory: false,
+    }));
+    expect(snap!.advisory).toBe(false);
+  });
+});
+
+describe('maintainAgeHours', () => {
+  it('returns null for missing or unparseable timestamps', () => {
+    expect(maintainAgeHours(null)).toBeNull();
+    expect(maintainAgeHours('not-a-date')).toBeNull();
+  });
+
+  it('computes hours elapsed', () => {
+    const now = new Date('2026-06-21T12:00:00Z');
+    expect(maintainAgeHours('2026-06-21T10:00:00Z', now)).toBeCloseTo(2, 5);
+  });
+});
+
+describe('isMaintainStale', () => {
+  it('treats unknown freshness (null) as STALE — never green', () => {
+    expect(isMaintainStale(null)).toBe(true);
+  });
+
+  it('fresh under the threshold, stale over it', () => {
+    expect(isMaintainStale(2, 36)).toBe(false);
+    expect(isMaintainStale(48, 36)).toBe(true);
+  });
+});

--- a/ReactComponents/ga-react-components/src/dev-data/parsers.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.ts
@@ -423,3 +423,107 @@ export function parseValueCatalog(content: string): ValueRecord[] {
     }
     return out;
 }
+
+// ── Maintain-gate advisory verdict (ga#446 / Phase C) ───────────────────
+// Parses the fused cross-signal maintain verdict IX emits in scorecard shape,
+// federated into state/quality/maintain-gate/last.json (producer ix
+// ix_maintain_snapshot; federation ix#146; schema ga#445). It is ADVISORY /
+// non-binding until IX Phase-3b (`advisory:true`) — GA surfaces it as the
+// fused verdict our per-axis gates individually lack, NOT another gate. See:
+//   docs/contracts/maintain-gate-snapshot.schema.json (allOf quality-snapshot)
+
+/** Hexavalent fused verdict. LOCKED enum (cross-repo contract surface). */
+export type MaintainStatus = 'T' | 'P' | 'U' | 'D' | 'F' | 'C';
+/** Coarse routing of `status`. */
+export type MaintainDecision = 'accept' | 'reject' | 'escalate';
+/** Traffic-light oracle status (shared quality-snapshot envelope). */
+export type MaintainOracleStatus = 'ok' | 'warn' | 'error';
+/** Per-lens sub-signal verdict. */
+export type MaintainSignalStatus = 'ok' | 'bad' | 'unknown';
+/** LOCKED sub-signal keys. */
+export type MaintainLens = 'metric' | 'guardrail' | 'convergence' | 'drift' | 'provenance';
+
+export interface MaintainSignal {
+    lens: MaintainLens;
+    status: MaintainSignalStatus;
+    detail?: string;
+}
+
+export interface MaintainTrend {
+    total?: number;
+    accepts?: number;
+    rejects?: number;
+    escalates?: number;
+    reward_hacks?: number;
+    latest_status?: string | null;
+}
+
+export interface MaintainVerdictSnapshot {
+    schema_version?: string;
+    domain: string;
+    emitted_at: string;
+    metric_name: string;
+    metric_value: number;
+    oracle_status: MaintainOracleStatus | string;
+    summary: string;
+    advisory: boolean;
+    status: MaintainStatus | string;
+    decision: MaintainDecision | string;
+    signals: MaintainSignal[];
+    maintain_trend?: MaintainTrend;
+}
+
+/**
+ * Parse the maintain-gate snapshot JSON. Tolerant: returns null on bad JSON or
+ * when the load-bearing contract fields are absent, so the tile renders an
+ * honest "no data" / "stale" state rather than throwing or faking green.
+ */
+export function parseMaintainGate(content: string): MaintainVerdictSnapshot | null {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== 'object') return null;
+    const r = parsed as Partial<MaintainVerdictSnapshot>;
+    if (typeof r.status !== 'string' || typeof r.emitted_at !== 'string') return null;
+    if (typeof r.oracle_status !== 'string') return null;
+    return {
+        schema_version: r.schema_version,
+        domain: r.domain ?? 'maintain-gate',
+        emitted_at: r.emitted_at,
+        metric_name: r.metric_name ?? 'maintain_yield_delta',
+        metric_value: typeof r.metric_value === 'number' ? r.metric_value : Number.NaN,
+        oracle_status: r.oracle_status,
+        summary: r.summary ?? '',
+        advisory: r.advisory !== false, // default to advisory (fail-safe to non-binding)
+        status: r.status,
+        decision: r.decision ?? 'escalate',
+        signals: Array.isArray(r.signals) ? (r.signals as MaintainSignal[]) : [],
+        maintain_trend: r.maintain_trend,
+    };
+}
+
+/**
+ * Hours elapsed since `emitted_at`. Returns null when the timestamp is absent
+ * or unparseable (so the caller treats "unknown freshness" as stale, never as
+ * fresh). `now` injected for testability.
+ */
+export function maintainAgeHours(emittedAt: string | null | undefined, now: Date = new Date()): number | null {
+    if (!emittedAt) return null;
+    const t = Date.parse(emittedAt);
+    if (Number.isNaN(t)) return null;
+    return Math.max(0, (now.getTime() - t) / 3_600_000);
+}
+
+/**
+ * A snapshot is stale once it is older than `maxAgeHours` (default 36h — a
+ * daily-federated artifact that hasn't refreshed in >1.5 days is no longer
+ * "today"). Unknown freshness (null age) is treated as stale: the green-but-
+ * dead guard the issue asks for — a missing/old snapshot must NOT read fresh.
+ */
+export function isMaintainStale(ageHours: number | null, maxAgeHours = 36): boolean {
+    if (ageHours == null) return true;
+    return ageHours > maxAgeHours;
+}

--- a/ReactComponents/ga-react-components/src/pages/OverviewSection.tsx
+++ b/ReactComponents/ga-react-components/src/pages/OverviewSection.tsx
@@ -30,6 +30,7 @@ import {
 import { InFlightCard } from '../components/Summary/InFlightCard';
 import { MissionControl } from '../components/Summary/MissionControl';
 import { ValueScorecard } from '../components/Summary/ValueScorecard';
+import { MaintainGateCard } from '../components/Summary/MaintainGateCard';
 import { deriveTileStatus, type QualitySnapshotLike } from '../utils/qualityStatus';
 
 interface BacklogItem {
@@ -549,6 +550,11 @@ export const OverviewSection: React.FC = () => {
           from the sibling ix repo (ix-value). Answers "what's worth the most"
           right after "what's in flight." */}
       <ValueScorecard />
+
+      {/* Maintain Gate — IX's fused cross-signal hexavalent maintain verdict
+          (advisory / non-binding until IX Phase-3b). The single fused verdict
+          GA's per-axis gates individually lack. Federated daily from ix. */}
+      <MaintainGateCard />
 
       {/* Top stat tiles */}
       <Grid container spacing={2}>

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import { createReadStream, existsSync, statSync, readFileSync, readdirSync, appendFileSync } from 'fs'
 import { execFileSync, spawn } from 'child_process'
 import type { Plugin } from 'vite'
-import { parseBacklog, extractDocTitle, binActivityByDay, projectLoopsGoals, parseValueCatalog } from './src/dev-data/parsers'
+import { parseBacklog, extractDocTitle, binActivityByDay, projectLoopsGoals, parseValueCatalog, parseMaintainGate, maintainAgeHours, isMaintainStale } from './src/dev-data/parsers'
 import type { BacklogPayload, LoopsGoalsProjection } from './src/dev-data/parsers'
 
 // Load ALL env vars (not just VITE_*) from .env.local for proxy auth injection
@@ -1623,6 +1623,44 @@ function devDataPlugin(): Plugin {
                 }
             });
 
+            // ── /dev-data/maintain-gate — fused advisory maintain verdict ───
+            // Reads the federated maintain-verdict snapshot IX emits in
+            // scorecard shape (state/quality/maintain-gate/last.json; producer
+            // ix ix_maintain_snapshot, federation ix#146, schema ga#445). It is
+            // ADVISORY / non-binding until IX Phase-3b. The server computes
+            // freshness (age_hours / stale) so the tile can never render a
+            // missing-or-old snapshot as a fake green (green-but-dead guard,
+            // ga#446). Falls back to a dev-data fixture when no live snapshot is
+            // present so the tile renders before the first federation run.
+            server.middlewares.use('/dev-data/maintain-gate', (req, res, next) => {
+                if (req.method !== 'GET') { next(); return; }
+                const live = path.join(repoRoot, 'state/quality/maintain-gate/last.json')
+                const fixture = path.join(repoRoot, 'ReactComponents/ga-react-components/src/dev-data/fixtures/maintain-gate.last.json')
+                const usingFixture = !existsSync(live)
+                const p = usingFixture ? fixture : live
+                if (!existsSync(p)) {
+                    res.writeHead(404, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({ error: `maintain-gate snapshot not found at ${live} — federated by ix#146 (ix_maintain_snapshot)` }))
+                    return
+                }
+                try {
+                    const snapshot = parseMaintainGate(readFileSync(p, 'utf-8'))
+                    if (!snapshot) {
+                        res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+                        res.end(JSON.stringify({ generated_at: new Date().toISOString(), snapshot: null, source: usingFixture ? 'fixture' : 'live', age_hours: null, stale: true, note: 'snapshot present but unparseable / missing contract fields' }))
+                        return
+                    }
+                    const age_hours = maintainAgeHours(snapshot.emitted_at)
+                    // A fixture is always advisory/stale context — never let it read fresh.
+                    const stale = usingFixture || isMaintainStale(age_hours)
+                    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+                    res.end(JSON.stringify({ generated_at: new Date().toISOString(), snapshot, source: usingFixture ? 'fixture' : 'live', age_hours, stale }))
+                } catch (err) {
+                    res.writeHead(500, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({ error: String(err) }))
+                }
+            });
+
             server.middlewares.use('/dev-data/agents', (req, res, next) => {
                 if (req.method !== 'GET') { next(); return; }
                 res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
@@ -2033,6 +2071,7 @@ function devDataPlugin(): Plugin {
                         test_plans: '/dev-data/test-plans',
                         in_flight: '/dev-data/in-flight',
                         recent_events: '/dev-data/recent-events',
+                        maintain_gate: '/dev-data/maintain-gate',
                         runtime_loops_goals: '/dev-data/runtime-loops-goals',
                         sentrux_health: '/dev-data/sentrux/health',
                         sentrux_rules: '/dev-data/sentrux/rules',


### PR DESCRIPTION
## PROTOTYPE — for human visual review (HITL Phase C)

Closes the build for **ga#446**. Adds a `MaintainGateCard` tile to the dev dashboard (`/test#dev/summary`, `OverviewSection`) that surfaces IX's **fused cross-signal hexavalent (T/P/U/D/F/C) maintain verdict**.

### What it reads
The federated snapshot `state/quality/maintain-gate/last.json` (already live + committed), produced by **ix#147/#150** (`ix_maintain_snapshot`), described by the **ga#447 schema** (`docs/contracts/maintain-gate-snapshot.schema.json`, `allOf` the shared `quality-snapshot` envelope) and delivered by **ga#450 federation**. A new `/dev-data/maintain-gate` Vite middleware parses it, falls back to a committed dev fixture when no live snapshot exists, and computes `age_hours` + `stale` server-side.

### What it renders
- **Hexavalent `status` chip**, colour by value (T/P green · U/D amber · F/C red), with an always-visible legend (T accept · P accept-w/-flags · U escalate · D disputed · F reject · C reward-hack).
- **`oracle_status` traffic-light** dot (ok=green · warn=amber · error=red).
- One-line **`summary`**.
- **Per-signal breakdown** — metric / guardrail / convergence / drift, each ok (✓ green) / bad (✗ red) / unknown (— neutral). `unknown` is deliberately neutral, **never green**.
- **"ADVISORY — non-binding until IX Phase-3b"** badge while `advisory:true`.
- **`emitted_at` freshness**, with an explicit **STALE** badge once the snapshot is old (>36h) or freshness is unknown — the **green-but-dead guard** (a missing/old snapshot can never read as fresh green).
- Advisory **trend** rollup line when `maintain_trend.total > 0`.

### It is NON-BINDING
This is **advisory** (the fused verdict GA's per-axis gates — CanonicalSignatureChecker, semantic-regression — individually lack), **not** another pass/fail gate. It stays advisory until IX Phase-3b flips `advisory:false`.

### Reuses the existing pattern
Self-fetching `<Paper>` tile copied from `ValueScorecard` (same `/dev-data/*` middleware + graceful loading/error/empty states), placed right after it in `OverviewSection`.

### How it was verified
- `vitest run` — **12/12 green** across a pure parser/freshness test (`maintainGate.test.ts`, asserts against the **real** committed `last.json`, plus the `null→stale` green-but-dead guards) and a component render test (`MaintainGateCard.test.tsx`: hexavalent chip + advisory badge + 4 sub-signals + STALE-not-green + quiet-hint-on-error).
- `eslint` clean on all changed files; `vite build` exits 0.
- **Headless screenshots** of three states (live `U`/warn, **STALE** amber-not-green, and a `C` reward-hack red with the ✓metric/✗guardrail split) — rendered and visually confirmed locally.

### Spots where I guessed a convention (please check)
1. **Snapshot location**: I read `state/quality/maintain-gate/last.json` from GA's repo root (the file is committed there). If federation later lands it under `IX_ROOT` instead, the middleware path needs flipping (one line).
2. **Staleness threshold**: 36h (a daily artifact that hasn't refreshed in >1.5 days). Tune `isMaintainStale`'s default if the federation cadence differs.
3. **Placement**: after `ValueScorecard` in `OverviewSection` (the `/test#dev/summary` tab). The issue says "GovernanceMetricsDashboard" — that component does not exist in the repo today; `OverviewSection` is the live dev dashboard that renders the other `state/quality/*` tiles, so I matched that. Confirm this is the intended host.
4. **Fixture**: seeded from the current live `last.json`; the tile always marks fixture-sourced data as stale so it can't read fresh.

HITL: a human should eyeball the rendered tile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)