### PR TITLE
test+fix: domain test coverage + fix Fretboard.GetNote and shape-graph dedup

### DIFF
--- a/AllProjects.slnx
+++ b/AllProjects.slnx
@@ -258,6 +258,7 @@
         <Project Path="Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj" />
         <Project Path="Tests/Common/GA.Business.Core.Tests/GA.Business.Core.Tests.csproj" />
         <Project Path="Tests/Common/GA.Core.Tests/GA.Core.Tests.csproj" />
+        <Project Path="Tests/GA.Domain.Core.Tests/GA.Domain.Core.Tests.csproj" />
         <Project Path="Tests/Common/GA.InteractiveExtension/GA.InteractiveExtension.Tests.csproj" />
         <Project Path="Tests/Common/GA.Business.DSL.Tests/GA.Business.DSL.Tests.csproj" />
         <Project Path="Tests/Apps/GA.MusicTheory.Service.Tests/GA.MusicTheory.Service.Tests.csproj" />

--- a/Common/GA.Domain.Core/Instruments/Primitives/Fretboard.cs
+++ b/Common/GA.Domain.Core/Instruments/Primitives/Fretboard.cs
@@ -57,11 +57,12 @@ public sealed class Fretboard(Tuning tuning, int fretCount)
             throw new ArgumentOutOfRangeException(nameof(fret));
         }
 
-        // Get the open string pitch and add the fret offset
+        // Get the open string pitch and add the fret offset (each fret raises the pitch one semitone).
         var openStringPitch = Tuning[new(stringIndex + 1)]; // Tuning uses 1-based string indexing
         var resultMidiNote = openStringPitch.MidiNote + fret; // Add semitones for fret position
-        var resultPitch = Pitch.Chromatic.FromPitch(openStringPitch).Note.PitchClass
-            .ToChromaticPitch(resultMidiNote.Octave);
+        // Derive the result from the FRETTED midi note's pitch class — not the open string's — so the
+        // fret changes the pitch class, not just the octave.
+        var resultPitch = resultMidiNote.PitchClass.ToChromaticPitch(resultMidiNote.Octave);
 
         return resultPitch.Note;
     }

--- a/Common/GA.Domain.Core/Theory/Harmony/Chord.cs
+++ b/Common/GA.Domain.Core/Theory/Harmony/Chord.cs
@@ -1,5 +1,6 @@
 namespace GA.Domain.Core.Theory.Harmony;
 
+using System.Text.RegularExpressions;
 using Atonal;
 using Design.Attributes;
 using Design.Schema;
@@ -63,6 +64,84 @@ public sealed class Chord : IEquatable<Chord>
         Quality = DetermineQuality();
         Extension = DetermineExtension();
         Symbol = GenerateSymbol();
+    }
+
+    // Splits a chord symbol into root (A-G with optional #/b) and a suffix describing quality/extension.
+    private static readonly Regex _symbolRegex =
+        new("^([A-G][#b]?)(.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    ///     Parses a chord symbol (e.g. "C", "Cm", "Cmaj7", "F#m7b5") into a <see cref="Chord" />.
+    /// </summary>
+    /// <param name="symbol">The chord symbol. The root is A-G with an optional # or b; the remainder is the quality/extension suffix.</param>
+    /// <returns>The parsed <see cref="Chord" />.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="symbol" /> is null/blank or not a recognizable chord symbol.</exception>
+    public static Chord FromSymbol(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Chord symbol cannot be null or empty", nameof(symbol));
+        }
+
+        var match = _symbolRegex.Match(symbol.Trim());
+        if (!match.Success)
+        {
+            throw new ArgumentException($"Invalid chord symbol: {symbol}", nameof(symbol));
+        }
+
+        var root = Note.Accidented.Parse(match.Groups[1].Value, null);
+        var formula = ParseSuffix(match.Groups[2].Value);
+        return new(root, formula, symbol);
+    }
+
+    /// <summary>
+    ///     Attempts to parse a chord symbol into a <see cref="Chord" /> without throwing.
+    /// </summary>
+    public static bool TryFromSymbol(string symbol, out Chord? chord)
+    {
+        try
+        {
+            chord = FromSymbol(symbol);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            chord = null;
+            return false;
+        }
+    }
+
+    private static ChordFormula ParseSuffix(string suffix)
+    {
+        var s = suffix.Trim().ToLowerInvariant().Replace(" ", "");
+        return s switch
+        {
+            "" or "maj" or "major" => ChordFormula.Major,
+            "m" or "min" or "minor" or "-" => ChordFormula.Minor,
+            "dim" or "°" => ChordFormula.Diminished,
+            "aug" or "+" => ChordFormula.Augmented,
+            "sus2" => ChordFormula.FromSemitones("Sus2", 2, 7),
+            "sus" or "sus4" => ChordFormula.FromSemitones("Sus4", 5, 7),
+            "6" => ChordFormula.FromSemitones("Sixth", 4, 7, 9),
+            "m6" or "min6" => ChordFormula.FromSemitones("Minor Sixth", 3, 7, 9),
+            "7" => ChordFormula.Dominant7,
+            "maj7" or "△7" => ChordFormula.Major7,
+            "m7" or "min7" or "-7" => ChordFormula.Minor7,
+            "dim7" or "°7" => ChordFormula.FromSemitones("Diminished 7th", 3, 6, 9),
+            "m7b5" or "ø7" => ChordFormula.FromSemitones("Half Diminished 7th", 3, 6, 10),
+            "9" => ChordFormula.FromSemitones("Dominant 9th", 4, 7, 10, 14),
+            "maj9" or "△9" => ChordFormula.FromSemitones("Major 9th", 4, 7, 11, 14),
+            "m9" or "min9" or "-9" => ChordFormula.FromSemitones("Minor 9th", 3, 7, 10, 14),
+            "11" => ChordFormula.FromSemitones("Dominant 11th", 4, 7, 10, 14, 17),
+            "maj11" or "△11" => ChordFormula.FromSemitones("Major 11th", 4, 7, 11, 14, 17),
+            "m11" or "min11" or "-11" => ChordFormula.FromSemitones("Minor 11th", 3, 7, 10, 14, 17),
+            "13" => ChordFormula.FromSemitones("Dominant 13th", 4, 7, 10, 14, 17, 21),
+            "maj13" or "△13" => ChordFormula.FromSemitones("Major 13th", 4, 7, 11, 14, 17, 21),
+            "m13" or "min13" or "-13" => ChordFormula.FromSemitones("Minor 13th", 3, 7, 10, 14, 17, 21),
+            "add9" => ChordFormula.FromSemitones("Add9", 4, 7, 14),
+            "6/9" or "69" => ChordFormula.FromSemitones("6/9", 4, 7, 9, 14),
+            _ => throw new ArgumentException($"Unrecognized chord suffix: '{suffix}'", nameof(suffix))
+        };
     }
 
     /// <summary>

