### PR TITLE
chore(quality): un-dark embeddings diagnostic + self-heal wiring

### DIFF
--- a/.claude/skills/optic-k-rebuild/SKILL.md
+++ b/.claude/skills/optic-k-rebuild/SKILL.md
@@ -121,6 +121,27 @@ Key numbers to watch (post v4-pp, pre-enrichment baseline was):
 - CONTEXT/SYMBOLIC/MODAL leak acc: 0.522 / 0.614 / 0.498 (target: drop).
 - Retrieval PC-set match: **92.8%** (target: hold or improve).
 
+### 1b. Refresh the dashboard embeddings tile (canonical snapshot)
+
+Step 1 writes a raw report to `state/baseline/<date>/` for the known-good table
+above — but the **dashboard / ix-quality-trend** read a *different* path:
+`state/quality/embeddings/<UTC-date>.json`. The daily `embeddings-snapshot.yml`
+cron can only ever write an amber "index absent on runner" carryforward there
+(the 175 MB index is gitignored, never on hosted CI). So after every local
+rebuild, emit the **real** canonical snapshot so the tile goes green instead of
+stale-amber:
+
+```bash
+pwsh "C:/Users/spare/source/repos/ga/Scripts/refresh-embeddings-snapshot.ps1"
+git add "state/quality/embeddings/$(date -u +%Y-%m-%d).json"
+git commit -m "chore(quality): real embeddings snapshot $(date -u +%Y-%m-%d)"
+```
+
+The cron's degraded path guards on the existing file's `degraded` flag, so it
+will **not** overwrite this real measurement. (Without this step the embeddings
+tile silently re-rots to amber the day after any rebuild — the gap that left it
+dark from 2026-05-16 to 2026-06-25.)
+
 ### 2. Invariant coverage
 
 ```bash

--- a/.github/workflows/embeddings-snapshot.yml
+++ b/.github/workflows/embeddings-snapshot.yml
@@ -142,6 +142,25 @@ jobs:
           $dst   = "$dir/$date.json"
           New-Item -ItemType Directory -Path $dir -Force | Out-Null
 
+          # Never downgrade a REAL measurement to amber. A real snapshot for
+          # today only lands when an operator ran ix-embedding-diagnostics
+          # locally against the on-disk index (Scripts/refresh-embeddings-snapshot.ps1,
+          # wired into the optic-k-rebuild skill). If such a snapshot already
+          # exists for $date and is not degraded, preserve it and exit without
+          # writing/committing — otherwise this cron would clobber the only real
+          # data point the dashboard ever gets.
+          if (Test-Path $dst) {
+            try {
+              $existing = Get-Content -Raw -Path $dst -Encoding UTF8 | ConvertFrom-Json
+              if ($existing.degraded -ne $true) {
+                Write-Host "Real (non-degraded) snapshot already exists at $dst — preserving it, not downgrading to amber."
+                exit 0
+              }
+            } catch {
+              Write-Host "::warning::Could not parse existing $dst; proceeding to overwrite with degraded envelope."
+            }
+          }
+
           # Find last-known-good full_classifier_accuracy. Search the most
           # recent 30 dated snapshots for one with degraded != true and a
           # numeric leak_detection.full_classifier_accuracy. Fall back to

--- a/Scripts/refresh-embeddings-snapshot.ps1
+++ b/Scripts/refresh-embeddings-snapshot.ps1
@@ -1,0 +1,64 @@
+#!/usr/bin/env pwsh
+# Refresh the embeddings quality snapshot from a LOCAL OPTIC-K index.
+#
+# WHY THIS EXISTS
+# ---------------
+# The daily .github/workflows/embeddings-snapshot.yml can only ever emit an
+# amber "OPTIC-K index absent on runner" carryforward: state/voicings/optick.index
+# is a ~175 MB gitignored binary that hosted CI runners never have. The ONLY way
+# to produce a REAL leak_detection measurement is to run ix-embedding-diagnostics
+# against the index on a host that actually has it (this dev machine).
+#
+# Run this after an OPTIC-K rebuild (see .claude/skills/optic-k-rebuild) — or any
+# time the dashboard embeddings tile is stuck stale-amber — to drop a real,
+# non-degraded snapshot at state/quality/embeddings/<UTC-date>.json. The cron
+# workflow's degraded path will NOT overwrite a real snapshot for the same day
+# (it guards on the existing file's `degraded` flag), so this measurement sticks.
+#
+# Idempotent: re-running on the same UTC day overwrites that day's snapshot.
+[CmdletBinding()]
+param(
+  [string]$Index         = "state/voicings/optick.index",
+  [string]$IxRepo        = "../ix",
+  [int]   $ClusterSample = 5000
+)
+$ErrorActionPreference = 'Stop'
+
+# Resolve to the ga repo root (this script lives in ga/scripts/).
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+if (-not (Test-Path $Index)) { throw "OPTIC-K index not found at $Index (cwd=$repoRoot)." }
+$bytes  = (Get-Item $Index).Length
+$sizeMb = [math]::Round($bytes / 1MB, 1)
+if ($bytes -le 100MB) {
+  throw "Index at $Index is only $sizeMb MB (<100 MB) — looks like a stub/LFS pointer, not a real index."
+}
+
+$bin = Join-Path $IxRepo "target/release/baseline-diagnostics.exe"
+if (-not (Test-Path $bin)) {
+  Write-Host "baseline-diagnostics not built — building (release)..."
+  & cargo build --release --manifest-path (Join-Path $IxRepo "Cargo.toml") `
+      -p ix-embedding-diagnostics --bin baseline-diagnostics
+  if ($LASTEXITCODE -ne 0) { throw "cargo build of baseline-diagnostics failed ($LASTEXITCODE)." }
+}
+
+$tmp = Join-Path $env:TEMP "ga-embeddings-refresh"
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+& $bin --index $Index --out-dir $tmp --cluster-sample $ClusterSample
+if ($LASTEXITCODE -ne 0) { throw "baseline-diagnostics exited $LASTEXITCODE." }
+
+$date = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+$src  = Join-Path $tmp "embedding-diagnostics-$date.json"
+if (-not (Test-Path $src)) { throw "Producer did not write $src — check the run output above." }
+
+$dstDir = "state/quality/embeddings"
+New-Item -ItemType Directory -Path $dstDir -Force | Out-Null
+$dst = Join-Path $dstDir "$date.json"
+Move-Item -Force $src $dst
+
+$acc = (Get-Content -Raw $dst -Encoding UTF8 | ConvertFrom-Json).leak_detection.full_classifier_accuracy
+Write-Host ""
+Write-Host "Wrote REAL embeddings snapshot -> $dst"
+Write-Host "  full_classifier_accuracy = $acc   (index $sizeMb MB, 313k voicings)"
+Write-Host "  commit it: git add $dst && git commit -m 'chore(quality): real embeddings snapshot $date'"

