### PR TITLE
refactor: deepen catalog skills + embeddings constructors (+ ADR-0004)

### DIFF
--- a/Common/GA.Business.ML/Agents/CONTEXT.md
+++ b/Common/GA.Business.ML/Agents/CONTEXT.md
@@ -23,6 +23,7 @@ The chatbot's deterministic-first skill surface. Each `IOrchestratorSkill` is a 
 - `Skills/ChordVoicingsSkill.cs` — canonical "domain-retrieval skill" template (2026-05-16). Parser → encoder → vector search → response. Read this first.
 - `Skills/ImprovisationSkill.cs` — canonical "domain-classifier skill" template (2026-05-16, #219). Pure switch over quality enum, no I/O. Read second.
 - `Skills/SkillMdDrivenSkill.cs` + `SkillMdDrivenWrapperBase.cs` — Path B (LLM-in-the-loop) wrapper for DSL-eval-backed skills (`TransposeSkill`, `CommonTonesSkill`, `DiatonicChordsSkill`).
+- `Skills/CatalogSkillBase.cs` — canonical "catalog skill" template (deep base, 2026-06-21). Owns the markdown loader, the `CanHandle⇒false` (semantic-routing-only) convention, and the high-confidence `AgentResponse` shape. Subclasses (`CircleOfFifthsSkill`, `PracticeRoutineSkill`, `GenreEssentialsSkill`, `WhatCanYouDoSkill`) declare only metadata: `Name`, `Description`, `ExamplePrompts`, `FolderName`, `Fallback`. Use for any zero-LLM "load a SKILL.md body and return it" skill.
 - `SemanticRouter.cs` — embedding-based agent router. Caches agent embeddings + a 256-entry query embedding cache.
 - `Intents/SemanticIntentRouter.cs` — the corresponding skill router (lives one layer up at the IIntent surface).
 - `AgentConstants.cs` — agent IDs (`tab`, `theory`, `voicing`, `qa-architect`, …). Magic-string-free.

--- a/Common/GA.Business.ML/Agents/Skills/CatalogSkillBase.cs
+++ b/Common/GA.Business.ML/Agents/Skills/CatalogSkillBase.cs
@@ -1,0 +1,65 @@
+namespace GA.Business.ML.Agents.Skills;
+
+/// <summary>
+/// Deep base for <b>catalog skills</b>: their entire behaviour is "load a
+/// markdown body from <c>skills/&lt;folder&gt;/SKILL.md</c> (with a hardcoded
+/// fallback), cache it, and return it as a high-confidence
+/// <see cref="AgentResponse"/>." Subclasses declare only the metadata that
+/// varies — <see cref="Name"/>, <see cref="Description"/>,
+/// <see cref="ExamplePrompts"/>, the <see cref="FolderName"/>, and the
+/// <see cref="Fallback"/> text.
+/// </summary>
+/// <remarks>
+/// The loader, the semantic-routing-only <see cref="CanHandle"/> convention,
+/// and the response shape live here once — so the four catalog skills
+/// (CircleOfFifths, PracticeRoutine, GenreEssentials, WhatCanYouDo) stop
+/// copying an identical body. A catalog skill participates in routing only via
+/// <see cref="ExamplePrompts"/> (embedding-first), never via keyword matching.
+/// </remarks>
+public abstract class CatalogSkillBase : IOrchestratorSkill
+{
+    private readonly ILogger _logger;
+    private readonly Lazy<string> _bodyCache;
+
+    protected CatalogSkillBase(ILogger logger)
+    {
+        _logger = logger;
+        // FolderName / Fallback are abstract; the delegate runs lazily on first
+        // ExecuteAsync (well after construction), so the virtual calls are safe.
+        _bodyCache = new Lazy<string>(
+            () => CatalogSkillMdLoader.LoadBodyOrFallback(FolderName, Fallback),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <inheritdoc />
+    public abstract string Name { get; }
+
+    /// <inheritdoc />
+    public abstract string Description { get; }
+
+    /// <inheritdoc />
+    public abstract IReadOnlyList<string> ExamplePrompts { get; }
+
+    /// <summary>The <c>skills/&lt;folder&gt;/SKILL.md</c> directory the body loads from.</summary>
+    protected abstract string FolderName { get; }
+
+    /// <summary>Body returned when the SKILL.md is missing or unparseable.</summary>
+    protected abstract string Fallback { get; }
+
+    /// <summary>Catalog skills route via semantic example-embeddings only.</summary>
+    public bool CanHandle(string message) => false;
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var body = _bodyCache.Value;
+        _logger.LogDebug("{Skill}: returned {Length} chars", Name, body.Length);
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId    = AgentIds.Theory,
+            Result     = body,
+            Confidence = 1.0f,
+            Evidence   = [$"Source: skills/{FolderName}/SKILL.md"],
+        });
+    }
+}