--- a/Common/GA.Domain.Core/Theory/Harmony/ChordFormula.cs
+++ b/Common/GA.Domain.Core/Theory/Harmony/ChordFormula.cs
@@ -74,10 +74,18 @@ public sealed class ChordFormula : IEquatable<ChordFormula>
     public ChordStackingType StackingType { get; }
 
     /// <summary>
-    ///     Gets whether this formula represents a suspended chord
+    ///     Gets whether this formula represents a suspended chord — the third is replaced by a major
+    ///     second (sus2) or perfect fourth (sus4).
     /// </summary>
-    public bool IsSuspended => Intervals.Any(i =>
-        i is { Function: ChordFunction.Third, Interval.Semitones.Value: 2 or 5 });
+    /// <remarks>
+    ///     Defined as "no third, plus a 2nd or 4th in its place". The previous definition required an
+    ///     interval whose <see cref="ChordFunction" /> was <see cref="ChordFunction.Third" /> with 2 or 5
+    ///     semitones, which never matched because <see cref="ChordFunctionExtensions.FromSemitones" /> maps
+    ///     2 -> Ninth and 5 -> Eleventh, so sus2/sus4 formulas were never recognized as suspended.
+    /// </remarks>
+    public bool IsSuspended =>
+        !Intervals.Any(i => i.Interval.Semitones.Value is 3 or 4) &&
+        Intervals.Any(i => i.Interval.Semitones.Value is 2 or 5);
 
     /// <summary>
     ///     Gets the essential intervals (cannot be omitted)

--- a/Common/GA.Domain.Services/Fretboard/Shapes/ShapeGraphBuilder.cs
+++ b/Common/GA.Domain.Services/Fretboard/Shapes/ShapeGraphBuilder.cs
@@ -72,12 +72,21 @@ public class ShapeGraphBuilder(
         ShapeGraphBuildOptions options)
     {
         // Generate all shapes
-        var allShapes = new List<FretboardShape>();
+        var generated = new List<FretboardShape>();
         foreach (var pcs in pitchClassSets)
         {
             var shapes = GenerateShapes(tuning, pcs, options);
-            allShapes.AddRange(shapes);
+            generated.AddRange(shapes);
         }
+
+        // Deduplicate by Id. A shape's Id is a hash of (tuning, positions), so an identical Id means an
+        // identical physical fingering — the same shape can legitimately be produced from several base
+        // frets or satisfy more than one requested pitch-class set. Keep the first occurrence rather than
+        // throwing on the duplicate key.
+        var allShapes = generated
+            .GroupBy(s => s.Id)
+            .Select(g => g.First())
+            .ToList();
 
         // Build shape dictionary
         var shapesDict = allShapes.ToImmutableDictionary(s => s.Id);

--- a/Tests/Common/GA.Business.Core.Tests/Fretboard/Shapes/ShapeGraphBuilderTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Fretboard/Shapes/ShapeGraphBuilderTests.cs
@@ -261,7 +261,6 @@ public class ShapeGraphBuilderTests
             Assert.That(shapes, Is.Not.Empty);
         }
         [Test]
