### PR TITLE
ci: AFK router self-heal + dead-letter sweep, agent-blackbox parity with tars

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -11,12 +11,15 @@ permissions:
   checks: write
 
 env:
-  AGENT_BLACKBOX_REF: "v0.1.0-beta.2"
+  # Pinned SHA (explicit imports > implicit inheritance) — same ref tars runs;
+  # brings the harness-audit command and --trace evidence support.
+  AGENT_BLACKBOX_REF: "90ed651c73a296c13c9b4953754a2f4898ac4114"
   DOTNET_VERSION: "10.0.1xx"
   VERIFY_COMMAND: >-
     dotnet test AllProjects.slnx
     --filter "TestCategory!=Integration&TestCategory!=RequiresModel"
     --logger "console;verbosity=normal"
+  HARNESS_AUDIT_FAIL_BELOW: "60"
 
 jobs:
   risk-report:
@@ -38,7 +41,7 @@ jobs:
           repository: GuitarAlchemist/agent-blackbox
           ref: ${{ env.AGENT_BLACKBOX_REF }}
           path: .agent-blackbox
-          token: ${{ secrets.AGENT_BLACKBOX_TOKEN }}
+          token: ${{ secrets.AGENT_BLACKBOX_TOKEN || github.token }}
 
       - name: Collect PR evidence
         shell: bash
@@ -51,8 +54,45 @@ jobs:
           verify_exit=$?
           set -e
           echo "verify_exit=$verify_exit" >> "$GITHUB_ENV"
+          export AGENT_BLACKBOX_VERIFY_EXIT="$verify_exit"
           echo "verify command exited with code $verify_exit" >> dist/test-output.txt
           cat dist/test-output.txt
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          def event(**kwargs):
+              payload = {
+                  "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                  **kwargs,
+              }
+              return json.dumps(payload, sort_keys=True)
+
+          changed_files = [
+              line.strip()
+              for line in Path("dist/changed-files.txt").read_text(encoding="utf-8").splitlines()
+              if line.strip()
+          ]
+          verify_exit = int(os.environ.get("AGENT_BLACKBOX_VERIFY_EXIT", "0"))
+          lines = [
+              event(
+                  event="workflow_evidence",
+                  tool="git.diff",
+                  status="ok",
+                  path="dist/changed-files.txt",
+                  data={"changed_file_count": len(changed_files)},
+              ),
+              event(
+                  event="verification",
+                  tool="shell.exec",
+                  command=os.environ.get("VERIFY_COMMAND", ""),
+                  status="ok" if verify_exit == 0 else "failed",
+              ),
+          ]
+          Path("dist/agent-trace.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
 
       - name: Generate risk report
         shell: bash
@@ -62,7 +102,16 @@ jobs:
             --changed-files dist/changed-files.txt \
             --diff dist/diff.patch \
             --test-output dist/test-output.txt \
+            --trace dist/agent-trace.jsonl \
             --out-dir dist
+
+      - name: Generate harness audit
+        shell: bash
+        run: |
+          PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox harness-audit \
+            --repo . \
+            --out-dir dist \
+            --fail-below "${HARNESS_AUDIT_FAIL_BELOW}"
 
       - name: Comment risk report
         uses: actions/github-script@v7
@@ -70,7 +119,10 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- agent-blackbox-risk-report -->';
-            const body = marker + '\n' + fs.readFileSync('dist/risk-report.md', 'utf8');
+            let body = marker + '\n' + fs.readFileSync('dist/risk-report.md', 'utf8');
+            if (fs.existsSync('dist/harness-audit.md')) {
+              body += '\n\n---\n\n' + fs.readFileSync('dist/harness-audit.md', 'utf8');
+            }
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });

--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -31,6 +31,12 @@ name: Auto-delegate to AFK agent
 on:
   issues:
     types: [labeled]
+  # Dead-letter sweep: issues labeled ready-for-agent before this workflow
+  # existed (or while it was broken) never produce a `labeled` event again.
+  # The daily sweep (and manual dispatch) re-routes them.
+  workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * *'
 
 permissions:
   contents: read
