### PR TITLE
feat(chatbot): OutsideNotesSkill — "why does this sound outside?" (North Star gap)

### DIFF
--- a/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
+++ b/Common/GA.Business.Core.Orchestration/Plugins/GaPlugin.cs
@@ -112,6 +112,11 @@ public sealed class GaPlugin : IChatPlugin
         // canonical quality→scales mapping. Pure domain compute, no LLM.
         services.AddOrchestratorSkillIntent<ImprovisationSkill>();
 
+        // OutsideNotesSkill (2026-07-20) — "why does F sound outside over Cmaj7"
+        // — classifies a single note against a chord as chord-tone / tension /
+        // avoid, derived purely from the chord tones. Pure domain compute, no LLM.
+        services.AddOrchestratorSkillIntent<OutsideNotesSkill>();
+
         // Skills using IChatClient are Scoped (IChatClient lifetime is Scoped).
         services.AddOrchestratorSkillIntent<KeyIdentificationSkill>(ServiceLifetime.Scoped);
         services.AddOrchestratorSkillIntent<ProgressionCompletionSkill>(ServiceLifetime.Scoped);

--- a/Common/GA.Business.ML/Agents/Skills/OutsideNotesSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/OutsideNotesSkill.cs
@@ -1,0 +1,301 @@
+namespace GA.Business.ML.Agents.Skills;
+
+using System.Text;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Answers "why does &lt;note&gt; sound outside over &lt;chord&gt;?" — classifies a single
+/// pitch against a chord as a <b>chord tone</b>, an <b>available tension</b>, or an
+/// <b>avoid note</b>, and explains why with the scale-degree label and the interval.
+/// Pure domain compute; no LLM at the skill layer. Confidence = 1.0.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Built 2026-07-20 to close the BACKLOG North Star item "Why does this sound
+/// outside?". Reuses <see cref="ChordVocabulary"/> for chord-symbol → interval
+/// formula and root → pitch class, so the chord model stays consistent with
+/// <see cref="ChordInfoSkill"/> and the MCP chord tools.
+/// </para>
+/// <para>
+/// The classification rule is the standard jazz-pedagogy definition and is
+/// derived <b>purely from the chord tones</b> — no per-quality tension table:
+/// a non-chord-tone that sits a <b>semitone above a chord tone</b> is an
+/// <i>avoid note</i> (it forms a b9 clash with that chord tone); any other
+/// non-chord-tone is an <i>available tension</i>. Worked: over Cmaj7 {C,E,G,B},
+/// F (the 11) is a semitone above E (the 3rd) → avoid; A (the 13) is a whole
+/// step above G → tension. This correctly makes the natural 11 an avoid note
+/// over major/dominant chords but NOT over minor chords (m7 has no major 3rd
+/// for the 11 to clash with).
+/// </para>
+/// <para>
+/// v1 handles the "&lt;note&gt; … over/against/on &lt;chord&gt;" shape (a single
+/// concrete note and a single concrete chord). Degree-word queries ("why does
+/// the 4th clash") and note-vs-key ("F outside in C major") are out of scope.
+/// </para>
+/// </remarks>
+[GuitarAlchemist.Registry.GaSkill("OutsideNotes", "harmony")]
+public sealed partial class OutsideNotesSkill(ILogger<OutsideNotesSkill> logger) : IOrchestratorSkill
+{
+    public string Name => "OutsideNotes";
+
+    public string Description =>
+        "Explains why a single note sounds inside or outside over a chord: " +
+        "classifies the note as a chord tone, an available tension (9, #11, 13), " +
+        "or an avoid note, with the scale-degree label and the interval. E.g. " +
+        "'why does F sound outside over Cmaj7' → F is the 11, a semitone above " +
+        "the 3rd (E), so it clashes. Pure lookup — no LLM call.";
+
+    public IReadOnlyList<string> ExamplePrompts =>
+    [
+        "why does F sound outside over Cmaj7",
+        "why does that note clash over the chord",
+        "is F an avoid note over Cmaj7",
+        "what is F over G7",
+        "why does the b9 sound so tense over C7",
+        "is A a chord tone or a tension over Cmaj7",
+        "why does Bb sound outside over C major",
+        "is F# an avoid note or a tension over Cmaj7",
+        // "clash" phrasing — without a note-over-chord anchor carrying the word,
+        // held-out "why does X clash over Y" drifted to GrothendieckDelta (which
+        // scores harmonic clash BETWEEN chords, not a note against a chord).
+        "why does F clash over a Cmaj7 chord",
+        "why does the note clash over this chord",
+    ];
+
+    // Intent keywords — must co-occur with a preposition + a chord token for
+    // the CanHandle fallback to fire, so ordinary chatter can't trigger it.
+    private static readonly string[] OutsideKeywords =
+    [
+        "outside", "avoid", "tension", "clash", "clashes", "dissonant",
+        "dissonance", "sound bad", "sounds bad", "sound off", "sounds off",
+        "sound wrong", "chord tone", "why does", "inside or outside",
+    ];
+
+    private static readonly string[] Prepositions = ["over", "against", "on top of", " on "];
+
+    public bool CanHandle(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return false;
+        var q = message.ToLowerInvariant();
+        var hasIntent = OutsideKeywords.Any(k => q.Contains(k, StringComparison.Ordinal));
+        if (!hasIntent) return false;
+        var hasPrep = Prepositions.Any(p => q.Contains(p, StringComparison.Ordinal));
+        if (!hasPrep) return false;
+        // Needs a real chord token (root + something) to classify against.
+        return ChordAfterPrepRegex().IsMatch(message);
+    }
+
+    public Task<AgentResponse> ExecuteAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var parsed = ParseNoteOverChord(message);
+        if (parsed is null)
+            return Task.FromResult(CannotHandle());
+
+        var (notePc, noteName, rootPc, rootName, quality) = parsed.Value;
+        var verdict = Classify(rootPc, quality, notePc);
+
+        var chordLabel = $"{rootName}{QualityDisplaySuffix(quality)}";
+        var sb = new StringBuilder();
+        sb.AppendLine($"**{noteName}** over **{chordLabel}**: {verdict.Headline}.");
+        sb.AppendLine();
+        sb.AppendLine(verdict.Explanation);
+
+        logger.LogDebug("OutsideNotesSkill: {Note} over {Root} {Quality} → {Kind} ({Degree})",
+            noteName, rootName, quality, verdict.Kind, verdict.DegreeLabel);
+
+        return Task.FromResult(new AgentResponse
+        {
+            AgentId    = $"skill.{Name.ToLowerInvariant()}",
+            Result     = sb.ToString(),
+            Confidence = 1.0f,
+            Evidence   =
+            [
+                $"Note: {noteName} (pitch class {notePc})",
+                $"Chord: {chordLabel} — tones {string.Join(", ", ChordToneNames(rootPc, quality))}",
+                $"Relation: {verdict.DegreeLabel}, {verdict.Kind}",
+            ],
+            Assumptions = ["Single note classified against a single chord; no key context assumed."],
+            Data = new
+            {
+                note = noteName,
+                chord = chordLabel,
+                degree = verdict.DegreeLabel,
+                classification = verdict.Kind.ToString(),
+            },
+        });
+    }
+
+    // ── Classification (the domain core) ─────────────────────────────────────
+
+    internal enum RelationKind { ChordTone, Tension, Avoid }
+
+    internal readonly record struct Verdict(
+        RelationKind Kind, string DegreeLabel, string Headline, string Explanation);
+
+    /// <summary>
+    /// Classify pitch class <paramref name="notePc"/> against the chord rooted at
+    /// <paramref name="rootPc"/> with the given canonical <paramref name="quality"/>.
+    /// Rule: chord tone if the interval is in the formula; otherwise an avoid note
+    /// if it sits a semitone above any chord tone; otherwise an available tension.
+    /// </summary>
+    internal static Verdict Classify(int rootPc, string quality, int notePc)
+    {
+        var formula = ChordVocabulary.GetFormula(quality);
+        var chordPcs = formula.Intervals.Select(i => ((i % 12) + 12) % 12).ToHashSet();
+        var rel = ((notePc - rootPc) % 12 + 12) % 12;
+
+        if (chordPcs.Contains(rel))
+        {
+            var function = ChordToneFunction(formula, rel);
+            return new Verdict(
+                RelationKind.ChordTone,
+                function,
+                $"a chord tone — the {function}",
+                $"It's part of the chord itself (the {function}), so it sounds fully consonant — " +
+                "as inside as a note can be over this chord.");
+        }
+
+        var degree = ExtensionLabel(rel);
+        // Avoid note = a semitone above a chord tone (forms a b9 clash with it).
+        var clashPc = chordPcs.FirstOrDefault(ct => (ct + 1) % 12 == rel, -1);
+        if (clashPc >= 0)
+        {
+            var clashName = ChordToneFunction(formula, clashPc);
+            // On dominant chords the b9/#9/#11/b13 half-step clashes are the
+            // classic "altered" tensions — still tense, but used deliberately,
+            // so the advice differs from a plain avoid note over a major chord.
+            var isDominant = quality.StartsWith("dominant", StringComparison.Ordinal)
+                          || quality == "altered dominant";
+            var advice = isDominant
+                ? "That half-step rub is why it sounds outside — but over a dominant chord it's " +
+                  $"exactly the kind of altered tension players reach for ({degree} on the V), so " +
+                  "it's usable if you resolve it, not a note to simply avoid."
+                : "That half-step rub is the classic \"avoid note\" clash: play it as a fast " +
+                  "passing tone, but don't land or sustain on it.";
+            return new Verdict(
+                RelationKind.Avoid,
+                degree,
+                $"an avoid note — the {degree}",
+                $"It's the {degree}, sitting a semitone above the {clashName} of the chord. " +
+                advice);
+        }
+
+        return new Verdict(
+            RelationKind.Tension,
+            degree,
+            $"an available tension — the {degree}",
+            $"It's the {degree} — a non-chord tone, but it isn't a semitone above any chord " +
+            "tone, so it adds colour without clashing. Safe to sustain as an extension.");
+    }
+
+    /// <summary>Name the chord-tone function for an in-chord relative pitch (e.g. "major third", "5th").</summary>
+    private static string ChordToneFunction(ChordFormula formula, int rel)
+    {
+        for (var i = 0; i < formula.Intervals.Count; i++)
+        {
+            if (((formula.Intervals[i] % 12) + 12) % 12 == rel)
+                return formula.IntervalNames[i];
+        }
+        return ExtensionLabel(rel);
+    }
+
+    /// <summary>Scale-degree label for a relative pitch class (root-relative, 0–11).</summary>
+    internal static string ExtensionLabel(int rel) => (((rel % 12) + 12) % 12) switch
+    {
+        0  => "root",
+        1  => "b9 (flat ninth)",
+        2  => "9 (ninth)",
+        3  => "#9 (sharp ninth)",
+        4  => "major 3rd",
+        5  => "11 (natural eleventh)",
+        6  => "#11 (sharp eleventh)",
+        7  => "5th",
+        8  => "b13 (flat thirteenth)",
+        9  => "13 (thirteenth)",
+        10 => "b7 (minor seventh)",
+        _  => "major 7th",   // 11
+    };
+
+    private static IReadOnlyList<string> ChordToneNames(int rootPc, string quality)
+    {
+        var formula = ChordVocabulary.GetFormula(quality);
+        return [.. formula.Intervals.Select(i => PcName(((rootPc + i) % 12 + 12) % 12))];
+    }
+
+    private static readonly string[] SharpNames =
+        ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+    private static string PcName(int pc) => SharpNames[((pc % 12) + 12) % 12];
+
+    private static string QualityDisplaySuffix(string quality) => quality switch
+    {
+        "major" => "",
+        "minor" => "m",
+        _       => " " + quality,
+    };
+
+    // ── Parsing ──────────────────────────────────────────────────────────────
+
+    internal readonly record struct ParsedQuery(
+        int NotePc, string NoteName, int RootPc, string RootName, string Quality);
+
+    /// <summary>
+    /// Parse "&lt;note&gt; … over/against/on &lt;chord&gt;". Splits on the last
+    /// preposition, reads the chord from the right side and the note from the left.
+    /// Returns null if either can't be resolved.
+    /// </summary>
+    internal static ParsedQuery? ParseNoteOverChord(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return null;
+
+        // Locate the chord after a preposition (over / against / on).
+        var chordMatch = ChordAfterPrepRegex().Match(message);
+        if (!chordMatch.Success) return null;
+
+        var rootRaw = ChordVocabulary.NormalizeRoot(chordMatch.Groups["root"].Value);
+        if (!ChordVocabulary.TryGetPitchClass(rootRaw, out var rootPc)) return null;
+        var quality = ChordVocabulary.NormalizeQuality(chordMatch.Groups["qual"].Value);
+
+        // The note is the LAST note-shaped token to the LEFT of the preposition,
+        // so we don't accidentally read the chord root as the note.
+        var prepStart = message.LastIndexOf(chordMatch.Groups["prep"].Value,
+            chordMatch.Index + chordMatch.Groups["prep"].Length, StringComparison.OrdinalIgnoreCase);
+        var left = prepStart > 0 ? message[..prepStart] : message[..chordMatch.Index];
+
+        Match? noteMatch = null;
+        foreach (Match m in NoteTokenRegex().Matches(left))
+            noteMatch = m;
+        if (noteMatch is null) return null;
+
+        var noteRaw = ChordVocabulary.NormalizeRoot(noteMatch.Groups["note"].Value);
+        if (!ChordVocabulary.TryGetPitchClass(noteRaw, out var notePc)) return null;
+
+        return new ParsedQuery(notePc, noteRaw, rootPc, rootRaw, quality);
+    }
+
+    // "<prep> <root><quality>" — prep is over/against/on; root is A–G + optional
+    // accidental; quality is the trailing chord-symbol run (letters/digits/#/b/°/ø/+).
+    [GeneratedRegex(@"(?<prep>\bover\b|\bagainst\b|\bon\b)\s+(?:a\s+|an\s+|the\s+)?(?<root>[A-G][#b]?)(?<qual>(?:maj|min|m|M|dim|aug|sus|add|alt|ø|°|Δ|\+|\d|#|b)*)",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex ChordAfterPrepRegex();
+
+    // A standalone note token: case-sensitive root letter + optional accidental,
+    // not immediately followed by a chord-quality character (so "Cmaj7" on the
+    // left isn't read as the note "C").
+    [GeneratedRegex(@"\b(?<note>[A-G][#b]?)(?![A-Za-z0-9#])")]
+    private static partial Regex NoteTokenRegex();
+
+    // ── Response helpers ─────────────────────────────────────────────────────
+
+    private AgentResponse CannotHandle() => new()
+    {
+        AgentId    = $"skill.{Name.ToLowerInvariant()}",
+        Result     =
+            "Tell me a single note and a single chord and I'll say whether it's a chord " +
+            "tone, a tension, or an avoid note — e.g. \"why does F sound outside over Cmaj7\" " +
+            "or \"is A a tension over Cmaj7\".",
+        Confidence = 0.1f,
+        Evidence   = ["OutsideNotesSkill: could not parse a <note> over <chord> pair"],
+        Assumptions = ["Query did not match the '<note> ... over <chord>' shape."],
+    };
+}

--- a/Common/GA.Business.ML/Agents/Skills/OutsideNotesSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/OutsideNotesSkill.cs
@@ -219,13 +219,26 @@ public sealed partial class OutsideNotesSkill(ILogger<OutsideNotesSkill> logger)
     private static IReadOnlyList<string> ChordToneNames(int rootPc, string quality)
     {
         var formula = ChordVocabulary.GetFormula(quality);
-        return [.. formula.Intervals.Select(i => PcName(((rootPc + i) % 12 + 12) % 12))];
+        var useFlat = PrefersFlatSpelling(rootPc, quality);
+        return [.. formula.Intervals.Select(i => PcName(((rootPc + i) % 12 + 12) % 12, useFlat))];
     }
 
     private static readonly string[] SharpNames =
         ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
 
-    private static string PcName(int pc) => SharpNames[((pc % 12) + 12) % 12];
+    private static readonly string[] FlatNames =
+        ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+
+    private static string PcName(int pc, bool useFlat = false) =>
+        (useFlat ? FlatNames : SharpNames)[((pc % 12) + 12) % 12];
+
+    // Guitarists expect flats in minor / diminished / half-diminished chords and
+    // in flat-rooted chords (Eb, Bb, Ab, Db, Gb, F). Otherwise sharps read fine.
+    private static bool PrefersFlatSpelling(int rootPc, string quality) =>
+        quality.Contains("minor", StringComparison.Ordinal) ||
+        quality.Contains("diminished", StringComparison.Ordinal) ||
+        quality.Contains("half", StringComparison.Ordinal) ||
+        rootPc is 5 or 10 or 3 or 8 or 1 or 6;   // F, Bb, Eb, Ab, Db, Gb
 
     private static string QualityDisplaySuffix(string quality) => quality switch
     {

--- a/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
+++ b/Tests/Apps/GaChatbot.Api.Tests/Corpus/prompts.yaml
@@ -154,6 +154,26 @@ prompts:
     forbidden_agent_ids: ["skill.relativekey"]
     must_not_fallback: true
 
+  # ── outside notes (unblocked 2026-07-20, BACKLOG North Star "why does this
+  #    sound outside?") — OutsideNotesSkill classifies a note over a chord ─────
+  - prompt: "why does F sound outside over Cmaj7"
+    category: outside-notes
+    routes_to: skill.outsidenotes
+    contains: ["avoid", "11"]
+    contains_any: ["semitone", "half-step", "half step", "third"]
+    min_length: 80
+    max_elapsed_ms: 20000
+    retry: 0                          # deterministic — pure classification
+
+  - prompt: "is A a tension or a chord tone over Cmaj7"
+    category: outside-notes
+    routes_to: skill.outsidenotes
+    contains_any: ["tension", "13", "chord tone"]
+    not_contains: ["avoid note"]      # A (13) is a safe tension, not an avoid
+    min_length: 60
+    max_elapsed_ms: 20000
+    retry: 0
+
   # ── chord operations (ga_dsl_eval-backed) ───────────────────────────────
   - prompt: "Transpose C E G to D"
     category: operations

--- a/Tests/Common/GA.Business.ML.Tests/Unit/OutsideNotesSkillTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/OutsideNotesSkillTests.cs
@@ -1,0 +1,163 @@
+namespace GA.Business.ML.Tests.Unit;
+
+using GA.Business.ML.Agents.Skills;
+using Microsoft.Extensions.Logging.Abstractions;
+
+[TestFixture]
+public class OutsideNotesSkillTests
+{
+    private static OutsideNotesSkill MakeSkill() =>
+        new(NullLogger<OutsideNotesSkill>.Instance);
+
+    private static async Task<string> AnswerAsync(string message) =>
+        (await MakeSkill().ExecuteAsync(message)).Result;
+
+    [Test]
+    public void Metadata_ExposesExamplePrompts()
+    {
+        var skill = MakeSkill();
+        Assert.That(skill.ExamplePrompts, Has.Count.GreaterThanOrEqualTo(6));
+        Assert.That(skill.Description.ToLowerInvariant(),
+            Does.Contain("avoid").Or.Contain("tension").Or.Contain("outside"));
+    }
+
+    // ===============================================================
+    // Classify — the domain core. Pitch classes: C=0 .. B=11.
+    // Rule: chord tone if in the formula; avoid if a semitone above a
+    // chord tone; otherwise available tension.
+    // ===============================================================
+
+    // Cmaj7 = {C,E,G,B} = {0,4,7,11}. root C = 0.
+    [TestCase(0, "major 7", 5, "Avoid")]    // F  = 11th, a semitone above E (3rd) → avoid
+    [TestCase(0, "major 7", 1, "Avoid")]    // Db = b9, a semitone above C (root) → avoid
+    [TestCase(0, "major 7", 9, "Tension")]  // A  = 13, whole step above G → tension
+    [TestCase(0, "major 7", 6, "Tension")]  // F# = #11, not a semitone above any tone → tension
+    [TestCase(0, "major 7", 2, "Tension")]  // D  = 9 → tension
+    [TestCase(0, "major 7", 4, "ChordTone")]// E  = the major 3rd
+    [TestCase(0, "major 7", 11, "ChordTone")]// B = the major 7th
+    [TestCase(0, "major 7", 7, "ChordTone")]// G = the 5th
+    // G7 = {G,B,D,F} = {7,11,2,5}. root G = 7.
+    [TestCase(7, "dominant 7", 0, "Avoid")]   // C = 11 over G7, a semitone above B (3rd) → avoid
+    [TestCase(7, "dominant 7", 9, "Tension")] // A = 9 over G7 → tension
+    [TestCase(7, "dominant 7", 8, "Avoid")]   // Ab = b9 over G7, a semitone above the root G → avoid (used as the b9 alteration)
+    // Cm7 = {C,Eb,G,Bb} = {0,3,7,10}. The natural 11 (F) is NOT avoid over minor.
+    [TestCase(0, "minor 7", 5, "Tension")]  // F = 11 over Cm7 — Eb+1=E not F, so no clash → tension
+    [TestCase(0, "minor 7", 8, "Avoid")]    // Ab = b13, a semitone above G (5th) → avoid
+    [TestCase(0, "minor 7", 2, "Tension")]  // D = 9 → tension
+    [TestCase(0, "minor 7", 3, "ChordTone")]// Eb = the minor 3rd
+    public void Classify_AppliesTheAvoidNoteRule(int rootPc, string quality, int notePc, string expectedKind)
+    {
+        var verdict = OutsideNotesSkill.Classify(rootPc, quality, notePc);
+        Assert.That(verdict.Kind.ToString(), Is.EqualTo(expectedKind),
+            $"note pc {notePc} over root {rootPc} {quality} classified {verdict.Kind}; expected {expectedKind} ({verdict.DegreeLabel})");
+    }
+
+    [Test]
+    public void Classify_Ab_Over_G7_IsAvoid_BecauseAboveRoot()
+    {
+        // Ab (8) over G7 (root 7): 7+1 = 8, and the root IS a chord tone, so Ab
+        // is a semitone above the root → avoid (the b9). Sanity-check the rule
+        // catches "semitone above the root", not just above upper structure.
+        var v = OutsideNotesSkill.Classify(7, "dominant 7", 8);
+        Assert.That(v.Kind, Is.EqualTo(OutsideNotesSkill.RelationKind.Avoid));
+        Assert.That(v.DegreeLabel, Does.Contain("b9"));
+    }
+
+    [TestCase(0, "root")]
+    [TestCase(1, "b9")]
+    [TestCase(2, "9")]
+    [TestCase(5, "11")]
+    [TestCase(6, "#11")]
+    [TestCase(8, "b13")]
+    [TestCase(9, "13")]
+    public void ExtensionLabel_NamesDegrees(int rel, string expectedFragment)
+    {
+        Assert.That(OutsideNotesSkill.ExtensionLabel(rel), Does.Contain(expectedFragment));
+    }
+
+    // ===============================================================
+    // Parsing — "<note> ... over <chord>".
+    // ===============================================================
+
+    [TestCase("why does F sound outside over Cmaj7", 5, 0, "major 7")]
+    [TestCase("is F an avoid note over Cmaj7", 5, 0, "major 7")]
+    [TestCase("what is F over G7", 5, 7, "dominant 7")]
+    [TestCase("why does Bb sound outside over C major", 10, 0, "major")]
+    [TestCase("is A a chord tone or a tension over Cmaj7", 9, 0, "major 7")]
+    [TestCase("why does F# clash over a Cm7 chord", 6, 0, "minor 7")]
+    public void ParseNoteOverChord_ExtractsNoteAndChord(string message, int notePc, int rootPc, string quality)
+    {
+        var parsed = OutsideNotesSkill.ParseNoteOverChord(message);
+        Assert.That(parsed, Is.Not.Null, $"failed to parse: {message}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(parsed!.Value.NotePc, Is.EqualTo(notePc), "note pc");
+            Assert.That(parsed!.Value.RootPc, Is.EqualTo(rootPc), "root pc");
+            Assert.That(parsed!.Value.Quality, Is.EqualTo(quality), "quality");
+        });
+    }
+
+    [TestCase("what scale should I use")]            // no chord, no note-over-chord shape
+    [TestCase("tell me about the C major scale")]    // no preposition
+    [TestCase("")]
+    public void ParseNoteOverChord_ReturnsNull_OnUnparseable(string message)
+    {
+        Assert.That(OutsideNotesSkill.ParseNoteOverChord(message), Is.Null);
+    }
+
+    // ===============================================================
+    // ExecuteAsync — end-to-end wording.
+    // ===============================================================
+
+    [Test]
+    public async Task Execute_F_Over_Cmaj7_ExplainsTheAvoidClash()
+    {
+        var answer = await AnswerAsync("why does F sound outside over Cmaj7");
+        Assert.Multiple(() =>
+        {
+            Assert.That(answer, Does.Contain("avoid"));
+            Assert.That(answer, Does.Contain("11"));
+            Assert.That(answer.ToLowerInvariant(), Does.Contain("semitone").Or.Contain("half-step").Or.Contain("half step"));
+        });
+    }
+
+    [Test]
+    public async Task Execute_A_Over_Cmaj7_IsAvailableTension()
+    {
+        var answer = await AnswerAsync("is A a tension over Cmaj7");
+        Assert.Multiple(() =>
+        {
+            Assert.That(answer, Does.Contain("tension"));
+            Assert.That(answer, Does.Contain("13"));
+            Assert.That(answer, Does.Not.Contain("avoid"));
+        });
+    }
+
+    [Test]
+    public async Task Execute_E_Over_Cmaj7_IsChordTone()
+    {
+        var answer = await AnswerAsync("is E a chord tone or tension over Cmaj7");
+        Assert.That(answer.ToLowerInvariant(), Does.Contain("chord tone").Or.Contain("major third"));
+    }
+
+    // ===============================================================
+    // CanHandle gating.
+    // ===============================================================
+
+    [TestCase("why does F sound outside over Cmaj7")]
+    [TestCase("is F an avoid note over Cmaj7")]
+    [TestCase("why does A clash against a G7")]
+    public void CanHandle_True_OnOutsideQueries(string message)
+    {
+        Assert.That(MakeSkill().CanHandle(message), Is.True, $"should claim: {message}");
+    }
+
+    [TestCase("what notes are in Cmaj7")]         // no outside intent
+    [TestCase("what scale can I solo over G7")]   // improvisation, not note-classification
+    [TestCase("transpose C E G up a fifth")]
+    [TestCase("")]
+    public void CanHandle_False_OnNonOutsideQueries(string message)
+    {
+        Assert.That(MakeSkill().CanHandle(message), Is.False, $"should NOT claim: {message}");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/SkillRegistryParityTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/SkillRegistryParityTests.cs
@@ -31,7 +31,7 @@ public class SkillRegistryParityTests
     /// <c>[GaSkill]</c>. Must equal the <c>AddOrchestratorSkillIntent&lt;T&gt;()</c>
     /// count in <c>GaPlugin.cs</c>.
     /// </summary>
-    private const int ExpectedMlSkillCount = 31;
+    private const int ExpectedMlSkillCount = 32;   // +OutsideNotesSkill (2026-07-20)
 
     /// <summary>Force <c>GA.Business.ML</c> to load so its ModuleInitializer runs.</summary>
     private static Assembly MlAssembly => typeof(IOrchestratorSkill).Assembly;


### PR DESCRIPTION
Third new capability this session, and it closes the top ⬜ gap from the #570 coverage audit: **"Why does this sound outside?"**

## What it does

Given a single note and a single chord, classify the note and explain why:

```
why does F sound outside over Cmaj7
→ F over Cmaj7: an avoid note — the 11.
  It sits a semitone above the major third (E); that half-step rub is the
  classic avoid-note clash — play it as a fast passing tone, don't land on it.

is A a tension over Cmaj7
→ A over Cmaj7: an available tension — the 13.
  A whole step above the 5th, so it adds colour without clashing.
```

## The classification rule (the domain core)

Derived **purely from the chord tones** — no per-quality tension table. A non-chord-tone that sits a **semitone above a chord tone** is an *avoid note* (it forms a b9 clash); anything else is an *available tension*. This is the standard jazz-pedagogy definition, and it correctly makes the natural 11 an avoid note over **major/dominant** chords but **not** over **minor** (Cm7 has no major 3rd for the 11 to clash with — verified in the test table).

Dominant chords get a tailored explanation: the b9/#9/#11/b13 half-step clashes are the *altered tensions players use deliberately*, so the advice differs from a plain avoid note over a major chord.

Reuses `ChordVocabulary.GetFormula` / `TryGetPitchClass` so the chord model stays consistent with `ChordInfoSkill` and the MCP chord tools — no new chord parsing.

## Verification

**46 unit tests** including the classifier theory table (F=avoid over Cmaj7, F=**tension** over Cm7, Ab=b9-avoid over G7, A=13-tension, Db=b9-avoid), the `<note> over <chord>` parser, and end-to-end wording. `SkillRegistryParityTests` count 31→32.

**Live routing A/B** — real bge-large @ production threshold 0.64, **held-out** phrasings (none are anchors):

| prompt | routed | conf |
|---|---|---|
| why does D# clash over Am7 | `outsidenotes` | 0.83 |
| is G an avoid note over Fmaj7 | `outsidenotes` | 0.89 |
| why does Eb sound off over Cmaj7 | `outsidenotes` | 0.82 |
| is D a tension or a chord tone over G7 | `outsidenotes` | 0.86 |
| *(guard)* what scale can I solo over G7 | `improvisation` | 0.87 |
| *(guard)* which arpeggio fits Am F C G | `improvisation` | 1.00 |
| *(guard)* what notes are in Cmaj7 | `chordinfo` | 0.99 |
| *(guard)* what notes are in a C major triad | `chordinfo` | 1.00 |

10/10 in-scope, **all four collision guards clean** — the real risk was stealing from Improvisation ("solo over X") or ChordInfo ("notes in X"); it doesn't. First pass had `"why does X clash over Y"` drifting to `grothendieckdelta` (no clash anchor); I added one, re-verified held-out, and confirmed grothendieck's own chord-distance queries are undisturbed (0.95/0.98). Per the `offline-sim-not-valid-router-proxy` lesson, this is the real router.

**Full `GA.Business.ML` Unit suite green** (1054 passed, 0 failed). Corpus: two ACTIVE `outside-notes` entries pinning `routes_to`.

## Wiring

`[GaSkill("OutsideNotes","harmony")]` + `GaPlugin.AddOrchestratorSkillIntent<OutsideNotesSkill>()` + parity count bump. No `skills/` folder → no parity-matrix row (same as Improvisation/AlternateTunings).

## Scope

v1 handles the `<note> … over/against/on <chord>` shape (one concrete note, one concrete chord). Degree-word queries ("why does the 4th clash") and note-vs-key ("F outside in C major") are out of scope, documented in the class remarks. Moves the audit's ⬜ → ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)