--- a/Common/GA.Business.ML/Agents/Skills/CircleOfFifthsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/CircleOfFifthsSkill.cs
@@ -3,27 +3,18 @@ namespace GA.Business.ML.Agents.Skills;
 /// <summary>
 /// Walks through the circle of fifths — key signatures, perfect-fifth
 /// relationships, the order of sharps and flats, and the practical use for
-/// navigation between keys. Pure catalog skill, zero LLM calls. Body is
-/// loaded from <c>skills/circle-of-fifths/SKILL.md</c> so the markdown
-/// stays the single source of truth.
+/// navigation between keys. Catalog skill (see <see cref="CatalogSkillBase"/>):
+/// body is loaded from <c>skills/circle-of-fifths/SKILL.md</c>, zero LLM calls.
 /// </summary>
-public sealed class CircleOfFifthsSkill(ILogger<CircleOfFifthsSkill> logger) : IOrchestratorSkill
+public sealed class CircleOfFifthsSkill(ILogger<CircleOfFifthsSkill> logger) : CatalogSkillBase(logger)
 {
-    private const string SkillFolderName = "circle-of-fifths";
-
-    private static readonly Lazy<string> _bodyCache = new(
-        () => CatalogSkillMdLoader.LoadBodyOrFallback(
-            SkillFolderName,
-            "The circle of fifths arranges the twelve major keys so each clockwise step is a perfect fifth up. Each step adds one sharp (clockwise) or one flat (counter-clockwise). C major sits at the top with no sharps or flats."),
-        LazyThreadSafetyMode.ExecutionAndPublication);
-
-    public string Name        => "CircleOfFifths";
-    public string Description =>
+    public override string Name        => "CircleOfFifths";
+    public override string Description =>
         "Explains the circle of fifths: key signatures, the order of sharps " +
         "(F C G D A E B) and flats (B E A D G C F), enharmonic equivalents at " +
         "the bottom, and practical use for modulation. Pure catalog lookup, no LLM call.";
 
-    public IReadOnlyList<string> ExamplePrompts =>
+    public override IReadOnlyList<string> ExamplePrompts =>
     [
         "Explain the circle of fifths",
         "How do key signatures work?",
@@ -42,19 +33,7 @@ public sealed class CircleOfFifthsSkill(ILogger<CircleOfFifthsSkill> logger) : I
         "Move three positions clockwise on the circle",
     ];
 
-    public bool CanHandle(string message) => false; // semantic-routing only
-
-    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
-    {
-        var body = _bodyCache.Value;
-        logger.LogDebug("CircleOfFifthsSkill: returned {Length} chars", body.Length);
-
-        return Task.FromResult(new AgentResponse
-        {
-            AgentId    = AgentIds.Theory,
-            Result     = body,
-            Confidence = 1.0f,
-            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
-        });
-    }
+    protected override string FolderName => "circle-of-fifths";
+    protected override string Fallback   =>
+        "The circle of fifths arranges the twelve major keys so each clockwise step is a perfect fifth up. Each step adds one sharp (clockwise) or one flat (counter-clockwise). C major sits at the top with no sharps or flats.";
 }

--- a/Common/GA.Business.ML/Agents/Skills/GenreEssentialsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/GenreEssentialsSkill.cs
@@ -2,23 +2,14 @@ namespace GA.Business.ML.Agents.Skills;
 
 /// <summary>
 /// Explains the harmonic, melodic, rhythmic, and timbral signatures of common
-/// genres (blues, jazz, pop, folk, modal, country, rock). Pure catalog skill,
-/// zero LLM calls. Body is loaded from
-/// <c>skills/genre-essentials/SKILL.md</c> so the markdown stays the single
-/// source of truth.
+/// genres (blues, jazz, pop, folk, modal, country, rock). Catalog skill (see
+/// <see cref="CatalogSkillBase"/>): body is loaded from
+/// <c>skills/genre-essentials/SKILL.md</c>, zero LLM calls.
 /// </summary>
