### PR TITLE
fix(smoke): classify Cloudflare 52x/530 as infra-down, not regression

### DIFF
--- a/.github/workflows/post-merge-smoke.yml
+++ b/.github/workflows/post-merge-smoke.yml
@@ -135,7 +135,8 @@ jobs:
                       body = bf.read()
                   marker_found = marker.encode('utf-8') in body
               unreachable = (status == 0)
-              gateway_error = status in (502, 503, 504)
+              # 52x/530 are Cloudflare origin-down codes (530 = tunnel down, error 1033)
+              gateway_error = status in (502, 503, 504) or 520 <= status <= 530
               if unreachable:
                   unreachable_count += 1
               ok = (status == 200 and size_bytes > 0 and marker_found)


### PR DESCRIPTION
## Summary

`post-merge-smoke` already suppresses issue creation when the operator's tunnel is down, but its gateway-error classification only recognized 502/503/504. A down `cloudflared` tunnel actually surfaces as **HTTP 530** (Cloudflare error 1033), so every merge to `main` during tonight's outage opened a fresh duplicate regression issue (#493, #495, #496). One-line fix: treat 52x/530 as infra-down alongside 502/503/504. Real per-URL regressions (200-with-missing-marker, 404) still page.

## Linked issue(s)

- #493 (kept as the canonical outage tracker), #495 / #496 (closed as duplicates)

## Scope

In scope:
- The `gateway_error` classification line in `.github/workflows/post-merge-smoke.yml`

Out of scope:
- Per-SHA dedup logic, tunnel auto-recovery (operator-side)

## Review mode

Mode:
- fast-review

Reason:
- One line; evidence is three duplicate issues from tonight's merges.

Risks / rollback:
- None / git revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih

---
_Generated by [Claude Code](https://claude.ai/code/session_01B69umcCT9ZowDSseVY2Xih)_