-        [Ignore("Shape ID generation produces duplicates - needs fix in shape generation logic")]
         public async Task ShouldBuildGraph_InLessThan5Seconds()
         {
             // Arrange: 10 pitch-class sets

--- a/Tests/GA.Domain.Core.Tests/GA.Domain.Core.Tests.csproj
+++ b/Tests/GA.Domain.Core.Tests/GA.Domain.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,10 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+    <PackageReference Include="NUnit" Version="4.2.2"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/GA.Domain.Core.Tests/Instruments/FretboardTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Instruments/FretboardTests.cs
@@ -1,0 +1,92 @@
+namespace GA.Domain.Core.Tests.Instruments;
+
+using System;
+using System.Linq;
+using GA.Domain.Core.Instruments.Primitives;
+using NUnit.Framework;
+
+/// <summary>
+///     Characterization tests for <see cref="Fretboard" /> — geometry, the string/fret -> note mapping
+///     (string index 0 = Str 1 = high E in standard tuning), and bounds checking.
+/// </summary>
+[TestFixture]
+public class FretboardTests
+{
+    [Test]
+    public void Default_IsSixStringTwentyFourFretGuitar()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Fretboard.Default.StringCount, Is.EqualTo(6));
+            Assert.That(Fretboard.Default.FretCount, Is.EqualTo(24));
+            Assert.That(Fretboard.Default.StringCount, Is.EqualTo(Fretboard.Default.Tuning.StringCount));
+        });
+    }
+
+    [Test]
+    public void CreateGuitar_HonoursRequestedFretCount()
+    {
+        Assert.That(Fretboard.CreateGuitar(12).FretCount, Is.EqualTo(12));
+    }
+
+    // Open-string pitch classes for standard tuning, indexed 0 (high E) .. 5 (low E).
+    [TestCase(0, 4)]  // E
+    [TestCase(1, 11)] // B
+    [TestCase(2, 7)]  // G
+    [TestCase(3, 2)]  // D
+    [TestCase(4, 9)]  // A
+    [TestCase(5, 4)]  // E
+    public void GetNote_OpenString_HasExpectedPitchClass(int stringIndex, int expectedPc)
+    {
+        Assert.That(Fretboard.Default.GetNote(stringIndex, 0).PitchClass.Value, Is.EqualTo(expectedPc));
+    }
+
+    [Test]
+    public void GetNote_TwelfthFret_IsSamePitchClassAsOpen()
+    {
+        // True under both the correct semantics and the current implementation (12 frets = one octave).
+        var open = Fretboard.Default.GetNote(0, 0).PitchClass.Value;
+        var octave = Fretboard.Default.GetNote(0, 12).PitchClass.Value;
+        Assert.That(octave, Is.EqualTo(open));
+    }
+
+    // High E string (index 0), fret -> pitch class: each fret raises the pitch one semitone.
+    [TestCase(0, 4)]  // E (open)
+    [TestCase(1, 5)]  // F
+    [TestCase(2, 6)]  // F#
+    [TestCase(3, 7)]  // G
+    [TestCase(5, 9)]  // A
+    [TestCase(12, 4)] // E (one octave up)
+    public void GetNote_AppliesFretAsSemitoneOffset(int fret, int expectedPc)
+    {
+        Assert.That(Fretboard.Default.GetNote(0, fret).PitchClass.Value, Is.EqualTo(expectedPc));
+    }
+
+    [Test]
+    public void GetPitchClass_AgreesWithGetNote()
+    {
+        Assert.That(Fretboard.Default.GetPitchClass(3, 5), Is.EqualTo(Fretboard.Default.GetNote(3, 5).PitchClass));
+    }
+
+    [TestCase(-1, 0)]  // string below range
+    [TestCase(6, 0)]   // string == StringCount (out of range)
+    [TestCase(0, -1)]  // fret below range
+    [TestCase(0, 25)]  // fret above FretCount
+    public void GetNote_OutOfRange_Throws(int stringIndex, int fret)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Fretboard.Default.GetNote(stringIndex, fret));
+    }
+
+    [Test]
+    public void GetPositionsForNote_ReturnsOnlyValidPositions()
+    {
+        var fretboard = Fretboard.CreateGuitar(12);
+        var positions = fretboard.GetPositionsForNote(fretboard.GetNote(0, 0)).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(positions, Is.Not.Empty);
+            Assert.That(positions.All(fretboard.IsValidPosition), Is.True);
+        });
+    }
+}

--- a/Tests/GA.Domain.Core.Tests/Instruments/TuningTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Instruments/TuningTests.cs
@@ -1,0 +1,59 @@
+namespace GA.Domain.Core.Tests.Instruments;
+
+using System;
+using GA.Domain.Core.Instruments;
+using GA.Domain.Core.Instruments.Primitives;
+using NUnit.Framework;
+
+/// <summary>
+///     Characterization tests for <see cref="Tuning" /> — string count, open-string pitches (highest
+///     string first), and out-of-range indexing.
+/// </summary>
+[TestFixture]
+public class TuningTests
+{
+    [TestCase(6)]
+    public void Default_IsSixStringGuitar(int expected)
+    {
+        Assert.That(Tuning.Default.StringCount, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void WellKnownTunings_HaveExpectedStringCounts()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Tuning.Ukulele.StringCount, Is.EqualTo(4));
+            Assert.That(Tuning.Bass.StringCount, Is.EqualTo(4));
+            Assert.That(Tuning.Guitar7String.StringCount, Is.EqualTo(7));
+        });
+    }
+
+    [Test]
+    public void Indexer_String1IsHighestPitch_String6IsLowest()
+    {
+        // Str 1 is the highest-pitch string (high E4); Str 6 is the lowest (low E2). Both are pitch class E.
+        var high = Tuning.Default[(Str)1];
+        var low = Tuning.Default[(Str)6];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(high.PitchClass.Value, Is.EqualTo(4));
+            Assert.That(low.PitchClass.Value, Is.EqualTo(4));
+            Assert.That(high > low, Is.True, "String 1 should sound higher than string 6");
+        });
+    }
+
+    [Test]
+    public void AsSpan_LengthMatchesStringCount()
+    {
+        Assert.That(Tuning.Default.AsSpan().Length, Is.EqualTo(Tuning.Default.StringCount));
+    }
+
+    [Test]
+    public void Indexer_StringBeyondTuning_Throws()
+    {
+        // String 7 is a valid Str value but undefined for a 6-string tuning.
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = Tuning.Default[(Str)7]);
+    }
+}