-public sealed class GenreEssentialsSkill(ILogger<GenreEssentialsSkill> logger) : IOrchestratorSkill
+public sealed class GenreEssentialsSkill(ILogger<GenreEssentialsSkill> logger) : CatalogSkillBase(logger)
 {
-    private const string SkillFolderName = "genre-essentials";
-
-    private static readonly Lazy<string> _bodyCache = new(
-        () => CatalogSkillMdLoader.LoadBodyOrFallback(
-            SkillFolderName,
-            "Genres are defined by harmony, melody, rhythm, and timbre. Blues uses 12-bar I7-IV7-V7 forms; jazz uses extended chords and ii-V-I cadences; pop favours diatonic 4-chord loops like I-V-vi-IV; modal music vamps on one chord with characteristic intervals."),
-        LazyThreadSafetyMode.ExecutionAndPublication);
-
-    public string Name        => "GenreEssentials";
-    public string Description =>
+    public override string Name        => "GenreEssentials";
+    public override string Description =>
         "Returns harmonic / melodic / rhythmic / timbral signatures for blues, " +
         "jazz, pop, folk, modal, country, and rock. Catalog answer; the user " +
         "learns what makes a genre sound like itself. No LLM call.";
@@ -32,7 +23,7 @@ public sealed class GenreEssentialsSkill(ILogger<GenreEssentialsSkill> logger) :
     //   - the "essential / must-know / starter / key chords" surface,
     //   - the genre token (blues, jazz, country, rock, funk, pop, folk),
     //   - the "for / in" preposition that the labeled corpus uses.
-    public IReadOnlyList<string> ExamplePrompts =>
+    public override IReadOnlyList<string> ExamplePrompts =>
     [
         "essential chords for blues guitar",
         "essential scales for jazz guitar",
@@ -44,19 +35,7 @@ public sealed class GenreEssentialsSkill(ILogger<GenreEssentialsSkill> logger) :
         "common chords in folk music",
     ];
 
-    public bool CanHandle(string message) => false; // semantic-routing only
-
-    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
-    {
-        var body = _bodyCache.Value;
-        logger.LogDebug("GenreEssentialsSkill: returned {Length} chars", body.Length);
-
-        return Task.FromResult(new AgentResponse
-        {
-            AgentId    = AgentIds.Theory,
-            Result     = body,
-            Confidence = 1.0f,
-            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
-        });
-    }
+    protected override string FolderName => "genre-essentials";
+    protected override string Fallback   =>
+        "Genres are defined by harmony, melody, rhythm, and timbre. Blues uses 12-bar I7-IV7-V7 forms; jazz uses extended chords and ii-V-I cadences; pop favours diatonic 4-chord loops like I-V-vi-IV; modal music vamps on one chord with characteristic intervals.";
 }

--- a/Common/GA.Business.ML/Agents/Skills/PracticeRoutineSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/PracticeRoutineSkill.cs
@@ -2,23 +2,14 @@ namespace GA.Business.ML.Agents.Skills;
 
 /// <summary>
 /// Suggests a structured practice routine for a stated goal — jazz comping,
-/// soloing, ear training, fingerstyle technique, etc. Pure catalog skill,
-/// zero LLM calls. Body is loaded from
-/// <c>skills/practice-routine/SKILL.md</c> so the markdown stays the single
-/// source of truth.
+/// soloing, ear training, fingerstyle technique, etc. Catalog skill (see
+/// <see cref="CatalogSkillBase"/>): body is loaded from
+/// <c>skills/practice-routine/SKILL.md</c>, zero LLM calls.
 /// </summary>
-public sealed class PracticeRoutineSkill(ILogger<PracticeRoutineSkill> logger) : IOrchestratorSkill
+public sealed class PracticeRoutineSkill(ILogger<PracticeRoutineSkill> logger) : CatalogSkillBase(logger)
 {
-    private const string SkillFolderName = "practice-routine";
-
-    private static readonly Lazy<string> _bodyCache = new(
-        () => CatalogSkillMdLoader.LoadBodyOrFallback(
-            SkillFolderName,
-            "Practice routines should match your goal: jazz comping, improvisation, ear training, fingerstyle, repertoire, or technique. Pick a 15-30 minute daily slot you can sustain rather than the time you'd ideally like."),
-        LazyThreadSafetyMode.ExecutionAndPublication);
-
-    public string Name        => "PracticeRoutine";
-    public string Description =>
+    public override string Name        => "PracticeRoutine";
+    public override string Description =>
         "Returns a structured practice plan for guitar/piano goals — jazz " +
         "comping, soloing, ear training, fingerstyle, repertoire, barre " +
         "technique. Templates with daily timings and drills. No LLM call.";
@@ -30,7 +21,7 @@ public sealed class PracticeRoutineSkill(ILogger<PracticeRoutineSkill> logger) :
     // practice routine" / "30 minute practice schedule" / "daily practice
     // outline" don't share enough lexical signal with the previous
     // "routine / plan / drill / exercises" wording.
-    public IReadOnlyList<string> ExamplePrompts =>
+    public override IReadOnlyList<string> ExamplePrompts =>
     [
         "give me a 20 minute practice routine",
         "build a 30 minute practice schedule",
@@ -46,19 +37,7 @@ public sealed class PracticeRoutineSkill(ILogger<PracticeRoutineSkill> logger) :
         "exercises for soloing over changes",
     ];
 
-    public bool CanHandle(string message) => false; // semantic-routing only
-
-    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
-    {
-        var body = _bodyCache.Value;
-        logger.LogDebug("PracticeRoutineSkill: returned {Length} chars", body.Length);
-
-        return Task.FromResult(new AgentResponse
-        {
-            AgentId    = AgentIds.Theory,
-            Result     = body,
-            Confidence = 1.0f,
-            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
-        });
-    }
+    protected override string FolderName => "practice-routine";
+    protected override string Fallback   =>
+        "Practice routines should match your goal: jazz comping, improvisation, ear training, fingerstyle, repertoire, or technique. Pick a 15-30 minute daily slot you can sustain rather than the time you'd ideally like.";
 }

