### PR TITLE
fix: Chord.Quality/Extension delegate to Formula

### DIFF
--- a/Common/GA.Domain.Core/Theory/Harmony/Chord.cs
+++ b/Common/GA.Domain.Core/Theory/Harmony/Chord.cs
@@ -40,8 +40,6 @@ public sealed class Chord : IEquatable<Chord>
         Notes = new(notes);
         PitchClassSet = Notes.ToPitchClassSet();
 
-        Quality = DetermineQuality();
-        Extension = DetermineExtension();
         Symbol = symbol ?? GenerateSymbol();
     }
 
@@ -61,8 +59,6 @@ public sealed class Chord : IEquatable<Chord>
 
         // Analyze the chord to determine formula
         Formula = AnalyzeChordFormula();
-        Quality = DetermineQuality();
-        Extension = DetermineExtension();
         Symbol = GenerateSymbol();
     }
 
@@ -165,14 +161,16 @@ public sealed class Chord : IEquatable<Chord>
     public string Symbol { get; }
 
     /// <summary>
-    ///     Gets the chord quality (major, minor, diminished, etc.)
+    ///     Gets the chord quality (major, minor, dominant, suspended, etc.).
+    ///     Delegates to <see cref="Formula" /> so a chord and its formula never disagree — e.g. a
+    ///     dominant-7th chord reports Dominant (not Major) and a sus chord reports Suspended.
     /// </summary>
-    public ChordQuality Quality { get; }
+    public ChordQuality Quality => Formula.Quality;
 
     /// <summary>
-    ///     Gets the chord extension (7th, 9th, 11th, 13th)
+    ///     Gets the chord extension (7th, 9th, 11th, 13th, sus, 6, …). Delegates to <see cref="Formula" />.
     /// </summary>
-    public ChordExtension Extension { get; }
+    public ChordExtension Extension => Formula.Extension;
 
     /// <summary>
     ///     Gets the pitch class set representation of the chord
@@ -259,74 +257,6 @@ public sealed class Chord : IEquatable<Chord>
         }
 
         return new($"Analyzed_{Root}", intervals);
-    }
-
-
-    private ChordQuality DetermineQuality()
-    {
-        // Grounded in standard chord-quality definitions (triad quality by 3rd and 5th).
-        // https://en.wikipedia.org/wiki/Chord_(music)#Chord_quality
-        var hasMinorThird = Formula.Intervals.Any(i => i.Interval.Semitones.Value == 3);
-        var hasMajorThird = Formula.Intervals.Any(i => i.Interval.Semitones.Value == 4);
-        var hasDiminishedFifth = Formula.Intervals.Any(i => i.Interval.Semitones.Value == 6);
-        var hasAugmentedFifth = Formula.Intervals.Any(i => i.Interval.Semitones.Value == 8);
-
-        if (hasDiminishedFifth && hasMinorThird)
-        {
-            return ChordQuality.Diminished;
-        }
-
-        if (hasAugmentedFifth && hasMajorThird)
-        {
-            return ChordQuality.Augmented;
-        }
-
-        if (hasMinorThird)
-        {
-            return ChordQuality.Minor;
-        }
-
-        if (hasMajorThird)
-        {
-            return ChordQuality.Major;
-        }
-
-        return ChordQuality.Other;
-    }
-
-    private ChordExtension DetermineExtension()
-    {
-        var hasSeventh = Formula.Intervals.Any(i => i.Interval.Semitones.Value is 10 or 11);
-        var hasNinth = Formula.Intervals.Any(i => i.Interval.Semitones.Value is 2 or 14);
-        var hasEleventh = Formula.Intervals.Any(i => i.Interval.Semitones.Value is 5 or 17);
-        var hasThirteenth = Formula.Intervals.Any(i => i.Interval.Semitones.Value is 9 or 21);
-
-        if (hasThirteenth)
-        {
-            return ChordExtension.Thirteenth;
-        }
-
-        if (hasEleventh)
-        {
-            return ChordExtension.Eleventh;
-        }
-
-        if (hasNinth && hasSeventh)
-        {
-            return ChordExtension.Ninth;
-        }
-
-        if (hasNinth && !hasSeventh)
-        {
-            return ChordExtension.Add9;
-        }
-
-        if (hasSeventh)
-        {
-            return ChordExtension.Seventh;
-        }
-
-        return ChordExtension.Triad;
     }
 
     private string GenerateSymbol()

--- a/Tests/GA.Domain.Core.Tests/Theory/Harmony/ChordTests.cs
+++ b/Tests/GA.Domain.Core.Tests/Theory/Harmony/ChordTests.cs
@@ -158,17 +158,20 @@ public class ChordTests
     }
 
     [Test]
-    public void Dominant7_FormulaQualityIsDominant_ButChordQualityFallsBackToMajor()
+    public void Chord_Quality_AgreesWithFormula()
     {
-        // Characterizes a real divergence: ChordFormula.DetermineQuality knows "Dominant"
-        // (major 3rd + minor 7th), but Chord.DetermineQuality only classifies the triad
-        // (3rd + 5th) and therefore reports Major for a dominant-7th chord. Pinned here so
-        // the inconsistency is visible and a future fix would deliberately update this test.
-        var chord = CChord(ChordFormula.Dominant7);
+        // Chord.Quality/Extension delegate to Formula, so a chord and its formula never disagree.
+        // A dominant-7th chord reports Dominant (not the old triad-only fallback of Major).
+        var dom = CChord(ChordFormula.Dominant7);
+        var sus = CChord(ChordFormula.Suspended2);
         Assert.Multiple(() =>
         {
-            Assert.That(chord.Formula.Quality, Is.EqualTo(ChordQuality.Dominant));
-            Assert.That(chord.Quality, Is.EqualTo(ChordQuality.Major));
+            Assert.That(dom.Quality, Is.EqualTo(ChordQuality.Dominant));
+            Assert.That(dom.Quality, Is.EqualTo(dom.Formula.Quality));
+            Assert.That(sus.Quality, Is.EqualTo(ChordQuality.Suspended));
+            Assert.That(sus.Quality, Is.EqualTo(sus.Formula.Quality));
+            Assert.That(sus.Extension, Is.EqualTo(ChordExtension.Sus2));
+            Assert.That(sus.Extension, Is.EqualTo(sus.Formula.Extension));
         });
     }
 


### PR DESCRIPTION
## Summary
Closes the last bug the `/tdd` domain session surfaced. The `Chord` class duplicated quality/extension classification with its own `DetermineQuality`/`DetermineExtension`, which only looked at the triad (3rd + 5th). So:
- `Chord.FromSymbol("C7").Quality` returned **Major** (not Dominant)
- a sus chord returned **Other** (not Suspended)

…disagreeing with the richer `ChordFormula.Quality`/`Extension` that already know Dominant, Suspended, Sus2/Sus4, 6, 6/9, etc.

## Change
`Chord.Quality => Formula.Quality` and `Chord.Extension => Formula.Extension`; deleted the redundant per-class `Determine*` methods (−84/+17 lines). A chord and its formula can no longer disagree. The prior known-divergence characterization test is flipped to assert agreement (dominant → Dominant, sus → Suspended/Sus2).

`Formula` is assigned before `GenerateSymbol()` in both constructors, so generated symbols are unaffected.

## Verification
- `GA.Domain.Core.Tests`: **175 / 0**
- `GA.Business.Core.Tests`: **859 / 0** (canonical chord recognition/naming)
- `GA.Business.ML.Tests`: **1610 / 0** (other `Chord` consumer)
- Full `dotnet build AllProjects.slnx`: **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)