--- a/Tests/GA.Domain.Core.Tests/Instruments/VoicingTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Instruments/VoicingTests.cs
@@ -1,0 +1,95 @@
+namespace GA.Domain.Core.Tests.Instruments;
+
+using GA.Domain.Core.Instruments.Fretboard.Voicings.Core;
+using GA.Domain.Core.Instruments.Positions;
+using GA.Domain.Core.Instruments.Primitives;
+using GA.Domain.Core.Primitives.Notes;
+using NUnit.Framework;
+
+/// <summary>
+///     Characterization tests for <see cref="Voicing" /> — the diagram-based identity and the derived
+///     fret-span / played-count / barre analysis read off the position list.
+/// </summary>
+[TestFixture]
+public class VoicingTests
+{
+    private static Position Played(int str, int fret) =>
+        new Position.Played(new PositionLocation((Str)str, (Fret)fret), (MidiNote)40);
+
+    private static Position Muted(int str) => new Position.Muted((Str)str);
+
+    private static Voicing Make(params Position[] positions) => new(positions, []);
+
+    [Test]
+    public void Diagram_RendersFretsAndMutes()
+    {
+        var voicing = Make(Played(1, 0), Played(2, 2), Muted(3));
+        Assert.That(voicing.Diagram, Is.EqualTo("0-2-x"));
+    }
+
+    [Test]
+    public void PlayedNoteCount_ExcludesMutedStrings()
+    {
+        var voicing = Make(Played(1, 0), Played(2, 2), Muted(3));
+        Assert.That(voicing.PlayedNoteCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void FretSpan_MeasuresAcrossFrettedNotesOnly()
+    {
+        // Frets 2 and 5 are fretted (open/0 ignored): span = 5 - 2 = 3.
+        var voicing = Make(Played(1, 0), Played(2, 2), Played(3, 5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(voicing.FretSpan, Is.EqualTo(3));
+            Assert.That(voicing.MinFret, Is.EqualTo(2));
+            Assert.That(voicing.MaxFret, Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public void FretSpan_AllOpenOrMuted_IsZero()
+    {
+        var voicing = Make(Played(1, 0), Muted(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(voicing.FretSpan, Is.EqualTo(0));
+            Assert.That(voicing.MinFret, Is.Null);
+            Assert.That(voicing.MaxFret, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void HasBarre_TrueWhenThreeOrMoreShareAFret()
+    {
+        var barred = Make(Played(1, 3), Played(2, 3), Played(3, 3));
+        var notBarred = Make(Played(1, 3), Played(2, 3), Played(3, 5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(barred.HasBarre(), Is.True);
+            Assert.That(notBarred.HasBarre(), Is.False);
+        });
+    }
+
+    [Test]
+    public void Equality_IsBasedOnDiagram_NotNoteArrays()
+    {
+        var a = new Voicing([Played(1, 0), Played(2, 2)], [(MidiNote)40, (MidiNote)45]);
+        var b = new Voicing([Played(1, 0), Played(2, 2)], [(MidiNote)52, (MidiNote)57]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void Equality_DifferentDiagrams_AreNotEqual()
+    {
+        var a = Make(Played(1, 0), Played(2, 2));
+        var b = Make(Played(1, 0), Played(2, 3));
+        Assert.That(a, Is.Not.EqualTo(b));
+    }
+}

--- a/Tests/GA.Domain.Core.Tests/Theory/Harmony/ChordTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Theory/Harmony/ChordTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace GA.Domain.Core.Tests.Theory.Harmony;
 
+using System.Linq;
 using GA.Domain.Core.Primitives;
 using GA.Domain.Core.Theory.Atonal;
 using GA.Domain.Core.Primitives.Intervals;
@@ -60,11 +61,7 @@ public class ChordTests
     [TestCase("Caug", ChordQuality.Augmented)]
     public void FromSymbol_ShouldCreateCorrectQuality(string symbol, ChordQuality expectedQuality)
     {
-        // Chord.FromSymbol (chord-symbol parsing) is not implemented; this test referenced an absent
-        // member and silently kept the whole GA.Domain.Core.Tests project from compiling. Ignored (not
-        // deleted) so the gap stays visible until a chord-symbol parser lands.
-        _ = (symbol, expectedQuality);
-        Assert.Ignore("Chord.FromSymbol (chord-symbol parsing) is not implemented yet.");
+        Assert.That(Chord.FromSymbol(symbol).Quality, Is.EqualTo(expectedQuality));
     }
 
     [TestCase("C7", ChordExtension.Seventh)]
@@ -74,9 +71,31 @@ public class ChordTests
     [TestCase("C13", ChordExtension.Thirteenth)]
     public void FromSymbol_ShouldCreateCorrectExtension(string symbol, ChordExtension expectedExtension)
     {
-        // See FromSymbol_ShouldCreateCorrectQuality: Chord.FromSymbol is not implemented yet.
-        _ = (symbol, expectedExtension);
-        Assert.Ignore("Chord.FromSymbol (chord-symbol parsing) is not implemented yet.");
+        Assert.That(Chord.FromSymbol(symbol).Extension, Is.EqualTo(expectedExtension));
+    }
+
+    [Test]
+    public void FromSymbol_ParsesRootWithAccidental()
+    {
+        var chord = Chord.FromSymbol("F#m7");
+        Assert.Multiple(() =>
+        {
+            Assert.That(chord.Root.PitchClass.Value, Is.EqualTo(6)); // F#
+            Assert.That(chord.Quality, Is.EqualTo(ChordQuality.Minor));
+            Assert.That(chord.Extension, Is.EqualTo(ChordExtension.Seventh));
+        });
+    }
+
+    [Test]
+    public void TryFromSymbol_InvalidSymbol_ReturnsFalse()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Chord.TryFromSymbol("H7", out _), Is.False);   // H is not a note letter
+            Assert.That(Chord.TryFromSymbol("Cwobble", out _), Is.False); // unknown suffix
+            Assert.That(Chord.TryFromSymbol("C", out var c), Is.True);
+            Assert.That(c!.Quality, Is.EqualTo(ChordQuality.Major));
+        });
     }
 
     [Test]
@@ -110,5 +129,105 @@ public class ChordTests
 
         // Assert
         Assert.That(chord1, Is.EqualTo(chord2));
+    }
+
+    private static Chord CChord(ChordFormula formula) =>
+        new(new Note.Accidented(NaturalNote.C, Accidental.Natural), formula);
+
+    private static int[] PitchClassValues(Chord chord) =>
+        chord.PitchClassSet.Select(pc => pc.Value).OrderBy(v => v).ToArray();
+
+    [Test]
+    public void MajorTriad_HasRootMajorThirdPerfectFifth()
+    {
+        // C major triad = {C, E, G} = {0, 4, 7}.
+        Assert.That(PitchClassValues(CChord(ChordFormula.Major)), Is.EqualTo(new[] { 0, 4, 7 }));
+    }
+
+    [Test]
+    public void Dominant7_HasExpectedPitchClasses()
+    {
+        // C7 = {C, E, G, Bb} = {0, 4, 7, 10}.
+        var chord = CChord(ChordFormula.Dominant7);
+        Assert.Multiple(() =>
+        {
+            Assert.That(chord.Notes.Count, Is.EqualTo(4));
+            Assert.That(PitchClassValues(chord), Is.EqualTo(new[] { 0, 4, 7, 10 }));
+            Assert.That(chord.Extension, Is.EqualTo(ChordExtension.Seventh));
+        });
+    }
+
+    [Test]
+    public void Dominant7_FormulaQualityIsDominant_ButChordQualityFallsBackToMajor()
+    {
+        // Characterizes a real divergence: ChordFormula.DetermineQuality knows "Dominant"
+        // (major 3rd + minor 7th), but Chord.DetermineQuality only classifies the triad
+        // (3rd + 5th) and therefore reports Major for a dominant-7th chord. Pinned here so
+        // the inconsistency is visible and a future fix would deliberately update this test.
+        var chord = CChord(ChordFormula.Dominant7);
+        Assert.Multiple(() =>
+        {
+            Assert.That(chord.Formula.Quality, Is.EqualTo(ChordQuality.Dominant));
+            Assert.That(chord.Quality, Is.EqualTo(ChordQuality.Major));
+        });
+    }
+
+    [TestCaseSource(nameof(SeventhChordCases))]
+    public void SeventhChords_ClassifyAsSeventhExtension(ChordFormula formula)
+    {
+        Assert.That(CChord(formula).Extension, Is.EqualTo(ChordExtension.Seventh));
+    }
+
+    public static IEnumerable<TestCaseData> SeventhChordCases
+    {
+        get
+        {
+            yield return new TestCaseData(ChordFormula.Dominant7).SetName("Dominant7");
+            yield return new TestCaseData(ChordFormula.Major7).SetName("Major7");
+            yield return new TestCaseData(ChordFormula.Minor7).SetName("Minor7");
+        }
+    }
+
+    [Test]
+    public void Formula_Quality_IsClassifiedFromIntervals()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(ChordFormula.Major.Quality, Is.EqualTo(ChordQuality.Major));
+            Assert.That(ChordFormula.Minor.Quality, Is.EqualTo(ChordQuality.Minor));
+            Assert.That(ChordFormula.Diminished.Quality, Is.EqualTo(ChordQuality.Diminished));
+            Assert.That(ChordFormula.Augmented.Quality, Is.EqualTo(ChordQuality.Augmented));
+            Assert.That(ChordFormula.Dominant7.Quality, Is.EqualTo(ChordQuality.Dominant));
+            Assert.That(ChordFormula.Major7.Quality, Is.EqualTo(ChordQuality.Major));
+            Assert.That(ChordFormula.Minor7.Quality, Is.EqualTo(ChordQuality.Minor));
+        });
+    }
+
+    [Test]
+    public void SuspendedFormulas_AreNotDetectedAsSuspended_KnownBug()
+    {
+        // LATENT BUG (characterized, not fixed here): ChordFormula.IsSuspended requires an interval
+        // whose Function == Third with 2 or 5 semitones, but ChordFunctionExtensions.FromSemitones maps
+        // 2 -> Ninth and 5 -> Eleventh (never Third). So the built-in Suspended2/Suspended4 formulas are
+        // never recognized as suspended, and their Quality falls back to Other. This test pins the actual
+        // behaviour; fixing the detection should flip these expectations deliberately.
+        Assert.Multiple(() =>
+        {
+            Assert.That(ChordFormula.Suspended2.IsSuspended, Is.False);
+            Assert.That(ChordFormula.Suspended4.IsSuspended, Is.False);
+            Assert.That(ChordFormula.Suspended2.Quality, Is.EqualTo(ChordQuality.Other));
+            Assert.That(ChordFormula.Major.IsSuspended, Is.False);
+        });
+    }
+
+    [Test]
+    public void ToInversion_PreservesPitchClassContent()
+    {
+        var root = new Note.Accidented(NaturalNote.C, Accidental.Natural);
+        var chord = new Chord(root, ChordFormula.Major);
+
+        var inverted = chord.ToInversion(1);
+
+        Assert.That(PitchClassValues(inverted), Is.EqualTo(PitchClassValues(chord)));
     }
 }

--- a/Tests/GA.Domain.Core.Tests/Theory/Harmony/ChordTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Theory/Harmony/ChordTests.cs
@@ -204,19 +204,29 @@ public class ChordTests
     }
 
     [Test]
-    public void SuspendedFormulas_AreNotDetectedAsSuspended_KnownBug()
+    public void SuspendedFormulas_AreDetectedAsSuspended()
     {
-        // LATENT BUG (characterized, not fixed here): ChordFormula.IsSuspended requires an interval
-        // whose Function == Third with 2 or 5 semitones, but ChordFunctionExtensions.FromSemitones maps
-        // 2 -> Ninth and 5 -> Eleventh (never Third). So the built-in Suspended2/Suspended4 formulas are
-        // never recognized as suspended, and their Quality falls back to Other. This test pins the actual
-        // behaviour; fixing the detection should flip these expectations deliberately.
+        // A suspended chord replaces the third with a 2nd (sus2) or 4th (sus4).
         Assert.Multiple(() =>
         {
-            Assert.That(ChordFormula.Suspended2.IsSuspended, Is.False);
-            Assert.That(ChordFormula.Suspended4.IsSuspended, Is.False);
-            Assert.That(ChordFormula.Suspended2.Quality, Is.EqualTo(ChordQuality.Other));
+            Assert.That(ChordFormula.Suspended2.IsSuspended, Is.True);
+            Assert.That(ChordFormula.Suspended4.IsSuspended, Is.True);
+            Assert.That(ChordFormula.Suspended2.Quality, Is.EqualTo(ChordQuality.Suspended));
+            Assert.That(ChordFormula.Suspended4.Quality, Is.EqualTo(ChordQuality.Suspended));
+            Assert.That(ChordFormula.Suspended2.Extension, Is.EqualTo(ChordExtension.Sus2));
+            Assert.That(ChordFormula.Suspended4.Extension, Is.EqualTo(ChordExtension.Sus4));
+        });
+    }
+
+    [Test]
+    public void NonSuspendedFormulas_AreNotSuspended()
+    {
+        // Chords that contain a third (major or minor) are never suspended.
+        Assert.Multiple(() =>
+        {
             Assert.That(ChordFormula.Major.IsSuspended, Is.False);
+            Assert.That(ChordFormula.Minor.IsSuspended, Is.False);
+            Assert.That(ChordFormula.Dominant7.IsSuspended, Is.False);
         });
     }
 

--- a/Tests/GA.Domain.Core.Tests/Theory/Tonal/KeySignatureTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Theory/Tonal/KeySignatureTests.cs
@@ -1,0 +1,73 @@
+namespace GA.Domain.Core.Tests.Theory.Tonal;
+
+using System.Linq;
+using GA.Domain.Core.Primitives.Notes;
+using GA.Domain.Core.Theory.Tonal;
+using NUnit.Framework;
+
+/// <summary>
+///     Characterization tests for <see cref="KeySignature" /> — the [-7, +7] sharp/flat count and the
+///     circle-of-fifths/fourths derivation of its accidented notes.
+/// </summary>
+[TestFixture]
+public class KeySignatureTests
+{
+    [Test]
+    public void Items_SpanFifteenSignatures()
+    {
+        // -7 (7 flats) through +7 (7 sharps), inclusive.
+        Assert.That(KeySignature.Items.Count, Is.EqualTo(15));
+    }
+
+    [TestCase(0, 0)]
+    [TestCase(3, 3)]
+    [TestCase(-2, 2)]
+    [TestCase(7, 7)]
+    [TestCase(-7, 7)]
+    public void AccidentalCount_IsAbsoluteValue(int value, int expectedCount)
+    {
+        Assert.That(((KeySignature)value).AccidentalCount, Is.EqualTo(expectedCount));
+    }
+
+    [TestCase(0, AccidentalKind.Sharp)]  // C major: no accidentals, classified sharp-side
+    [TestCase(4, AccidentalKind.Sharp)]
+    [TestCase(-1, AccidentalKind.Flat)]
+    [TestCase(-5, AccidentalKind.Flat)]
+    public void AccidentalKind_TracksSign(int value, AccidentalKind expectedKind)
+    {
+        Assert.That(((KeySignature)value).AccidentalKind, Is.EqualTo(expectedKind));
+    }
+
+    [Test]
+    public void SharpAndFlat_FactoriesProduceSignedValues()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(KeySignature.Sharp(3).Value, Is.EqualTo(3));
+            Assert.That(KeySignature.Flat(2).Value, Is.EqualTo(-2));
+            Assert.That(KeySignature.Sharp(3).IsSharpKey, Is.True);
+            Assert.That(KeySignature.Flat(2).IsFlatKey, Is.True);
+        });
+    }
+
+    [Test]
+    public void AccidentedNotes_CountMatchesAccidentalCount()
+    {
+        foreach (var ks in KeySignature.Items)
+        {
+            Assert.That(ks.AccidentedNotes.Count, Is.EqualTo(ks.AccidentalCount),
+                $"Key signature {ks.Value} accidented-note count mismatch");
+        }
+    }
+
+    [Test]
+    public void FirstSharp_IsFSharp_FirstFlat_IsBFlat()
+    {
+        // Circle of fifths begins on F# for sharps; circle of fourths begins on Bb for flats.
+        Assert.Multiple(() =>
+        {
+            Assert.That(KeySignature.Sharp(1).AccidentedNotes.Single().PitchClass.Value, Is.EqualTo(6));  // F#
+            Assert.That(KeySignature.Flat(1).AccidentedNotes.Single().PitchClass.Value, Is.EqualTo(10)); // Bb
+        });
+    }
+}

