### PR TITLE
feat(models): default to claude-sonnet-5 for chatbot + pin architecture-refinement lane

### DIFF
--- a/.github/workflows/architecture-refinement.yml
+++ b/.github/workflows/architecture-refinement.yml
@@ -212,7 +212,7 @@ jobs:
                Check `gh issue list --search "[arch-refinement] ${{ needs.gate.outputs.slug }}"`
                first and do NOT file a duplicate if an open one already covers
                the same candidates.
-          claude_args: '--allowed-tools "Agent,Read,Grep,Glob,Write,Bash(gh issue list:*),Bash(gh issue create:*),Bash(date:*)"'
+          claude_args: '--model claude-sonnet-5 --allowed-tools "Agent,Read,Grep,Glob,Write,Bash(gh issue list:*),Bash(gh issue create:*),Bash(date:*)"'
 
       - name: Commit the report
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,10 @@ _Appended by `/correct` when the user corrects an approach. Persists across sess
 
 **How to apply:** treat the modified-file system-reminder as a stomp signal, re-read, rewrite. Don't argue with the hook; fixing it is a separate concern.
 
+```untrusted-correction
+- **2026-07-02**: Écrire le français directement en français idiomatique — jamais de calques de l'anglais ; garder les termes techniques du projet en anglais (limb, lane, tracer bullet, presence snapshot). (Correction utilisateur : « effet de bord agréable », « limbe morte » sont des traductions littérales.)
+```
+
 ## Agent skills
 
 Per-repo config for the installed aihero/mattpocock engineering skills (`grill-with-docs`, `grill-me`, `to-prd`, `to-issues`, `tdd`, `improve-codebase-architecture`, `teach`), installed project-scoped into `.claude/skills/` via `npx skills@latest add mattpocock/skills --copy` (MIT; Socket/Snyk clean). Configured 2026-06-14 via `/setup-matt-pocock-skills`.

