### PR TITLE
fix(ci): repair Post-Merge Smoke env vars + Fleet Status checkout

### DIFF
--- a/.github/workflows/fleet-status.yml
+++ b/.github/workflows/fleet-status.yml
@@ -49,12 +49,17 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Non-fatal: agent-blackbox is a separate repo the default GITHUB_TOKEN can't reach (private /
+      # cross-repo scope). The install-audit step below already tolerates its absence (every call is
+      # guarded with `|| true`), so a failed checkout must not fail the whole snapshot job.
       - name: Checkout agent-blackbox (for install-audit CLI)
         uses: actions/checkout@v4
+        continue-on-error: true
         with:
           repository: GuitarAlchemist/agent-blackbox
           ref: main
           path: agent-blackbox
+          token: ${{ secrets.AGENT_BLACKBOX_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/post-merge-smoke.yml
+++ b/.github/workflows/post-merge-smoke.yml
@@ -77,9 +77,12 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
         run: |
           set -u
-          RUN_AT_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          RUN_AT_FS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
-          OUT="state/quality/e2e/${RUN_AT_FS}.json"
+          # export (not just assign) so the python3 child process in this same step inherits these via
+          # os.environ. Writing to $GITHUB_ENV alone only exposes them to *subsequent* steps, which is why
+          # the in-step aggregator below previously died with KeyError: 'RUN_AT_ISO'.
+          export RUN_AT_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export RUN_AT_FS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+          export OUT="state/quality/e2e/${RUN_AT_FS}.json"
           echo "OUT=${OUT}" >> "$GITHUB_ENV"
           echo "RUN_AT_ISO=${RUN_AT_ISO}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
Fixes two pre-existing **infra** CI failures observed on `main` (both unrelated to any code under test — they fail on every run).

### 1. Post-Merge Smoke — `KeyError: 'RUN_AT_ISO'`
`RUN_AT_ISO` and `OUT` were assigned as plain shell variables and written to `$GITHUB_ENV`, which only exposes them to **subsequent** steps. The Python aggregator runs in the **same** step as a child process and reads them via `os.environ`, so it always crashed. Fixed by `export`ing them (kept the `$GITHUB_ENV` writes for the later commit/comment steps).

### 2. Fleet Status — `repository 'GuitarAlchemist/agent-blackbox' not found`
The `agent-blackbox` checkout step has no fallback, so the missing/cross-repo-scoped checkout killed the whole job. The downstream install-audit step already tolerates the CLI being absent (every call guarded with `|| true`). Fixed by:
- `continue-on-error: true` on that checkout, and
- allowing an optional `AGENT_BLACKBOX_TOKEN` secret (`secrets.AGENT_BLACKBOX_TOKEN || secrets.GITHUB_TOKEN`) for when it should succeed.

## Validation
Both workflow files parse cleanly (`yaml.safe_load`). These are workflow-only changes — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)