--- a/Tests/GA.Domain.Core.Tests/Theory/Tonal/KeyTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Theory/Tonal/KeyTests.cs
@@ -1,0 +1,85 @@
+namespace GA.Domain.Core.Tests.Theory.Tonal;
+
+using GA.Domain.Core.Primitives.Notes;
+using GA.Domain.Core.Theory.Tonal;
+using GA.Domain.Core.Theory.Tonal.Scales;
+using NUnit.Framework;
+
+/// <summary>
+///     Characterization tests for <see cref="Key" /> (Major | Minor) — 15 keys per mode, key roots,
+///     diatonic note content, and the relative-key relationship via shared key signatures.
+/// </summary>
+[TestFixture]
+public class KeyTests
+{
+    [Test]
+    public void Items_ContainThirtyKeys()
+    {
+        // 15 major + 15 minor.
+        Assert.That(Key.Items.Count, Is.EqualTo(30));
+        Assert.That(Key.Major.MajorItems.Count, Is.EqualTo(15));
+        Assert.That(Key.Minor.MinorItems.Count, Is.EqualTo(15));
+    }
+
+    [TestCase(0, 0)]  // C
+    [TestCase(1, 7)]  // G
+    [TestCase(-1, 5)] // F
+    [TestCase(2, 2)]  // D
+    public void MajorKey_RootPitchClass_TracksSignature(int signature, int expectedRootPc)
+    {
+        var key = new Key.Major(signature);
+        Assert.That(key.Root.PitchClass.Value, Is.EqualTo(expectedRootPc));
+    }
+
+    [Test]
+    public void MajorKey_HasSevenNotes()
+    {
+        Assert.That(Key.Major.C.Notes.Count, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void CMajorKey_PitchClassSet_MatchesMajorScale()
+    {
+        Assert.That(Key.Major.C.PitchClassSet.Id, Is.EqualTo(Scale.Major.PitchClassSet.Id));
+    }
+
+    [Test]
+    public void RelativeKeys_ShareSamePitchClassSet()
+    {
+        // C major (0 sharps/flats) and A minor (0 sharps/flats) are relative keys — same notes.
+        Assert.That(Key.Minor.Am.PitchClassSet.Id, Is.EqualTo(Key.Major.C.PitchClassSet.Id));
+    }
+
+    [Test]
+    public void KeyMode_IsModeSpecific()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Key.Major.C.KeyMode, Is.EqualTo(KeyMode.Major));
+            Assert.That(Key.Minor.Am.KeyMode, Is.EqualTo(KeyMode.Minor));
+        });
+    }
+
+    [Test]
+    public void MajorKey_AccidentalKind_TracksSignature()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(Key.Major.G.AccidentalKind, Is.EqualTo(AccidentalKind.Sharp));
+            Assert.That(Key.Major.F.AccidentalKind, Is.EqualTo(AccidentalKind.Flat));
+        });
+    }
+
+    [Test]
+    public void TryParse_KnownRoot_ResolvesKey()
+    {
+        var ok = Key.Major.TryParse("G", out var g);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ok, Is.True);
+            Assert.That(g.Root.PitchClass.Value, Is.EqualTo(7));
+            Assert.That(g.KeySignature.Value, Is.EqualTo(1));
+        });
+    }
+}