@@ -40,7 +46,7 @@ jobs:
   delegate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ github.event.label.name == 'ready-for-agent' }}
+    if: ${{ github.event_name == 'issues' && github.event.label.name == 'ready-for-agent' }}
     steps:
       - name: Checkout (read the governance halt marker)
         uses: actions/checkout@v4
@@ -104,6 +110,11 @@ jobs:
         run: |
           case "$AGENT" in
             jules)
+              # Self-heal: the label must exist before gh can apply it (run #2
+              # failed with "'jules' not found"); --force also repairs
+              # color/description if the label was auto-created bare.
+              gh label create jules --repo "$REPO" --color 1A73E8 \
+                --description "Delegate this issue to Google Jules" --force
               gh issue edit "$ISSUE" --repo "$REPO" --add-label jules
               echo "Delegated issue #${ISSUE} to Jules (\`jules\` label, PAT-attributed)." ;;
             codex)
@@ -115,3 +126,63 @@ jobs:
             *)
               echo "::error::unknown agent '$AGENT'"; exit 1 ;;
           esac
+
+  # Dead-letter sweep: re-route open ready-for-agent issues that never got
+  # delegated. Only the Jules default lane is swept (detectable by the absence
+  # of the `jules` label); worker:codex / worker:claude lanes are comment-
+  # triggered and are skipped to avoid duplicate @-mentions — re-apply the
+  # ready-for-agent label on those to re-trigger them manually.
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout (read the governance halt marker)
+        uses: actions/checkout@v4
+
+      - name: Governance halt-gate + preflight
+        id: gate
+        env:
+          HAS_PAT: ${{ secrets.PAT_TOKEN != '' }}
+        run: |
+          MARKER="governance/state/afk-halt.json"
+          if [ -f "$MARKER" ]; then
+            EXPIRES=$(jq -r '.expires_at // empty' "$MARKER" 2>/dev/null || true)
+            HALTED=true
+            if [ -n "$EXPIRES" ]; then
+              NOW=$(date -u +%s)
+              EXP=$(date -u -d "$EXPIRES" +%s 2>/dev/null || echo 0)
+              if [ "$EXP" -gt 0 ] && [ "$NOW" -ge "$EXP" ]; then
+                HALTED=false
+              fi
+            fi
+            if [ "$HALTED" = "true" ]; then
+              echo "::notice::AFK delegation halted by governance marker — skipping sweep"
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::PAT_TOKEN not configured — skipping sweep"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Sweep undelegated ready-for-agent issues (PAT-attributed)
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create jules --repo "$REPO" --color 1A73E8 \
+            --description "Delegate this issue to Google Jules" --force
+          SWEPT=0
+          for ISSUE in $(gh issue list --repo "$REPO" --state open \
+              --label ready-for-agent --json number,labels \
+              --jq '.[] | select([.labels[].name] | any(. == "jules" or . == "worker:codex" or . == "worker:claude") | not) | .number'); do
+            gh issue edit "$ISSUE" --repo "$REPO" --add-label jules
+            echo "::notice::Swept issue #${ISSUE} to Jules (dead-letter re-route)"
+            SWEPT=$((SWEPT+1))
+          done
+          echo "::notice::Sweep complete — ${SWEPT} issue(s) re-routed"


### PR DESCRIPTION
## Summary

Two workflow-reliability fixes discovered during the 2026-07-01 bottleneck audit.

