### PR TITLE
fix(ci): smoke treats all-gateway-error as infra-down; fleet-status push retry

### DIFF
--- a/.github/workflows/fleet-status.yml
+++ b/.github/workflows/fleet-status.yml
@@ -130,4 +130,13 @@ jobs:
           fi
 
           git commit -m "chore(fleet): fleet-status snapshot $(date -u +%Y-%m-%d) [skip ci]"
-          git push origin HEAD:main
+          # Retry on a non-fast-forward race: other [skip ci] chore workflows commit to main concurrently.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "::warning::push failed (attempt ${attempt}); rebasing on origin/main and retrying."
+            git pull --rebase origin main || true
+          done
+          echo "::error::Could not push fleet-status after 3 attempts."
+          exit 1

--- a/.github/workflows/post-merge-smoke.yml
+++ b/.github/workflows/post-merge-smoke.yml
@@ -135,6 +135,7 @@ jobs:
                       body = bf.read()
                   marker_found = marker.encode('utf-8') in body
               unreachable = (status == 0)
+              gateway_error = status in (502, 503, 504)
               if unreachable:
                   unreachable_count += 1
               ok = (status == 200 and size_bytes > 0 and marker_found)
@@ -142,6 +143,7 @@ jobs:
                   failures.append({
                       'url': url, 'status': status,
                       'marker_found': marker_found, 'unreachable': unreachable,
+                      'gateway_error': gateway_error,
                   })
               checks.append({
                   'url': url,
@@ -152,10 +154,18 @@ jobs:
                   'content_marker': marker,
                   'content_marker_found': marker_found,
                   'unreachable': unreachable,
+                  'gateway_error': gateway_error,
               })
 
-          tunnel_down = unreachable_count >= 2
+          # "Infra down" (kept under the name tunnel_down so the YAML step conditions don't change):
+          # every failure is either unreachable (connection refused / timeout) or a gateway error
+          # (502/503/504 = Cloudflare is up but the operator's origin is offline). That is the operator's
+          # workstation/tunnel being down, not a code regression — log it and exit 0, don't page. A real
+          # per-URL regression (e.g. HTTP 200 but the content marker is missing, or a 404) still pages.
+          infra_failures = [f for f in failures if f['unreachable'] or f['gateway_error']]
+          real_failures  = [f for f in failures if not (f['unreachable'] or f['gateway_error'])]
           all_passed  = len(failures) == 0
+          tunnel_down = len(real_failures) == 0 and len(infra_failures) >= 2
 
           doc = {
               'schema': 'post-merge-smoke-v1',


### PR DESCRIPTION
## Summary
Round-2 follow-ups. The first CI repair (#460) fixed the hard crashes; running the workflows then exposed their real behaviour, fixed here.

### Post-Merge Smoke — don't page when the origin is down
After the `export` fix it ran correctly and found **all three demo URLs returning HTTP 502** (Cloudflare up, operator origin offline) — then mis-classified that as a per-URL regression and paged. The existing "don't page" heuristic only covered `status==0` (connection refused/timeout). Now a failure counts as **infra** if it's unreachable **or** a gateway error (502/503/504); when *every* failure is infra and ≥2 occur, the job logs and exits 0 instead of opening an issue. A real per-URL regression (HTTP 200 but marker missing, 404, etc.) still pages.

### Fleet Status — push race
After the `continue-on-error` fix it reached the final `git push`, which lost a non-fast-forward race against concurrent `[skip ci]` chore commits. Added the same 3-attempt `pull --rebase` retry the smoke workflow already uses.

## Note (not a CI bug)
The 502s are real: **`demos.guitaralchemist.com` is currently down at the origin** (all paths 502 — workstation services/tunnel offline). This PR stops CI from false-paging on it, but the live demo itself needs the operator's stack brought back up.

Workflow-only changes; YAML validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)