### PR TITLE
fix(chords): canonical Forte 1973 numbering for set-class labels (#544)

### DIFF
--- a/Common/GA.Domain.Services/Chords/CanonicalChordRecognizer.cs
+++ b/Common/GA.Domain.Services/Chords/CanonicalChordRecognizer.cs
@@ -293,7 +293,13 @@ public static class CanonicalChordRecognizer
     /// </summary>
     private static CanonicalChordResult FallbackFromForte(PitchClassSet pcSet)
     {
-        var forte = ProgrammaticForteCatalog.GetForteNumber(pcSet);
+        // Human-facing label: use Allen Forte's canonical 1973 numbering
+        // (CanonicalForteCatalog), NOT the internal Rahn-ordered
+        // ProgrammaticForteCatalog. The two disagree for some set classes — e.g.
+        // {0,1,6,7} is canonical Forte 4-9 but Rahn 4-21 — and this string is read
+        // by users, so it must match the standard catalog. It also preserves the
+        // Z marker (e.g. "4-Z15"), which the Rahn catalog does not model. See #544.
+        var hasForte = CanonicalForteCatalog.TryGetForteLabel(pcSet, out var canonicalLabel);
         var cardinality = pcSet.Count;
         var cardinalityName = cardinality switch
         {
@@ -310,7 +316,7 @@ public static class CanonicalChordRecognizer
             _ => $"{cardinality}-note set",
         };
 
-        var forteLabel = forte.HasValue ? $"Forte {forte}" : "set";
+        var forteLabel = hasForte ? $"Forte {canonicalLabel}" : "set";
         return new CanonicalChordResult(
             CanonicalName: $"{forteLabel} ({cardinalityName})",
             Root: null,
@@ -318,7 +324,7 @@ public static class CanonicalChordRecognizer
             Extension: null,
             Alterations: [],
             SlashSuffix: null,
-            PatternName: forte?.ToString(),
+            PatternName: canonicalLabel,
             MatchDistance: -1,
             IsNaturallyOccurring: false);
     }

--- a/Tests/Common/GA.Business.Core.Tests/Chords/CanonicalForteLabelTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Chords/CanonicalForteLabelTests.cs
@@ -1,0 +1,68 @@
+namespace GA.Business.Core.Tests.Chords;
+
+using System.Linq;
+using Domain.Core.Primitives.Notes;
+using Domain.Core.Theory.Atonal;
+using Domain.Services.Chords;
+
+/// <summary>
+///     Regression tests for #544: the set-class fallback label must use Allen Forte's
+///     canonical 1973 numbering (<see cref="CanonicalForteCatalog"/>), NOT the internal
+///     Rahn-ordered <see cref="ProgrammaticForteCatalog"/>. The two disagree for some
+///     set classes — {0,1,6,7} is canonical Forte 4-9 but Rahn 4-21 — and the label is
+///     human-facing (it lands in OPTIC-K's <c>quality_inferred</c> and chatbot output).
+/// </summary>
+[TestFixture]
+public class CanonicalForteLabelTests
+{
+    private static PitchClassSet Pcs(params int[] pcs) => new(pcs.Select(PitchClass.FromValue));
+
+    private static string Label(PitchClassSet s)
+    {
+        Assert.That(CanonicalForteCatalog.TryGetForteLabel(s, out var l), Is.True, $"no canonical label for {s}");
+        return l!;
+    }
+
+    [Test]
+    public void TryGetForteLabel_UsesCanonical1973Numbering()
+    {
+        Assert.Multiple(() =>
+        {
+            // The #544 bug: {0,1,6,7} (and its transposition {4,5,10,11}) is Forte 4-9,
+            // was mislabelled 4-21 by the Rahn catalog.
+            Assert.That(Label(Pcs(0, 1, 6, 7)), Is.EqualTo("4-9"), "{0,1,6,7} is Forte 4-9");
+            Assert.That(Label(Pcs(4, 5, 10, 11)), Is.EqualTo("4-9"), "#544 fixture (a transposition of 0167)");
+            // 4-21 is genuinely the whole-tone tetrachord — guard against a mere label swap.
+            Assert.That(Label(Pcs(0, 2, 4, 6)), Is.EqualTo("4-21"), "whole-tone tetrachord is 4-21");
+            // Z marker preserved (ProgrammaticForteCatalog does not model it).
+            Assert.That(Label(Pcs(0, 1, 3, 7)), Is.EqualTo("4-Z29"), "Z marker preserved");
+        });
+    }
+
+    [Test]
+    public void Identify_SetClassFallback_EmitsCanonicalForteLabel()
+    {
+        var result = CanonicalChordRecognizer.Identify(Pcs(4, 5, 10, 11));
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.CanonicalName, Does.Contain("Forte 4-9"), "fallback must emit the canonical label");
+            Assert.That(result.CanonicalName, Does.Not.Contain("4-21"), "must not emit the Rahn ordinal");
+        });
+    }
+
+    [Test]
+    public void CanonicalLabels_PrimeFormRoundTrip()
+    {
+        // Every stored core label (cardinalities 0-6) resolves to a prime form whose own
+        // label round-trips to the same string: pc-set → prime form → Forte label → itself.
+        Assert.Multiple(() =>
+        {
+            foreach (var (label, primeForm) in CanonicalForteCatalog.CoreByLabel)
+            {
+                Assert.That(CanonicalForteCatalog.TryGetForteLabel(primeForm, out var back), Is.True,
+                    $"{label}: prime form has no canonical label");
+                Assert.That(back, Is.EqualTo(label), $"round-trip mismatch for {label}");
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Problem
The set-class fallback in `CanonicalChordRecognizer.FallbackFromForte` built a human-facing `Forte X-Y` label but looked it up in the internal **Rahn-ordered** `ProgrammaticForteCatalog` (whose own docs warn it "may differ from Allen Forte's historical 1973 numbering"). So `{0,1,6,7}` — and transpositions like `{4,5,10,11}` — was labelled **Forte 4-21** (the whole-tone tetrachord) when it is canonically **Forte 4-9**. The label is user-facing (OPTIC-K `quality_inferred`, chatbot output), so it must match the standard catalog.

Found as a byproduct of research study 0' (`docs/research/2026-07-19-optick-sae-feature-atlas.md`), verified during its Fable 5 validation pass.

## Fix
`FallbackFromForte` now calls `CanonicalForteCatalog.TryGetForteLabel` — the repo's canonical 1973 catalog, documented as "for human-facing Forte-label lookups" — which also preserves the **Z marker** (e.g. `4-Z29`) the Rahn catalog can't model. `ProgrammaticForteCatalog` is untouched and remains GA's internal Rahn-consistent catalog.

## Test
`CanonicalForteLabelTests` in `GA.Business.Core.Tests` (a project CI runs — deliberately **not** the orphaned `GA.Domain.Core.Tests`):
- `{0,1,6,7}` / `{4,5,10,11}` → `4-9`; `{0,2,4,6}` → `4-21` (guard against a bare swap); `{0,1,3,7}` → `4-Z29` (Z preserved)
- recognizer fallback emits "Forte 4-9", not "4-21"
- full prime-form → label round-trip over the canonical catalog

**3/3 green locally** (`dotnet test` after stopping the DLL-locking GaApi).

Fixes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)