--- a/Common/GA.Business.ML/Agents/Skills/WhatCanYouDoSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/WhatCanYouDoSkill.cs
@@ -3,22 +3,13 @@ namespace GA.Business.ML.Agents.Skills;
 /// <summary>
 /// The chatbot's self-disclosure / capabilities meta-skill. Lists what the
 /// chatbot can do (chord/scale lookup, progression analysis, voicing search,
-/// etc.) with one-line examples. Pure catalog skill, zero LLM calls. Body
-/// is loaded from <c>skills/what-can-you-do/SKILL.md</c> so the markdown
-/// stays the single source of truth.
+/// etc.) with one-line examples. Catalog skill (see <see cref="CatalogSkillBase"/>):
+/// body is loaded from <c>skills/what-can-you-do/SKILL.md</c>, zero LLM calls.
 /// </summary>
-public sealed class WhatCanYouDoSkill(ILogger<WhatCanYouDoSkill> logger) : IOrchestratorSkill
+public sealed class WhatCanYouDoSkill(ILogger<WhatCanYouDoSkill> logger) : CatalogSkillBase(logger)
 {
-    private const string SkillFolderName = "what-can-you-do";
-
-    private static readonly Lazy<string> _bodyCache = new(
-        () => CatalogSkillMdLoader.LoadBodyOrFallback(
-            SkillFolderName,
-            "Guitar Alchemist's chatbot answers grounded music-theory questions — chord and scale lookup, progression analysis, voice leading, transposition, voicing search, and more. Every answer is computed from the GA symbolic engine, not recalled from training data."),
-        LazyThreadSafetyMode.ExecutionAndPublication);
-
-    public string Name        => "WhatCanYouDo";
-    public string Description =>
+    public override string Name        => "WhatCanYouDo";
+    public override string Description =>
         "Lists the chatbot's currently-shipped capabilities — chord and scale " +
         "lookup, key identification, progression completion, voicing search, " +
         "interval computation, fret-span analysis. Discoverability skill for " +
@@ -31,7 +22,7 @@ public sealed class WhatCanYouDoSkill(ILogger<WhatCanYouDoSkill> logger) : IOrch
     // match at all, not even close. Lowering the router threshold didn't
     // help (verified at 0.60 — same failures). These prompts need to BE
     // examples to lift them above threshold.
-    public IReadOnlyList<string> ExamplePrompts =>
+    public override IReadOnlyList<string> ExamplePrompts =>
     [
         "what can you do",
         "what can the chatbot do",
@@ -50,19 +41,7 @@ public sealed class WhatCanYouDoSkill(ILogger<WhatCanYouDoSkill> logger) : IOrch
         "list your skills",
     ];
 
-    public bool CanHandle(string message) => false; // semantic-routing only
-
-    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
-    {
-        var body = _bodyCache.Value;
-        logger.LogDebug("WhatCanYouDoSkill: returned {Length} chars", body.Length);
-
-        return Task.FromResult(new AgentResponse
-        {
-            AgentId    = AgentIds.Theory,
-            Result     = body,
-            Confidence = 1.0f,
-            Evidence   = [$"Source: skills/{SkillFolderName}/SKILL.md"],
-        });
-    }
+    protected override string FolderName => "what-can-you-do";
+    protected override string Fallback   =>
+        "Guitar Alchemist's chatbot answers grounded music-theory questions — chord and scale lookup, progression analysis, voice leading, transposition, voicing search, and more. Every answer is computed from the GA symbolic engine, not recalled from training data.";
 }