--- a/Tests/GA.Domain.Core.Tests/Theory/Tonal/ScaleModeTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Theory/Tonal/ScaleModeTests.cs
@@ -1,0 +1,77 @@
+namespace GA.Domain.Core.Tests.Theory.Tonal;
+
+using System.Linq;
+using GA.Domain.Core.Theory.Atonal;
+using GA.Domain.Core.Theory.Tonal.Modes.Diatonic;
+using GA.Domain.Core.Theory.Tonal.Primitives.Diatonic;
+using GA.Domain.Core.Theory.Tonal.Scales;
+using NUnit.Framework;
+
+/// <summary>
+///     Characterization tests for the modes of the major scale (<see cref="MajorScaleMode" />).
+///     The seven modes are rotations of the parent <see cref="Scale.Major" />; each has a distinct
+///     tonal centre and name but shares the parent's pitch-class content.
+/// </summary>
+[TestFixture]
+public class ScaleModeTests
+{
+    [Test]
+    public void Items_ReturnsSevenModes()
+    {
+        Assert.That(MajorScaleMode.Items.Count(), Is.EqualTo(7));
+    }
+
+    // Degree -> (mode name, tonal-centre pitch class) for the C-major parent scale.
+    [TestCase(1, "Ionian", 0)]   // C
+    [TestCase(2, "Dorian", 2)]   // D
+    [TestCase(3, "Phrygian", 4)] // E
+    [TestCase(4, "Lydian", 5)]   // F
+    [TestCase(5, "Mixolydian", 7)] // G
+    [TestCase(6, "Aeolian", 9)]  // A
+    [TestCase(7, "Locrian", 11)] // B
+    public void Mode_HasExpectedNameAndTonalCentre(int degree, string expectedName, int expectedTonalCentrePc)
+    {
+        var mode = MajorScaleMode.Get(degree);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mode.Name, Is.EqualTo(expectedName));
+            Assert.That(mode.TonalCenter.PitchClass.Value, Is.EqualTo(expectedTonalCentrePc));
+            Assert.That(mode.Notes.Count, Is.EqualTo(7));
+            Assert.That(mode.ParentScale.PitchClassSet.Id, Is.EqualTo(Scale.Major.PitchClassSet.Id));
+        });
+    }
+
+    // Dorian, Phrygian, Aeolian and Locrian carry a minor third; Ionian, Lydian, Mixolydian are major.
+    [TestCase(1, false)] // Ionian
+    [TestCase(2, true)]  // Dorian
+    [TestCase(3, true)]  // Phrygian
+    [TestCase(4, false)] // Lydian
+    [TestCase(5, false)] // Mixolydian
+    [TestCase(6, true)]  // Aeolian
+    [TestCase(7, true)]  // Locrian
+    public void Mode_IsMinorMode_TracksMinorThird(int degree, bool expectedMinor)
+    {
+        Assert.That(MajorScaleMode.Get(degree).IsMinorMode, Is.EqualTo(expectedMinor));
+    }
+
+    [Test]
+    public void Get_ByDegreeValueObject_EqualsGetByInt()
+    {
+        var byObject = MajorScaleMode.Get(MajorScaleDegree.Dorian);
+        var byInt = MajorScaleMode.Get(2);
+
+        Assert.That(byObject.Name, Is.EqualTo(byInt.Name));
+    }
+
+    [Test]
+    public void AllModes_ShareParentScaleIntervalClassVector()
+    {
+        // Modal invariance: every rotation of the diatonic scale has the same interval-class vector.
+        foreach (var mode in MajorScaleMode.Items)
+        {
+            Assert.That(mode.ParentScale.IntervalClassVector, Is.EqualTo(IntervalClassVector.Major),
+                $"Mode {mode.Name} does not share the diatonic interval-class vector");
+        }
+    }
+}

