### PR TITLE
feat(chatbot): improvise over a whole progression — arpeggio + scale per chord (#555 sibling North Star)

### DIFF
--- a/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ImprovisationSkill.cs
@@ -9,9 +9,33 @@ using GA.Business.ML.Search;
 /// typed chord parser to extract a chord symbol from the user query, infers
 /// the chord quality, and returns matching modes / scales drawn from a
 /// canonical chord-scale mapping. Pure domain compute; no LLM at the skill
-/// layer. Single-chord queries only in v1 — progression handling (ii-V-I,
-/// minor blues, etc.) is documented as v2 scope.
+/// layer.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>v2 (2026-07-20)</b> adds the progression path: when the query contains a
+/// run of two or more chord symbols ("Am F C G"), each chord is classified
+/// independently and returned with its arpeggio and chord-scale candidates.
+/// This closes the BACKLOG North Star item "which arpeggio fits this chord
+/// progression?".
+/// </para>
+/// <para>
+/// The per-chord classification is deliberately <b>key-agnostic</b>. The
+/// obvious alternative — infer the key, then map each chord to a scale degree
+/// and hand back that degree's mode — is what
+/// <c>GaMcpServer/Tools/GuitaristProblemTools.cs</c> does, and it is wrong for
+/// any borrowed or secondary chord: it locates the degree by root pitch-class
+/// alone, so an A major chord in C major is still reported as degree vi and
+/// handed Aeolian, putting a natural C against the chord's C#. Reusing
+/// <see cref="InferQuality"/> per chord cannot make that mistake, because it
+/// reads the quality the user actually wrote.
+/// </para>
+/// <para>
+/// Roman-numeral queries ("how do I solo over a ii-V-I") are still out of
+/// scope — there are no chord symbols to classify without a stated key. The
+/// no-chord branch says so explicitly rather than guessing.
+/// </para>
+/// </remarks>
 [GuitarAlchemist.Registry.GaSkill("Improvisation", "scale")]
 public sealed partial class ImprovisationSkill(
     ILogger<ImprovisationSkill> logger,
@@ -20,10 +44,11 @@ public sealed partial class ImprovisationSkill(
     public string Name => "Improvisation";
 
     public string Description =>
-        "Suggests scales and modes to improvise / solo over a given chord. " +
-        "Parses the chord symbol from the user query (e.g. 'Cmaj7', 'G7', " +
-        "'Am7b5') and returns canonical chord-scale candidates with their " +
-        "note spellings and a one-line color note. Single-chord queries only.";
+        "Suggests scales, modes and arpeggios to improvise / solo over a chord " +
+        "or a whole chord progression. For a single chord (e.g. 'Cmaj7', 'G7', " +
+        "'Am7b5') it returns canonical chord-scale candidates with a one-line " +
+        "color note. For a run of chords (e.g. 'Am F C G') it returns, for each " +
+        "chord in turn, the matching arpeggio and the scales to play over it.";
 
     public IReadOnlyList<string> ExamplePrompts =>
     [
@@ -37,6 +62,22 @@ public sealed partial class ImprovisationSkill(
         "what to play over a Bm7b5",
         "improvisation choices for E7alt",
         "solo over a Cmaj9 chord",
+        // v2 (2026-07-20) progression anchors. These carry MORE than one chord
+        // symbol and lean on the noun "progression" / "over these chords" so the
+        // router separates them from single-chord scale lookups and from
+        // ProgressionCompletionSkill (which is about what chord comes NEXT, not
+        // what to play over the existing ones). Keep at least two chord symbols
+        // in every anchor — that multi-chord shape is the routing signal.
+        "which arpeggio fits Am F C G",
+        "what arpeggios work over Dm7 G7 Cmaj7",
+        "arpeggios to solo over Am F C G",
+        "what scales fit over the progression Cmaj7 A7 Dm7 G7",
+        "how do I improvise over Am F C G",
+        "which arpeggio for each chord in Em C G D",
+        // "solo over the changes" — jazz idiom for improvising through a
+        // progression. Held-out testing showed this phrasing drifting to
+        // practiceroutine (0.78); it belongs here. "changes" = the chords.
+        "what do I solo over the changes Dm7 G7 Cmaj7",
     ];
 
     // Intent keywords. The CanHandle gate is "improvisation intent AND a
@@ -53,6 +94,10 @@ public sealed partial class ImprovisationSkill(
         // fallback path (semantic router catches them; fallback didn't).
         "which mode", "which modes", "what mode", "what modes",
         "chord-scale", "chord scale",
+        // v2 (2026-07-20) progression / arpeggio intent. "arpeggio" makes the
+        // "which arpeggio fits ..." family reachable through the CanHandle
+        // fallback path, not just the semantic router.
+        "arpeggio", "arpeggios",
     ];
 
     public bool CanHandle(string message)
@@ -71,6 +116,14 @@ public sealed partial class ImprovisationSkill(
 
     public async Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
     {
+        // Progression path (v2): if the query names two or more chord symbols,
+        // classify each independently and return per-chord arpeggio + scales.
+        // Checked BEFORE the single-chord extractor, whose ExtractAsync collapses
+        // a run to one symbol.
+        var run = ExtractChordRun(message);
+        if (run.Count >= 2)
+            return BuildProgressionResponse(run);
+
         var structured = await extractor.ExtractAsync(message, cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(structured.ChordSymbol))
@@ -79,10 +132,11 @@ public sealed partial class ImprovisationSkill(
             {
                 AgentId = $"skill.{Name.ToLowerInvariant()}",
                 Result =
-                    "I couldn't find a chord name in your request. Try naming a single " +
-                    "chord (e.g. 'Cmaj7', 'G7', 'Am7b5') and I'll suggest scales to " +
-                    "improvise over it. Progression-level questions (ii-V-I, minor blues) " +
-                    "aren't supported yet — name a specific chord.",
+                    "I couldn't find a chord name in your request. Name one chord " +
+                    "(e.g. 'Cmaj7', 'G7', 'Am7b5') and I'll suggest scales to improvise " +
+                    "over it, or a run of chords (e.g. 'Am F C G') and I'll give the " +
+                    "arpeggio and scales for each. Roman-numeral progressions (ii-V-I) " +
+                    "need concrete chord symbols — name the chords in your key.",
                 Confidence = 0.2f,
                 Evidence = [],
                 Assumptions = ["Typed parser produced no ChordSymbol from the query."],
@@ -125,6 +179,109 @@ public sealed partial class ImprovisationSkill(
             },
         };
     }
+
+    // -------------------------------------------------------------------
+    // Progression path (v2). Extract a run of chord symbols in query order,
+    // then classify each with the same InferQuality used for single chords.
+    // -------------------------------------------------------------------
+
+    /// <summary>
+    /// Pull chord symbols out of <paramref name="message"/> in order, de-noising
+    /// the English words around them. Case-sensitive root (a bare lowercase "a"
+    /// is the article, not an A chord) with a required accidental / quality /
+    /// extension-digit suffix — same shape as <see cref="ChordSuffixRegex"/> but
+    /// capturing every match rather than testing for one.
+    /// </summary>
+    // Internal for direct unit-test coverage of the tokenizer.
+    internal static IReadOnlyList<string> ExtractChordRun(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return [];
+        var chords = new List<string>();
+        foreach (Match m in ChordTokenRegex().Matches(message))
+        {
+            var tok = m.Value.Trim();
+            // A quality-less single uppercase letter (A-G) with a following
+            // space is ambiguous with a plain note / roman-ish token, but in a
+            // run like "Am F C G" the bare "F", "C", "G" ARE chords. Accept
+            // them; the run length gate (>=2) already excludes lone letters.
+            if (tok.Length > 0) chords.Add(tok);
+        }
+        return chords;
+    }
+
+    private AgentResponse BuildProgressionResponse(IReadOnlyList<string> chords)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Over **{string.Join(" – ", chords)}**, for each chord:");
+        sb.AppendLine();
+
+        var evidence = new List<string>();
+        var data = new List<object>();
+
+        foreach (var chord in chords)
+        {
+            var root = ExtractRoot(chord);
+            var quality = InferQuality(chord);
+            var arpeggio = ArpeggioFor(root, quality);
+            var scales = ScalesFor(quality);
+            // Best/most-common scale first — that is the one to lead with per chord.
+            var lead = scales.Count > 0 ? scales[0] : new Scale("Major scale of the root", "fallback");
+
+            sb.AppendLine(
+                $"- **{chord}** → arpeggio **{arpeggio}**, play **{root} {lead.Name}** " +
+                $"({lead.Color}).");
+
+            evidence.Add($"{chord}: arpeggio {arpeggio}; scales {string.Join(", ", scales.Select(s => root + " " + s.Name))}");
+            data.Add(new
+            {
+                chord,
+                quality = quality.Display,
+                arpeggio,
+                scales = scales.Select(s => new { name = $"{root} {s.Name}", color = s.Color }).ToList(),
+            });
+        }
+
+        sb.AppendLine();
+        sb.AppendLine(
+            "Each arpeggio spells the chord tones; the scale adds the passing notes " +
+            "for lines between them.");
+
+        logger.LogDebug("ImprovisationSkill: progression [{Chords}] → {Count} chords classified",
+            string.Join(" ", chords), chords.Count);
+
+        return new AgentResponse
+        {
+            AgentId = $"skill.{Name.ToLowerInvariant()}",
+            Result = sb.ToString(),
+            Confidence = 0.85f,
+            Evidence = evidence,
+            Assumptions = ["Each chord classified independently from its written quality; no key inferred."],
+            Data = new { progression = chords, perChord = data },
+        };
+    }
+
+    /// <summary>Chord-tone arpeggio label for a classified quality, e.g. "Am7", "Fmaj7".</summary>
+    // Internal for unit-test coverage — the single most-broken behavior of the
+    // MCP arpeggio tool was root + full-suffix concatenation ("Amm7").
+    internal static string ArpeggioFor(string root, QualityClass quality) =>
+        root + quality.Kind switch
+        {
+            QualityKind.Major            => "",       // C  → major triad
+            QualityKind.Major7           => "maj7",
+            QualityKind.LydianMaj7       => "maj7#11",
+            QualityKind.Dominant7        => "7",
+            QualityKind.AlteredDominant  => "7alt",
+            QualityKind.Altered          => "7alt",
+            QualityKind.SuspendedDominant => "7sus4",
+            QualityKind.Minor            => "m",      // Am → minor triad
+            QualityKind.Minor7           => "m7",
+            QualityKind.MinorMajor7      => "mMaj7",
+            QualityKind.HalfDiminished   => "m7b5",
+            QualityKind.Diminished       => "dim",
+            QualityKind.Diminished7      => "dim7",
+            QualityKind.Augmented        => "aug",
+            _                            => "",
+        };
 
     // -------------------------------------------------------------------
     // Chord symbol → root + quality. Conservative: the parser already
@@ -292,6 +449,17 @@ public sealed partial class ImprovisationSkill(
 
     [GeneratedRegex(@"\b[A-G][#b]?\s+(?:[Mm]ajor|[Mm]inor|[Mm]aj|[Mm]in|[Dd]im|[Aa]ug|[Ss]us)\b")]
     private static partial Regex ChordWithSpacedQualityRegex();
+
+    // Progression tokenizer (v2). Captures each chord symbol in a run, longest
+    // quality alternation first so "Cmaj7" is one token, not "C" + "maj7". The
+    // quality group is OPTIONAL so a bare triad in a run ("F", "C", "G" in
+    // "Am F C G") still matches — the >=2 run-length gate in ExecuteAsync keeps
+    // a lone capital letter from being read as a one-chord "progression".
+    // Case-sensitive root: a lowercase "a"/"e" is an English article, never a
+    // chord. Known edge case: "the E string and A string" yields [E, A]; the
+    // improv-intent gate in CanHandle makes that combination rare in practice.
+    [GeneratedRegex(@"\b[A-G][#b]?(?:maj7#11|maj7\+11|maj7|maj9|maj13|maj|mmaj7|minmaj7|m7b5|m7#5|m7|m9|m11|m13|m6|min7|min|m|dim7|dim|aug|°7|°|ø|sus2|sus4|sus|add9|add11|7alt|alt|7b9|7#9|7b5|7#11|13b9|13|11|9|7|69|6|5|\+|Δ|-7|-)?\b")]
+    private static partial Regex ChordTokenRegex();
 
     internal enum QualityKind
     {

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
@@ -447,6 +447,30 @@ prompts:
     max_elapsed_ms: 20000
     retry: 0
 
+  # ── arpeggio-over-progression (unblocked 2026-07-20, BACKLOG North Star
+  #    "which arpeggio fits this chord progression?") ──────────────────────
+  # ImprovisationSkill v2: a run of 2+ chord symbols is classified per chord
+  # and returned with each chord's arpeggio + scales. routes_to pins the
+  # semantic route in both directions — the #555 lesson: a content-only
+  # invariant is structurally blind to a routing regression.
+  - prompt: "which arpeggio fits Am F C G"
+    category: improvisation-progression
+    routes_to: skill.improvisation
+    contains_any: ["Aeolian", "Dorian", "arpeggio"]
+    not_contains: ["Amm"]              # the MCP tool's root+suffix concat bug
+    min_length: 40
+    max_elapsed_ms: 20000
+    retry: 0                           # deterministic — pure classification
+
+  - prompt: "what arpeggios work over Dm7 G7 Cmaj7"
+    category: improvisation-progression
+    routes_to: skill.improvisation
+    contains_any: ["Dorian", "Mixolydian", "Ionian", "arpeggio"]
+    not_contains: ["Dmm7"]
+    min_length: 40
+    max_elapsed_ms: 20000
+    retry: 0
+
   - prompt: "Give me a Cadd9 in DADGAD"
     category: alternate-tunings
     skip: true

--- a/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/ImprovisationSkillTests.cs
@@ -195,4 +195,118 @@ public class ImprovisationSkillTests
         Assert.That(ImprovisationSkill.InferQuality("7").Kind.ToString(), Is.EqualTo("Unknown"));
         Assert.That(ImprovisationSkill.InferQuality("#G").Kind.ToString(), Is.EqualTo("Unknown"));
     }
+
+    // ===============================================================
+    // v2 (2026-07-20) — progression / arpeggio path.
+    // ===============================================================
+
+    // ---------------------------------------------------------------
+    // ArpeggioFor — the label must be the CANONICAL chord symbol, never
+    // root + full-suffix concatenation. This is the exact defect in the
+    // MCP arpeggio tool (GuitaristProblemTools.cs), which built "Am" +
+    // "m7" = "Amm7". Pin every quality so it cannot regress here.
+    // ---------------------------------------------------------------
+
+    [TestCase("Am", "Am")]      // minor triad — NOT "Amm"
+    [TestCase("A", "A")]        // major triad — bare root, no suffix
+    [TestCase("Dm7", "Dm7")]    // NOT "Dmm7"
+    [TestCase("Cmaj7", "Cmaj7")]
+    [TestCase("G7", "G7")]
+    [TestCase("Bm7b5", "Bm7b5")]
+    [TestCase("Cdim7", "Cdim7")]
+    [TestCase("Cdim", "Cdim")]
+    [TestCase("Caug", "Caug")]
+    [TestCase("CmMaj7", "CmMaj7")]
+    [TestCase("C7alt", "C7alt")]
+    [TestCase("Cmaj7#11", "Cmaj7#11")]
+    public void ArpeggioFor_ReturnsCanonicalSymbol_NotConcatenatedSuffix(string chord, string expected)
+    {
+        var root = ImprovisationSkill.ExtractRoot(chord);
+        var quality = ImprovisationSkill.InferQuality(chord);
+        Assert.That(ImprovisationSkill.ArpeggioFor(root, quality), Is.EqualTo(expected),
+            $"ArpeggioFor({chord}) must be the canonical chord symbol, not a concatenation");
+    }
+
+    // ---------------------------------------------------------------
+    // ExtractChordRun — pulls chord symbols out of a progression query
+    // in order, ignoring the English words around them.
+    // ---------------------------------------------------------------
+
+    [TestCase("which arpeggio fits Am F C G", new[] { "Am", "F", "C", "G" })]
+    [TestCase("what arpeggios work over Dm7 G7 Cmaj7", new[] { "Dm7", "G7", "Cmaj7" })]
+    [TestCase("arpeggios to solo over Am F C G", new[] { "Am", "F", "C", "G" })]
+    [TestCase("how do I improvise over Am F C G", new[] { "Am", "F", "C", "G" })]
+    [TestCase("Em C G D", new[] { "Em", "C", "G", "D" })]
+    // Single chord — still extracted, but the >=2 gate in ExecuteAsync keeps it
+    // on the single-chord path.
+    [TestCase("solo over Cmaj7", new[] { "Cmaj7" })]
+    public void ExtractChordRun_PullsChordsInOrder(string message, string[] expected)
+    {
+        var run = ImprovisationSkill.ExtractChordRun(message);
+        Assert.That(run, Is.EqualTo(expected).AsCollection,
+            $"ExtractChordRun({message}) did not return the expected chord run");
+    }
+
+    [Test]
+    public void ExtractChordRun_IgnoresLowercaseArticlesAndVerbs()
+    {
+        // "do", "I", "a" must not be read as D / — / A chords.
+        var run = ImprovisationSkill.ExtractChordRun("how do I improvise over a Dm7 and a G7");
+        Assert.That(run, Is.EqualTo(new[] { "Dm7", "G7" }).AsCollection);
+    }
+
+    // ---------------------------------------------------------------
+    // CanHandle — progression / arpeggio queries claim the skill.
+    // ---------------------------------------------------------------
+
+    [TestCase("which arpeggio fits Am F C G")]
+    [TestCase("what arpeggios work over Dm7 G7 Cmaj7")]
+    [TestCase("arpeggios to solo over Am F C G")]
+    [TestCase("which arpeggio for each chord in Em C G D")]
+    public void CanHandle_True_OnProgressionArpeggioQueries(string message)
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.CanHandle(message), Is.True,
+            $"expected ImprovisationSkill to claim progression query: {message}");
+    }
+
+    // ---------------------------------------------------------------
+    // ExecuteAsync — progression path returns one line per chord with the
+    // correct (non-concatenated) arpeggio, and never routes through the
+    // single-chord extractor (which is null in this fixture — proving the
+    // progression branch runs first).
+    // ---------------------------------------------------------------
+
+    [Test]
+    public async Task ExecuteAsync_Progression_ReturnsPerChordArpeggios()
+    {
+        var skill = MakeSkill(); // extractor is null! — must not be called
+        var response = await skill.ExecuteAsync("which arpeggio fits Am F C G");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.Result, Does.Contain("Am"));
+            Assert.That(response.Result, Does.Not.Contain("Amm"),
+                "the Amm7-class concatenation bug must not appear");
+            Assert.That(response.Result, Does.Contain("Aeolian").Or.Contain("Dorian"),
+                "each chord should carry a scale suggestion");
+            Assert.That(response.Evidence, Has.Count.EqualTo(4),
+                "one evidence line per chord in the progression");
+        });
+    }
+
+    [Test]
+    public async Task ExecuteAsync_Progression_ClassifiesBorrowedChordByWrittenQuality()
+    {
+        // The whole point of the key-agnostic design: an A MAJOR chord in a
+        // C-major context is a secondary dominant / borrowed chord. The MCP
+        // tool would call it degree vi and hand back A minor. We must classify
+        // it as major from what the user wrote.
+        var skill = MakeSkill();
+        var response = await skill.ExecuteAsync("arpeggios over C A Dm G");
+
+        // "A" (major) must yield the A major arpeggio, not "Am".
+        Assert.That(response.Evidence.Any(e => e.StartsWith("A:") && !e.StartsWith("Am")),
+            Is.True, $"A major must be classified major, not minor. Evidence: {string.Join(" | ", response.Evidence)}");
+    }
 }


