### PR TITLE
feat(chatbot-qa): LLM-as-judge gate so answer quality becomes measurable

### DIFF
--- a/Scripts/run-prompt-corpus.ps1
+++ b/Scripts/run-prompt-corpus.ps1
@@ -279,6 +279,10 @@ if ($Snapshot) {
     $inPromptBlock = $false
     $currentCategory = $null
     $currentSkip = $false
+    # Per-prompt roster. The aggregates above reduce this away; the verdict
+    # ledger below needs the individual entries, so retain them here.
+    $currentPrompt = $null
+    $promptRoster = [System.Collections.ArrayList]::new()
 
     function _Flush {
         if (-not $script:inPromptBlock) { return }
@@ -292,6 +296,12 @@ if ($Snapshot) {
                 }
                 $script:categoryTotals[$script:currentCategory]++
             }
+            if ($script:currentPrompt) {
+                [void]$script:promptRoster.Add([pscustomobject]@{
+                    prompt   = $script:currentPrompt
+                    category = $script:currentCategory
+                })
+            }
         }
     }
 
@@ -301,6 +311,15 @@ if ($Snapshot) {
             $script:inPromptBlock = $true
             $script:currentCategory = $null
             $script:currentSkip = $false
+            # Prompt text is the join key against the "[category] 'prompt'"
+            # failure labels from PromptCorpusTests.EvaluatePromptAsync.
+            $script:currentPrompt = if ($_ -match '^\s*-\s*prompt:\s*"(.*)"\s*(#.*)?$') {
+                $matches[1]
+            } elseif ($_ -match '^\s*-\s*prompt:\s*(\S.*?)\s*(#.*)?$') {
+                $matches[1]
+            } else {
+                $null
+            }
         }
         elseif ($script:inPromptBlock -and $_ -match '^\s+category:\s*"?([^"#]+?)"?\s*(#.*)?$') {
             if ($null -eq $script:currentCategory) {
@@ -489,6 +508,66 @@ if ($Snapshot) {
     $snap | ConvertTo-Json -Depth 4 | Set-Content $snapshotPath -Encoding UTF8
     Write-Host ""
     Write-Host "Wrote trend snapshot to $snapshotPath" -ForegroundColor Cyan
+
+    # ── Per-prompt verdict ledger (additive; consumer: GuitarAlchemist/hari#13) ──
+    # The snapshot answers "what fraction passed today". It cannot answer "did
+    # prompt X's verdict change since yesterday" — the per-prompt join is
+    # computed and then discarded. This persists it.
+    #
+    # Why hari wants it: hari's contradiction-preserving lattice needs the SAME
+    # proposition observed MORE THAN ONCE with the possibility of disagreement.
+    # Nothing else in the ecosystem supplies that. ix-autoresearch's targets
+    # perturb continuous config spaces, so a config is never revisited (2000
+    # perturbations → 2000 distinct configs); the invariant firings re-observe
+    # daily but have been 1.0/ok every day since 2026-04-18. This corpus is the
+    # only candidate: same 52 active prompts, judged daily.
+    #
+    # Separate artifact, NOT new fields on $snap: the snapshot's shape is pinned
+    # by ix-quality-trend (ix/crates/ix-quality-trend/src/snapshot.rs) and read by
+    # emit-ga-retrieval-quality.ps1. Nothing above this line changes.
+    $verdictDir = Join-Path $snapshotDir "verdicts"
+    if (-not (Test-Path $verdictDir)) {
+        New-Item -ItemType Directory -Path $verdictDir -Force | Out-Null
+    }
+    $verdictPath = Join-Path $verdictDir "$date.jsonl"
+
+    # Failure labels are "[category] 'prompt'" — index the prompt text so the
+    # roster join is exact rather than a substring scan.
+    $failedPrompts = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($f in $failures) {
+        if ($f -match "^\[[^\]]*\]\s*'(.*)'") {
+            [void]$failedPrompts.Add($matches[1])
+        }
+    }
+
+    $verdictLines = foreach ($entry in $promptRoster) {
+        # Degraded runs are recorded as "unknown", not dropped: "the backend was
+        # incomplete" is real evidence ABOUT the observation, and omitting the day
+        # would let a consumer misread the gap as agreement. Uses the same
+        # $environmentDegraded computed above, so it inherits both the declared
+        # GA_CORPUS_ENV_DEGRADED verdict and the BACKEND_DEGRADED marker.
+        $verdict = if ($environmentDegraded) {
+            "unknown"
+        } elseif ($failedPrompts.Contains($entry.prompt)) {
+            "fail"
+        } else {
+            "pass"
+        }
+        ([pscustomobject]@{
+            date      = $date
+            timestamp = $snap.timestamp
+            prompt    = $entry.prompt
+            category  = $entry.category
+            verdict   = $verdict
+            degraded  = [bool]$environmentDegraded
+        } | ConvertTo-Json -Depth 3 -Compress)
+    }
+    $verdictLines | Set-Content $verdictPath -Encoding UTF8
+
+    $vPass = @($verdictLines | Where-Object { $_ -match '"verdict":"pass"' }).Count
+    $vFail = @($verdictLines | Where-Object { $_ -match '"verdict":"fail"' }).Count
+    $vUnk  = @($verdictLines | Where-Object { $_ -match '"verdict":"unknown"' }).Count
+    Write-Host "Wrote $(@($verdictLines).Count) per-prompt verdicts to $verdictPath (pass=$vPass fail=$vFail unknown=$vUnk)" -ForegroundColor Cyan
 
     # ── Unified Quality Gate Ledger (v1) — also emit a row ──
     # See ix/docs/contracts/2026-05-24-quality-gate-ledger.contract.md.

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/LlmJudge.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/LlmJudge.cs
@@ -1,0 +1,168 @@
+namespace GaChatbot.Api.Tests.Corpus;
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+///     An LLM-as-judge gate for answer <em>quality</em>, complementing the
+///     substring invariants in <see cref="PromptCorpusTests"/>.
+///
+///     <para><b>Why this exists.</b> The substring corpus measures the domain
+///     layer, not the language model. Pointing the chatbot at a deliberately
+///     bogus chat model still left 50 of 52 prompts passing, because most
+///     answers are assembled from deterministic skill output that contains the
+///     asserted tokens no matter how weak the model is. That makes "is the
+///     model good enough?" unmeasurable with substrings alone: a 3B model and a
+///     frontier model both emit the word "Ionian".</para>
+///
+///     <para><b>Why a stronger judge.</b> The judge must outclass the models it
+///     grades, or the eval is circular — a weak model rating its own prose will
+///     rate it fine, which is how you end up with a second confidently-wrong
+///     oracle. Default is <c>gpt-oss:120b-cloud</c> through the same Ollama
+///     endpoint the app already uses (no extra SDK, no extra key).</para>
+///
+///     <para><b>Scope discipline.</b> The rubric deliberately restricts the
+///     judge to general music theory and to answering-the-question. During
+///     bring-up the judge failed a correct answer for stating "there are 26
+///     mode families in the catalog" — a true claim about GA's own inventory
+///     that no general-purpose model can verify. Judging claims the judge
+///     cannot check is how a quality gate becomes a liar, so catalog/inventory
+///     and product-specific claims are explicitly out of scope and are
+///     validated by the deterministic invariants instead.</para>
+/// </summary>
+internal sealed class LlmJudge(HttpClient http, string model)
+{
+    /// <summary>Env var overriding the Ollama endpoint (default localhost:11434).</summary>
+    internal const string EndpointEnvVar = "GA_JUDGE_ENDPOINT";
+
+    /// <summary>Env var overriding the judge model.</summary>
+    internal const string ModelEnvVar = "GA_JUDGE_MODEL";
+
+    internal const string DefaultEndpoint = "http://localhost:11434";
+    internal const string DefaultModel = "gpt-oss:120b-cloud";
+
+    /// <summary>
+    ///     Stamped into a failure message when the judge itself could not be
+    ///     reached. Callers must treat this as "no signal", never as a quality
+    ///     failure — the same distinction the degraded-backend token draws in
+    ///     <see cref="PromptCorpusTests.BackendDegradedToken"/>.
+    /// </summary>
+    internal const string JudgeUnavailableToken = "JUDGE_UNAVAILABLE";
+
+    private const string Rubric = """
+        You are a strict music-theory examiner grading one answer from a guitar
+        theory assistant.
+
+        Judge ONLY:
+          1. Factual and theoretical correctness of any music-theory claim.
+          2. Whether the answer actually answers the question that was asked,
+             including its shape (if a 3-note triad was requested, a 7-note
+             scale is a FAIL even though every note listed may be valid).
+          3. The specific rubric supplied below, if any.
+
+        Explicitly DO NOT judge:
+          - Style, tone, formatting, markdown, or length. A terse but correct
+            answer PASSES.
+          - Claims about this product's own catalog, inventory, counts of
+            available scales/modes/voicings, or its feature set. You cannot
+            verify those and they are covered by other tests. Ignore them
+            entirely, even if they look surprising.
+          - Pedagogical choices, ordering, or which extra detail was included.
+
+        A confidently-stated wrong fact is a FAIL. An answer that dodges the
+        question, or that reports a service error instead of answering, is a
+        FAIL.
+
+        QUESTION:
+        {{QUESTION}}
+
+        RUBRIC (in addition to the above; may be empty):
+        {{RUBRIC}}
+
+        ANSWER:
+        {{ANSWER}}
+
+        Reply ONLY with JSON of exactly this shape:
+        {"verdict":"pass","reason":"<at most 15 words>"}
+        """;
+
+    internal static LlmJudge Create()
+    {
+        var endpoint = Environment.GetEnvironmentVariable(EndpointEnvVar) ?? DefaultEndpoint;
+        var model = Environment.GetEnvironmentVariable(ModelEnvVar) ?? DefaultModel;
+        var http = new HttpClient { BaseAddress = new Uri(endpoint), Timeout = TimeSpan.FromMinutes(2) };
+        return new LlmJudge(http, model);
+    }
+
+    /// <summary>
+    ///     Returns true when the judge endpoint answers and advertises the
+    ///     configured model. Used to decide between "run the gate" and "report
+    ///     no signal" — never to silently pass.
+    /// </summary>
+    internal async Task<bool> IsAvailableAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await http.GetAsync("/api/tags", ct);
+            if (!resp.IsSuccessStatusCode) return false;
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            // Model names carry an optional ":tag"; match the bare name so a
+            // locally-retagged copy of the same weights still counts.
+            var bareName = model.Split(':')[0];
+            return body.Contains(bareName, StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Grades one answer. Throws only on transport failure.</summary>
+    internal async Task<JudgeVerdict> JudgeAsync(
+        string question,
+        string answer,
+        string? rubric,
+        CancellationToken ct = default)
+    {
+        var prompt = Rubric
+            .Replace("{{QUESTION}}", question)
+            .Replace("{{RUBRIC}}", string.IsNullOrWhiteSpace(rubric) ? "(none)" : rubric)
+            .Replace("{{ANSWER}}", answer);
+
+        var request = new
+        {
+            model,
+            stream = false,
+            format = "json",
+            messages = new[] { new { role = "user", content = prompt } },
+        };
+
+        using var resp = await http.PostAsJsonAsync("/api/chat", request, ct);
+        resp.EnsureSuccessStatusCode();
+
+        var envelope = await resp.Content.ReadFromJsonAsync<OllamaChatResponse>(cancellationToken: ct)
+            ?? throw new InvalidOperationException("judge returned an empty envelope");
+
+        var content = envelope.Message?.Content
+            ?? throw new InvalidOperationException("judge returned no message content");
+
+        var verdict = JsonSerializer.Deserialize<JudgeVerdict>(content)
+            ?? throw new InvalidOperationException($"judge returned unparseable JSON: {content}");
+
+        return verdict;
+    }
+
+    private sealed record OllamaChatResponse(
+        [property: JsonPropertyName("message")] OllamaMessage? Message);
+
+    private sealed record OllamaMessage(
+        [property: JsonPropertyName("content")] string? Content);
+}
+
+internal sealed record JudgeVerdict(
+    [property: JsonPropertyName("verdict")] string Verdict,
+    [property: JsonPropertyName("reason")] string? Reason)
+{
+    internal bool IsPass => string.Equals(Verdict, "pass", StringComparison.OrdinalIgnoreCase);
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/PromptCorpusTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/PromptCorpusTests.cs
@@ -201,6 +201,113 @@ public class PromptCorpusTests
             $"Prompts violating invariants ({failures.Count}):\n  - {string.Join("\n  - ", failures)}");
     }
 
+    /// <summary>
+    ///     Grades every prompt carrying a <c>judge:</c> rubric with a stronger
+    ///     model. This is the only gate in the corpus that can see answer
+    ///     <em>quality</em> — the substring invariants measure the deterministic
+    ///     skill layer, so they stay green even when the chat model is replaced
+    ///     with a bogus one (measured: 50 of 52 still passed).
+    /// </summary>
+    /// <remarks>
+    ///     Fails loudly with <see cref="LlmJudge.JudgeUnavailableToken"/> rather
+    ///     than passing when the judge cannot be reached. A quality gate that
+    ///     reports success because it could not run is precisely the bug this
+    ///     corpus already shipped once — see the note on
+    ///     <see cref="BackendDegradedMarkers"/>.
+    /// </remarks>
+    [Test]
+    [Explicit("Slow + calls an external judge model. Run before releases and when comparing chat models.")]
+    public async Task JudgedPrompts_SatisfyTheirRubric()
+    {
+        var judged = _corpus!.Prompts
+            .Where(p => !p.Skip && !string.IsNullOrWhiteSpace(p.Judge))
+            .ToList();
+
+        Assert.That(judged, Is.Not.Empty,
+            "No prompts carry a `judge:` rubric — the quality gate would silently measure nothing.");
+
+        var judge = LlmJudge.Create();
+        if (!await judge.IsAvailableAsync())
+        {
+            Assert.Fail(
+                $"{LlmJudge.JudgeUnavailableToken}: judge model unreachable " +
+                $"(set {LlmJudge.EndpointEnvVar} / {LlmJudge.ModelEnvVar}). " +
+                "Reporting no signal rather than a pass.");
+        }
+
+        var failures = new List<string>();
+
+        foreach (var entry in judged)
+        {
+            var (answer, _, error) = await FetchAnswerAsync(entry);
+            if (error is not null)
+            {
+                failures.Add($"{JudgeLabel(entry)} → {error}");
+                continue;
+            }
+
+            JudgeVerdict verdict;
+            try
+            {
+                verdict = await judge.JudgeAsync(entry.Prompt, answer!, entry.Judge);
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{JudgeLabel(entry)} → {LlmJudge.JudgeUnavailableToken}: {ex.Message}");
+                continue;
+            }
+
+            if (!verdict.IsPass)
+            {
+                failures.Add($"{JudgeLabel(entry)} → JUDGE_FAIL: {verdict.Reason}");
+            }
+        }
+
+        Assert.That(failures, Is.Empty,
+            $"Prompts rejected by the judge ({failures.Count}/{judged.Count}):\n  - {string.Join("\n  - ", failures)}");
+    }
+
+    private static string JudgeLabel(PromptEntry entry) =>
+        $"[{entry.Category ?? "uncategorized"}] \"{entry.Prompt}\"";
+
+    /// <summary>
+    ///     Fetches one answer without applying any invariant. Shared by the
+    ///     judge gate, which needs the raw prose rather than a pass/fail.
+    ///     Returns <c>error</c> non-null for transport-level problems and for
+    ///     the degraded-backend case, so the judge is never asked to grade a
+    ///     fallback apology as if it were an answer.
+    /// </summary>
+    private async Task<(string? answer, long elapsedMs, string? error)> FetchAnswerAsync(PromptEntry entry)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        HttpResponseMessage response;
+        try
+        {
+            response = await _client!.PostAsJsonAsync("/api/chatbot/chat", new { message = entry.Prompt });
+        }
+        catch (Exception ex)
+        {
+            return (null, sw.ElapsedMilliseconds, $"exception: {ex.GetType().Name}: {ex.Message}");
+        }
+        sw.Stop();
+
+        if (response.StatusCode != HttpStatusCode.OK)
+            return (null, sw.ElapsedMilliseconds, $"HTTP {(int)response.StatusCode}");
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var answer = body.TryGetProperty("naturalLanguageAnswer", out var a) ? a.GetString() ?? "" : "";
+
+        if (string.IsNullOrWhiteSpace(answer))
+            return (null, sw.ElapsedMilliseconds, "empty response");
+
+        foreach (var marker in BackendDegradedMarkers)
+            if (answer.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                return (null, sw.ElapsedMilliseconds,
+                    $"{BackendDegradedToken}: backend returned a degraded fallback answer");
+
+        return (answer, sw.ElapsedMilliseconds, null);
+    }
+
     // ── evaluation ──────────────────────────────────────────────────────────
 
     private async Task<(string? failure, string? warning)> EvaluatePromptAsync(PromptEntry entry)
@@ -403,6 +510,22 @@ public class PromptCorpusTests
         // total). Set to 0 for deterministic-skill prompts where any
         // wording variance is a real bug.
         public int? Retry { get; set; }
+
+        /// <summary>
+        ///     Opt-in LLM-judge rubric. When set, <c>JudgedPrompts_SatisfyTheirRubric</c>
+        ///     sends the answer to a stronger model (see <see cref="LlmJudge"/>) and
+        ///     fails the prompt if the judge rejects it.
+        ///
+        ///     Use this for prompts whose correctness lives in the <em>prose</em>
+        ///     rather than in a substring — explanations, comparisons, reasoning.
+        ///     Substring invariants cannot distinguish a 3B model from a frontier
+        ///     one on those, since both emit the same keywords.
+        ///
+        ///     Keep the rubric about music theory and about answering the question.
+        ///     Do not ask the judge to verify claims about GA's own catalog; it
+        ///     cannot check them and will produce false failures.
+        /// </summary>
+        public string? Judge { get; set; }
 
         // ── Trace-shape invariants (GitHub agentic-behavior validation) ─────
         // These check the structured trace returned with every chat

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
@@ -541,6 +541,73 @@ prompts:
     max_elapsed_ms: 20000
     retry: 0
 
+  # ── judged (LLM-as-judge quality gate) ─────────────────────────────────
+  #
+  # Prompts carrying `judge:` are graded by a STRONGER model
+  # (gpt-oss:120b-cloud by default) in JudgedPrompts_SatisfyTheirRubric,
+  # not by substring matching.
+  #
+  # Why: the substring gate measures the deterministic skill layer, not the
+  # chat model. Pointed at a deliberately bogus chat model, 50 of 52 prompts
+  # still passed — the asserted tokens come from domain output regardless of
+  # model quality. So "did the model upgrade help?" was unmeasurable until
+  # these existed. Reasoning prompts are where model strength actually shows.
+  #
+  # Rubric discipline: keep `judge:` about music theory and about answering
+  # the question asked. Do NOT ask the judge to verify claims about GA's own
+  # catalog — during bring-up it failed a correct answer over the true
+  # statement "there are 26 mode families in the catalog", which no general
+  # model can check. Those belong in `contains` / `not_contains`.
+
+  - prompt: "Explain why a tritone substitution works"
+    category: reasoning
+    min_length: 120
+    max_elapsed_ms: 60000
+    judge: >-
+      Must explain that the substitute dominant shares the same tritone
+      (guide tones: 3rd and b7th) as the original dominant, which is why it
+      can replace it. Mentioning the resulting chromatic bass descent is a
+      plus, not a requirement.
+
+  - prompt: "What is the difference between a major seventh and a minor seventh chord"
+    category: reasoning
+    min_length: 100
+    max_elapsed_ms: 60000
+    judge: >-
+      Must correctly distinguish the two chord qualities by their intervals
+      (major 7th = major triad + major 7th; minor 7th = minor triad + minor
+      7th). Confusing either quality, or conflating "minor seventh chord"
+      with "dominant seventh", is a failure.
+
+  - prompt: "Why does the Lydian mode sound brighter than Ionian"
+    category: reasoning
+    min_length: 100
+    max_elapsed_ms: 60000
+    judge: >-
+      Must identify the raised fourth (#4 / #11) as the single degree that
+      distinguishes Lydian from Ionian, and connect it to the brighter
+      character. Naming any other degree as the difference is a failure.
+
+  # ── known-bad, awaiting fix (skipped so the gate stays honest about scope)
+  #
+  # These reproduce confirmed defects found by the judge probe on 2026-07-20.
+  # They are committed skipped — documented and ready to flip to active the
+  # moment the underlying issue closes — rather than left out, so the repro
+  # does not have to be rediscovered.
+
+  - prompt: "What is the relative minor of E-flat major"
+    category: scales-keys
+    routes_to: skill.relativekey
+    contains: ["C minor"]
+    not_contains: ["E major", "C#m", "4 sharps"]
+    min_length: 30
+    skip: true
+    skip_reason: >-
+      Issue #554 — spelled-out accidentals parse as naturals, so "E-flat major"
+      is answered as "E major" (C#m, 4 sharps). Shorthand "Eb major" is correct.
+
+  # #555 is FIXED (PR #558, 2026-07-20) — this prompt is an ACTIVE guard now,
+  # not the skipped repro it was when this branch first added it.
   - prompt: "What notes are in a C major triad"
     category: chord-tones
     routes_to: skill.chordinfo


### PR DESCRIPTION
## Why

The substring corpus measures the **deterministic skill layer**, not the chat model.

Measured: pointing the chatbot at a deliberately bogus chat model still left
**50 of 52 prompts passing**. The asserted tokens come from domain output no
matter how weak the model is. So "is the model good enough?" and "did the
upgrade help?" were unmeasurable — a 3B model and a frontier model both emit
"Ionian".

This is the prerequisite for the model-upgrade work, not a nice-to-have
alongside it.

## What

Opt-in `judge:` rubric per prompt, graded by a stronger model
(`gpt-oss:120b-cloud` through the Ollama endpoint the app already uses — no new
SDK, no new key). New `[Explicit]` test `JudgedPrompts_SatisfyTheirRubric`.

## Verified end-to-end

Gate runs and rejects 3/3 seeded reasoning prompts. The one worth reading:

> **Q:** Why does the Lydian mode sound brighter than Ionian
> **A:** Lydian is mode 4 of the Major Scale family; on C its notes are
> `C D E F# G A B` (formula `1 2 3 #4 5 6 7`). Characteristic interval(s):
> `#4`, `2`, `3`, `6`, `7`.

A data dump, not an explanation — the "why" is never answered. Any
`contains: ["#4", "Lydian"]` invariant passes it. The judge fails it.
(Also 111s elapsed, consistent with the round-trip problem.)

## Scope discipline — how this avoids becoming a second lying oracle

The judge is deliberately fenced, because during bring-up it **failed a correct
answer**: it rejected "there are 26 mode families in the catalog" as a false
claim. That statement is true — it is about GA's own inventory, which no
general-purpose model can verify. 1 false positive in 6.

So:

- Rubric **excludes** claims about GA's catalog/inventory/feature set. Those
  stay with the deterministic invariants.
- Judge must **outclass** what it grades, or the eval is circular (a weak model
  grading its own prose rates it fine).
- An unreachable judge fails with `JUDGE_UNAVAILABLE` rather than passing —
  the same no-signal-vs-fabricated-pass distinction this corpus already got
  wrong once, which is what #553 fixes.
- Discrimination validated **before** wiring in: 5/5 on a hand-built battery,
  including the terse-but-correct case where naive judges produce false
  failures.

## Bugs this found within minutes of existing

Committed as **skipped** repros (documented, ready to flip when fixed) rather
than omitted, so they don't have to be rediscovered:

- **#554** — spelled-out accidentals parse as naturals. `E-flat major` is
  answered as `E major` → `C#m`, "4 sharps". `Eb major` is correct. A fluent
  wrong answer with invented supporting detail.
- **#555** — `what notes are in a C major triad` misroutes to `skill.scaleinfo`
  at **0.90 confidence** and returns the 7-note scale, despite
  `skills/chord-info/SKILL.md` already declaring the `"what notes are in"`
  trigger. Router-ranking bug; fix is embedding-side, not keyword rules.

## Known gap, deliberately not addressed

The LLM-timeout fallback ("the LLM call exceeded the 15s timeout") is a **third**
degradation signature missing from `BackendDegradedMarkers`. Whether a model too
slow to answer within budget counts as an *environment* failure or a *product*
failure is a judgement call that should be made deliberately, so it is left as
follow-up rather than silently classified either way.

## Stacking

Branched on `fix/chatbot-qa-oracle-degraded-detection` (**#553**) because it
reuses that PR's `BackendDegradedMarkers` / `BackendDegradedToken` to avoid
asking the judge to grade a fallback apology as if it were an answer.
**Merge #553 first.**

## Test

```
Build succeeded.
JudgedPrompts_SatisfyTheirRubric — gate runs, 3/3 rejected as expected (2m24s)
```

Judge latency ~1.6s per verdict.


---

## ⚠️ This PR carries a second, unrelated commit — please decide before merging

```
dc6f9f7e  feat(chatbot-qa): persist per-prompt verdict ledger alongside the trend snapshot
          Scripts/run-prompt-corpus.ps1  +79
```

**I did not write this commit and did not review it.** It was sitting
uncommitted in the working tree when I branched, and got carried onto this
branch. It exists on no other branch.

What it does: builds a per-prompt roster during the corpus run and writes a
verdict ledger under `<snapshot>/verdicts/`, so per-prompt verdict *changes*
can be joined day-over-day. The comments name `GuitarAlchemist/hari#13` as the
consumer.

It looks like legitimate and useful work — it is adjacent to this PR's subject
(both concern corpus output), and it is additive. But it is not the judge gate,
it is not described by this PR's title, and merging as-is lands it silently
under a description that never mentions it.

**Two clean options:**

1. **Keep it here** — I amend the title/description to cover both changes, so
   the history is honest about what landed.
2. **Split it out** — I move `dc6f9f7e` to its own branch and PR, and rebase
   this one to contain only the judge gate.

Option 2 is the tidier history; option 1 is fewer moving parts. I have not
picked for you because the work is not mine to reassign.

Flagging rather than quietly merging, per the same reasoning that keeps me from
self-applying the `agent-blackbox-reviewed` label on #553.


---

_Replaces #556, which GitHub auto-closed when its base branch (`fix/chatbot-qa-oracle-degraded-detection`, now merged as #553) was deleted. Rebased onto main; the #553 commit is dropped since it landed squashed. No content change._
