### PR TITLE
refactor(chat): route /chat/stream through the seam + drop wrapper deps (slice #1, PR D)

### DIFF
--- a/Apps/ga-server/GaApi/Controllers/ChatbotController.cs
+++ b/Apps/ga-server/GaApi/Controllers/ChatbotController.cs
@@ -26,11 +26,9 @@ using Services;
 // @ai:business-value SSE chatbot ingress — the demo flow every visitor sees on guitaralchemist.com; outage here = product invisible [T:manually-reviewed conf:0.95 src:product-owner@2026-05-24]
 public class ChatbotController(
     ILogger<ChatbotController> logger,
-    IChatApplicationService chatService,
     IChatIntake chatIntake,
     IAgenticTraceCapture traceCapture,
-    IChatService statusService,
-    ILlmConcurrencyGate concurrencyGate)
+    IChatService statusService)
     : ControllerBase
 {
     private static readonly JsonSerializerOptions _jsonOptions =
@@ -93,17 +91,28 @@ public class ChatbotController(
         // the orchestrator finishes generating a response.
         await Response.StartAsync(cancellationToken);
 
-        if (!await concurrencyGate.TryEnterAsync(cancellationToken))
-        {
-            await WriteSseErrorAsync("Service is busy. Please try again in a few seconds.", cancellationToken);
-            return;
-        }
-
         try
         {
-            var response = await chatService.ChatAsync(
-                new GA.Business.Core.Orchestration.Models.ChatRequest(message, SessionId: sessionId),
+            // Cross the chat intake seam (#1): validation + gating + dispatch live
+            // there. Busy/Validation become SSE error frames (the wire never returns
+            // 503 after StartAsync); Ok streams the routing frame + chunks + [DONE].
+            var result = await chatIntake.IntakeAsync(
+                new ChatIntakeRequest(message, sessionId),
                 cancellationToken);
+
+            if (result.IsFailure)
+            {
+                var errorMessage = result.GetErrorOrThrow() switch
+                {
+                    ChatIntakeError.Busy => "Service is busy. Please try again in a few seconds.",
+                    ChatIntakeError.Validation v => v.Reason,
+                    _ => "Failed to process message. Please try again."
+                };
+                await WriteSseErrorAsync(errorMessage, cancellationToken);
+                return;
+            }
+
+            var response = result.GetValueOrThrow();
 
             // 1. Emit routing metadata event (first, before text). Trace and
             // grounding are included on this frame to match the JSON wire's
@@ -140,10 +149,6 @@ public class ChatbotController(
             // Headers already committed — cannot change status code.
             // Signal the error via an SSE error event so the client can react.
             await WriteSseErrorAsync("Failed to process message. Please try again.", cancellationToken);
-        }
-        finally
-        {
-            concurrencyGate.Release();
         }
     }
 


### PR DESCRIPTION
## Impact

Fourth and final **non-streaming-dispatch** transport onto the **chat intake seam** (campaign slice **#1**). `ChatbotController.ChatStream` now crosses `IChatIntake`; with both `/chat` and `/chat/stream` on the seam, the controller sheds its direct orchestration deps.

> **Stacked: PR D → [#471](https://github.com/GuitarAlchemist/ga/pull/471) (C) → [#470](https://github.com/GuitarAlchemist/ga/pull/470) (B) → [#469](https://github.com/GuitarAlchemist/ga/pull/469) (A).** Retarget down as parents merge.

## Changes (`ChatbotController` only)

- `ChatStream` crosses `IChatIntake.IntakeAsync` and frames the typed result as SSE: `Busy`/`Validation` → SSE error frame (the wire never returns 503 after `StartAsync`), `Ok` → routing frame + sentence chunks + `[DONE]`. Same wire, same dispatch (`message` + `sessionId`), same error strings.
- **Dropped `IChatApplicationService` + `ILlmConcurrencyGate` from the ctor** — neither endpoint uses them now. Controller injects only `logger` + `IChatIntake` + `IAgenticTraceCapture` + `IChatService` (status probe). This is the wrapper-dependency cleanup the plan named PR D.

## Why `/chat/stream` doesn't need a streaming-seam method

It does **non-streaming dispatch + client-side chunking** (`SseChunker`) — it gets the full answer then splits it. So `IntakeAsync` is the right fit. The **only** true token-streaming transport left is `AgUiStream`, which gets its own dedicated `IntakeStreamingAsync` PR.

## Verify

- GaApi build green (**0 errors**).
- `ChatbotControllerTests` → **16** green (incl. `/chat/stream` empty / whitespace / event-stream contract).

## Slice #1 after this lands

All **four** non-streaming-dispatch transports (`/chat`, SignalR hub, AG-UI JSON, `/chat/stream`) route through `IChatIntake`. Remaining: **`AgUiStream`** (the streaming-seam method) + the optional `ChatbotSessionOrchestrator`/`NormalizeHistory` relocation (now unblocked since #468 merged). Then #4 (readiness/fallback) and #8a (CRLF SSE) decorate the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)