### PR DESCRIPTION
Ships the BACKLOG North Star item **"which arpeggio fits this chord progression?"** — the first *new user-facing capability* in this session's queue, not measurement apparatus.

## What changed

`ImprovisationSkill` grows from single-chord (v1) to progression-aware (v2). A run of two or more chord symbols is classified per chord and returned with each chord's **arpeggio** and **lead scale**:

```
which arpeggio fits Am F C G
→ Am → arpeggio Am, play A Aeolian (natural minor)
  F  → arpeggio F,  play F Ionian (major)
  C  → arpeggio C,  play C Ionian (major)
  G  → arpeggio G,  play G Ionian (major)
```

Single-chord queries and the no-chord fallback are unchanged. Extending the existing skill (rather than adding a new one) is deliberate: a separate `Arpeggio` skill would collide with Improvisation on "what do I play over X" — the exact chord-vs-scale routing failure documented in #555.

## Why key-agnostic (the design call)

The obvious alternative — infer the key, map each chord to a scale degree, return that degree's mode — is what the MCP tool `GaArpeggioSuggestions` does, and it is **wrong for any borrowed or secondary chord**: it locates the degree by root pitch-class alone, so an A major chord in C major is still called degree vi and handed Aeolian, putting a natural C against the chord's C#. Reusing the existing `InferQuality` per chord reads the quality the user actually wrote and cannot make that mistake.

