### PR TITLE
feat(chatbot): add drop-C to AlternateTuningsSkill — closes the drop-C North Star gap

### DIFF
--- a/Common/GA.Business.ML/Agents/Skills/AlternateTuningsSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/AlternateTuningsSkill.cs
@@ -5,8 +5,8 @@ using System.Text.RegularExpressions;
 
 /// <summary>
 /// Domain-backed alternate-tuning skill. Answers tuning-info questions and
-/// shape questions for common alternate tunings (DADGAD, drop-D, open-G, open-D,
-/// double drop-D, DGCGCD, half-step down, whole-step down).
+/// shape questions for common alternate tunings (DADGAD, drop-D, drop-C, open-G,
+/// open-D, double drop-D, DGCGCD, half-step down, whole-step down).
 /// Surface forms:
 /// <list type="bullet">
 /// <item><b>"What is DADGAD tuning"</b> → string-by-string note layout + interval analysis</item>
@@ -26,8 +26,8 @@ public sealed class AlternateTuningsSkill(ILogger<AlternateTuningsSkill> logger)
 {
     public string Name => "AlternateTunings";
     public string Description =>
-        "Answers alternate-tuning questions: what is DADGAD / drop-D / open-G / " +
-        "open-D / double-drop-D / DGCGCD / half-step-down / whole-step-down. " +
+        "Answers alternate-tuning questions: what is DADGAD / drop-D / drop-C / " +
+        "open-G / open-D / double-drop-D / DGCGCD / half-step-down / whole-step-down. " +
         "Returns the string-by-string layout (low → high) and explains the " +
         "intervallic difference from standard tuning. Pure lookup — no LLM call.";
 
@@ -35,6 +35,8 @@ public sealed class AlternateTuningsSkill(ILogger<AlternateTuningsSkill> logger)
     [
         "what is DADGAD tuning",
         "what's drop D tuning",
+        "how do I tune to drop C",
+        "drop C tuning notes",
         "how do I tune to open G",
         "open D tuning notes",
         "what is double drop D tuning",
@@ -56,6 +58,9 @@ public sealed class AlternateTuningsSkill(ILogger<AlternateTuningsSkill> logger)
         (new Regex(@"(?<!\bdouble\s)(?<!\bdouble-)\bdrop[\s-]?d\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "drop-d"),
         // Double drop D
         (new Regex(@"\bdouble[\s-]?drop[\s-]?d\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "double-drop-d"),
+        // Drop C — the (?![#b]) rejects "drop C#" / "drop Cb", which are
+        // different tunings not in this table (better no match than a wrong one).
+        (new Regex(@"\bdrop[\s-]?c\b(?![#b])", RegexOptions.IgnoreCase | RegexOptions.Compiled), "drop-c"),
         // Open G
         (new Regex(@"\bopen[\s-]?g\b", RegexOptions.IgnoreCase | RegexOptions.Compiled), "open-g"),
         // Open D
@@ -87,6 +92,12 @@ public sealed class AlternateTuningsSkill(ILogger<AlternateTuningsSkill> logger)
             Notes: ["D", "A", "D", "G", "B", "D"],
             VsStandard: "Strings 6 and 1 both dropped a whole step (E→D). Strings 5–2 are standard.",
             Flavor: "Neil Young's signature ('Cinnamon Girl', 'Cortez the Killer'). Both Ds frame any voicing with a fat low-and-high D drone."),
+
+        ["drop-c"] = new(
+            DisplayName: "Drop C",
+            Notes: ["C", "G", "C", "F", "A", "D"],
+            VsStandard: "Whole-step-down (D standard) with the 6th string dropped one more whole step: string 6 is down a major third (E→C), strings 5–1 each down a whole step. Equivalently, drop-D shifted down a whole step.",
+            Flavor: "Metal / metalcore staple — System of a Down, Bullet for My Valentine, Killswitch Engage. Heavy low-C chug with one-finger power chords on the bottom three strings, like drop-D but darker and slacker. Pairs with thicker strings (.011–.056+) to keep tension."),
 
         ["open-g"] = new(
             DisplayName: "Open G",
@@ -268,7 +279,7 @@ public sealed class AlternateTuningsSkill(ILogger<AlternateTuningsSkill> logger)
     private static AgentResponse CannotHandle() => new()
     {
         AgentId    = AgentIds.Theory,
-        Result     = "Ask about a named alternate tuning (DADGAD, drop-D, open-G, open-D, double-drop-D, DGCGCD, half-step-down, whole-step-down), or give 6 notes low→high.",
+        Result     = "Ask about a named alternate tuning (DADGAD, drop-D, drop-C, open-G, open-D, double-drop-D, DGCGCD, half-step-down, whole-step-down), or give 6 notes low→high.",
         Confidence = 0.1f,
         Evidence   = ["AlternateTuningsSkill: no recognised tuning name or note sequence"],
     };

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
@@ -471,6 +471,17 @@ prompts:
     max_elapsed_ms: 20000
     retry: 0
 
+  # Tuning-INFO path (works today via AlternateTuningsSkill). Distinct from the
+  # chord-shapes-IN-a-tuning entries below, which still need the voicing tool.
+  - prompt: "How do I tune to drop C"
+    category: alternate-tunings
+    routes_to: skill.alternatetunings
+    contains: ["C", "G", "F", "A", "D"]
+    contains_any: ["Drop C", "major third", "-4"]
+    min_length: 60
+    max_elapsed_ms: 20000
+    retry: 0                          # deterministic — tuning-table lookup
+
   - prompt: "Give me a Cadd9 in DADGAD"
     category: alternate-tunings
     skip: true

--- a/Tests/Common/GA.Business.ML.Tests/Unit/AlternateTuningsSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/AlternateTuningsSkillTests.cs
@@ -1,0 +1,95 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[TestFixture]
+public class AlternateTuningsSkillTests
+{
+    private static AlternateTuningsSkill MakeSkill() =>
+        new(NullLogger<AlternateTuningsSkill>.Instance);
+
+    private static async Task<string> AnswerAsync(string message)
+    {
+        var response = await MakeSkill().ExecuteAsync(message);
+        return response.Result;
+    }
+
+    [Test]
+    public void Metadata_ListsDropC()
+    {
+        var skill = MakeSkill();
+        Assert.Multiple(() =>
+        {
+            Assert.That(skill.Description.ToLowerInvariant(), Does.Contain("drop-c"));
+            Assert.That(skill.ExamplePrompts.Any(p => p.Contains("drop C", StringComparison.OrdinalIgnoreCase)),
+                Is.True, "an ExamplePrompt must anchor the drop-C phrasing for the router");
+        });
+    }
+
+    // ---------------------------------------------------------------
+    // Drop C (2026-07-20) — C G C F A D, closing the BACKLOG "how do I
+    // tune to drop-C" gap. Named-lookup and reverse (6-note) lookup.
+    // ---------------------------------------------------------------
+
+    [TestCase("how do I tune to drop C")]
+    [TestCase("drop C tuning notes")]
+    [TestCase("what is drop-C tuning")]
+    [TestCase("drop c")]
+    public async Task DropC_NamedLookup_ReturnsCGCFAD(string message)
+    {
+        var answer = await AnswerAsync(message);
+        Assert.Multiple(() =>
+        {
+            Assert.That(answer, Does.Contain("Drop C"));
+            // low → high: C – G – C – F – A – D
+            Assert.That(answer, Does.Contain("C – G – C – F – A – D"),
+                $"drop-C must present the C G C F A D layout for: {message}");
+        });
+    }
+
+    [Test]
+    public async Task DropC_ReverseLookup_FromSixNotes_NamesDropC()
+    {
+        var answer = await AnswerAsync("what tuning is C G C F A D");
+        Assert.That(answer, Does.Contain("Drop C"),
+            "a bare 6-note C G C F A D sequence should resolve to the Drop C name");
+    }
+
+    [Test]
+    public async Task DropC_LowSixthString_IsMajorThirdBelowStandard()
+    {
+        // The distinguishing interval: string 6 E→C is -4 semitones (a major
+        // third), not the -2 whole step of the other five strings. The delta
+        // column must show it, or the answer is musically wrong.
+        var answer = await AnswerAsync("how do I tune to drop C");
+        Assert.That(answer, Does.Contain("-4st"),
+            "string 6 (E→C) must be reported as -4 semitones (major third down)");
+    }
+
+    // ---------------------------------------------------------------
+    // Guards — drop-C must not collide with its neighbours.
+    // ---------------------------------------------------------------
+
+    [Test]
+    public async Task DropD_StillResolvesToDropD_NotDropC()
+    {
+        var answer = await AnswerAsync("what's drop D tuning");
+        Assert.Multiple(() =>
+        {
+            Assert.That(answer, Does.Contain("Drop D"));
+            Assert.That(answer, Does.Not.Contain("Drop C"));
+        });
+    }
+
+    [Test]
+    public async Task DropCSharp_DoesNotMatchDropC()
+    {
+        // "drop C#" is a different tuning not in the table. The (?![#b])
+        // lookahead must keep it from resolving to plain Drop C — better to
+        // decline than to hand back the wrong tuning.
+        var answer = await AnswerAsync("how do I tune to drop C#");
+        Assert.That(answer, Does.Not.Contain("C – G – C – F – A – D"),
+            "drop C# must not be answered as Drop C");
+    }
+}


### PR DESCRIPTION
Second North Star capability this session (after arpeggio #568), and a **surgical** one — extends an existing routed skill, no new registry burden.

## The gap

"How do I tune to drop-C?" was 🟡 partial: `AlternateTuningsSkill` handled drop-D, half-/whole-step-down, and the open tunings, but **not drop-C** — one of the most common downtuned setups in metal/metalcore (System of a Down, Bullet for My Valentine, Killswitch Engage).

## What changed

**Drop C = C G C F A D** (low → high): 6th string down a major third (E→C), strings 5–1 each down a whole step — equivalently drop-D shifted down a whole step.

- tuning-table entry + name pattern with a `(?![#b])` lookahead so `drop C#` / `drop Cb` (different tunings, not in the table) don't false-match to plain drop-C
- two ExamplePrompt anchors; drop-C added to the Description + cannot-handle list

## Verification

**9 new unit tests** (`AlternateTuningsSkillTests` — the skill had none): named lookup, reverse 6-note lookup (`C G C F A D` → "Drop C"), the −4 semitone major-third delta on string 6, and two guards (drop-D still resolves to drop-D; `drop C#` does **not** resolve to drop-C).

**Live routing A/B** — real bge-large at production threshold 0.64, **held-out** phrasings (none are anchors):

| prompt | routed | conf |
|---|---|---|
| how do I get my guitar into drop C | `alternatetunings` | 0.88 |
| tune to drop C for metal | `alternatetunings` | 0.90 |
| what are the strings in drop C | `alternatetunings` | 0.80 |
| *(guard)* explain DADGAD tuning to me | `alternatetunings` | 0.98 |
| *(guard)* how do I set up drop D | `alternatetunings` | 0.86 |
| *(guard)* what are the notes for open G tuning | `alternatetunings` | 0.95 |
| *(guard)* what notes are in a C major triad | `chordinfo` | 1.000 |

8/8 — held-out drop-C routes, no neighbour regressed, and the anchor's "C" doesn't pull chord queries. Per the `offline-sim-not-valid-router-proxy` lesson, this is the real router, not a sim.

**Corpus**: one ACTIVE `alternate-tunings` entry (`routes_to: skill.alternatetunings`), distinct from the still-skipped chord-shapes-*in*-a-tuning entries that need the voicing tool.

Moves "how do I tune to drop-C?" from 🟡 toward ✅ (string-tension guidance is the remaining sliver). Updates the coverage picture in #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)