--- a/Apps/GaChatbotCli/Program.cs
+++ b/Apps/GaChatbotCli/Program.cs
@@ -74,7 +74,7 @@ var anthropicKeyForCli = builder.Configuration["Anthropic:ApiKey"]
 builder.Services.TryAddSingleton<IChatClient>(_ =>
     !string.IsNullOrWhiteSpace(anthropicKeyForCli)
         ? new AnthropicClient { ApiKey = anthropicKeyForCli }
-              .AsIChatClient("claude-sonnet-4-6")
+              .AsIChatClient("claude-sonnet-5")
               .AsBuilder()
               .UseFunctionInvocation()
               .Build()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,10 @@ _Appended by `/correct` when the user corrects an approach. Persists across sess
 
 **How to apply:** treat the modified-file system-reminder as a stomp signal, re-read, rewrite. Don't argue with the hook; fixing it is a separate concern.
 
+```untrusted-correction
+- **2026-07-02**: Écrire le français directement en français idiomatique — jamais de calques de l'anglais ; garder les termes techniques du projet en anglais (limb, lane, tracer bullet, presence snapshot). (Correction utilisateur : « effet de bord agréable », « limbe morte » sont des traductions littérales.)
+```
+
 ## Agent skills
 
 Per-repo config for the installed aihero/mattpocock engineering skills (`grill-with-docs`, `grill-me`, `to-prd`, `to-issues`, `tdd`, `improve-codebase-architecture`, `teach`), installed project-scoped into `.claude/skills/` via `npx skills@latest add mattpocock/skills --copy` (MIT; Socket/Snyk clean). Configured 2026-06-14 via `/setup-matt-pocock-skills`.

--- a/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurator.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurator.cs
@@ -31,9 +31,14 @@ public sealed class MemoryCurator(IChatClient chatClient, ILogger<MemoryCurator>
 
     /// <summary>
     /// Output-token budget for the curator's single LLM call. See the
-    /// CurateAsync XML doc for why this needs to be generous.
+    /// CurateAsync XML doc for why this needs to be generous. Sized for
+    /// claude-sonnet-5: max_tokens covers thinking PLUS response text
+    /// (adaptive thinking is on by default when the request omits the
+    /// thinking parameter), and the Sonnet 5 tokenizer produces ~30% more
+    /// tokens than Sonnet 4.6 for the same text — the previous 32_768 cap,
+    /// sufficient for ≤300 entries on 4.6, could truncate equivalent output.
     /// </summary>
-    public const int MaxOutputTokens = 32_768;
+    public const int MaxOutputTokens = 65_536;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -65,9 +70,11 @@ public sealed class MemoryCurator(IChatClient chatClient, ILogger<MemoryCurator>
         // smoke run (86 entries → truncated mid-Timestamp at byte ~2940
         // under the provider default cap of ~4096 tokens). The curator
         // produces ONE entry per kept/merged/new output × ~150 tokens for
-        // the JSON shape, plus per-input rationales in the diff. 32k is
-        // safely over Sonnet 4.6's typical sufficiency for ≤300 input
-        // entries; bump if you see truncation again.
+        // the JSON shape, plus per-input rationales in the diff. 32k was
+        // sized for ≤300 entries on Sonnet 4.6; 64k covers the same batch
+        // on claude-sonnet-5, whose max_tokens also absorbs default-on
+        // adaptive thinking and a ~30% heavier tokenizer. Bump if you see
+        // truncation again.
         var options = new ChatOptions { MaxOutputTokens = MaxOutputTokens };
 
         var response = await chatClient.GetResponseAsync(messages, options, cancellationToken);

--- a/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurator.cs
+++ b/Common/GA.Business.ML/Agents/Memory/Curator/MemoryCurator.cs
@@ -27,7 +27,7 @@ using Microsoft.Extensions.Logging;
 /// </remarks>
 public sealed class MemoryCurator(IChatClient chatClient, ILogger<MemoryCurator>? logger = null)
 {
-    public const string DefaultModelId = "claude-sonnet-4-6";
+    public const string DefaultModelId = "claude-sonnet-5";
 
     /// <summary>
     /// Output-token budget for the curator's single LLM call. See the

--- a/Common/GA.Providers.Anthropic/AnthropicProvider.cs
+++ b/Common/GA.Providers.Anthropic/AnthropicProvider.cs
@@ -25,7 +25,7 @@ using Microsoft.Extensions.Configuration;
 /// </remarks>
 public static class AnthropicProvider
 {
-    public const string DefaultModel = "claude-sonnet-4-6";
+    public const string DefaultModel = "claude-sonnet-5";
 
     /// <summary>
     /// Returns true if an Anthropic API key is reachable from configuration or
@@ -40,7 +40,7 @@ public static class AnthropicProvider
     /// </summary>
     /// <param name="configuration">Application configuration; resolves the API key
     /// from <c>Anthropic:ApiKey</c> first, then <c>ANTHROPIC_API_KEY</c>.</param>
-    /// <param name="model">Anthropic model name (e.g. <c>claude-sonnet-4-6</c>).
+    /// <param name="model">Anthropic model name (e.g. <c>claude-sonnet-5</c>).
     /// Falls back to <see cref="DefaultModel"/> when null/empty.</param>
     /// <param name="timeout">HTTP timeout for chat requests. Default is 100s
     /// (Anthropic SDK default). Long-output tasks (curator, summarizer with


### PR DESCRIPTION
## Summary

Sonnet 5 rollout on the GA side, measured not decreed:

- **Chatbot default model**: `AnthropicProvider.DefaultModel`, `MemoryCurator.DefaultModelId` and the `GaChatbotCli` client move from `claude-sonnet-4-6` to `claude-sonnet-5`. Haiku-backed services (`ClaudeChatService`, `VisualCritic`, `NebulaSidekick`) are untouched — Haiku still fits there.
- **CI lane pin**: `architecture-refinement.yml` now passes `--model claude-sonnet-5` explicitly instead of riding the action's default. Propose-only scheduled work is exactly where the cheaper tier belongs (subscription cost doctrine), which also makes the daily churn-gate cadence cheaper.
- Also carries a docs-only commit: a `/correct` session-learned rule in `CLAUDE.md` (+ `AGENTS.md` resync) about writing idiomatic French instead of English calques.

## Baseline + guardrail (Karpathy rule 6)

- **Metric**: nightly chatbot-qa snapshot (`state/quality/chatbot-qa/`), surfaced by the `sensor:quality-snapshot` presence limb.
- **Expected direction**: flat or up.
- **Guardrail / revisit trigger**: if the next two nightly snapshots regress, revert is a one-line change per file. hari forecast `ga-chatbot-sonnet5-no-regression` (p = 0.8, horizon 2026-07-04T18:00Z) tracks exactly this outcome in the J2 ledger.

## Verification

- No test pins the old default (`DefaultChatClientFactoryTests` passes the model as an explicit config override).
- Workflow YAML parses. .NET build/tests run in this PR's CI (no dotnet SDK in the authoring container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW)_