### PR TITLE
refactor(chat): route SignalR ChatbotHub through the seam (slice #1, PR B)

### DIFF
--- a/Apps/ga-server/GaApi/Controllers/ChatbotController.cs
+++ b/Apps/ga-server/GaApi/Controllers/ChatbotController.cs
@@ -27,6 +27,7 @@ using Services;
 public class ChatbotController(
     ILogger<ChatbotController> logger,
     IChatApplicationService chatService,
+    IChatIntake chatIntake,
     IAgenticTraceCapture traceCapture,
     IChatService statusService,
     ILlmConcurrencyGate concurrencyGate)
@@ -158,40 +159,40 @@ public class ChatbotController(
         [FromBody] ChatRequest request,
         CancellationToken cancellationToken)
     {
-        var message = request.Message?.Trim();
-        if (string.IsNullOrWhiteSpace(message))
-            return BadRequest(new { error = "Message cannot be empty." });
+        // Thin adapter over the chat intake seam (#1): validate + gate + dispatch
+        // live in IChatIntake. This method only resolves the transport-specific
+        // session id (HTTP cookie — Phase C plumbing, see ChatStream above) and
+        // frames the typed result. The seam takes an opaque SessionId; it never
+        // touches HttpContext.
+        var sw = Stopwatch.StartNew();
+        var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
+        var result = await chatIntake.IntakeAsync(
+            new ChatIntakeRequest(request.Message, sessionId),
+            cancellationToken);
+        sw.Stop();
 
-        if (!await concurrencyGate.TryEnterAsync(cancellationToken))
-            return StatusCode(StatusCodes.Status503ServiceUnavailable,
-                new { error = "Service is busy. Please try again in a few seconds." });
-
-        try
-        {
-            var sw = Stopwatch.StartNew();
-            // Phase C plumbing — see ChatStream above.
-            var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
-            var response = await chatService.ChatAsync(
-                new GA.Business.Core.Orchestration.Models.ChatRequest(message, SessionId: sessionId),
-                cancellationToken);
-            sw.Stop();
-
-            var routing = response.Routing ?? new AgentRoutingMetadata("direct", 0f, "none");
-            var traceId = Activity.Current?.TraceId.ToString();
-            return Ok(new ChatJsonResponse(
-                NaturalLanguageAnswer: response.NaturalLanguageAnswer ?? string.Empty,
-                routing.AgentId,
-                routing.Confidence,
-                routing.RoutingMethod,
-                Grounding: response.Grounding,
-                ElapsedMs: sw.ElapsedMilliseconds,
-                TraceId: traceId,
-                Trace: traceCapture.Build()));
-        }
-        finally
-        {
-            concurrencyGate.Release();
-        }
+        return result.Match<ActionResult<ChatJsonResponse>>(
+            response =>
+            {
+                var routing = response.Routing ?? new AgentRoutingMetadata("direct", 0f, "none");
+                return Ok(new ChatJsonResponse(
+                    NaturalLanguageAnswer: response.NaturalLanguageAnswer ?? string.Empty,
+                    routing.AgentId,
+                    routing.Confidence,
+                    routing.RoutingMethod,
+                    Grounding: response.Grounding,
+                    ElapsedMs: sw.ElapsedMilliseconds,
+                    TraceId: Activity.Current?.TraceId.ToString(),
+                    Trace: traceCapture.Build()));
+            },
+            error => error switch
+            {
+                ChatIntakeError.Busy => StatusCode(StatusCodes.Status503ServiceUnavailable,
+                    new { error = "Service is busy. Please try again in a few seconds." }),
+                ChatIntakeError.Validation v => BadRequest(new { error = v.Reason }),
+                _ => StatusCode(StatusCodes.Status500InternalServerError,
+                    new { error = "Unexpected error." })
+            });
     }
 
     /// <summary>

--- a/Apps/ga-server/GaApi/Hubs/ChatbotHub.cs
+++ b/Apps/ga-server/GaApi/Hubs/ChatbotHub.cs
@@ -21,11 +21,10 @@ using Services;
 [AllowAnonymous]
 public sealed class ChatbotHub(
     ILogger<ChatbotHub> logger,
-    IChatApplicationService chatService,
+    IChatIntake chatIntake,
     IAgenticTraceCapture traceCapture,
     ChatbotSessionOrchestrator sessionOrchestrator,
-    ISemanticKnowledgeSource semanticKnowledge,
-    ILlmConcurrencyGate concurrencyGate)
+    ISemanticKnowledgeSource semanticKnowledge)
     : Hub
 {
     private static readonly ConcurrentDictionary<string, List<ChatMessage>> _conversations = new();
@@ -104,32 +103,36 @@ public sealed class ChatbotHub(
         var history = _conversations.GetOrAdd(connectionId, _ => []);
         var connectionAborted = Context.ConnectionAborted;
 
-        if (!await concurrencyGate.TryEnterAsync(connectionAborted))
-        {
-            await Clients.Caller.SendAsync("Error", "Service is busy. Please try again in a few seconds.");
-            return;
-        }
-
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(connectionAborted);
         cts.CancelAfter(_pipelineBudget);
         var cancellationToken = cts.Token;
 
         try
         {
-            // SessionId = Context.ConnectionId — the anonymous demo doesn't
-            // have an authenticated user identity, but SignalR's server-issued
-            // ConnectionId IS a 128-bit cryptographically-random per-tab handle
-            // (per Microsoft.AspNetCore.SignalR's default IConnectionIdGenerator).
-            // That's exactly what MemoryHook needs to scope retrieval per
-            // conversation rather than across every anonymous tab — see PR
-            // #157 Phase A (storage layer) for the leak this closes.
-            //
-            // After this Phase B change ships AND Memory:EnrichOnRetrieve=true
-            // is flipped in config, MemoryHook will scope reads/writes to
-            // (sessionId=connectionId) instead of skipping retrieval entirely.
-            var response = await chatService.ChatAsync(
-                new ChatRequest(trimmedMessage, SessionId: connectionId),
+            // Cross the chat intake seam (#1): it owns validation + gating + dispatch.
+            // SessionId = Context.ConnectionId — SignalR's server-issued ConnectionId is a
+            // 128-bit cryptographically-random per-tab handle (default
+            // IConnectionIdGenerator), exactly what MemoryHook needs to scope retrieval per
+            // conversation rather than across every anonymous tab (PR #157 Phase A). The
+            // seam takes it as an opaque id. Rate-limit + length cap stay here above
+            // (SignalR-specific: the HTTP limiter only fires on the WS upgrade).
+            var result = await chatIntake.IntakeAsync(
+                new ChatIntakeRequest(trimmedMessage, connectionId),
                 cancellationToken);
+
+            if (result.IsFailure)
+            {
+                var errorMessage = result.GetErrorOrThrow() switch
+                {
+                    ChatIntakeError.Busy => "Service is busy. Please try again in a few seconds.",
+                    ChatIntakeError.Validation v => v.Reason,
+                    _ => "Failed to process message. Please try again."
+                };
+                await Clients.Caller.SendAsync("Error", errorMessage, cancellationToken);
+                return;
+            }
+
+            var response = result.GetValueOrThrow();
 
             // Emit routing metadata to client. Grounding is included when the
             // intent that handled the request was deterministic-compute-backed
@@ -183,10 +186,6 @@ public sealed class ChatbotHub(
         {
             logger.LogError(ex, "Error processing message from {ConnectionId}", connectionId);
             await Clients.Caller.SendAsync("Error", "Failed to process message. Please try again.");
-        }
-        finally
-        {
-            concurrencyGate.Release();
         }
     }
 

--- a/Apps/ga-server/GaApi/Program.cs
+++ b/Apps/ga-server/GaApi/Program.cs
@@ -65,8 +65,8 @@ builder.Services.AddSingleton<IHealthCheckService, HealthCheckService>();
 builder.Services.AddSingleton<ContextualChordService>();
 builder.Services.AddSingleton<VoicingFilterService>();
 
-// Shared LLM concurrency gate (3 parallel calls) — applied to both hub and REST controller
-builder.Services.AddSingleton<ILlmConcurrencyGate, LlmConcurrencyGate>();
+// ILlmConcurrencyGate is registered by AddChatbotOrchestration() (it moved into the
+// orchestration layer with the chat intake seam, campaign slice #1).
 
 // Add session context provider (scoped = one per HTTP request)
 builder.Services.AddSessionContextScoped();

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,6 +29,19 @@ at layer 4, orchestration at 5; never in lower layers.
   suffix, never in the ranking.
 - **Chatbot routing** — **embedding-first** (15s query-embed timeout); don't tune
   skill keyword gates to fix routing.
+- **Chat intake seam** — the single host-neutral entry (`IChatIntake`, layer 5
+  `GA.Business.Core.Orchestration`) every GaApi chat transport crosses. Owns
+  *validate → concurrency-gate → history-normalize → orchestrate* on an **opaque
+  session id** and returns a typed result (`Ok | Rejected | Busy`). What it does
+  **not** own is the giveaway: session-id *resolution* (HTTP signed cookie, or
+  SignalR `ConnectionId`), history *storage*, and response *framing* stay in the
+  per-transport **thin adapter** — the seam never touches `HttpContext` nor emits
+  an SSE byte. The plumbing it dedupes (validate, gate) was genuinely copy-pasted;
+  **session handling was divergent, not duplicated** (cookie vs ConnectionId vs
+  none), so the seam normalizes it to the opaque-id *contract* rather than unifying
+  the mechanics. Canonical host is **GaApi**; `GaChatbot.Api` and `GA.AI.Service`
+  are retired (`docs/adr/0005-gaapi-single-canonical-chat-host.md`). Supersedes
+  GaApi's thin `IChatApplicationService`/`HarmonicChatApplicationService` wrapper.
 - **dev-data middleware** — the `/dev-data/*` Vite endpoints powering the dashboard
   (`demos.guitaralchemist.com/test#dev/...`); dev-server-only (stripped by `vite build`).
 - **Prime Radiant** — the 3D governance/assumption-graph visualization.

--- a/Common/GA.Business.Core.Orchestration/Abstractions/IChatIntake.cs
+++ b/Common/GA.Business.Core.Orchestration/Abstractions/IChatIntake.cs
@@ -1,0 +1,55 @@
+namespace GA.Business.Core.Orchestration.Abstractions;
+
+using GA.Business.Core.Orchestration.Models;
+using GA.Core.Functional;
+
+/// <summary>
+/// The chat intake seam (campaign slice #1). The single host-neutral entry every
+/// GaApi chat transport crosses: it concentrates <c>validate → concurrency-gate →
+/// orchestrate</c> on an <b>opaque</b> session id and hands back a typed outcome the
+/// transport frames. It never touches <c>HttpContext</c> and never emits an SSE byte —
+/// session-id <i>resolution</i> (HTTP cookie / SignalR ConnectionId) and response
+/// framing stay in the per-transport thin adapter.
+/// </summary>
+/// <remarks>
+/// Supersedes the thin <see cref="IChatApplicationService"/> wrapper as the surface
+/// adapters depend on; the wrapper is removed once all three GaApi transports route
+/// through this seam (PR D). See <c>docs/adr/0005-gaapi-single-canonical-chat-host.md</c>
+/// and the <c>#1</c> section of <c>docs/plans/2026-06-21-arch-deepening-campaign-plan.md</c>.
+/// Streaming (<c>IntakeStreamingAsync</c>) lands with the AG-UI migration (PR C) — added
+/// only when a streaming transport routes through the seam, not speculatively.
+/// </remarks>
+public interface IChatIntake
+{
+    /// <summary>
+    /// Validate, gate, and dispatch a non-streaming chat request. The success value is
+    /// the orchestrator's <see cref="ChatResponse"/>; the failure value distinguishes a
+    /// rejected request from a busy gate so the adapter can frame each correctly.
+    /// </summary>
+    Task<Result<ChatResponse, ChatIntakeError>> IntakeAsync(
+        ChatIntakeRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Transport-neutral chat request handed to <see cref="IChatIntake"/>. <paramref name="SessionId"/>
+/// is opaque: the adapter resolves it (HTTP cookie / SignalR ConnectionId) and the seam
+/// only forwards it.
+/// </summary>
+public sealed record ChatIntakeRequest(string Message, string? SessionId = null);
+
+/// <summary>
+/// Closed outcome of a rejected intake. The adapter maps each case to its wire shape
+/// (e.g. <see cref="Validation"/> → HTTP 400 / SSE error frame; <see cref="Busy"/> →
+/// HTTP 503 / <c>RUN_ERROR</c> / SignalR <c>Error</c>).
+/// </summary>
+public abstract record ChatIntakeError
+{
+    private ChatIntakeError() { }
+
+    /// <summary>The request was malformed (e.g. empty message).</summary>
+    public sealed record Validation(string Reason) : ChatIntakeError;
+
+    /// <summary>The concurrency gate was full; the caller should retry shortly.</summary>
+    public sealed record Busy : ChatIntakeError;
+}

--- a/Common/GA.Business.Core.Orchestration/Abstractions/ILlmConcurrencyGate.cs
+++ b/Common/GA.Business.Core.Orchestration/Abstractions/ILlmConcurrencyGate.cs
@@ -1,0 +1,20 @@
+namespace GA.Business.Core.Orchestration.Abstractions;
+
+/// <summary>
+/// Shared concurrency gate for LLM calls. One process-wide owner so every chat
+/// transport (REST, SignalR, AG-UI) draws from the same pool and no single
+/// surface can independently saturate the model backend.
+/// </summary>
+/// <remarks>
+/// Moved out of GaApi into the host-neutral orchestration layer as part of the
+/// chat intake seam (campaign slice #1): the seam owns gating, so the gate has to
+/// live where the seam lives. Transports that have not yet migrated to
+/// <see cref="IChatIntake"/> still acquire this same singleton directly.
+/// </remarks>
+public interface ILlmConcurrencyGate
+{
+    /// <summary>Attempt to enter the gate. Returns false immediately if all slots are taken.</summary>
+    ValueTask<bool> TryEnterAsync(CancellationToken cancellationToken = default);
+
+    void Release();
+}

--- a/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
+++ b/Common/GA.Business.Core.Orchestration/Extensions/ChatbotOrchestrationExtensions.cs
@@ -223,6 +223,19 @@ public static class ChatbotOrchestrationExtensions
             return new ReadinessGatedChatApplicationService(fallback, probe, capture);
         });
 
+        // Shared LLM concurrency gate — one process-wide owner so every chat
+        // transport (REST, SignalR, AG-UI) draws from the same 3-slot pool and no
+        // single surface can saturate the model backend. Moved out of GaApi's
+        // Program.cs into the seam's layer (campaign slice #1) because the chat
+        // intake seam owns gating.
+        services.AddSingleton<ILlmConcurrencyGate, LlmConcurrencyGate>();
+
+        // Chat intake seam (#1) — the single host-neutral entry that concentrates
+        // validate → gate → orchestrate. Scoped because it composes the Scoped
+        // IChatApplicationService decorator stack. Transports adapt to it
+        // (ChatbotController first; hub + AG-UI follow), framing the typed result.
+        services.AddScoped<IChatIntake, ChatIntake>();
+
         return services;
     }
 }

--- a/Common/GA.Business.Core.Orchestration/Services/ChatIntake.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/ChatIntake.cs
@@ -1,0 +1,54 @@
+namespace GA.Business.Core.Orchestration.Services;
+
+using GA.Business.Core.Orchestration.Abstractions;
+using GA.Business.Core.Orchestration.Models;
+using GA.Core.Functional;
+
+/// <summary>
+/// Default <see cref="IChatIntake"/>: validate → acquire the shared
+/// <see cref="ILlmConcurrencyGate"/> → dispatch through the canonical
+/// <see cref="IChatApplicationService"/> (the existing decorator stack:
+/// readiness → fallback → trace → orchestrator) → release. Returns a typed
+/// <see cref="ChatIntakeError"/> on rejection so the transport adapter frames the
+/// outcome; this type never produces an HTTP status or SSE byte.
+/// </summary>
+/// <remarks>
+/// Behavior-preserving for the first transport (<c>POST /api/chatbot/chat</c>): the
+/// only inputs forwarded to the orchestrator are <c>Message</c> + <c>SessionId</c>,
+/// matching the controller before the seam existed. Length-cap unification (the
+/// divergent 2000/4000/none across transports) is a deliberate policy change deferred
+/// until all three transports route through the seam — see the <c>#1</c> plan section.
+/// </remarks>
+public sealed class ChatIntake(
+    IChatApplicationService chatService,
+    ILlmConcurrencyGate concurrencyGate) : IChatIntake
+{
+    public async Task<Result<ChatResponse, ChatIntakeError>> IntakeAsync(
+        ChatIntakeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var message = request.Message?.Trim();
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return Result<ChatResponse, ChatIntakeError>.Failure(
+                new ChatIntakeError.Validation("Message cannot be empty."));
+        }
+
+        if (!await concurrencyGate.TryEnterAsync(cancellationToken))
+        {
+            return Result<ChatResponse, ChatIntakeError>.Failure(new ChatIntakeError.Busy());
+        }
+
+        try
+        {
+            var response = await chatService.ChatAsync(
+                new ChatRequest(message, SessionId: request.SessionId),
+                cancellationToken);
+            return Result<ChatResponse, ChatIntakeError>.Success(response);
+        }
+        finally
+        {
+            concurrencyGate.Release();
+        }
+    }
+}

--- a/Common/GA.Business.Core.Orchestration/Services/LlmConcurrencyGate.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/LlmConcurrencyGate.cs
@@ -1,16 +1,6 @@
-namespace GaApi.Services;
+namespace GA.Business.Core.Orchestration.Services;
 
-/// <summary>
-/// Shared concurrency gate for LLM calls. Applied to both the SignalR hub and the REST controller
-/// so that they draw from the same pool and cannot independently saturate Ollama.
-/// </summary>
-public interface ILlmConcurrencyGate
-{
-    /// <summary>Attempt to enter the gate. Returns false immediately if all slots are taken.</summary>
-    ValueTask<bool> TryEnterAsync(CancellationToken cancellationToken = default);
-
-    void Release();
-}
+using GA.Business.Core.Orchestration.Abstractions;
 
 /// <summary>SemaphoreSlim-backed implementation (3 concurrent LLM calls).</summary>
 public sealed class LlmConcurrencyGate : ILlmConcurrencyGate, IDisposable

--- a/Tests/Common/GA.Business.Core.Tests/Orchestration/ChatIntakeTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Orchestration/ChatIntakeTests.cs
@@ -1,0 +1,111 @@
+namespace GA.Business.Core.Tests.Orchestration;
+
+using GA.Business.Core.Orchestration.Abstractions;
+using GA.Business.Core.Orchestration.Models;
+using GA.Business.Core.Orchestration.Services;
+using Moq;
+
+/// <summary>
+/// Unit tests for <see cref="ChatIntake"/> — the chat intake seam (campaign slice #1).
+/// Locks the seam's contract: empty input rejects before the gate, a full gate yields
+/// <see cref="ChatIntakeError.Busy"/> without dispatching, the happy path forwards the
+/// trimmed message + opaque session id, and the gate is always released.
+/// </summary>
+[TestFixture]
+public class ChatIntakeTests
+{
+    private static ChatResponse SampleResponse() =>
+        new(NaturalLanguageAnswer: "ok",
+            Candidates: [],
+            Routing: new AgentRoutingMetadata("theory", 0.9f, "semantic"));
+
+    private static (ChatIntake intake, Mock<IChatApplicationService> service, Mock<ILlmConcurrencyGate> gate)
+        MakeIntake(bool gateOpen = true, ChatResponse? response = null)
+    {
+        var service = new Mock<IChatApplicationService>();
+        service.Setup(s => s.ChatAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response ?? SampleResponse());
+
+        var gate = new Mock<ILlmConcurrencyGate>();
+        gate.Setup(g => g.TryEnterAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gateOpen);
+
+        return (new ChatIntake(service.Object, gate.Object), service, gate);
+    }
+
+    [Test]
+    public async Task IntakeAsync_EmptyMessage_RejectsBeforeGate()
+    {
+        var (intake, service, gate) = MakeIntake();
+
+        var result = await intake.IntakeAsync(new ChatIntakeRequest("", "sess-1"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsFailure, Is.True);
+            Assert.That(result.GetErrorOrThrow(), Is.InstanceOf<ChatIntakeError.Validation>());
+        });
+        gate.Verify(g => g.TryEnterAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "validation must short-circuit before the gate is touched");
+        service.Verify(s => s.ChatAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task IntakeAsync_WhitespaceMessage_Rejects()
+    {
+        var (intake, _, _) = MakeIntake();
+
+        var result = await intake.IntakeAsync(new ChatIntakeRequest("   ", "sess-1"));
+
+        Assert.That(result.IsFailure, Is.True);
+        Assert.That(result.GetErrorOrThrow(), Is.InstanceOf<ChatIntakeError.Validation>());
+    }
+
+    [Test]
+    public async Task IntakeAsync_GateFull_ReturnsBusy_WithoutDispatching()
+    {
+        var (intake, service, gate) = MakeIntake(gateOpen: false);
+
+        var result = await intake.IntakeAsync(new ChatIntakeRequest("hi", "sess-1"));
+
+        Assert.That(result.IsFailure, Is.True);
+        Assert.That(result.GetErrorOrThrow(), Is.InstanceOf<ChatIntakeError.Busy>());
+        service.Verify(s => s.ChatAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        gate.Verify(g => g.Release(), Times.Never, "a gate that was never entered must not be released");
+    }
+
+    [Test]
+    public async Task IntakeAsync_HappyPath_ForwardsTrimmedMessageAndSessionId_AndReleasesGate()
+    {
+        var (intake, service, gate) = MakeIntake();
+        ChatRequest? dispatched = null;
+        service.Setup(s => s.ChatAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ChatRequest, CancellationToken>((req, _) => dispatched = req)
+            .ReturnsAsync(SampleResponse());
+
+        var result = await intake.IntakeAsync(new ChatIntakeRequest("  what is a tritone?  ", "sess-42"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.GetValueOrThrow().NaturalLanguageAnswer, Is.EqualTo("ok"));
+            Assert.That(dispatched, Is.Not.Null);
+            Assert.That(dispatched!.Message, Is.EqualTo("what is a tritone?"), "message must be trimmed");
+            Assert.That(dispatched.SessionId, Is.EqualTo("sess-42"), "opaque session id must be forwarded");
+        });
+        gate.Verify(g => g.Release(), Times.Once);
+    }
+
+    [Test]
+    public void IntakeAsync_DispatchThrows_StillReleasesGate()
+    {
+        var (intake, service, gate) = MakeIntake();
+        service.Setup(s => s.ChatAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            () => intake.IntakeAsync(new ChatIntakeRequest("hi", "sess-1")));
+
+        gate.Verify(g => g.Release(), Times.Once, "gate must be released even when dispatch throws");
+    }
+}


### PR DESCRIPTION
## Impact

Second GaApi transport onto the **chat intake seam** (campaign slice **#1**). The SignalR `ChatbotHub` — the **de-facto canonical** transport for the deployed public `/chatbot/` demo — now crosses `IChatIntake` for validation + gating + dispatch instead of managing the gate and calling `IChatApplicationService` itself.

> **Stacked on [#469](https://github.com/GuitarAlchemist/ga/pull/469) (PR A)** — base is `feat/chat-intake-seam`, which carries `IChatIntake`. Retarget to `main` once #469 merges.

## Changes (`ChatbotHub` only)

- `SendMessage` calls `chatIntake.IntakeAsync(message, ConnectionId)` and frames the typed result: `Busy`/`Validation` → `"Error"` event, `Ok` → `MessageRoutingMetadata` + `ReceiveMessageChunk` + `MessageComplete` (unchanged).
- **Dropped** ctor deps `IChatApplicationService` + `ILlmConcurrencyGate` (the seam owns both); removed the gate acquire/release + `finally`. **Added** `IChatIntake`.
- **Kept adapter-side, unchanged** (all SignalR-specific): per-connection token-bucket rate limit, 4000-char cap, `ConnectionId`-as-`SessionId`, the static per-connection history dict + `NormalizeHistory` + 50-msg cap, and the 25s pipeline budget (now wrapping the seam call).

## Behavior-preserving

Same dispatch (`Message` + `SessionId = ConnectionId`), same event wire shape, same error strings, same history behavior.

`ChatbotSessionOrchestrator` is **left in place** (still used for `NormalizeHistory`) — its relocation/removal is deliberately deferred to avoid conflicting with the unmerged **#468** (#8b). It becomes a clean cleanup once #468 lands.

## Verify / test gap

- GaApi build green (**0 errors**).
- The dispatch path is covered by `ChatIntakeTests` (PR A); the framing is byte-preserved from the prior hub.
- **No SignalR hub integration test exists in the suite** — the hub change is verified by build + review. Adding a hub test client is tracked as a follow-up (worth doing given the hub is the deployed canonical).

## Sequence

After this: **PR C** AG-UI → seam (+ `IntakeStreamingAsync`), **PR D** `/chat/stream` → seam then delete the `IChatApplicationService` wrapper. Then #4/#8a decorate the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)