### PR TITLE
fix(chatbot-qa): revive the daily producer — gate in-runner Ollama, add artifact-freshness sensor

### DIFF
--- a/.github/workflows/chatbot-qa-freshness.yml
+++ b/.github/workflows/chatbot-qa-freshness.yml
@@ -1,0 +1,184 @@
+name: Chatbot QA Freshness
+
+# Tripwire for the chatbot-qa producer. The producer
+# (.github/workflows/chatbot-qa-snapshot.yml) writes a daily
+# state/quality/chatbot-qa/YYYY-MM-DD.json that four live readers +
+# hari issues #13/#20 depend on. It died SILENTLY: every scheduled run
+# since 2026-06-21 is CANCELLED at the 60-minute job timeout during the
+# in-runner-Ollama corpus step (PR #411, 2026-06-16), so the commit step
+# never runs and no snapshot lands. The Actions UI showed "cancelled",
+# not "failed", and nobody was watching that workflow — so the freshest
+# snapshot stayed 2026-06-19 for a month (the 2026-07-19 snapshot on main
+# is a one-off LOCAL hand-run committed via #553, not the producer).
+#
+# The producer's own in-run degradation guards (algedonic + tracking issue)
+# can't catch this: they only fire when the run REACHES them. A run that is
+# cancelled at the wall never reaches any guard. This sensor watches the
+# ARTIFACT instead — it fails loudly when the newest snapshot is older than
+# MAX_AGE_DAYS, converting a silent 30-day death into a 3-day alarm.
+#
+# See docs/runbooks/chatbot-qa-producer-revival.md for the root cause and
+# the manual-run command. This sensor does NOT run the corpus and costs
+# nothing; it only reads the committed snapshots.
+#
+# Precedent: README Drift Sensor (readme-drift-sensor.yml) — same
+# green-but-dead failure mode, same single-tracking-issue pattern.
+
+on:
+  schedule:
+    - cron: '0 12 * * *'   # 12:00 UTC daily — after the 06:00 producer run + its ~08:00 commit window
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Override staleness threshold (days)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: chatbot-qa-freshness
+  cancel-in-progress: false
+
+env:
+  # Producer cadence is daily (one YYYY-MM-DD.json per day, 2026-05-16..2026-06-19).
+  # 3 days tolerates a couple of legitimately-missed daily runs before alarming,
+  # while still catching a real death ~10x faster than the month it actually took.
+  MAX_AGE_DAYS: '3'
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check newest chatbot-qa snapshot age
+        id: check
+        shell: pwsh
+        run: |
+          $maxAge = if (-not [string]::IsNullOrWhiteSpace('${{ github.event.inputs.max_age_days }}')) {
+            [int]'${{ github.event.inputs.max_age_days }}'
+          } else {
+            [int]$env:MAX_AGE_DAYS
+          }
+          $dir = 'state/quality/chatbot-qa'
+
+          # Only real daily snapshots count — ignore baseline.json / last*.json / dirs.
+          $snaps = @()
+          if (Test-Path $dir) {
+            $snaps = Get-ChildItem $dir -Filter '*.json' -File |
+              Where-Object { $_.BaseName -match '^\d{4}-\d{2}-\d{2}$' }
+          }
+
+          if (-not $snaps -or $snaps.Count -eq 0) {
+            "stale=true"          | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "newest_date=none"    | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "age_days=infinite"   | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "max_age=$maxAge"     | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+            Write-Host "::error::No chatbot-qa snapshots found under $dir — producer has never produced or the path moved."
+            exit 0
+          }
+
+          $newest = $snaps |
+            ForEach-Object { [datetime]::ParseExact($_.BaseName, 'yyyy-MM-dd', $null) } |
+            Sort-Object -Descending | Select-Object -First 1
+          $today   = [datetime]::UtcNow.Date
+          $ageDays = ($today - $newest).Days
+          $isStale = $ageDays -gt $maxAge
+
+          "stale=$($isStale.ToString().ToLower())"     | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "newest_date=$($newest.ToString('yyyy-MM-dd'))" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "age_days=$ageDays"                          | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "max_age=$maxAge"                            | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          if ($isStale) {
+            Write-Host "::error::Chatbot QA snapshot is STALE — newest $($newest.ToString('yyyy-MM-dd')) is $ageDays days old (threshold $maxAge). The daily producer is not landing snapshots. See docs/runbooks/chatbot-qa-producer-revival.md."
+          } else {
+            Write-Host "Chatbot QA snapshot is FRESH — newest $($newest.ToString('yyyy-MM-dd')), $ageDays days old (threshold $maxAge)."
+          }
+
+      - name: Open or update tracking issue when stale
+        if: steps.check.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          NEWEST: ${{ steps.check.outputs.newest_date }}
+          AGE: ${{ steps.check.outputs.age_days }}
+          MAX_AGE: ${{ steps.check.outputs.max_age }}
+        shell: pwsh
+        run: |
+          $title = '[meta] Chatbot QA snapshot stale — producer not landing daily snapshots'
+          $run   = "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/actions/runs/${env:GITHUB_RUN_ID}"
+          $bt    = [char]0x60
+          $body  = @(
+            "## Chatbot QA producer appears dead",
+            "",
+            "The freshness sensor found the newest ${bt}state/quality/chatbot-qa/YYYY-MM-DD.json${bt}",
+            "is **$($env:NEWEST)** — $($env:AGE) days old (threshold $($env:MAX_AGE) days).",
+            "",
+            "Four live readers + hari issues #13/#20 consume this snapshot. A stale",
+            "snapshot means they are running on month-old (or fabricated-fresh) data.",
+            "",
+            "**Known root cause (2026-06-21 onward):** the producer workflow",
+            "${bt}chatbot-qa-snapshot.yml${bt} is CANCELLED at its 60-minute job timeout during",
+            "the in-runner-Ollama corpus step (introduced by #411), so the commit step",
+            "never runs. The Actions UI shows ${bt}cancelled${bt}, not ${bt}failed${bt}.",
+            "",
+            "**Fix / triage:** see ${bt}docs/runbooks/chatbot-qa-producer-revival.md${bt}.",
+            "The one-line manual unblock is:",
+            "",
+            "$bt$bt$bt",
+            "pwsh Scripts/run-prompt-corpus.ps1 -Snapshot   # then commit state/quality/chatbot-qa/<today>.json",
+            "$bt$bt$bt",
+            "",
+            "Sensor run: $run",
+            "",
+            "_This issue is updated (not duplicated) daily by ${bt}chatbot-qa-freshness.yml${bt}",
+            "and closed automatically once a fresh snapshot lands._"
+          ) -join "`n"
+
+          # Self-heal the label first — `gh issue create --label` hard-fails when the
+          # label is absent, which is exactly how readme-drift-sensor silently broke.
+          gh label create chatbot --color 1D76DB --description "Chatbot / chatbot-qa" --force 2>$null
+
+          $existing = gh issue list --search "$title in:title" --state open --json number,title --limit 5 | ConvertFrom-Json
+          $match = $null
+          if ($existing) { $match = $existing | Where-Object { $_.title -eq $title } | Select-Object -First 1 }
+          if ($match) {
+            Write-Host "Updating existing tracking issue #$($match.number)"
+            $body | gh issue comment $match.number -F -
+          } else {
+            Write-Host "Opening new tracking issue"
+            $body | gh issue create --title $title --label chatbot -F -
+          }
+
+      - name: Close tracking issue when fresh
+        if: steps.check.outputs.stale == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          NEWEST: ${{ steps.check.outputs.newest_date }}
+        shell: pwsh
+        run: |
+          $title = '[meta] Chatbot QA snapshot stale — producer not landing daily snapshots'
+          $existing = gh issue list --search "$title in:title" --state open --json number,title --limit 5 | ConvertFrom-Json
+          if ($existing) {
+            foreach ($i in $existing) {
+              if ($i.title -eq $title) {
+                gh issue close $i.number --comment "Fresh snapshot landed ($($env:NEWEST)). Closing automatically; the sensor will reopen if the producer stalls again."
+              }
+            }
+          } else {
+            Write-Host "No open staleness issue — nothing to close."
+          }
+
+      - name: Fail the run when stale
+        if: steps.check.outputs.stale == 'true'
+        shell: pwsh
+        run: |
+          Write-Host "Failing the workflow so the stale producer is a loud red X, not a silent gap."
+          exit 1

