### PR TITLE
fix: align ChatbotTestBase selectors with chatbot-demo.html (#145)

### DIFF
--- a/Tests/GuitarAlchemistChatbot.Tests.Playwright/ChatbotTestBase.cs
+++ b/Tests/GuitarAlchemistChatbot.Tests.Playwright/ChatbotTestBase.cs
@@ -38,12 +38,16 @@ public class ChatbotTestBase : PageTest
     /// </summary>
     protected async Task SendMessageAsync(string message)
     {
-        // Find the input field
-        var input = Page.Locator("input.form-control[placeholder*='Ask about']");
+        // Input field. chatbot-demo.html: <input id="messageInput" class="chat-input"
+        // placeholder="Ask me about chords, scales, or techniques...">. The old
+        // `input.form-control[placeholder*='Ask about']` matched a Bootstrap UI that
+        // was never built (ga#145).
+        var input = Page.Locator("#messageInput");
         await input.FillAsync(message);
 
-        // Click the send button
-        var sendButton = Page.Locator("button.btn-primary:has(i.fa-paper-plane)");
+        // Send button: <button id="sendButton" class="send-button">Send</button>
+        // (no Bootstrap btn-primary, no FontAwesome paper-plane icon).
+        var sendButton = Page.Locator("#sendButton");
         await sendButton.ClickAsync();
     }
 
@@ -59,8 +63,11 @@ public class ChatbotTestBase : PageTest
             Timeout = DefaultTimeout
         });
 
