### PR TITLE
ci(afk): tame claude-code-review + add jules-auto-delegate (tars#159)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,8 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    # Cost-safe: drop `synchronize` so review fires once per PR, not once per push.
+    types: [opened, reopened, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -10,8 +11,15 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Cost-safe: at most one review run per PR at a time; new events cancel the in-flight one.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
+    # Cost-safe: skip draft PRs — review runs when the PR is marked ready_for_review.
+    if: github.event.pull_request.draft == false
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -1,0 +1,117 @@
+name: Auto-delegate to AFK agent
+
+# Multi-agent AFK router (mirrored from tars/.github/workflows/afk-router.yml).
+# When a maintainer triages an issue with the `ready-for-agent` label, this picks
+# an agent and triggers it to work the issue and open a PR. The PR still waits for
+# human review before merge — agents open PRs, they never merge to main, so
+# review-gating holds by default.
+#
+# Routing (by the repo's existing worker:* labels; default Jules):
+#   - default            -> Jules  : add the `jules` label
+#   - + `worker:codex`   -> Codex  : comment `@codex`
+#   - + `worker:claude`  -> Claude : comment `@claude`
+# (worker:claude wins over worker:codex if both are present; worker:jules — or no
+#  worker:* label — falls through to the Jules default.)
+#
+# Why a user-owned PAT (PAT_TOKEN): agents ignore trigger events authored by
+# a bot (github-actions[bot]) — proven for Jules (bot-applied `jules` label was
+# ignored; user-applied worked). So every trigger (label or comment) is applied
+# with the PAT, making it user-attributed.
+#
+# Security: GitHub only lets users with write/triage access apply labels, so
+# `ready-for-agent` (and `agent:*`) are collaborator-gated even on a public repo.
+#
+# Governance (Demerzel): gated on the cloud-readable halt marker
+# `governance/state/afk-halt.json` (present+unexpired => paused).
+#
+# Requires the PAT_TOKEN secret: a fine-grained PAT with Issues: write on
+# this repo. Codex additionally needs Codex quota; Claude needs its GitHub app
+# (see claude.yml).
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  delegate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event.label.name == 'ready-for-agent' }}
+    steps:
+      - name: Checkout (read the governance halt marker)
+        uses: actions/checkout@v4
+
+      - name: Governance halt-gate + preflight + route
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          HAS_PAT: ${{ secrets.PAT_TOKEN != '' }}
+        run: |
+          MARKER="governance/state/afk-halt.json"
+          if [ -f "$MARKER" ]; then
+            EXPIRES=$(jq -r '.expires_at // empty' "$MARKER" 2>/dev/null || true)
+            HALTED=true
+            if [ -n "$EXPIRES" ]; then
+              NOW=$(date -u +%s)
+              EXP=$(date -u -d "$EXPIRES" +%s 2>/dev/null || echo 0)
+              if [ "$EXP" -gt 0 ] && [ "$NOW" -ge "$EXP" ]; then
+                HALTED=false
+                echo "::notice::afk-halt marker present but expired ($EXPIRES) — proceeding"
+              fi
+            fi
+            if [ "$HALTED" = "true" ]; then
+              REASON=$(jq -r '.reason // "no reason given"' "$MARKER" 2>/dev/null || echo "no reason given")
+              BY=$(jq -r '.halted_by // "Demerzel"' "$MARKER" 2>/dev/null || echo "Demerzel")
+              gh issue comment "$ISSUE" --repo "$REPO" --body "⏸️ AFK delegation is **halted by governance** (\`$MARKER\`, by $BY): $REASON. The \`ready-for-agent\` label is kept; re-apply it after resume to delegate."
+              echo "::notice::AFK delegation halted by governance marker — skipping issue #${ISSUE}"
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          if [ "$HAS_PAT" != "true" ]; then
+            gh issue comment "$ISSUE" --repo "$REPO" --body "⚠️ AFK delegation is configured but the \`PAT_TOKEN\` secret is not set, so no agent was triggered. Add a fine-grained PAT with Issues: write as \`PAT_TOKEN\` and re-apply the \`ready-for-agent\` label."
+            echo "::warning::PAT_TOKEN not configured — skipping issue #${ISSUE}"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Route by the repo's worker:* labels (default Jules). worker:claude
+          # wins over worker:codex if both; worker:jules / none -> Jules default.
+          LABELS=$(gh issue view "$ISSUE" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          if echo "$LABELS" | grep -q '"worker:claude"'; then
+            AGENT=claude
+          elif echo "$LABELS" | grep -q '"worker:codex"'; then
+            AGENT=codex
+          else
+            AGENT=jules
+          fi
+          echo "agent=$AGENT" >> "$GITHUB_OUTPUT"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::AFK routing issue #${ISSUE} to ${AGENT}"
+
+      - name: Trigger the agent (PAT-attributed so the agent doesn't ignore it)
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          AGENT: ${{ steps.gate.outputs.agent }}
+        run: |
+          case "$AGENT" in
+            jules)
+              gh issue edit "$ISSUE" --repo "$REPO" --add-label jules
+              echo "Delegated issue #${ISSUE} to Jules (\`jules\` label, PAT-attributed)." ;;
+            codex)
+              gh issue comment "$ISSUE" --repo "$REPO" --body "@codex please implement this issue and open a pull request. Follow the conventions in AGENTS.md / CLAUDE.md."
+              echo "Delegated issue #${ISSUE} to Codex (@codex, PAT-attributed)." ;;
+            claude)
+              gh issue comment "$ISSUE" --repo "$REPO" --body "@claude please implement this issue and open a pull request. Follow the conventions in AGENTS.md / CLAUDE.md."
+              echo "Delegated issue #${ISSUE} to Claude (@claude, PAT-attributed)." ;;
+            *)
+              echo "::error::unknown agent '$AGENT'"; exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary

Part of GuitarAlchemist/tars#159 (cost-safe AI agent harness rollout). Covers the two **ga** per-repo tasks from that issue.

- **`claude-code-review.yml`** — tame the per-push review multiplier flagged in the issue's inventory: drop `synchronize` (fire once per PR, not once per push), skip drafts (`github.event.pull_request.draft == false`), add `concurrency: cancel-in-progress`.
- **`jules-auto-delegate.yml`** (new) — label-gated AFK delegation loop mirrored from `tars/.github/workflows/afk-router.yml`. A `ready-for-agent` label routes the issue to Jules / Codex / Claude by its `worker:*` labels (default Jules), PAT-attributed so the agent doesn't ignore a bot-authored trigger, and governance-gated on `governance/state/afk-halt.json`.

## Cost design (per the issue)

- Auto-review no longer fires per-push (one review per PR).
- Delegation stays opt-in: only maintainers with triage access can apply `ready-for-agent`.

## Dependencies (not blocking merge, but required for function)

- **`jules-auto-delegate.yml`** needs a **`PAT_TOKEN`** secret (fine-grained PAT, Issues: write). Without it the workflow posts a warning comment and no-ops — safe by default.
- **`claude-code-review.yml`** continues to use the existing `CLAUDE_CODE_OAUTH_TOKEN` (already wired in ga).

## Test plan

- [x] Both workflow YAMLs parse (validated with `yaml.safe_load`).
- [ ] Live: open a PR → confirm review fires once, not per push, and is skipped while draft.
- [ ] Live: apply `ready-for-agent` to a test issue (with `PAT_TOKEN` set) → confirm it routes to Jules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqmsdJ4PgpQHV37vys5Erb)_