--- a/state/quality/embeddings/2026-06-25.json
+++ b/state/quality/embeddings/2026-06-25.json
@@ -1,0 +1,227 @@
+{
+  "timestamp": "2026-06-25T03:22:29.348368300+00:00",
+  "tool": "ix-embedding-diagnostics 0.1.0",
+  "seed": 42,
+  "corpus": {
+    "file": "state/voicings/optick.index",
+    "count": 313047,
+    "dims": 124,
+    "instruments": {
+      "bass": 7795,
+      "guitar": 297910,
+      "ukulele": 7342
+    }
+  },
+  "leak_detection": {
+    "sample_size": 12000,
+    "per_class": {
+      "bass": 4000,
+      "guitar": 4000,
+      "ukulele": 4000
+    },
+    "n_folds": 5,
+    "classifier": "RandomForest(n_trees=30, max_depth=10)",
+    "full_classifier_accuracy": 0.8310833333333333,
+    "baseline_random": 0.3333333333333333,
+    "by_partition": [
+      {
+        "partition": "STRUCTURE",
+        "start": 0,
+        "end": 24,
+        "dims": 24,
+        "accuracy_mean": 0.502,
+        "accuracy_std": 0.011047247017545418,
+        "per_fold": [
+          0.49333333333333335,
+          0.5025,
+          0.5145833333333333,
+          0.5133333333333333,
+          0.48625
+        ],
+        "leak_hypothesis": "likely_leak",
+        "leak_confirmed": true
+      },
+      {
+        "partition": "MORPHOLOGY",
+        "start": 24,
+        "end": 48,
+        "dims": 24,
+        "accuracy_mean": 0.9031666666666667,
+        "accuracy_std": 0.004920196473041838,
+        "per_fold": [
+          0.9058333333333334,
+          0.9020833333333333,
+          0.9083333333333333,
+          0.9054166666666666,
+          0.8941666666666667
+        ],
+        "leak_hypothesis": "by_design",
+        "leak_confirmed": false
+      },
+      {
+        "partition": "CONTEXT",
+        "start": 48,
+        "end": 60,
+        "dims": 12,
+        "accuracy_mean": 0.3333333333333333,
+        "accuracy_std": 0.0,
+        "per_fold": [
+          0.3333333333333333,
+          0.3333333333333333,
+          0.3333333333333333,
+          0.3333333333333333,
+          0.3333333333333333
+        ],
+        "leak_hypothesis": "possible",
+        "leak_confirmed": false
+      },
+      {
+        "partition": "SYMBOLIC",
+        "start": 60,
+        "end": 72,
+        "dims": 12,
+        "accuracy_mean": 0.5374166666666668,
+        "accuracy_std": 0.008938058451861271,
+        "per_fold": [
+          0.5379166666666667,
+          0.54875,
+          0.5395833333333333,
+          0.5395833333333333,
+          0.52125
+        ],
+        "leak_hypothesis": "likely_leak",
+        "leak_confirmed": true
+      },
+      {
+        "partition": "MODAL",
+        "start": 72,
+        "end": 112,
+        "dims": 40,
+        "accuracy_mean": 0.487,
+        "accuracy_std": 0.005859465277082317,
+        "per_fold": [
+          0.4979166666666667,
+          0.48625,
+          0.48625,
+          0.4841666666666667,
+          0.48041666666666666
+        ],
+        "leak_hypothesis": "possible",
+        "leak_confirmed": true
+      },
+      {
+        "partition": "ROOT",
+        "start": 112,
+        "end": 124,
+        "dims": 12,
+        "accuracy_mean": 0.34983333333333333,
+        "accuracy_std": 0.0045384162680633475,
+        "per_fold": [
+          0.35291666666666666,
+          0.3466666666666667,
+          0.3545833333333333,
+          0.3525,
+          0.3425
+        ],
+        "leak_hypothesis": "by_design",
+        "leak_confirmed": false
+      }
+    ]
+  },
+  "retrieval_consistency": {
+    "queries_tested": 50,
+    "top_k": 10,
+    "avg_pc_set_match_pct": 1.0,
+    "per_query_match_pct": [
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.0
+    ],
+    "note": "A STRUCTURE-only query should return voicings sharing the query's pitch-class set. A low match rate indicates the STRUCTURE partition is not cleanly encoding PC-set."
+  },
+  "cluster_baseline": {
+    "k": 50,
+    "n_voicings": 5000,
+    "sampled_from": 313047,
+    "iterations_ran": 30,
+    "file": "tmp-baseline\\embedding-clusters-k50.json"
+  },
+  "topology": {
+    "guitar": {
+      "sample_size": 1000,
+      "beta_0": 642,
+      "beta_1": 193,
+      "filtration_radius": 0.3500739602285053,
+      "avg_pairwise_distance": 0.8751849005712632
+    },
+    "bass": {
+      "sample_size": 1000,
+      "beta_0": 695,
+      "beta_1": 85,
+      "filtration_radius": 0.3998380789371856,
+      "avg_pairwise_distance": 0.9995951973429639
+    },
+    "ukulele": {
+      "sample_size": 1000,
+      "beta_0": 699,
+      "beta_1": 67,
+      "filtration_radius": 0.4056615859523934,
+      "avg_pairwise_distance": 1.0141539648809834
+    },
+    "cross_instrument_match": "beta0_range=57, beta1_range=126 (larger = more instrument-specific topology)"
+  },
+  "notes": [
+    "LogisticRegression in ix-supervised is binary-only; RandomForest used instead for 3-class",
+    "ix-topo has no native Adjusted Rand Index; post-refactor comparison will add one",
+    "Rips complex is O(n²) in edges — topology sampled at 1000 points per instrument",
+    "Leak confirmed criterion: mean accuracy > 0.40 on balanced 3-class problem (baseline=0.333)"
+  ],
+  "runtime_seconds": 23.7894199
+}