**1. AFK router (`jules-auto-delegate.yml`)** — the router had never successfully delegated: its first real run ([run #2](https://github.com/GuitarAlchemist/ga/actions/runs/28548970019), issue #328) failed with `'jules' not found` because the `jules` label was only ever created in `tars`. Now self-healing (`gh label create --force` before each Jules delegation) plus a daily/dispatchable dead-letter sweep for `ready-for-agent` issues that never produced a `labeled` event.

**2. Agent Blackbox (`agent-blackbox.yml`)** — brought to parity with the tars version: `AGENT_BLACKBOX_REF` upgraded from the `v0.1.0-beta.2` tag to the pinned SHA tars already runs (`90ed651c…`, explicit-imports principle), structured `agent-trace.jsonl` evidence emitted and passed via `--trace`, harness-audit step added (report appended to the sticky PR comment), and `github.token` fallback when `AGENT_BLACKBOX_TOKEN` is absent. ga's live override-label re-check is kept (tars lacks it). The always-skipped response-quality step was deliberately NOT ported (no `agent-response.txt` producer in ga — no speculative steps).

## Linked issue(s)

Parent / issue:
- Discovered while re-triggering delegation of #328 (chatbot QA degradation)

Related:
- `tars/.github/workflows/afk-router.yml` (router mirror; same self-heal/sweep fix to be applied after tars#171 merges)

## Scope

In scope:
- `.github/workflows/jules-auto-delegate.yml` (self-heal + sweep + event guard)
- `.github/workflows/agent-blackbox.yml` (pinned SHA, trace evidence, harness audit, token fallback)

Out of scope:
- `worker:codex` / `worker:claude` lanes in the sweep (comment-triggered; sweeping would duplicate @-mentions)
- Any policy change (`agent-blackbox.policy.json` untouched)
- The tars mirrors (deferred to keep tars#171 docs-only)

## Boundary contract

Namespace affected:
- `.github/workflows/` only

Contract changed:
- [x] no

Expected dependencies touched:
- `PAT_TOKEN` secret (already required), `governance/state/afk-halt.json` gate (honored by the sweep), `GuitarAlchemist/agent-blackbox` at pinned SHA

Dependencies intentionally avoided:
- No new labels, governance docs, or policy edits

Derived state kept derived:
- [x] yes

Boundary notes:
- Delegation stays PAT-attributed; agents open PRs, never merge. Blackbox verdicts stay enforced with the `agent-blackbox-reviewed` human override.

## Business value

Outcome supported:
- AFK delegation actually works in `ga`; PR risk verdicts carry the same evidence quality as tars

How this PR helps:
- Removes the observed failure modes: missing label (hard failure), pre-router labels (silent dead letter), missing trace evidence and stale blackbox ref (weaker verdicts).

## Review mode

Mode:
- fast-review

Reason:
- Two workflow files; additive changes; governance gates preserved. Note: this PR itself trips the blackbox `blocked_path` finding (`.github/workflows/**`) — that is the gate working as designed on workflow changes; apply `agent-blackbox-reviewed` after human review.

Human question, if any:
- None

Safe default:
- Merge; revert restores previous behavior.

## Evidence

Changed files:
- `.github/workflows/jules-auto-delegate.yml` (+72/−1)
- `.github/workflows/agent-blackbox.yml` (+55/−3)

Checks:
- YAML validated locally; router failure evidence from run #2 logs (`'jules' not found`); blackbox parity taken from the tars workflow at the same pinned SHA (running green there since 2026-06-30)

Manual review notes:
- The `jules` label now exists in `ga` (auto-created via API), so delegation works even before merge; `--force` + sweep add durable protection.

Risks:
- Low; worst case the sweep no-ops and the blackbox behaves as before with richer evidence

Rollback / reversibility:
- Fully reversible via git revert

## Acceptance criteria

- [x] Scope is narrow and reviewable.
- [x] Boundary impact is explicit.
- [x] Evidence is sufficient for the selected review mode.
- [x] Non-goals are respected.
- [ ] Linked issue has hierarchy and business value.
- [x] Follow-up issues are created if scope was split. (tars mirror noted in-body — no new issue per anti-over-process rule)

## Post-merge learning

Retrospective needed?
- [x] no

Pattern / anti-pattern candidate:
- Pattern: event-triggered automations need idempotent resource creation + a sweep for pre-automation state; shared workflows should import at one pinned SHA across repos

Memory update needed?
- [x] no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih