### PR TITLE
docs: reference AI-coding dictionary in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,9 @@ The aihero skills themselves (`/grill-me`, `/to-prd`, `/to-issues`, `/tdd`,
 `/improve-codebase-architecture`, `/teach`) are installed project-scoped under
 `.claude/skills/` (see **Agent skills** above) and complement this ecosystem's
 existing brainstorming, planning-doc, test, and structural-quality machinery.
+
+**AI-coding vocabulary (shared ecosystem reference):**
+<https://github.com/mattpocock/dictionary-of-ai-coding> — the plain-English
+glossary behind this methodology (smart-zone, tracer-bullets, context windows,
+handoffs, failure modes). Referenced, not vendored, so it tracks upstream. The
+`/ask-matt` skill links its *smart-zone* page directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,3 +175,9 @@ The aihero skills themselves (`/grill-me`, `/to-prd`, `/to-issues`, `/tdd`,
 `/improve-codebase-architecture`, `/teach`) are installed project-scoped under
 `.claude/skills/` (see **Agent skills** above) and complement this ecosystem's
 existing brainstorming, planning-doc, test, and structural-quality machinery.
+
+**AI-coding vocabulary (shared ecosystem reference):**
+<https://github.com/mattpocock/dictionary-of-ai-coding> — the plain-English
+glossary behind this methodology (smart-zone, tracer-bullets, context windows,
+handoffs, failure modes). Referenced, not vendored, so it tracks upstream. The
+`/ask-matt` skill links its *smart-zone* page directly.


### PR DESCRIPTION
## Summary
Adds a one-line reference to [mattpocock/dictionary-of-ai-coding](https://github.com/mattpocock/dictionary-of-ai-coding) in `CLAUDE.md` (and re-synced `AGENTS.md`).

It's a plain-English **glossary** — the vocabulary behind the aihero methodology this repo already adopted (smart-zone, tracer-bullets, handoffs). The `/ask-matt` skill already links its *smart-zone* page.

**Referenced, not vendored** — so it tracks upstream, needs no license clearance, and adds no maintenance/drift burden.

## Scope
First of the **5 core repos** (`ga`, `ix`, `Demerzel`, `hari`, `tars`), matching the existing aihero skills rollout. If this lands well, the same one-liner fans out to the other four (peripheral/personal repos excluded, per the earlier rollout choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)