--- a/Tests/GA.Domain.Core.Tests/Theory/Tonal/ScaleTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Theory/Tonal/ScaleTests.cs
@@ -1,0 +1,63 @@
+namespace GA.Domain.Core.Tests.Theory.Tonal;
+
+using GA.Domain.Core.Theory.Atonal;
+using GA.Domain.Core.Theory.Tonal.Scales;
+using NUnit.Framework;
+
+/// <summary>
+///     Characterization tests for <see cref="Scale" /> — the tonal realization of a pitch-class set.
+///     These pin down observable behaviour through the public API (note count, pitch-class content,
+///     interval-class vector) so refactors of the internal rotation/indexer machinery stay honest.
+/// </summary>
+[TestFixture]
+public class ScaleTests
+{
+    [Test]
+    public void Major_HasSevenNotes()
+    {
+        Assert.That(Scale.Major.Count, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Major_IntervalClassVector_IsCanonicalDiatonic()
+    {
+        // The major (diatonic) scale's interval-class vector is the famous <2 5 4 3 6 1>.
+        Assert.That(Scale.Major.IntervalClassVector, Is.EqualTo(IntervalClassVector.Major));
+    }
+
+    [Test]
+    public void RelativeMajorAndMinor_ShareSamePitchClassSet()
+    {
+        // A natural minor ("A B C D E F G") is the relative minor of C major: same pitch classes,
+        // different tonal centre. Their unordered pitch-class content must be identical.
+        Assert.That(Scale.NaturalMinor.PitchClassSet.Id, Is.EqualTo(Scale.Major.PitchClassSet.Id));
+    }
+
+    [Test]
+    public void Major_IsModal()
+    {
+        // The diatonic scale generates a non-degenerate modal family (7 distinct rotations).
+        Assert.That(Scale.Major.IsModal, Is.True);
+    }
+
+    [TestCase(nameof(Scale.MajorPentatonic), 5)]
+    [TestCase(nameof(Scale.WholeTone), 6)]
+    [TestCase(nameof(Scale.Blues), 6)]
+    [TestCase(nameof(Scale.Augmented), 6)]
+    [TestCase(nameof(Scale.HarmonicMinor), 7)]
+    [TestCase(nameof(Scale.MelodicMinor), 7)]
+    [TestCase(nameof(Scale.Diminished), 8)]
+    [TestCase(nameof(Scale.BebopDominant), 8)]
+    public void NamedScale_HasExpectedCardinality(string scaleName, int expectedCount)
+    {
+        var scale = (Scale)typeof(Scale).GetProperty(scaleName)!.GetValue(null)!;
+        Assert.That(scale.Count, Is.EqualTo(expectedCount));
+    }
+
+    [Test]
+    public void Constructor_FromNoteString_RoundTripsCardinality()
+    {
+        var scale = new Scale("C D E F G A B");
+        Assert.That(scale.Count, Is.EqualTo(7));
+    }
+}


### PR DESCRIPTION
## Summary

Started as a `/tdd` session on the GA **domain layer**, which surfaced three real bugs that are fixed here.

### Test infrastructure + coverage
- **Wired `Tests/GA.Domain.Core.Tests` into `AllProjects.slnx`** — it existed on disk but was never in the solution, so CI never built or ran it. Bumped NUnit 3.14 → **4.2.2** (+ Test.Sdk 17.12, adapter 4.6, analyzers 4.4, coverlet) to match the other test projects.
- Added **~90 characterization tests**: Scale/Mode (ICV invariants, modal rotations), Key/KeySignature (circle of fifths/fourths, relative keys), Chord (qualities/extensions/inversions), Fretboard/Tuning/Voicing (geometry, note mapping, diagram identity).

### Bugs fixed
1. **`Fretboard.GetNote` ignored the fret for pitch class.** It rebuilt the result note from the *open* string's pitch class and applied the fret only to the octave, so every non-octave fret returned the wrong note (`GetNote(0,1)` → E instead of F). Frets 0/12/24 happened to look correct. Fixed to derive from the fretted MIDI note's pitch class. Also corrects `GetPositionsForNote` / `GetPitchClass` and downstream `ShapeGraphBuilder` / `FretboardChordAnalyzer`.
2. **`ShapeGraphBuilder.BuildGraphAsync` threw on duplicate shape Ids.** A shape Id is a SHA-256 of `(tuning, positions)`, so an identical Id means the same physical fingering (legitimately produced from multiple base frets / pitch-class sets). Dedupe by Id instead of throwing. Previously masked because the buggy `GetNote` produced fewer shapes. Re-enables `ShouldBuildGraph_InLessThan5Seconds` (was `[Ignore]`d for this exact reason).
3. **`ChordFormula.IsSuspended` never detected sus2/sus4.** It required an interval whose `ChordFunction` was `Third` with 2/5 semitones, but `ChordFunctionExtensions.FromSemitones` maps 2→Ninth and 5→Eleventh (never Third) — so the built-in `Suspended2`/`Suspended4` formulas were classified `Quality=Other`, `Extension=Add9`/`Triad`. Redefined as the standard "no third, plus a 2nd or 4th in its place"; sus formulas now classify as `Suspended` / `Sus2`/`Sus4`. `IsSuspended` is consumed only inside `ChordFormula`, so no external ripple.

### New public API
- **`Chord.FromSymbol` / `Chord.TryFromSymbol`** — a self-contained chord-symbol parser in the **core layer** (mirrors the grammar of the existing `GA.Domain.Services` `ChordSymbolParser`, which the bottom-up layering rule forbids referencing from layer 1). This lets the 9 previously-ignored `FromSymbol` tests run. *Note: adds a layer-1 public API (a one-way door per `CLAUDE.md`) — flagged for review.*

## Test output
- `GA.Domain.Core.Tests`: **175 passed, 0 skipped**
- `GA.Business.Core.Tests`: **859 passed, 0 failed**
- Full `dotnet build AllProjects.slnx -c Debug`: **0 errors**

## Scope note
Only ignored tests connected to this work were re-enabled. The remaining solution-wide `Assert.Ignore`/`[Ignore]` are environmental guards (missing services/index/files) or unrelated unimplemented features and were intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)