### PR TITLE
fix(docs): unblock docs-health link gate — repoint deleted GA.AI.Service link to ADR-0005

### DIFF
--- a/docs/architecture/chat-surfaces.md
+++ b/docs/architecture/chat-surfaces.md
@@ -237,7 +237,7 @@ The deployed `https://demos.guitaralchemist.com/chatbot/` static SPA calls `/hub
 | **`IChatService` (GaApi-local)** | ✅ used by `ChatbotSessionOrchestrator.NormalizeHistory` and `ChatbotController.GetStatus` only. Provider chosen via `AI:ChatProvider`. | 🟡 `ChatbotSessionOrchestrator.GetResponseAsync` / `StreamResponseAsync` exist but are not called from any controller or hub today. |
 | **Specialized agent invocation** | ✅ via `SemanticRouter.RouteAsync` (called by `ProductionOrchestrator`). | 🟡 `SemanticRouter.AggregateAsync` and `DebateAsync` exist but are not currently exposed through any HTTP/SignalR surface. |
 | **Voicing-grounded retrieval inside chat** | ✅ `SpectralRagOrchestrator` reached via `TabAwareOrchestrator`. | 🟡 `VoicingAgent` performs an independent OPTIC-K retrieval path through `EnhancedVoicingSearchService` whenever the router selects it — produces a structured-list response rather than a narrated one. Two independent retrieval surfaces over the same corpus. |
-| **GA.AI.Service / `POST /api/Chat`** | _N/A_ | 🪦 **frozen 2026-05-07** — see [`Apps/ga-server/GA.AI.Service/DEPRECATED.md`](../../Apps/ga-server/GA.AI.Service/DEPRECATED.md). Read-only until a concrete deploy reason emerges or the next architecture review decides to delete. |
+| **GA.AI.Service / `POST /api/Chat`** | _N/A_ | 🪦 **deleted** (campaign slice #6, #467) — GaApi is the single canonical chat host; see [ADR-0005](../adr/0005-gaapi-single-canonical-chat-host.md). |
 | **`POST /api/chatbot/ask`** | _N/A_ | 🪦 dangling frontend call (TriageDropZone) with no server implementation. |
 
 ---


### PR DESCRIPTION
## What & why
The `docs-health` link gate (`Scripts/audit-doc-links.py --ci`) was failing on **every** PR (#475, #476, and any new one), blocking clean green. Root cause: `docs/architecture/chat-surfaces.md` linked to `Apps/ga-server/GA.AI.Service/DEPRECATED.md`, deleted with the service in campaign slice #6 (#467).

This was the **only live-doc broken link** — the gate fails only on non-frozen docs; the other 79 broken links are all in `docs/archive|plans|reports|solutions|...` (frozen, ignored by the gate).

## Fix
Repoint the link to **ADR-0005** (records GaApi as the single canonical chat host); correct status `frozen -> deleted`.

## Verification
`python Scripts/audit-doc-links.py HEAD --ci` -> **OK: no broken links in live docs** (exit 0).

Unblocks `docs-health` on #475 and #476 once this merges and they update-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)