--- a/Common/GA.Business.ML/Embeddings/MusicalEmbeddingGenerator.cs
+++ b/Common/GA.Business.ML/Embeddings/MusicalEmbeddingGenerator.cs
@@ -44,15 +44,14 @@ using Services;
 /// Initializes a new instance of the <see cref="MusicalEmbeddingGenerator"/> class.
 /// </remarks>
 public class MusicalEmbeddingGenerator(
-    IdentityVectorService identityService,
-    TheoryVectorService theoryService,
-    MorphologyVectorService morphologyService,
-    ContextVectorService contextService,
-    SymbolicVectorService symbolicService,
     ModalVectorService modalService,
-    PhaseSphereService phaseSphereService,
-    RootVectorService rootService) : IEmbeddingGenerator
+    PhaseSphereService phaseSphereService) : IEmbeddingGenerator
 {
+    // IDENTITY / STRUCTURE / MORPHOLOGY / CONTEXT / SYMBOLIC / ROOT and the
+    // spectral vector are produced via the static *VectorService.ComputeEmbedding
+    // overloads; only MODAL (modalService) and the spectral entropy term
+    // (phaseSphereService) are computed through injected instances. The generator
+    // therefore takes only the two dependencies it actually uses.
     /// <summary>Returns the total embedding dimension (216 for v1.4/v1.5).</summary>
     public int Dimension => EmbeddingSchema.TotalDimension;
 

--- a/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
+++ b/Common/GA.Business.ML/Search/MusicalQueryEncoder.cs
@@ -34,12 +34,12 @@ public sealed record StructuredQuery(
 ///     The encoder produces a vector already pre-scaled by sqrt(partition weight) and
 ///     L2-normalized, matching the on-disk convention so dot product = cosine similarity.
 /// </summary>
-public sealed class MusicalQueryEncoder(
-    TheoryVectorService theory,
-    ModalVectorService modal,
-    SymbolicVectorService symbolic,
-    RootVectorService rootService)
+public sealed class MusicalQueryEncoder(ModalVectorService modal)
 {
+    // STRUCTURE, SYMBOLIC, and ROOT partitions are produced via the static
+    // TheoryVectorService / SymbolicVectorService / RootVectorService overloads;
+    // only MODAL is computed through an injected instance. The encoder therefore
+    // takes the one dependency it actually uses.
     public double[] Encode(StructuredQuery q)
     {
         var raw = new double[EmbeddingSchema.TotalDimension];

--- a/GaMcpServer/Tools/CompositionTools.cs
+++ b/GaMcpServer/Tools/CompositionTools.cs
@@ -273,10 +273,7 @@ public static class CompositionTools
 
     private static readonly Lazy<MusicalQueryEncoder> EncoderShared = new(() =>
         new MusicalQueryEncoder(
-            new GA.Business.ML.Embeddings.Services.TheoryVectorService(),
-            new GA.Business.ML.Embeddings.Services.ModalVectorService(),
-            new GA.Business.ML.Embeddings.Services.SymbolicVectorService(),
-            new GA.Business.ML.Embeddings.Services.RootVectorService()));
+            new GA.Business.ML.Embeddings.Services.ModalVectorService()));
 
     private static async Task<SearchOutcome> SearchByChordAsync(
         string chordSymbol, int limit, string? instrument, CancellationToken ct)

--- a/GaMcpServer/Tools/VoicingEmbeddingTool.cs
+++ b/GaMcpServer/Tools/VoicingEmbeddingTool.cs
@@ -17,14 +17,8 @@ public static class VoicingEmbeddingTool
 {
     private static readonly Lazy<MusicalEmbeddingGenerator> Generator = new(() =>
         new MusicalEmbeddingGenerator(
-            new IdentityVectorService(),
-            new TheoryVectorService(),
-            new MorphologyVectorService(),
-            new ContextVectorService(),
-            new SymbolicVectorService(),
             new ModalVectorService(),
-            new PhaseSphereService(),
-            new RootVectorService()));
+            new PhaseSphereService()));
 
     /// <summary>
     ///     HttpClient for calling GaApi's voicing-retrieve endpoint. Base address is read from

--- a/GaMcpServer/Tools/VoicingSearchTool.cs
+++ b/GaMcpServer/Tools/VoicingSearchTool.cs
@@ -84,10 +84,7 @@ public static class VoicingSearchTool
 
     private static readonly Lazy<MusicalQueryEncoder> Encoder = new(() =>
         new MusicalQueryEncoder(
-            new TheoryVectorService(),
-            new ModalVectorService(),
-            new SymbolicVectorService(),
-            new RootVectorService()));
+            new ModalVectorService()));
 
     private static readonly Lazy<TypedMusicalQueryExtractor> Extractor = new(() =>
         new TypedMusicalQueryExtractor());

