### PR TITLE
docs(roadmap): navigable PI roadmap + AIW workflow (#482)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,94 @@
+# Guitar Alchemist — Product Roadmap (PI)
+
+> Program-Increment roadmap for `GuitarAlchemist/ga`. Implements issue **#482**.
+> Parent org roadmap: **GuitarAlchemist/.github#5** · AIW roadmap: **GuitarAlchemist/Demerzel#473**.
+
+This file is the **navigable index over the work** — not a second backlog. Three sources feed it; this roadmap maps them into one hierarchy:
+
+| Source | What it holds | This roadmap's job |
+|---|---|---|
+| [`BACKLOG.md`](../BACKLOG.md) | Ideas waiting to become features (Guitarist Problems, Prime Radiant, Pro-Guitarist Gaps, Chatbot Track P0–P2) | Group ideas under epics |
+| [`docs/plans/`](plans/) | Active, in-flight plans | Link from the relevant story |
+| GitHub Issues | Executable, grabbable work | Map each open issue to an epic/story |
+
+So any contributor — human or AI worker — can navigate from *"where are we going"* (Epic) → *"what slice"* (Story) → *"what do I grab next"* (Issue).
+
+## Hierarchy
+
+```text
+PI  (this file — the program increment)
+  └─ Epic     major capability                 [Epic]
+       └─ Story    user-facing slice           [Story]
+            └─ Task     concrete implementation [Task]
+                 └─ Subtask  file/test/checklist[Subtask]
+```
+
+**Triage labels** (see [`docs/agents/triage-labels.md`](agents/triage-labels.md)): `ready-for-agent` (fully specified, AFK-safe) · `ready-for-human` (needs a decision/design/verification first) · `needs-info` · `wontfix`.
+
+**Verification reality (2026-06):** .NET build is policy-gated in some AI sandboxes, but the **frontend toolchain (`npm run build`/`lint`/`tsc`/`vitest`) runs locally** — so frontend-heavy stories (Epic 1–2) are the most AFK-friendly today; pure-C# stories generally need a build-capable worker.
+
+---
+
+## Epic 1 — Product architecture & app shell
+
+**Goal:** a coherent React/Vite/Jotai shell with clean feature boundaries, a documented state model, and explicit integration seams to the backend services. Healthy foundation everything else mounts on.
+
+| Story | Open issues / backlog | Status |
+|---|---|---|
+| App shell, routing & feature boundaries | `BACKLOG.md` → Prime Radiant infra | ready-for-human |
+| Governance/observability panels | [#50](https://github.com/GuitarAlchemist/ga/issues/50) GovernanceMetricsDashboard · [#49](https://github.com/GuitarAlchemist/ga/issues/49) GovernanceCompliancePanel · [#56](https://github.com/GuitarAlchemist/ga/issues/56) AdminInbox→Demerzel | ready-for-human |
+| Federation / data-backend panels | [#47](https://github.com/GuitarAlchemist/ga/issues/47) Prime Radiant ← ix `governance.graph` · [#52](https://github.com/GuitarAlchemist/ga/issues/52) AgentSpectralPanel · [#53](https://github.com/GuitarAlchemist/ga/issues/53) KnowledgeGraphPanel ← TARS · [#51](https://github.com/GuitarAlchemist/ga/issues/51) Discord→Prime Radiant WS | ready-for-human |
+| App-level architecture doc + route smoke tests | _(task — unfiled)_ | ready-for-agent (frontend-verifiable) |
+
+## Epic 2 — Guitar visualization & interaction
+
+**Goal:** fast, correct 2D/3D rendering of fretboard, chords, scales, and hand pose — with clear ownership between the React/R3F path and the Godot path.
+
+| Story | Open issues / backlog | Status |
+|---|---|---|
+| 3D scene performance (Prime Radiant / R3F) | [#42](https://github.com/GuitarAlchemist/ga/issues/42) InstancedMesh nodes (+6–12 FPS) · [#43](https://github.com/GuitarAlchemist/ga/issues/43) bake skybox to cubemap (+2–4 FPS) | **ready-for-agent** (frontend-verifiable locally) |
+| Godot scene integration / inspection | [#54](https://github.com/GuitarAlchemist/ga/issues/54) GodotSceneInspectorPanel | ready-for-human |
+| Live fretboard overlay | `BACKLOG.md` → `fretboard-overlay-live`, `chord-diagram-inline` | ready-for-human |
+| Rendering ownership boundaries (2D vs 3D, WebGPU/Three/Pixi) | _(task — unfiled)_ | ready-for-human |
+
+## Epic 3 — Audio & music-intelligence UX
+
+**Goal:** make the chatbot/theory engine genuinely usable by a working guitarist — the largest and most differentiated surface. The detailed, prioritized work already lives in `BACKLOG.md`; this epic is its index.
+
+| Story | Backlog track | Status |
+|---|---|---|
+| Chatbot trust (load-bearing) | Chatbot Track **P0**: `memory-session-scope`, `router-quality` | ready (tribunal-gated) |
+| Capability completeness | Chatbot Track **P1**: `extended-chord-support`, `chord-identify`, `transpose-capo`, `voice-leading-pair`, `alternate-tuning-voicings`, `text-embedder-evaluation` | ready (tribunal-gated) |
+| Advanced theory & arrangement | Chatbot Track **P2**: `modal-key-identify`, `modulation-detection`, `style-progression-gen`, `lead-sheet-arranger` | ready / blocked-by-deps |
+| Pro-guitarist dealbreakers | `BACKLOG.md` → "Pro-Guitarist Usability Gaps" | ready |
+| North-star problems | `BACKLOG.md` → "Guitarist Problems to Solve" | shaping |
+
+> Epic 3 work that touches `GA.Business.ML/Agents/**`, MCP tooling, or the DSL parser is **tribunal-gated** (`Scripts/check-chatbot-tribunal-gate.ps1`) and routed via `/chatbot-iterate`, not picked ad hoc.
+
+## Epic 4 — AIW integration for product work
+
+**Goal:** consume Demerzel AIW-generated issues, keep product issues "Matt-ready" (scoped, testable, evidence-bearing), route implementation to the right worker (local/cloud/build-capable), and write product-specific evidence artifacts.
+
+| Story | Open issues / artifact | Status |
+|---|---|---|
+| AIW intake + evidence/test contract | **new:** [`docs/workflows/ga-aiw.md`](workflows/ga-aiw.md) | ✅ shipped with this PR |
+| Skills-driven issue quality | [#481](https://github.com/GuitarAlchemist/ga/issues/481) use Matt Pocock skills for scoped slices | ready-for-human |
+| Autonomous-loop evidence | [#428](https://github.com/GuitarAlchemist/ga/issues/428) first real `/auto-optimize` iteration + ix maintain-gate | ready-for-human (needs live oracle) |
+| CI signal honesty | [#328](https://github.com/GuitarAlchemist/ga/issues/328) chatbot-QA snapshot degradation | ready-for-agent (workflow override required) |
+
+---
+
+## How to pick work
+
+1. Find the Epic that matches the capability you're advancing.
+2. Within it, prefer a **`ready-for-agent`** issue if you're an AI worker (or running AFK); `ready-for-human` items need a decision/design/verification from a person first.
+3. For Epic 3 (chatbot/theory): don't hand-pick — go through `/chatbot-iterate`, which reads the `BACKLOG.md` Chatbot Track and enforces the tribunal gate.
+4. New idea, not yet a slice? Add it to `BACKLOG.md` and run `/feature <idea>` (brainstorm → plan → PR).
+
+## Completion criteria (#482)
+
+- [x] `ga` has a navigable roadmap (this file) that indexes BACKLOG + plans + issues under PI→Epic→Story.
+- [x] Product tasks can link to Demerzel AIW issues when implemented by AI workers (Epic 4 + `docs/workflows/ga-aiw.md`).
+- [x] Product issues have clear scope, demo/evidence, and test expectations (codified in `docs/workflows/ga-aiw.md`).
+
+> **Living document.** When an epic's stories shift, update the tables here in the same PR. The roadmap is only useful while it tracks reality.

--- a/docs/workflows/ga-aiw.md
+++ b/docs/workflows/ga-aiw.md
@@ -1,0 +1,65 @@
+# GA ↔ AIW workflow (product issues for AI workers)
+
+> How product-facing work in `GuitarAlchemist/ga` is shaped, routed, implemented, and evidenced by AI workers (the **AI Workforce** — "AIW"). Implements the Epic 4 task of [`docs/roadmap.md`](../roadmap.md) (issue #482).
+>
+> AIW orchestration lives in **Demerzel** (GuitarAlchemist/Demerzel#473). GA is a **consumer**: it receives AIW-generated issues, implements the product ones, and writes evidence back. This doc is the GA-side contract so a worker can pick up an issue and finish it without guessing.
+
+## 1. Lanes (who does what)
+
+| Lane | Worker | Best at | Gate |
+|---|---|---|---|
+| **shape** | any model (local/cloud) | research, decomposition, issue authoring | human review of the resulting issues |
+| **frontend** | build-capable **or** an npm-equipped sandbox | React/R3F/TS — locally verifiable (`npm run build`/`lint`/`tsc`) | CI |
+| **backend (C#/F#)** | **build-capable worker only** (needs the .NET SDK) | services, MCP tools, DSL | CI + tribunal (if Agents/MCP/DSL) |
+| **governance / CI** | human-in-the-merge-path | `.github/workflows/*`, schemas, contracts | **explicit human override** (blocked path) |
+
+Route by capability, not by author. A sandbox without a .NET SDK should take **shape** or **frontend** lane work; C# implementation routes to a build-capable worker.
+
+## 2. A "Matt-ready" product issue
+
+An issue is ready for an AI worker (`ready-for-agent`) only if it states all of:
+
+1. **Goal** — the user pain and what changes for them (one paragraph).
+2. **Exact files in scope** — paths, not "the chat module".
+3. **Non-goals** — what NOT to touch (prevents scope creep).
+4. **Acceptance criteria** — verifiable, e.g. a test name, an endpoint contract, a metric threshold.
+5. **Verification command** — how CI/a human confirms it (`dotnet test --filter …`, `npm run build`, a curl, a screenshot).
+6. **Risk classification** — `pure-additive` / `refactor` / `api-change` / `one-way-door`. One-way doors (OPTIC-K dims, schemas, contracts, public API, pricing, `.github/workflows/*`) require human sign-off and may need `/council`.
+
+If an issue can't state these, it's `ready-for-human` (needs shaping) — not agent work yet. Use the Matt Pocock skills (#481) or `/to-issues` to convert vague asks into Matt-ready slices.
+
+## 3. Evidence requirements (definition of done)
+
+Every AIW product PR carries evidence proportional to its surface:
+
+| Surface | Required evidence |
+|---|---|
+| Any | passing CI (build + tests); `Fixes #N`; conventional commit |
+| Backend logic | unit/integration test named in acceptance criteria; key test output quoted in the PR |
+| User-visible UI | **before/after screenshot or short capture** of the rendered change |
+| Perf claim (e.g. "+N FPS") | the measurement, or an explicit "needs human FPS verification" note if the worker can't run a browser |
+| Metric-moving change | baseline + direction + guardrail (`state/quality/` snapshot), per the Karpathy rule |
+| One-way door | `/council` verdict or named human override |
+
+**Written-blind disclosure:** if a worker authored code it could not build/run locally (no SDK/browser), it must say so in the PR and name CI as the verification gate. Honesty about what was *not* verified is part of done.
+
+## 4. Tracer-bullets, not horizontal layers
+
+Per the ecosystem's aihero delta (see `CLAUDE.md`): a product slice is a **thin vertical** cutting through every layer (data → service → API → UI), tested end-to-end — never a layer built in isolation. AIW issues should describe one tracer-bullet with a single measurable success criterion.
+
+## 5. Loop back to Demerzel AIW gates
+
+- AIW-generated issues arrive from Demerzel; GA implements the **product** ones (UI/gameplay/audio/theory UX) and leaves governance/runtime ones to their lane.
+- Autonomous-loop runs record evidence to `state/quality/loops/` and are scored by the ix `maintain-gate` ([#428](https://github.com/GuitarAlchemist/ga/issues/428)) — advisory, never auto-revert.
+- The Galactic-Protocol / tribunal verdicts and contracts live in `../Demerzel/` and `docs/contracts/`; GA reads them, doesn't re-implement them.
+
+## 6. Worker checklist (copy into the PR)
+
+```text
+[ ] Lane correct for my capability (didn't blind-write C# I couldn't verify)
+[ ] Only the files in scope changed (non-goals respected)
+[ ] Acceptance criteria met + verification command run (or CI named as the gate)
+[ ] Evidence attached (test output / screenshot / metric / written-blind disclosure)
+[ ] Risk class stated; one-way door → human/council sign-off
+[ ] Fixes #N + conventional commit + roadmap table updated if an epic shifted
+```


### PR DESCRIPTION
Implements **#482** — the `[PI][GA]` roadmap & issue-hierarchy.

## What

Two docs, **mapping the work that already exists** (not a blank skeleton):

- **`docs/roadmap.md`** — the Program-Increment roadmap. PI→Epic→Story hierarchy across the four proposed epics, each table mapping `BACKLOG.md` sections + `docs/plans/` + the **open issues** into one navigable index:
  - **Epic 1 · App shell** → #47, #49, #50, #52, #53, #56
  - **Epic 2 · Guitar visualization** → #42, #43 (now `ready-for-agent`, frontend-verifiable), #54
  - **Epic 3 · Audio/theory UX** → the `BACKLOG.md` Chatbot Track (P0–P2) + Pro-Guitarist Gaps
  - **Epic 4 · AIW integration** → #481, #428, #328 + the new workflow doc
  - Calls out the **frontend-verifiable vs build-capable-worker** routing reality.
- **`docs/workflows/ga-aiw.md`** — the GA↔AIW contract: capability lanes, the "Matt-ready" product-issue definition (scope/non-goals/acceptance/verification/risk), evidence requirements (screenshots for UI, written-blind disclosure, metric baselines), tracer-bullet discipline, and the loop-back to Demerzel AIW gates.

## #482 completion criteria

- ✅ `ga` has a navigable roadmap (indexes BACKLOG + plans + issues under PI→Epic→Story).
- ✅ Product tasks can link to Demerzel AIW issues (Epic 4 + `ga-aiw.md`).
- ✅ Product issues have clear scope / demo evidence / test expectations (codified in `ga-aiw.md`).

Docs-only; no code surface. Authored in a parallel git worktree so it didn't block the in-flight #483 draft.

Fixes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XykDQVT7R8LYGyuLR5rX1)_