### PR TITLE
fix(ci): rebase-and-retry push in Quality Snapshot workflow

### DIFF
--- a/.github/workflows/quality-snapshot.yml
+++ b/.github/workflows/quality-snapshot.yml
@@ -142,4 +142,22 @@ jobs:
           fi
 
           git commit -m "chore(quality): snapshot ${DATE} [skip ci]"
-          git push origin HEAD:main
+
+          # main moves while this job runs (~40 min), so a plain push is
+          # routinely rejected as non-fast-forward. Rebase onto the current
+          # tip and retry; snapshot paths are date-namespaced so the rebase
+          # is conflict-free unless a same-day run already landed.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); rebasing onto latest main."
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "::error::Rebase conflict while landing snapshot ${DATE}; manual attention needed."
+              exit 1
+            fi
+          done
+          echo "::error::Push still rejected after 5 rebase attempts."
+          exit 1


### PR DESCRIPTION
## Impact

The Quality Snapshot job runs ~40 min while `main` keeps moving, so its final `git push origin HEAD:main` was routinely rejected as non-fast-forward — runs #472–#477 (2026-07-01/02) all failed at **Commit + push if changed** with `! [rejected] HEAD -> main (fetch first)`. The snapshots themselves were generated fine; only the landing step broke. Not a product regression.

## Fix

In the push step: on rejection, `git fetch origin main` + `git rebase origin/main`, then retry — up to 5 attempts. A genuine rebase conflict aborts cleanly with an explicit `::error::`. Snapshot artifacts are date-namespaced (`state/quality/**`, `docs/quality/**`) and concurrent pushes to `main` don't touch those paths, so the rebase is expected to be conflict-free except when a same-day run already landed.

## Verification

- YAML validated (`yaml.safe_load`).
- Failure cause confirmed from run 28560693541 job logs (push rejected non-fast-forward after successful commit).

Workflow-surface change (`.github/workflows/**`): an Agent Blackbox `fail` verdict on this PR is the expected protected-path guardrail. Merge is human-delegated (operator instruction, 2026-07-02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9)_