--- a/Tests/Common/GA.Business.Core.Tests/Embeddings/AdvancedEmbeddingScenarios.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Embeddings/AdvancedEmbeddingScenarios.cs
@@ -10,14 +10,8 @@ public class AdvancedEmbeddingScenarios
     [SetUp]
     public void SetUp() =>
         _generator = new MusicalEmbeddingGenerator(
-            new IdentityVectorService(),
-            new TheoryVectorService(),
-            new MorphologyVectorService(),
-            new ContextVectorService(),
-            new SymbolicVectorService(),
             new ModalVectorService(),
-            new PhaseSphereService(),
-            new RootVectorService()
+            new PhaseSphereService()
         );
 
     private MusicalEmbeddingGenerator _generator;

--- a/Tests/Common/GA.Business.Core.Tests/Embeddings/ExtendedTextureFeatureTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Embeddings/ExtendedTextureFeatureTests.cs
@@ -13,14 +13,8 @@ public class ExtendedTextureFeatureTests
     [SetUp]
     public void SetUp() =>
         _generator = new MusicalEmbeddingGenerator(
-            new IdentityVectorService(),
-            new TheoryVectorService(),
-            new MorphologyVectorService(),
-            new ContextVectorService(),
-            new SymbolicVectorService(),
             new ModalVectorService(),
-            new PhaseSphereService(),
-            new RootVectorService()
+            new PhaseSphereService()
         );
 
     private MusicalEmbeddingGenerator _generator;

--- a/Tests/Common/GA.Business.Core.Tests/Embeddings/SchemaContractTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Embeddings/SchemaContractTests.cs
@@ -30,14 +30,8 @@ public class SchemaContractTests
     [SetUp]
     public void SetUp() =>
         _generator = new MusicalEmbeddingGenerator(
-            new IdentityVectorService(),
-            new TheoryVectorService(),
-            new MorphologyVectorService(),
-            new ContextVectorService(),
-            new SymbolicVectorService(),
             new ModalVectorService(),
-            new PhaseSphereService(),
-            new RootVectorService()
+            new PhaseSphereService()
         );
 
     #region ICV Computation Tests

--- a/Tests/Common/GA.Business.ML.Tests/Musical/DatasetExportTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Musical/DatasetExportTests.cs
@@ -24,14 +24,8 @@ public class DatasetExportTests
     {
         // 1. Initialize Embedding Generator
         _generator = new MusicalEmbeddingGenerator(
-            new IdentityVectorService(),
-            new TheoryVectorService(),
-            new MorphologyVectorService(),
-            new ContextVectorService(),
-            new SymbolicVectorService(),
             new ModalVectorService(),
-            new PhaseSphereService(),
-            new RootVectorService()
+            new PhaseSphereService()
         );
 
         // 2. Build Chord Template Lookup (Reverse Index)

--- a/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/MusicalQueryEncoderTests.cs
@@ -16,10 +16,7 @@ public class MusicalQueryEncoderTests
 
     [SetUp]
     public void SetUp() => _encoder = new MusicalQueryEncoder(
-            new TheoryVectorService(),
-            new ModalVectorService(),
-            new SymbolicVectorService(),
-            new RootVectorService());
+            new ModalVectorService());
 
     // ─── ChordPitchClasses.TryParse ────────────────────────────────────────
 

--- a/Tests/Common/GA.Business.ML.Tests/Search/OptickHardPromptBatteryTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/OptickHardPromptBatteryTests.cs
@@ -23,10 +23,7 @@ public class OptickHardPromptBatteryTests
     {
         // These are index-independent and used by tests that don't touch the mmap.
         _encoder = new MusicalQueryEncoder(
-            new TheoryVectorService(),
-            new ModalVectorService(),
-            new SymbolicVectorService(),
-            new RootVectorService());
+            new ModalVectorService());
         _extractor = new TypedMusicalQueryExtractor();
 
         _indexPath = FindIndex();