--- a/.github/workflows/chatbot-qa-snapshot.yml
+++ b/.github/workflows/chatbot-qa-snapshot.yml
@@ -100,14 +100,27 @@ jobs:
             }
           }
 
-      # Default backend: run Ollama ON the runner — no secret, no tunnel, no
-      # Cloudflare. Only runs when the remote OLLAMA_BASE_URL secret did NOT set
-      # a backend above, so a remote override still wins if one is ever configured.
-      # Pulls the exact models the chatbot config declares (Apps/GaChatbot.Api/
-      # appsettings.json: ChatModel llama3.2:3b, EmbeddingModel nomic-embed-text) so
-      # the measured pass_pct is comparable to the local baseline (0.94, llama3.2:3b).
-      - name: Install + warm in-runner Ollama (default backend)
-        if: ${{ env.OLLAMA_BASE_URL == '' }}
+      # In-runner backend: run Ollama ON the runner — no secret, no tunnel, no
+      # Cloudflare. Pulls the exact models the chatbot config declares (Apps/
+      # GaChatbot.Api/appsettings.json: ChatModel llama3.2:3b, EmbeddingModel
+      # nomic-embed-text) so the measured pass_pct is comparable to the local
+      # baseline (0.94, llama3.2:3b).
+      #
+      # OPT-IN, DEFAULT OFF. The model pull + ~50 CPU-inference prompts do not fit
+      # timeout-minutes: 60 on a 2-core hosted runner. Enabling this by default
+      # (#411, 2026-06-16) is what SILENTLY killed the producer: every scheduled
+      # run from 2026-06-21 on was CANCELLED at the 60-min wall before the commit
+      # step, so no snapshot landed for a month (the job read "cancelled", not
+      # "failed"). With the var unset this step is skipped, the backend preflight
+      # degrades, the corpus writes an HONEST degraded snapshot (pass_pct=null,
+      # carryforward) via #553's GA_CORPUS_ENV_DEGRADED path, and the commit step
+      # lands it fast — the proven pre-#411 behaviour. Set repo variable
+      # CHATBOT_QA_INRUNNER_OLLAMA=true to opt back into real in-runner measurement
+      # (accepting the >60-min timeout risk). A remote OLLAMA_BASE_URL secret still
+      # wins over this either way. For real pass_pct without the timeout, see
+      # docs/runbooks/chatbot-qa-producer-revival.md (remote backend / self-hosted).
+      - name: Install + warm in-runner Ollama (opt-in; default off)
+        if: ${{ env.OLLAMA_BASE_URL == '' && vars.CHATBOT_QA_INRUNNER_OLLAMA == 'true' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/docs/runbooks/chatbot-qa-producer-revival.md
+++ b/docs/runbooks/chatbot-qa-producer-revival.md
@@ -1,0 +1,107 @@
+# Runbook: chatbot-qa producer revival
+
+**Producer:** `.github/workflows/chatbot-qa-snapshot.yml` → `Scripts/run-prompt-corpus.ps1 -Snapshot`
+**Output:** `state/quality/chatbot-qa/YYYY-MM-DD.json` (one per day)
+**Consumers:** `ix-quality-trend` (`ix/crates/ix-quality-trend/src/snapshot.rs`, `ChatbotQaSnapshot`), the quality dashboard, the routing-eval gate, and hari issues #13/#20.
+**Freshness sensor:** `.github/workflows/chatbot-qa-freshness.yml` (fails loudly when the newest snapshot is stale).
+
+## What died, and why
+
+The daily producer has landed **nothing since 2026-06-19**. The `2026-07-19.json`
+on `main` is not a producer run — its timestamp carries a local `-04:00` offset,
+i.e. it was hand-run and committed via #553. The scheduled producer itself is dead.
+
+Root cause: **every scheduled run since 2026-06-21 is `cancelled` at the 60-minute
+job timeout**, during the `Run corpus + emit snapshot` step.
+
+Evidence:
+
+```
+$ gh run list --workflow chatbot-qa-snapshot.yml --repo GuitarAlchemist/ga
+completed  cancelled  ... main  schedule  1h0m21s  2026-07-20T08:34Z
+completed  cancelled  ... main  schedule  1h0m22s  2026-07-19T07:54Z
+...every scheduled run, 1h0mXX each...
+$ gh run view <id>
+ANNOTATIONS
+  X The job has exceeded the maximum execution time of 1h0m0s
+  X The operation was canceled.        (step: Run corpus + emit snapshot)
+```
+
+The trigger was **PR #411 (2026-06-16, "in-runner Ollama")** + **#409 (2026-06-20,
+CF Access headers)**. #411 made the hosted runner install Ollama, pull
+`nomic-embed-text` + `llama3.2:3b`, and run ~50 **CPU** inference prompts. That does
+not fit in `timeout-minutes: 60` on a 2-core `ubuntu-latest` runner, so GitHub
+cancels the whole job at the wall — **before** the `Commit snapshot if produced`
+step ever runs. No snapshot is committed; no degraded snapshot either.
+
+Why it stayed silent for a month:
+
+- The job shows as **`cancelled`**, not `failed` — no red X on a PR, no default alert.
+- The producer's own degradation guards (algedonic signal + `[meta] Chatbot QA
+  degradation` issue) only fire when the run *reaches* them. A run killed at the
+  timeout never reaches any guard.
+- Nobody watches this scheduled workflow's tab.
+
+This is the same green-but-dead shape that silently broke `readme-drift-sensor.yml`
+for 5+ weekly runs (see its header comment) and the `feedback_green_but_dead` rule.
+
+Note: **#553 and #564 do not fix this.** #553 (merged) corrected a *different* bug —
+a fabricated `pass_pct: 7.69, degraded: false` for a degraded environment — via the
+`GA_CORPUS_ENV_DEGRADED` plumbing; it does not touch the timeout. #564 (open,
+`feat/chatbot-llm-judge-invariants`) adds an LLM-as-judge to `run-prompt-corpus.ps1`
+and the tests; it does not touch the workflow and, being more work per prompt, can
+only make the timeout worse.
+
+## Immediate unblock (manual, free, ~2 min of your time)
+
+Run the corpus locally against your warm Ollama and commit the snapshot:
+
+```pwsh
+pwsh Scripts/run-prompt-corpus.ps1 -Snapshot
+# writes state/quality/chatbot-qa/<today>.json (+ last.json, loop-history.jsonl)
+git add state/quality/chatbot-qa/<today>.json
+git commit -m "chore(quality): chatbot-qa snapshot <today> [skip ci]"
+```
+
+That is exactly how the `2026-07-19` snapshot got there. It clears the freshness
+sensor but does **not** revive the automation — do one of the durable fixes below.
+
+## Durable fix — this is an OWNER DECISION (pick one)
+
+All three restore a daily snapshot; they differ in cost and in whether CI measures
+a *real* `pass_pct` or an honest *degraded* one. I did **not** apply any of these,
+because each changes the producer's declared behaviour (`#411`'s "measure real
+pass_pct in-runner" intent) or spends money/infra — an owner call, not a silent one.
+
+1. **Gate the in-runner Ollama off by default → free daily *degraded* snapshots.**
+   Make the `Install + warm in-runner Ollama (default backend)` step opt-in (e.g.
+   `if: vars.CHATBOT_QA_INRUNNER_OLLAMA == 'true'`). With it off, the corpus runs
+   fast, the chatbot degrades gracefully, and — thanks to #553 — the snapshot is
+   written honestly (`pass_pct: null, degraded: true, carryforward`) and committed
+   within budget. **Smallest revival; restores freshness at zero cost; loses real
+   measurement until option 2/3.** Recommended as the immediate automation fix.
+
+2. **Provision the remote backend → real `pass_pct`.** Follow
+   [`chatbot-qa-ollama-ci-endpoint.md`](chatbot-qa-ollama-ci-endpoint.md): stand up
+   the Cloudflare-Access-fronted Ollama and set `OLLAMA_BASE_URL` +
+   `OLLAMA_CF_ACCESS_CLIENT_ID/SECRET` + `OPTICK_INDEX_URL`. The workflow already
+   routes to it when those secrets are set. Costs the box + tunnel; gives real data.
+
+3. **Move the job to a self-hosted runner** with Ollama + the OPTIC-K index warm,
+   and raise/remove `timeout-minutes`. Real measurement, but ties the daily signal
+   to that runner's uptime.
+
+Recommendation: ship **(1)** now to stop the bleeding (free, restores the daily
+artifact the four readers need), then do **(2)** when someone wants live `pass_pct`
+back. Whichever you pick, the freshness sensor stays as the tripwire so this can't
+silently rot again.
+
+## Verify after fixing
+
+```pwsh
+gh workflow run chatbot-qa-snapshot.yml --repo GuitarAlchemist/ga   # dispatch the producer
+gh workflow run chatbot-qa-freshness.yml --repo GuitarAlchemist/ga  # then the sensor
+```
+
+Green sensor + a `state/quality/chatbot-qa/<today>.json` committed by
+`github-actions[bot]` = revived.

--- a/docs/runbooks/chatbot-qa-producer-revival.md
+++ b/docs/runbooks/chatbot-qa-producer-revival.md
@@ -64,22 +64,26 @@ git commit -m "chore(quality): chatbot-qa snapshot <today> [skip ci]"
 ```
 
 That is exactly how the `2026-07-19` snapshot got there. It clears the freshness
-sensor but does **not** revive the automation — do one of the durable fixes below.
+sensor for a few days but is a one-off; the durable automation fix is below (option
+1 is now implemented on this branch).
 
-## Durable fix — this is an OWNER DECISION (pick one)
+## Durable fix
 
-All three restore a daily snapshot; they differ in cost and in whether CI measures
-a *real* `pass_pct` or an honest *degraded* one. I did **not** apply any of these,
-because each changes the producer's declared behaviour (`#411`'s "measure real
-pass_pct in-runner" intent) or spends money/infra — an owner call, not a silent one.
+Option 1 below is now **IMPLEMENTED on branch `ci/chatbot-qa-producer-revival`**
+(unpushed). Options 2 and 3 remain available if/when live `pass_pct` is wanted.
 
-1. **Gate the in-runner Ollama off by default → free daily *degraded* snapshots.**
-   Make the `Install + warm in-runner Ollama (default backend)` step opt-in (e.g.
-   `if: vars.CHATBOT_QA_INRUNNER_OLLAMA == 'true'`). With it off, the corpus runs
-   fast, the chatbot degrades gracefully, and — thanks to #553 — the snapshot is
-   written honestly (`pass_pct: null, degraded: true, carryforward`) and committed
-   within budget. **Smallest revival; restores freshness at zero cost; loses real
-   measurement until option 2/3.** Recommended as the immediate automation fix.
+1. **DONE — in-runner Ollama gated off by default → free daily *degraded* snapshots.**
+   The `Install + warm in-runner Ollama` step is now
+   `if: ${{ env.OLLAMA_BASE_URL == '' && vars.CHATBOT_QA_INRUNNER_OLLAMA == 'true' }}`,
+   i.e. opt-in. On a scheduled run with the variable unset (the default): the step
+   is skipped, the backend preflight reports `ollama_ok=false`, the `Run corpus`
+   step forwards `GA_CORPUS_ENV_DEGRADED=1`, and `run-prompt-corpus.ps1` writes an
+   honest degraded snapshot (`pass_pct: null, degraded: true`, carryforward) and
+   exits 2 — which the workflow tolerates and commits within the 60-min budget.
+   This restores the proven pre-#411 behaviour; the `timeout-minutes: 60` cap is
+   kept. To opt back into real in-runner measurement (accepting the >60-min risk),
+   set repo variable `CHATBOT_QA_INRUNNER_OLLAMA=true`; a remote `OLLAMA_BASE_URL`
+   secret still overrides either way.
 
 2. **Provision the remote backend → real `pass_pct`.** Follow
    [`chatbot-qa-ollama-ci-endpoint.md`](chatbot-qa-ollama-ci-endpoint.md): stand up
@@ -91,10 +95,13 @@ pass_pct in-runner" intent) or spends money/infra — an owner call, not a silen
    and raise/remove `timeout-minutes`. Real measurement, but ties the daily signal
    to that runner's uptime.
 
-Recommendation: ship **(1)** now to stop the bleeding (free, restores the daily
-artifact the four readers need), then do **(2)** when someone wants live `pass_pct`
-back. Whichever you pick, the freshness sensor stays as the tripwire so this can't
-silently rot again.
+Status: **(1) is shipped on this branch** — free, restores the daily artifact the
+four readers need. Do **(2)** when someone wants live `pass_pct` back. Either way,
+the freshness sensor stays as the tripwire so this can't silently rot again.
+
+Remaining owner decisions: **push branch `ci/chatbot-qa-producer-revival` + open a
+PR** (deliberately unpushed here), and **optionally provision the remote Ollama
+backend** (option 2) for real `pass_pct`.
 
 ## Verify after fixing
 


### PR DESCRIPTION
Revives the chatbot-qa producer, dead since 2026-06-21 (hari GuitarAlchemist/hari#29 Feed item 3).

**Root cause** (evidence in the runbook): every scheduled run since 06-21 was CANCELLED at the 60-min job-timeout wall — #411's in-runner Ollama (model pulls + ~50 CPU-inference prompts) doesn't fit a 2-core hosted runner. 'Cancelled' reads green-ish (no red X), so it rotted silently for a month; the producer's own degrade guards never run because the job dies before reaching them.

**Changes:**
- `chatbot-qa-snapshot.yml`: the in-runner Ollama step is now opt-in (`vars.CHATBOT_QA_INRUNNER_OLLAMA == 'true'`, default off). Default scheduled runs take the proven pre-#411 path: fast degraded corpus → #553's `GA_CORPUS_ENV_DEGRADED` wiring → honest `pass_pct=null, degraded=true` snapshot committed daily. A remote `OLLAMA_BASE_URL` secret still overrides for real pass_pct.
- `chatbot-qa-freshness.yml` (new): zero-cost daily sensor that watches the committed ARTIFACT (not the process) — fails + maintains a tracking issue when the newest snapshot is >3 days old. Catches wall-cancelled runs structurally invisible to in-job guards.
- `docs/runbooks/chatbot-qa-producer-revival.md`: root cause, manual unblock, remaining options (remote backend / self-hosted runner).

Edits `.github/workflows/` → human merge per ecosystem policy. Un-starves hari #13/#20; resolves forecast `ga-chatbot-qa-producer-revival` (p=0.5, horizon 08-19) if merged in time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)