### PR TITLE
test: add D5 positive music-context routing case (follow-up to #261)

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Unit/ChordVoicingsSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ChordVoicingsSkillTests.cs
@@ -38,6 +38,7 @@ public class ChordVoicingsSkillTests
     // Valid bare-extension chords must still route after the ga#261 regex
     // tightening (power chord, 6th, 13th — all real chord-extension digits).
     [TestCase("voicings for E5")]
+    [TestCase("voicings for D5")] // power chord in music context — mirror of the "D5 batteries" negative
     [TestCase("shapes for C6")]
     [TestCase("G13 voicings")]
     public void CanHandle_True_OnRealVoicingQueries(string message)


### PR DESCRIPTION
Tiny follow-up to the merged #484 (#261).

#484 covered the power-chord / bare-`5` routing path with a `"voicings for E5"` positive, but `D5` only appeared as the `"buy some D5 batteries"` **negative**. This adds the symmetric **positive** `"voicings for D5"` so the power-chord path is asserted for D5 directly.

- **Test-only.** No production change.
- Verified by simulation: `"voicings for D5"` → `CanHandle` true; `"buy some D5 batteries"` → false (unchanged).
- No scope expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XykDQVT7R8LYGyuLR5rX1)_