--- a/Tests/Common/GA.Business.ML.Tests/Search/OptickIntegrationTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Search/OptickIntegrationTests.cs
@@ -85,10 +85,7 @@ public class OptickIntegrationTests
         SkipIfNoIndex();
 
         var encoder = new MusicalQueryEncoder(
-            new TheoryVectorService(),
-            new ModalVectorService(),
-            new SymbolicVectorService(),
-            new RootVectorService());
+            new ModalVectorService());
 
         using var strategy = new OptickSearchStrategy(_indexPath!);
         var query = encoder.Encode(new StructuredQuery(
@@ -146,10 +143,7 @@ public class OptickIntegrationTests
         SkipIfNoIndex();
 
         var encoder = new MusicalQueryEncoder(
-            new TheoryVectorService(),
-            new ModalVectorService(),
-            new SymbolicVectorService(),
-            new RootVectorService());
+            new ModalVectorService());
 
         using var strategy = new OptickSearchStrategy(_indexPath!);
 

--- a/Tests/Common/GA.Business.ML.Tests/TestInfrastructure/TestServices.cs
+++ b/Tests/Common/GA.Business.ML.Tests/TestInfrastructure/TestServices.cs
@@ -10,14 +10,8 @@ public static class TestServices
 {
     public static MusicalEmbeddingGenerator CreateGenerator() =>
         new MusicalEmbeddingGenerator(
-            new IdentityVectorService(),
-            new TheoryVectorService(),
-            new MorphologyVectorService(),
-            new ContextVectorService(),
-            new SymbolicVectorService(),
             new ModalVectorService(),
-            new PhaseSphereService(),
-            new RootVectorService());
+            new PhaseSphereService());
 
     public static TabAnalysisService CreateTabAnalysisService()
     {

--- a/docs/adr/0004-musical-voicing-analysis-stays-wide.md
+++ b/docs/adr/0004-musical-voicing-analysis-stays-wide.md
@@ -1,0 +1,77 @@
+---
+status: accepted
+date: 2026-06-21
+---
+
+# `MusicalVoicingAnalysis` stays wide — it is the analyzer→corpus-document carrier, not a bag of dead fields
+
+## Context
+
+`MusicalVoicingAnalysis` (`Common/GA.Business.Core/Analysis/Voicings/MusicalVoicingAnalysis.cs`)
+is a 15-field record. An architecture review flagged it as a **shallow** value type:
+its interface is nearly as wide as its implementation, and the sole production
+producer — `VoicingAnalyzer.AnalyzeEnhanced` (`Common/GA.Domain.Services/Fretboard/Voicings/Analysis/VoicingAnalyzer.cs:154–197`) —
+hardcodes several fields to placeholders:
+
+- `EquivalenceInfo = new("Unknown", "Unknown", "Unknown", 0)`
+- `ToneInventory   = new([], false, [], [])`
+- `AlternateChordNames = []`
+- `SymmetricalInfo = new("Unknown")`
+
+The obvious deepening — "drop the never-populated fields and the duplicate
+`ChordId`" — looks like a clean deletion test. It is not.
+
+## Decision
+
+**Keep `MusicalVoicingAnalysis` at its current width.** The placeholder fields
+are **unfilled pipeline slots**, not dead weight, and the record is the shared
+carrier between the analyzer (layer 3) and the OPTIC-K corpus/index document
+factory (layer 4). Deleting fields is a corpus-document schema change, not a
+refactor.
+
+## Why (the trade-off)
+
+- **The "empty" fields are read downstream into the index document.**
+  `VoicingDocumentFactory` (`Common/GA.Business.ML/Rag/VoicingDocumentFactory.cs:41–71`)
+  and `IndexVoicingsCommand` (`GaCLI/Commands/IndexVoicingsCommand.cs:475–497`)
+  read `analysis.ToneInventory.{HasGuideTones,OmittedTones,DoubledTones}`,
+  `analysis.EquivalenceInfo?.{PrimeFormId,ForteCode,TranslationOffset}`, and
+  `analysis.AlternateChordNames` to populate `ChordVoicingRagDocument` /
+  `VoicingEntity` fields. They currently receive `"Unknown"`/empties — but the
+  **plumbing to the OPTIC-K document exists**. Removing the carrier fields means
+  removing those reads and the corresponding document fields — a coordinated
+  re-index, which is the OPTIC-K **one-way door** (CLAUDE.md).
+- **`ChordId` is not a clean duplicate.** The top-level `analysis.ChordId` is
+  read everywhere (factory, index, tests, demos). The copy inside
+  `VoicingCharacteristics.ChordId` is read via a *different* handle —
+  `VoicingTagEnricher` and `VoicingAnalyzer` consume `curVoiceChars.ChordId`
+  directly, not through `analysis`. Both access paths are live; collapsing them
+  is not free.
+- **The real work is a feature, not a deletion.** The honest fix for the
+  placeholders is to *populate* them (equivalence info, tone inventory, alternate
+  names are genuine analysis the producer hasn't implemented yet), which **adds**
+  implementation behind the existing interface — deepening it — rather than
+  shrinking the interface toward a thinner implementation.
+
+## Consequences
+
+- Future architecture reviews will re-flag "these fields are always `Unknown`,
+  delete them." This ADR is the answer: they are stubbed slots wired to the
+  corpus document; deletion is a one-way-door schema change, and the value is in
+  filling them, not removing them.
+- If a producer is written that genuinely fills `EquivalenceInfo` /
+  `ToneInventory` / `AlternateChordNames`, that is a layer-3 feature and does not
+  reopen this ADR.
+- A separate, observed friction stands on its own: `MusicalEmbeddingGenerator`
+  and `MusicalQueryEncoder` inject vector services they never use (they call the
+  static `*.ComputeEmbedding` overloads), producing `CS9113` warnings. That is a
+  constructor-interface cleanup unrelated to this record's width and is tracked
+  outside this ADR.
+
+## Related
+
+- Carrier: `Common/GA.Business.Core/Analysis/Voicings/MusicalVoicingAnalysis.cs`
+- Producer: `Common/GA.Domain.Services/Fretboard/Voicings/Analysis/VoicingAnalyzer.cs`
+- Consumers (the wiring): `Common/GA.Business.ML/Rag/VoicingDocumentFactory.cs`,
+  `GaCLI/Commands/IndexVoicingsCommand.cs`
+- OPTIC-K one-way door: `CLAUDE.md` ("never change dimension without coordinated re-index").


### PR DESCRIPTION
## Impact

Outcome of an `/improve-codebase-architecture` review. Six candidates were surfaced; **verifying each against source filtered them to two real surgical deepenings + one documentation decision.** The other three were the explorer over-reading encapsulated helpers as friction — see "Investigated & rejected" below. No behaviour change; pure structure + warning cleanup.

## What's in here (3 commits)

**1. Catalog skills → deep `CatalogSkillBase`** (`d2239739`)
Four catalog skills (`CircleOfFifths`, `PracticeRoutine`, `GenreEssentials`, `WhatCanYouDo`) were shallow modules copying an identical body — a `Lazy<string>` markdown loader, `CanHandle⇒false`, and the same `AgentResponse` shape. Only metadata varied. A new `CatalogSkillBase` owns the loader, the semantic-routing-only convention, and the response shape once; each skill now declares only `Name / Description / ExamplePrompts / FolderName / Fallback` (~50 → ~25 lines each). Deletion test passes. Bodies, fallbacks, and example prompts preserved verbatim. (`Agents/CONTEXT.md` updated with the new template.)

**2. ADR-0004 — `MusicalVoicingAnalysis` stays wide** (`78e43560`)
Records why "drop the placeholder fields" was investigated and **rejected**: the empty `EquivalenceInfo` / `ToneInventory` / `AlternateChordNames` are stubbed-but-wired pipeline slots that `VoicingDocumentFactory` + `IndexVoicingsCommand` read into the OPTIC-K corpus/index document. Deletion is a coordinated re-index (one-way door), not a refactor; the real work is populating them (a feature). Prevents future reviews from re-suggesting the same deletion.

**3. Embeddings constructor cleanup** (`a62dfbfb`)
`MusicalQueryEncoder` and `MusicalEmbeddingGenerator` advertised constructor dependencies they never used — they call the static `*VectorService.ComputeEmbedding` overloads, so 6 + 3 injected instances were dead (9 × `CS9113`), and every manual `new` site was allocating them only to discard them. Constructors shrunk to the dependency each actually uses (MODAL for both, plus the spectral-entropy term for the generator). 12 manual construction sites updated; reflection-based `AddSingleton<T>` registrations adapt automatically.

## Investigated & rejected (no code)

- **Registration fan-out** — naive "make `IOrchestratorSkill` extend `IIntent`" won't compile (conflicting `ExecuteAsync` return types); the 3 `ServiceDescriptor`s are already encapsulated behind a one-line helper.
- **MCP input-guard seam** — the surgical version *anti-deepens* (spreads per-tool guards wider); the real `[ValidatedString]` seam is a feature-sized build into `InProcessMcpToolsProvider` + the governance scan.
- **Router unification** — the two routers differ in a load-bearing way (intents resolve per-request for Scoped skills; agents are captured at construction); one dispatcher would hide two behaviours.

## Test evidence

- `GA.Business.ML` · `GaChatbot.Api` · `GaMcpServer` — build, **0 errors**; targeted `CS9113` warnings eliminated.
- `GA.Business.ML.Tests` + `GA.Business.Core.Tests` — build clean; **45 catalog/skill** + **130 encoder/generator/embedding** tests pass (Optick integration ran against the live index, so the encoder change is genuinely exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)