(That MCP tool also emits `Amm7` from root+suffix concatenation — filed separately as **#567**; this PR does not touch it.)

## Verification — live A/B, held-out, real embedder

Ran the **real** `SemanticIntentRouter` through `RoutingEvalHarness` against **bge-large at the production threshold (0.64)**, on prompts that are **not** ExamplePrompt anchors (the memorization trap from #555):

| result | detail |
|---|---|
| **6/6 held-out** progression prompts | → `skill.improvisation` @ 0.86–0.92 |
| adversarial guard `"what key is Am F C G in"` (4-chord run) | → `skill.keyidentification` @ **1.000** — not stolen |
| guard `"20 minute practice routine"` | → `skill.practiceroutine` @ 1.000 (the neighbor an earlier draft drifted toward) |
| guard `"what notes are in a C major triad"` | → `skill.chordinfo` @ 1.000 (confirms #558 present in base) |

A few-intent offline sim was **not** used as proof, per the `offline-sim-not-valid-router-proxy` lesson.

## Tests (108/108 green)

- `ArpeggioFor_ReturnsCanonicalSymbol_NotConcatenatedSuffix` — pins `Am` not `Amm7` for every quality
- `ExtractChordRun_*` — tokenizer incl. lowercase-article rejection (`"do"`/`"I"`/`"a"` are not chords)
- `ExecuteAsync_Progression_*` — per-chord output + borrowed-chord correctness (A major classified major, not vi-minor)
- corpus: two `routes_to: skill.improvisation` entries with a `not_contains: ["Amm"]` guard

## Closes

Closes the arpeggio-over-progression North Star item (BACKLOG "Improvisation & Scale Choice"). Files #567 for the sibling MCP-tool bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)