### PR TITLE
fix(ci): self-heal the readme-drift label so the sensor stops failing weekly

### DIFF
--- a/.github/workflows/readme-drift-sensor.yml
+++ b/.github/workflows/readme-drift-sensor.yml
@@ -103,6 +103,14 @@ jobs:
           DATE: ${{ steps.survey.outputs.date }}
         shell: pwsh
         run: |
+          # Self-heal the label before any issue op. `gh issue create --label`
+          # hard-fails with "could not add label: 'readme-drift' not found" when
+          # the label is absent, which silently broke this sensor for 5+ weekly
+          # runs (2026-06-15 .. 2026-07-13 all red) while it kept committing
+          # snapshots the dashboard consumed. --force is idempotent and also
+          # repairs colour/description if the label was auto-created bare.
+          gh label create readme-drift --color 5319E7 `
+            --description "Tracking issue for cross-repo README staleness" --force
           $report = Get-Content "state/quality/readme-drift/${env:DATE}.json" -Raw | ConvertFrom-Json
           $stale  = $report.repos | Where-Object { $_.status -in @('stale','very-stale') }
           if (-not $stale) {
@@ -127,7 +135,11 @@ jobs:
             $n = $existing[0].number
             Write-Host "Updating existing issue #$n"
             $body | gh issue comment $n -F -
-            gh issue edit $n --title "README drift — ${env:DATE} (${($stale.Count)} stale)"
+            # $(...) is the subexpression operator; ${...} is variable-NAME syntax,
+            # so ${($stale.Count)} looks up a variable literally named
+            # "($stale.Count)" and yields nothing. Latent until an issue exists —
+            # this branch had never run, because creation failed on the label.
+            gh issue edit $n --title "README drift — ${env:DATE} ($($stale.Count) stale)"
           } else {
             Write-Host "Opening new tracking issue"
             $body | gh issue create --title "README drift — ${env:DATE} ($($stale.Count) stale)" --label readme-drift -F -


### PR DESCRIPTION
## The problem

The README Drift Sensor has **failed every scheduled run for at least five weeks** — 2026-06-15, 06-22, 06-29, 07-06, 07-13, all red — while continuing to commit snapshots that `ix-quality-trend` and the dashboard consume.

That is the green-but-dead shape the harness exists to prevent: `readme-drift` shows up on the scorecard as DEGRADED with a real-looking `metric_value` of 0.3333, and nothing signals that its producer has not completed successfully since mid-June.

## Root cause

From the job log:

```
could not add label: 'readme-drift' not found
```

The `readme-drift` label was never created in this repo, so `gh issue create --label readme-drift` hard-fails. Step-level conclusions show why it stayed invisible:

| step | result |
|---|---|
| Run drift survey | ✅ success |
| Commit snapshot if new | ✅ success |
| **Open or update tracking issue** | ❌ **failure** |
| Upload report artifact | ✅ success |

Only the tracking-issue step dies. The data kept flowing, so the dashboard looked alive.

## Fix

Create the label with `--force` before any issue operation, mirroring the self-heal already in `.github/workflows/jules-auto-delegate.yml`, which hit this exact failure mode in its run #2. Idempotent, and repairs colour/description if the label was auto-created bare.

**Also fixes a latent PowerShell bug** in the update branch:

```diff
- gh issue edit $n --title "README drift — ${env:DATE} (${($stale.Count)} stale)"
+ gh issue edit $n --title "README drift — ${env:DATE} ($($stale.Count) stale)"
```

`${...}` is variable-*name* syntax, so the original looks up a variable literally named `($stale.Count)` and yields nothing. It had never fired because issue creation always failed first — **it would have broken the very next run after this fix landed.** The adjacent `gh issue create` line already had it right.

## What happens after merge

The sensor goes green and opens a tracking issue for the real drift, which is genuine and has been accumulating unreported:

| repo | status |
|---|---|
| ga | stale |
| ix | borderline |
| agent-blackbox | stale |
| demerzel-bot | very-stale |
| ga-godot | very-stale |
| hari | very-stale |

3 ok / 1 borderline / 2 stale / 3 very-stale out of 9. Refreshing those READMEs is separate work; this PR only makes the sensor able to report it.

YAML validated with pyyaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)