### PR TITLE
fix(ci): trust Gemini triage runner workspace

### DIFF
--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -57,6 +57,7 @@ jobs:
           ${{ steps.get_labels.outputs.available_labels != '' }}
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do NOT pass any auth tokens here since this runs on untrusted inputs
           ISSUE_TITLE: '${{ github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.issue.body }}'


### PR DESCRIPTION
## Outcome

Unblocks Gemini CLI automatic issue triage in GitHub Actions by explicitly trusting the ephemeral runner workspace for the single Gemini analysis step.

This is intentionally stacked on #534 so its environment-output fix and this trust fix can be reviewed together before #534 merges to `main`.

## Evidence

Both production runs failed at `Run Gemini issue analysis` with:

> Gemini CLI is not running in a trusted directory. To proceed, either use `--skip-trust`, set the `GEMINI_CLI_TRUST_WORKSPACE=true` environment variable...

- Run 29653974603 / job 88104969546
- Run 29653974471 / job 88104969662

## Scope and safety

- Adds only `GEMINI_CLI_TRUST_WORKSPACE: 'true'`.
- Scopes it to `google-github-actions/run-gemini-cli@v0`, not the workflow, job, GitHub Script steps, or label writer.
- Preserves the existing empty `GITHUB_TOKEN` boundary for untrusted issue text.
- Does not expose or alter secrets.

## Verification

- `actionlint .github/workflows/gemini-triage.yml` (official Docker image): pass
- PyYAML static assertion: exactly one Gemini CLI step; trust flag is `true`; absent from workflow/job env: pass
- `git diff --check`: pass
- GA pre-commit hook: pass; no buildable project affected

Depends on #534.