-        // Get the last assistant message
-        var messages = await Page.Locator(".assistant-message .message-text").AllAsync();
+        // Get the last assistant message. chatbot-demo.html renders each turn as
+        // `<div class="message assistant"><div class="message-content">…</div></div>`
+        // (the typing indicator is a sibling `.message.assistant` WITHOUT a
+        // `.message-content`, so it is naturally excluded from this query).
+        var messages = await Page.Locator(".message.assistant .message-content").AllAsync();
         if (messages.Count == 0)
         {
             throw new Exception("No assistant messages found");
@@ -75,6 +82,9 @@ public class ChatbotTestBase : PageTest
     /// </summary>
     protected async Task<string?> WaitForFunctionCallAsync()
     {
+        // NOTE: chatbot-demo.html (the CI-served page) does not render a
+        // `.function-indicator`; this helper degrades to null on that page and is
+        // here for richer chatbot hosts. See ga#145.
         try
         {
             var functionIndicator = Page.Locator(".function-indicator");
@@ -92,6 +102,7 @@ public class ChatbotTestBase : PageTest
     /// </summary>
     protected async Task<string?> GetContextSummaryAsync()
     {
+        // NOTE: not rendered by chatbot-demo.html — degrades to null there (ga#145).
         try
         {
             var contextIndicator = Page.Locator(".context-indicator");
@@ -109,7 +120,10 @@ public class ChatbotTestBase : PageTest
     /// </summary>
     protected async Task ClickNewChatAsync()
     {
-        var newChatButton = Page.Locator("button:has-text('New Chat')");
+        // chatbot-demo.html exposes a "Clear" button (clearHistory()) rather than a
+        // "New Chat" button; it empties the message list, which is what callers of
+        // this helper rely on (ga#145).
+        var newChatButton = Page.Locator("button.clear-button");
         await newChatButton.ClickAsync();
 
         // Wait for messages to clear
@@ -121,7 +135,7 @@ public class ChatbotTestBase : PageTest
     /// </summary>
     protected async Task<List<string>> GetUserMessagesAsync()
     {
-        var messages = await Page.Locator(".user-message .message-text").AllAsync();
+        var messages = await Page.Locator(".message.user .message-content").AllAsync();
         var texts = new List<string>();
         foreach (var msg in messages)
         {
@@ -140,7 +154,7 @@ public class ChatbotTestBase : PageTest
     /// </summary>
     protected async Task<List<string>> GetAssistantMessagesAsync()
     {
-        var messages = await Page.Locator(".assistant-message .message-text").AllAsync();
+        var messages = await Page.Locator(".message.assistant .message-content").AllAsync();
         var texts = new List<string>();
         foreach (var msg in messages)
         {
@@ -157,6 +171,9 @@ public class ChatbotTestBase : PageTest
     /// <summary>
     ///     Check if VexTab element exists
     /// </summary>
+    // NOTE: chatbot-demo.html does not render VexTab (`.vex-tabdiv`); HasVexTabAsync
+    // returns false there and WaitForVexTabRenderAsync will time out. Both exist for
+    // richer chatbot hosts that embed notation. See ga#145.
     protected async Task<bool> HasVexTabAsync()
     {
         try

--- a/Tests/GuitarAlchemistChatbot.Tests.Playwright/ChatbotTestBase.cs
+++ b/Tests/GuitarAlchemistChatbot.Tests.Playwright/ChatbotTestBase.cs
@@ -20,6 +20,15 @@ public class ChatbotTestBase : PageTest
         ?? "http://localhost:5232/chatbot-demo.html";
     protected const int DefaultTimeout = 30000; // 30 seconds
 
+    // Count of assistant messages observed at the moment the last message was
+    // sent. WaitForResponseAsync waits for a NEW assistant message beyond this
+    // baseline, so it never returns the static welcome message or a prior reply.
+    // (Codex P2 on ga#486: on chatbot-demo.html the welcome text already matches
+    // `.message.assistant .message-content`, and the typing indicator may not be
+    // in the DOM yet when the send completes — so a hidden-wait alone can return
+    // stale text.)
+    private int _assistantBaselineCount;
+
     [SetUp]
     public async Task Setup()
     {
@@ -48,6 +57,13 @@ public class ChatbotTestBase : PageTest
         // Send button: <button id="sendButton" class="send-button">Send</button>
         // (no Bootstrap btn-primary, no FontAwesome paper-plane icon).
         var sendButton = Page.Locator("#sendButton");
+
+        // Snapshot how many assistant messages exist BEFORE sending so the
+        // response wait can require a strictly newer one (excludes the welcome
+        // message and any prior reply). The typing-indicator div has no
+        // `.message-content`, so it is not counted here.
+        _assistantBaselineCount = await Page.Locator(".message.assistant .message-content").CountAsync();
+
         await sendButton.ClickAsync();
     }
 
@@ -56,18 +72,28 @@ public class ChatbotTestBase : PageTest
     /// </summary>
     protected async Task<string> WaitForResponseAsync()
     {
-        // Wait for typing indicator to disappear
+        // chatbot-demo.html renders each turn as
+        // `<div class="message assistant"><div class="message-content">…</div></div>`
+        // (the typing indicator is a sibling `.message.assistant` WITHOUT a
+        // `.message-content`, so it is naturally excluded from this query).
+        var assistantMessages = Page.Locator(".message.assistant .message-content");
+
+        // Wait for a NEW assistant message beyond the baseline captured in
+        // SendMessageAsync (index == baseline is the first one past it). Without
+        // this, a hidden-wait on a typing indicator that isn't in the DOM yet can
+        // complete immediately and return the welcome / previous reply (Codex P2).
+        await assistantMessages.Nth(_assistantBaselineCount)
+            .WaitForAsync(new() { Timeout = DefaultTimeout });
+
+        // Then let streaming settle — the typing indicator is removed when the
+        // reply completes.
         await Page.WaitForSelectorAsync(".typing-indicator", new()
         {
             State = WaitForSelectorState.Hidden,
             Timeout = DefaultTimeout
         });
 
-        // Get the last assistant message. chatbot-demo.html renders each turn as
-        // `<div class="message assistant"><div class="message-content">…</div></div>`
-        // (the typing indicator is a sibling `.message.assistant` WITHOUT a
-        // `.message-content`, so it is naturally excluded from this query).
-        var messages = await Page.Locator(".message.assistant .message-content").AllAsync();
+        var messages = await assistantMessages.AllAsync();
         if (messages.Count == 0)
         {
             throw new Exception("No assistant messages found");


### PR DESCRIPTION
Fixes **#145** (Bug #6 — test-vs-UI selector mismatch), option **A** (update tests to match the real served page).

## Problem
`ChatbotTestBase` was written against a Bootstrap + FontAwesome chatbot UI that was never built, so its selectors never matched the served `Apps/ga-server/GaApi/wwwroot/chatbot-demo.html`.

## Fix — selectors corrected to the real DOM
| Helper | Old (imaginary UI) | New (chatbot-demo.html) |
|---|---|---|
| input | `input.form-control[placeholder*='Ask about']` | `#messageInput` |
| send | `button.btn-primary:has(i.fa-paper-plane)` | `#sendButton` |
| assistant msgs | `.assistant-message .message-text` | `.message.assistant .message-content` |
| user msgs | `.user-message .message-text` | `.message.user .message-content` |
| clear/new-chat | `button:has-text('New Chat')` | `button.clear-button` (`clearHistory()`) |

`.chat-container` (Setup) and `.typing-indicator` already matched — unchanged. Documented that `.function-indicator` / `.context-indicator` / `.vex-tabdiv` aren't rendered by this page, so those helpers degrade to null/false (kept for richer chatbot hosts).

## Verification & scope
- **Selector-strings + comments only** — compiles unchanged; all new selectors verified by inspection against the served HTML (file read line-by-line).
- ⚠️ I can't run Playwright in this environment (no .NET SDK); CI builds the project and the inspection-match is the verification.
- **Honest caveat:** CI currently runs only the `WebSocket_ShouldConnectSuccessfully` smoke test (narrowed in #226), which does **not** exercise these selectors. So this makes the catalog *honest and locally-runnable* rather than CI-gating. If the team would rather **retire** the broader catalog (per #226's direction) than fix it, say so and I'll close this in favor of that.

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XykDQVT7R8LYGyuLR5rX1)_