### PR DESCRIPTION
## What

Un-darks the **embeddings** quality tile (amber since 2026-05-16, ~6 weeks) and wires it so it self-heals instead of silently re-rotting.

## Why it was dark — structural, not a broken pipeline

The real producer (`ix-embedding-diagnostics::baseline-diagnostics`) mmaps the **175 MB gitignored** `state/voicings/optick.index`, which hosted CI runners never have. So `embeddings-snapshot.yml`'s preflight always fails on CI and writes the amber "index absent on runner" last-known-good envelope — by design (anti-green-but-dead), but it can **never self-heal**. The metric froze at the May-16 baseline because that was the last manual local run. The frozen `0.7522` was even the stale **dim-112** number, predating the v1.8 (dim-124) schema.

## The fix (all local-host, zero stale-data risk)

The index on the dev host is current and header-verified: magic `OPTK`, schema **v4** (`v4-pp-r`), **dim 124**, **313,047** voicings — and GaApi already serves it read-only, so the producer runs alongside it.

- **`state/quality/embeddings/2026-06-25.json`** — a REAL snapshot. `full_classifier_accuracy = 0.831`, retrieval **100% PC-match**, CONTEXT 0.333 / ROOT 0.350 — matches the v1.8 known-good baseline in the rebuild skill almost exactly.
- **`Scripts/refresh-embeddings-snapshot.ps1`** — local producer that emits the canonical snapshot. Run after an OPTIC-K rebuild or any time the tile is stale-amber.
- **`embeddings-snapshot.yml`** — guard so the cron's degraded path **never downgrades an existing real snapshot to amber** (the re-rot that kept it dark). YAML validated.
- **`optic-k-rebuild` skill** — step 1b wires the refresh into every rebuild, so the tile self-heals.

## Verification

| Metric | v1.8 known-good (skill) | This snapshot |
|---|---|---|
| Voicings | 313,047 | 313,047 |
| Full-dim acc | 0.835 | **0.831** |
| STRUCTURE | 0.503 | 0.502 |
| MORPHOLOGY | 0.903 | 0.903 |
| CONTEXT | 0.333 | 0.333 |
| ROOT | 0.345 | 0.350 |
| Retrieval PC-match | 100% | 100% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
