### PR TITLE
feat(atonal): phase-aligned similarity — distinguish the Z-pairs and chirality ICV cannot

### DIFF
--- a/Common/GA.Domain.Core/Theory/Atonal/SpectralPhaseAlignment.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/SpectralPhaseAlignment.cs
@@ -1,0 +1,183 @@
+namespace GA.Domain.Core.Theory.Atonal;
+
+using System.Numerics;
+
+/// <summary>
+///     Transposition/inversion-aligned similarity via DFT phase correlation on Z₁₂
+///     (the shift theorem + Lewin's lemma + phase correlation; Amiot,
+///     <em>Music Through Fourier Space</em>, 2016; Quinn 2006–07; Lewin 1959).
+///     <para>
+///     Fixes the two blind spots of the interval-class vector, which — being the
+///     autocorrelation of the chroma — determines exactly the DFT magnitudes and
+///     nothing more (<see cref="SetClass.GetMagnitudeSpectrum" />). Magnitude/ICV
+///     similarity therefore scores as identical (a) the 23 homometric
+///     <em>Z-related</em> set-class pairs and (b) a major triad vs its minor
+///     (chirality). The <em>phase</em> spectrum, transformed predictably under
+///     transposition, separates both — in closed form, at query time.
+///     </para>
+///     Spec + numerical oracle: <c>docs/research/2026-07-04-optick-spectral-phase-alignment.md</c>.
+/// </summary>
+public static class SpectralPhaseAlignment
+{
+    private const int PitchClassSpaceSize = 12;
+    private const double Epsilon = 1e-9;
+
+    /// <summary>Outcome of a phase-aligned comparison of two pitch-class sets.</summary>
+    /// <param name="Similarity">
+    ///     <c>S ∈ [-1, 1]</c>. <c>S = 1</c> iff the sets are transposition-aligned
+    ///     (one is a transposition of the other, or its inversion on the TnI path).
+    /// </param>
+    /// <param name="AligningTranspositions">
+    ///     Every <c>t</c> achieving the maximum (<c>t*</c>) — the transposition(s)
+    ///     that align <c>b</c> onto <c>a</c>. Multiple values occur for sets fixed by
+    ///     some transposition (augmented triad, diminished 7th, whole-tone …); empty
+    ///     only in the disjoint-support degenerate case.
+    /// </param>
+    /// <param name="Inverted">True iff the winning alignment used <c>b</c>'s inversion (TnI path).</param>
+    public readonly record struct Alignment(
+        double Similarity,
+        IReadOnlyList<int> AligningTranspositions,
+        bool Inverted);
+
+    /// <summary>
+    ///     Theorem 3 — transposition-aligned similarity <c>S(a, b)</c>, chirality
+    ///     preserving (major ≠ minor). Maximises magnitude-weighted phase agreement
+    ///     over the 12 transpositions.
+    /// </summary>
+    /// <param name="weights">Optional per-coefficient weights for k = 1..6 (Quinn quality
+    ///     semantics); uniform when null.</param>
+    public static Alignment Similarity(PitchClassSet a, PitchClassSet b, double[]? weights = null)
+        => Align(Coefficients(a), Coefficients(b), weights, inverted: false);
+
+    /// <summary>
+    ///     Theorem 4 — TnI-aligned similarity, <c>max(S(a, b), S(a, inv b))</c>. Inversion
+    ///     conjugates the DFT, so set-class (TnI) matching is available on demand while
+    ///     plain <see cref="Similarity" /> keeps chirality. Separates all 23 Z-pairs.
+    /// </summary>
+    public static Alignment SimilarityTnI(PitchClassSet a, PitchClassSet b, double[]? weights = null)
+    {
+        var fa = Coefficients(a);
+        var fb = Coefficients(b);
+
+        var direct = Align(fa, fb, weights, inverted: false);
+
+        // Inversion I: n ↦ −n conjugates every coefficient (X_k ↦ conj X_k).
+        var fbInv = new Complex[fb.Length];
+        for (var k = 1; k <= 6; k++)
+        {
+            fbInv[k] = Complex.Conjugate(fb[k]);
+        }
+
+        var inverted = Align(fa, fbInv, weights, inverted: true);
+        return inverted.Similarity > direct.Similarity ? inverted : direct;
+    }
+
+    /// <summary>Fourier coefficients <c>X_k, k = 0..6</c> of the set's ACTUAL chroma
+    /// (not the prime form — phases carry the transposition, which is the point).</summary>
+    private static Complex[] Coefficients(PitchClassSet set)
+    {
+        ArgumentNullException.ThrowIfNull(set);
+        var chroma = set.ToBinaryVector(PitchClassSpaceSize);
+        var x = new Complex[7];
+        for (var k = 0; k <= 6; k++)
+        {
+            var sum = Complex.Zero;
+            for (var n = 0; n < PitchClassSpaceSize; n++)
+            {
+                if (chroma[n] == 0.0)
+                {
+                    continue;
+                }
+
+                var angle = -2.0 * Math.PI * k * n / PitchClassSpaceSize;
+                sum += Complex.Exp(new Complex(0.0, angle));
+            }
+
+            x[k] = sum;
+        }
+
+        return x;
+    }
+
+    private static Alignment Align(Complex[] fa, Complex[] fb, double[]? weights, bool inverted)
+    {
+        // denom = Σ_{k=1..6} w_k |X_k(a)| |X_k(b)|
+        var denom = 0.0;
+        for (var k = 1; k <= 6; k++)
+        {
+            denom += Weight(weights, k) * fa[k].Magnitude * fb[k].Magnitude;
+        }
+
+        if (denom < Epsilon)
+        {
+            // Zero-denominator convention (Codex review, ga#513):
+            //  - a or b null on k=1..6 (empty set / chromatic aggregate): transpositionally
+            //    trivial, fixed by every T_t → S := 1 with every t aligning.
+            //  - otherwise both non-trivial with disjoint periodicity support → S := 0, no t*.
+            return AllNull(fa, weights) || AllNull(fb, weights)
+                ? new Alignment(1.0, AllTranspositions(), inverted)
+                : new Alignment(0.0, [], inverted);
+        }
+
+        // numerator(t) = Σ_k w_k · Re[ X_k(a) · conj(X_k(b)) · e^{i·2πkt/12} ]
+        //             = Σ_k w_k · m_k(a) m_k(b) · cos( φ_k(a) − φ_k(b) + 2πkt/12 )
+        var cross = new Complex[7];
+        for (var k = 1; k <= 6; k++)
+        {
+            cross[k] = fa[k] * Complex.Conjugate(fb[k]);
+        }
+
+        var best = double.NegativeInfinity;
+        var argmax = new List<int>();
+        for (var t = 0; t < PitchClassSpaceSize; t++)
+        {
+            var num = 0.0;
+            for (var k = 1; k <= 6; k++)
+            {
+                var rot = Complex.Exp(new Complex(0.0, 2.0 * Math.PI * k * t / PitchClassSpaceSize));
+                num += Weight(weights, k) * (cross[k] * rot).Real;
+            }
+
+            var s = num / denom;
+            if (s > best + Epsilon)
+            {
+                best = s;
+                argmax.Clear();
+                argmax.Add(t);
+            }
+            else if (Math.Abs(s - best) <= Epsilon)
+            {
+                argmax.Add(t);
+            }
+        }
+
+        return new Alignment(best, argmax, inverted);
+    }
+
+    private static double Weight(double[]? weights, int k)
+        => weights is null ? 1.0 : weights[k - 1];
+
+    private static bool AllNull(Complex[] f, double[]? weights)
+    {
+        for (var k = 1; k <= 6; k++)
+        {
+            if (Weight(weights, k) > 0.0 && f[k].Magnitude >= Epsilon)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static IReadOnlyList<int> AllTranspositions()
+    {
+        var all = new int[PitchClassSpaceSize];
+        for (var t = 0; t < PitchClassSpaceSize; t++)
+        {
+            all[t] = t;
+        }
+
+        return all;
+    }
+}

--- a/Common/GA.Domain.Core/Theory/Atonal/SpectralPhaseAlignment.cs
+++ b/Common/GA.Domain.Core/Theory/Atonal/SpectralPhaseAlignment.cs
@@ -111,10 +111,10 @@ public static class SpectralPhaseAlignment
         if (denom < Epsilon)
         {
             // Zero-denominator convention (Codex review, ga#513):
-            //  - a or b null on k=1..6 (empty set / chromatic aggregate): transpositionally
-            //    trivial, fixed by every T_t → S := 1 with every t aligning.
+            //  - both a and b null on k=1..6 (empty set / chromatic aggregate):
+            //    transpositionally trivial, fixed by every T_t → S := 1 with every t aligning.
             //  - otherwise both non-trivial with disjoint periodicity support → S := 0, no t*.
-            return AllNull(fa, weights) || AllNull(fb, weights)
+            return AllNull(fa, weights) && AllNull(fb, weights)
                 ? new Alignment(1.0, AllTranspositions(), inverted)
                 : new Alignment(0.0, [], inverted);
         }

--- a/GaMcpServer/Tools/ChordAtonalTool.cs
+++ b/GaMcpServer/Tools/ChordAtonalTool.cs
@@ -146,6 +146,60 @@ public static class ChordAtonalTool
 
     [McpServerTool]
     [Description(
+        "Distinguish two chords that the interval-class vector (ICV) treats as identical — the two blind " +
+        "spots of ICV: homometric (Z-related) pairs and major-vs-minor chirality. Reports whether they " +
+        "share an ICV, the phase-aligned similarity S (chirality-preserving) and S_TnI (set-class), and the " +
+        "transposition t* that best aligns them. Example: 4-Z15 and 4-Z29 share an ICV yet S_TnI = 0.67 " +
+        "(genuinely different shapes); C major and C minor share an ICV but S = 0.57 (distinct handedness), " +
+        "S_TnI = 1 (inversion-equivalent).")]
+    public static async Task<string> GaHomometricDistinguish(
+        [Description("First chord, e.g. 'C'")] string chord1,
+        [Description("Second chord, e.g. 'Cm'")] string chord2)
+    {
+        var pcs1 = await GetPitchClassesAsync(chord1);
+        var pcs2 = await GetPitchClassesAsync(chord2);
+        if (pcs1.Length == 0) return $"Error: could not parse '{chord1}'";
+        if (pcs2.Length == 0) return $"Error: could not parse '{chord2}'";
+
+        var setA = ToPitchClassSet(pcs1);
+        var setB = ToPitchClassSet(pcs2);
+        var icvA = setA.IntervalClassVector;
+        var icvB = setB.IntervalClassVector;
+        var icvEqual = icvA.Id.Equals(icvB.Id);
+
+        var plain = SpectralPhaseAlignment.Similarity(setA, setB);
+        var tni = SpectralPhaseAlignment.SimilarityTnI(setA, setB);
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"Distinguishing {chord1} {FormatPcs(pcs1)} vs {chord2} {FormatPcs(pcs2)}");
+        sb.AppendLine($"  ICV {chord1}: {icvA}");
+        sb.AppendLine($"  ICV {chord2}: {icvB}");
+        sb.AppendLine(icvEqual
+            ? "  ICV verdict: IDENTICAL — the interval-class vector is blind here."
+            : "  ICV verdict: different — ICV already distinguishes these.");
+        var tStar = plain.AligningTranspositions.Count > 0
+            ? $"  t*=[{string.Join(",", plain.AligningTranspositions)}]"
+            : "  (no alignment)";
+        sb.AppendLine($"  Phase-aligned S (chirality-kept): {plain.Similarity:F4}{tStar}");
+        sb.AppendLine($"  Phase-aligned S_TnI (set-class):  {tni.Similarity:F4}" +
+                      (tni.Inverted ? "  (via inversion)" : string.Empty));
+
+        string verdict;
+        if (plain.Similarity >= 1.0 - 1e-6)
+            verdict = "Same shape up to transposition — one is a transposition of the other.";
+        else if (tni.Similarity >= 1.0 - 1e-6)
+            verdict = "Chirality pair — same set class (T/I-equivalent), opposite handedness (e.g. major vs minor).";
+        else if (icvEqual)
+            verdict = "Homometric but distinct — a Z-related pair: identical interval content, genuinely " +
+                      "different shape. ICV cannot separate them; DFT phase can.";
+        else
+            verdict = "Distinct set classes.";
+        sb.Append($"  → {verdict}");
+        return sb.ToString();
+    }
+
+    [McpServerTool]
+    [Description(
         "Find all standard chords (triads, 7ths, 9ths) that are set-class equivalent (T/I) to the input chord — " +
         "same prime form under transposition or inversion. These are the deepest substitutions: " +
         "same interval content regardless of root. " +

--- a/GaMcpServer/Tools/ChordAtonalTool.cs
+++ b/GaMcpServer/Tools/ChordAtonalTool.cs
@@ -86,6 +86,11 @@ public static class ChordAtonalTool
 
     private static async Task<int[]> GetPitchClassesAsync(string symbol)
     {
+        if (CanonicalForteCatalog.TryGetPrimeForm(symbol, out var primeForm))
+        {
+            return [.. primeForm.Select(pc => pc.Value).Order()];
+        }
+
         var rootPc = ParseRootPc(symbol);
         var intervals = await GetIntervalNamesAsync(symbol);
         return [.. intervals

--- a/Tests/Apps/GaMcpServer.Tests/ChordAtonalToolTests.cs
+++ b/Tests/Apps/GaMcpServer.Tests/ChordAtonalToolTests.cs
@@ -1,0 +1,20 @@
+namespace GaMcpServer.Tests;
+
+using GaMcpServer.Tools;
+
+[TestFixture]
+public sealed class ChordAtonalToolTests
+{
+    [Test]
+    public async Task GaHomometricDistinguish_AcceptsCanonicalForteLabels()
+    {
+        var result = await ChordAtonalTool.GaHomometricDistinguish("4-Z15", "4-Z29");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Does.Contain("ICV verdict: IDENTICAL"));
+            Assert.That(result, Does.Contain("Homometric but distinct"));
+            Assert.That(result, Does.Not.StartWith("Error:"));
+        });
+    }
+}

--- a/Tests/Common/GA.Business.Core.Tests/Atonal/SpectralPhaseAlignmentTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Atonal/SpectralPhaseAlignmentTests.cs
@@ -1,0 +1,150 @@
+namespace GA.Business.Core.Tests.Atonal;
+
+using GA.Domain.Core.Theory.Atonal;
+
+/// <summary>
+///     Verifies the phase-aligned similarity operator against the numeric oracle in
+///     docs/research/2026-07-04-optick-spectral-phase-alignment.md §4, plus the
+///     exhaustive separation guarantee: it distinguishes all 23 homometric Z-pairs
+///     (and major/minor chirality) that the interval-class vector cannot.
+/// </summary>
+[TestFixture]
+public class SpectralPhaseAlignmentTests
+{
+    private static PitchClassSet Pcs(params int[] pcs)
+        => new(pcs.Select(PitchClass.FromValue));
+
+    // ── §4 oracle table ──────────────────────────────────────────────────────
+
+    [Test]
+    public void Similarity_RecoversTransposition_ForMajorTriads()
+    {
+        // C major {0,4,7} vs D major {2,6,9} = T₂ — same shape, aligned, t* = 10.
+        var r = SpectralPhaseAlignment.Similarity(Pcs(0, 4, 7), Pcs(2, 6, 9));
+        TestContext.WriteLine($"S={r.Similarity:F4} t*=[{string.Join(",", r.AligningTranspositions)}]");
+        Assert.That(r.Similarity, Is.EqualTo(1.0).Within(1e-9));
+        Assert.That(r.AligningTranspositions, Does.Contain(10));
+    }
+
+    [Test]
+    public void Similarity_PreservesChirality_MajorVsMinor()
+    {
+        // Major {0,4,7} vs minor {0,3,7}: ICV-identical (both 3-11) — plain S must NOT be 1
+        // (chirality preserved), but the TnI path recovers their equivalence.
+        var major = Pcs(0, 4, 7);
+        var minor = Pcs(0, 3, 7);
+
+        var plain = SpectralPhaseAlignment.Similarity(major, minor);
+        var tni = SpectralPhaseAlignment.SimilarityTnI(major, minor);
+
+        TestContext.WriteLine($"S={plain.Similarity:F4}  S_TnI={tni.Similarity:F4}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(plain.Similarity, Is.EqualTo(0.5714).Within(1e-3), "chirality-preserving S");
+            Assert.That(tni.Similarity, Is.EqualTo(1.0).Within(1e-9), "TnI-equivalent");
+            Assert.That(tni.Inverted, Is.True, "the winning TnI alignment is the inversion");
+        });
+    }
+
+    [Test]
+    public void Similarity_SeparatesZPair_4Z15_4Z29()
+    {
+        var r = SpectralPhaseAlignment.Similarity(Pcs(0, 1, 4, 6), Pcs(0, 1, 3, 7));
+        var tni = SpectralPhaseAlignment.SimilarityTnI(Pcs(0, 1, 4, 6), Pcs(0, 1, 3, 7));
+        TestContext.WriteLine($"4-Z15 vs 4-Z29: S={r.Similarity:F4} S_TnI={tni.Similarity:F4}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.Similarity, Is.EqualTo(0.3333).Within(1e-3));
+            Assert.That(tni.Similarity, Is.EqualTo(0.6667).Within(1e-3));
+        });
+    }
+
+    [Test]
+    public void Similarity_SeparatesZPair_6Z17_6Z43()
+    {
+        var r = SpectralPhaseAlignment.Similarity(Pcs(0, 1, 2, 4, 7, 8), Pcs(0, 1, 2, 5, 6, 8));
+        TestContext.WriteLine($"6-Z17 vs 6-Z43: S={r.Similarity:F4}");
+        Assert.That(r.Similarity, Is.EqualTo(0.4000).Within(1e-3));
+    }
+
+    // ── exhaustive separation (the product guarantee) ────────────────────────
+
+    [Test]
+    public void SimilarityTnI_SeparatesAll23ZRelatedPairs()
+    {
+        // Z-related = same ICV, different set class. Grouping set classes by ICV yields
+        // the 23 homometric pairs of 12-TET — but only after excluding the degenerate
+        // classes: SetClass.Items includes the empty set and the singleton, which BOTH
+        // carry the null ICV <0 0 0 0 0 0> and would otherwise form a spurious 24th
+        // "pair" (trivially unseparable). Real Z-pairs are cardinality 4..8.
+        var zPairs = SetClass.Items
+            .Where(sc => sc.Cardinality >= 3)
+            .GroupBy(sc => sc.IntervalClassVector.Id)
+            .Where(g => g.Count() == 2)
+            .Select(g => (A: g.First(), B: g.Last()))
+            .ToList();
+
+        Assert.That(zPairs, Has.Count.EqualTo(23), "the 23 12-TET Z-pairs (guards the enumeration)");
+
+        var worst = double.NegativeInfinity;
+        var separated = 0;
+        foreach (var (a, b) in zPairs)
+        {
+            // Precondition: ICV genuinely cannot tell them apart.
+            Assert.That(a.IntervalClassVector.Id, Is.EqualTo(b.IntervalClassVector.Id));
+
+            var s = SpectralPhaseAlignment.SimilarityTnI(a.PrimeForm, b.PrimeForm).Similarity;
+            TestContext.WriteLine($"card {a.Cardinality}: {a.PrimeForm} / {b.PrimeForm}  ICV={a.IntervalClassVector.Id}  S_TnI={s:F4}");
+            Assert.That(s, Is.LessThan(1.0 - 1e-6), $"Z-pair {a} / {b} not separated: S_TnI={s:F4}");
+            worst = Math.Max(worst, s);
+            separated++;
+        }
+
+        TestContext.WriteLine($"separated {separated}/{zPairs.Count}; worst S_TnI = {worst:F4}");
+        Assert.That(separated, Is.EqualTo(zPairs.Count));
+    }
+
+    [Test]
+    public void Similarity_IsOne_OnEveryTransposition_Randomized()
+    {
+        var rng = new Random(42);
+        for (var iter = 0; iter < 1000; iter++)
+        {
+            var card = rng.Next(1, 12); // 1..11 (skip empty / aggregate — degenerate)
+            var pool = Enumerable.Range(0, 12).OrderBy(_ => rng.Next()).Take(card).ToArray();
+            var t = rng.Next(0, 12);
+
+            var a = Pcs(pool);
+            var b = Pcs([.. pool.Select(p => (p + t) % 12)]);
+
+            var r = SpectralPhaseAlignment.Similarity(a, b);
+            Assert.That(r.Similarity, Is.EqualTo(1.0).Within(1e-9),
+                $"iter {iter}: card={card} t={t} pcs=[{string.Join(",", pool)}] S={r.Similarity}");
+            Assert.That(r.AligningTranspositions, Does.Contain((12 - t) % 12));
+        }
+    }
+
+    // ── zero-denominator convention (ga#513) ─────────────────────────────────
+
+    [Test]
+    public void EmptySet_IsTriviallyAligned()
+    {
+        var r = SpectralPhaseAlignment.Similarity(new PitchClassSet([]), Pcs(0, 4, 7));
+        Assert.That(r.Similarity, Is.EqualTo(1.0).Within(1e-9), "empty set is fixed by every T_t");
+        Assert.That(r.AligningTranspositions, Has.Count.EqualTo(12));
+    }
+
+    [Test]
+    public void DisjointSupport_IsMaximallyDissimilar()
+    {
+        // Augmented triad {0,4,8} (spectral support {3,6}) vs diminished 7th
+        // {0,3,6,9} (support {4}) share no periodicity content → S := 0, no t*.
+        var r = SpectralPhaseAlignment.Similarity(Pcs(0, 4, 8), Pcs(0, 3, 6, 9));
+        TestContext.WriteLine($"aug vs dim7: S={r.Similarity:F4} t*count={r.AligningTranspositions.Count}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.Similarity, Is.EqualTo(0.0).Within(1e-9));
+            Assert.That(r.AligningTranspositions, Is.Empty);
+        });
+    }
+}

--- a/Tests/Common/GA.Business.Core.Tests/Atonal/SpectralPhaseAlignmentTests.cs
+++ b/Tests/Common/GA.Business.Core.Tests/Atonal/SpectralPhaseAlignmentTests.cs
@@ -127,11 +127,26 @@ public class SpectralPhaseAlignmentTests
     // ── zero-denominator convention (ga#513) ─────────────────────────────────
 
     [Test]
-    public void EmptySet_IsTriviallyAligned()
+    public void OneNullSpectrum_IsNotAlignedWithNonNullSpectrum()
     {
         var r = SpectralPhaseAlignment.Similarity(new PitchClassSet([]), Pcs(0, 4, 7));
-        Assert.That(r.Similarity, Is.EqualTo(1.0).Within(1e-9), "empty set is fixed by every T_t");
-        Assert.That(r.AligningTranspositions, Has.Count.EqualTo(12));
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.Similarity, Is.EqualTo(0.0).Within(1e-9));
+            Assert.That(r.AligningTranspositions, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void BothNullSpectra_AreTriviallyAligned()
+    {
+        var empty = new PitchClassSet([]);
+        var r = SpectralPhaseAlignment.Similarity(empty, empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(r.Similarity, Is.EqualTo(1.0).Within(1e-9));
+            Assert.That(r.AligningTranspositions, Has.Count.EqualTo(12));
+        });
     }
 
     [Test]

--- a/docs/research/2026-07-22-phase-retrieval-integration.md
+++ b/docs/research/2026-07-22-phase-retrieval-integration.md
@@ -1,0 +1,49 @@
+# Integrating phase-based similarity into OPTIC-K retrieval — deep-research synthesis
+
+**Status: research note, 2026-07-22. Deep-research harness (5-angle fan-out → 15 sources → 3-vote adversarial verification → synthesis; 104 agents, 0 errors on the completed run). Extends the 2026-07-04 phase-alignment note and operationalizes its deferred §6 retrieval wiring. Companion to the shipped operator (`SpectralPhaseAlignment`, ga#579) and its IX reference implementation (GuitarAlchemist/ix#252).**
+
+---
+
+## Question
+
+`SpectralPhaseAlignment` (ga#579) gives a closed-form, transposition/inversion-aware similarity that separates the homometric (Z-related) pairs and major/minor chirality the interval-class vector cannot. How should it become an actual retrieval feature over the ~313k-voicing OPTIC-K corpus? Re-rank vs index; closed-form vs learned; how to evaluate.
+
+## Verdict
+
+The mathematics is **settled and fully closed-form — not a research gamble.** Cosine-over-magnitude is *provably* blind to exactly the confusions that matter; the fix is a **two-stage retriever** (magnitude-cosine top-K for recall → closed-form phase re-rank for disambiguation). A specialised phase-aware ANN index is not worth building. One higher-leverage finding upgrades the plan: **coefficient products** turn chirality/homometry discrimination into *indexable* scalar features, not just a re-rank pass.
+
+## Verified findings (all merged 3-0 unless noted)
+
+### 1. Magnitude-only cosine is provably blind — and it is the crystallographic phase-retrieval problem
+DFT magnitudes are transposition- **and** inversion-invariant (they encode only the set class), but homometric sets are *defined* by sharing equal magnitude on all Fourier coefficients — equivalently the same Patterson autocorrelation = interval vector = squared magnitude spectrum (Wiener–Khinchin on ℤ/12). "The musical concept of Z-related sets coincides with the crystallographic notion of homometric sets." Because the DFT is lossless, the residual discriminating information sits **entirely in the phases**.
+*Sources:* Amiot & Yust, MCM 2022 (Springer, 10.1007/978-3-031-07015-0_23); Jedrzejewski & Johnson, *Z-relation and homometry in musical distributions*; Amiot, arXiv:1304.6608.
+
+### 2. Transposition is a pure rotation on phase — closed-form, trivial group
+Transposition by `x` multiplies each Fourier component by a unit vector, shifting the k-th phase by exactly `k·x mod 12`; the n-th phase equals the chord's pitch-class sum (Yust / Tymoczko). The transposition group over ℤ/12 is a trivial 12-element search, so the offset is recovered algebraically. **Candid caveat from the sources:** over a 12-element group "closed-form saves little vs a 12-way search — the real payoff is chirality disambiguation, not transposition speed."
+*Sources:* Yust, *Fourier Phase Space* (Princeton PDF); Yust, *Fourier Phase and Pitch-Class Sum* (MCM 2019); Yust, *Schubert's Harmonic Language and Fourier Phase Space*, JMT 59(1), 2015.
+
+### 3. Coefficient products = indexable, chirality-aware invariant signatures (the upgrade)
+Transposition-invariant **scalar** signatures come in closed form as *products of Fourier coefficients whose indices partition 12* — e.g. `a₂·a₃·a₇` for the diatonic (2+3+7=12); Amiot & Yust, Proposition 3. Crucially, **inversion conjugates every coefficient, which negates the imaginary part of a coefficient product while preserving the real part** — a direct closed-form handle on major/minor chirality. Unlike ga#579's query-time max-over-group operator, these products are **precomputable per voicing and directly indexable** (real part = T/I-invariant magnitude-like coordinate; imaginary part = signed chirality coordinate). Limit: inversionally-symmetric sets yield real products (the non-chiral case, correctly out of scope).
+*Source:* Amiot & Yust, MCM 2022 (Springer). Independently derivable (A ↦ −A conjugates every `X_k`).
+
+### 4. Architecture — re-rank, don't build a bespoke phase-aware index
+Recommended production shape for research-question (a): **magnitude-cosine top-K → closed-form phase re-rank / coefficient-product disambiguation.** Rationale: (i) the transposition group is a trivial 12-way search, so a specialised invariant index buys almost nothing; (ii) a low-order phase pair (k=3, 5 — Yust's Tonnetz-embedding coordinates) already discriminates; (iii) learned equivariant embeddings measurably discard task-relevant information relative to the exact closed-form features. A learned D₁₂-equivariant embedding (Music102-style, parameter-efficient — arXiv:2410.18151) remains a viable *longer-term* alternative, deferred.
+
+## ⚠ Open discrepancy to reconcile before wiring
+
+The web sources cite **"19 homometric pairs at N=12"** (first homometric *triple* at N=16). But ga#579's test **verified 23** by enumerating GA's own `SetClass.Items` (grouped by ICV, degenerate classes excluded) — matching the 2026-07-04 note's canon and Forte. This is a **counting-convention conflict** (subset-pairs vs TnI set-class pairs, or a source miscount), **not** a reason to distrust the code-verified 23. The evaluation harness (below) must pin the exact inventory first; the code-verified 23 is the stronger evidence.
+
+## Evaluation methodology (research-question (d))
+
+Do **not** score with top-K overlap alone. Build a labelled probe set from the ground-truth inventory and measure the two blind-spot metrics directly:
+- **Homometric (Z-pair) confusion rate** — fraction of Z-pair members retrieved as mutually "identical". Requires the reconciled pair inventory (23 per ga#579, pending the 19-vs-23 reconciliation).
+- **Chirality confusion rate** — major/minor (and general non-inversionally-symmetric) pairs scored as identical.
+- A/B vs the ICV path on the voicing corpus: top-K overlap **plus** the two confusion metrics (per the 2026-07-04 note §7 acceptance criteria — now literature-backed).
+
+## Integration path (unchanged one-way-door posture)
+
+Query-time arithmetic + optional precomputed coefficient-product scalars over the SPECTRAL partition as stored. No schema change, no re-index for the re-rank path; the coefficient-product features, if indexed, are a **new dimension addition** deferred to the next corpus rebuild (same posture as the ICV / phase wiring). The re-rank path ships now; the indexed-feature path is the rebuild-gated upgrade.
+
+## Sources
+
+Amiot & Yust, "Fourier Phase and Pitch-Class Sum" / MCM 2022 (Springer 10.1007/978-3-031-07015-0_23); Yust, *Schubert's Harmonic Language and Fourier Phase Space*, JMT 59(1), 2015; Yust, *Fourier Phase Space* (Princeton); Jedrzejewski & Johnson, *Z-relation and homometry in musical distributions*; Amiot, arXiv:1304.6608; Music102 (D₁₂-equivariant transformer), arXiv:2410.18151. (A latency data point on closed-form vs learned re-rankers surfaced in an earlier partial run but rested on an unresolved arXiv id and is deliberately omitted here pending a citation check.)


### PR DESCRIPTION
Fixes the two blind spots of the interval-class vector, using the phase information the embedding already stores but never used. Grounded in the verified in-repo research note `docs/research/2026-07-04-optick-spectral-phase-alignment.md` (Codex-reviewed, ga#513).

## Why

The ICV is the autocorrelation of the pitch-class chroma, so it determines exactly the DFT **magnitudes** and nothing more (Lewin's lemma). It is therefore blind two ways:
- **Homometry** — the 23 Z-related set-class pairs share an ICV; any ICV/magnitude similarity scores them 1.0.
- **Chirality** — a major triad and a minor triad share ICV `<001110>`; ICV cannot tell them apart.

`SetClass` already computed the magnitude **and phase** spectra, but the phase was unused. The phase resolves both — in closed form, at query time.

## What

`SpectralPhaseAlignment` (`GA.Domain.Core.Theory.Atonal`), implementing the note's operators over `System.Numerics.Complex`:
- **`Similarity`** (Thm 3) — Tₙ-aligned, **chirality-preserving**, returns the aligning transposition `t*`.
- **`SimilarityTnI`** (Thm 4) — set-class matching via DFT conjugation (inversion).
- Both maximise a magnitude-weighted phase cross-correlation over the group, with explicit **zero-denominator branches** (both spectra null → 1; one-null/non-null or disjoint support → 0).

**Chatbot:** `ga_homometric_distinguish` MCP tool — *"how do these two same-interval chords differ?"* — reports ICV-blindness, `S` / `S_TnI`, `t*`, and a plain-language verdict.

## Verification — 10 focused NUnit tests

Reproduce the note's §4 oracle **exactly**: maj/maj `S=1.0 t*=10`; maj/min `S=0.5714, S_TnI=1.0`; 4-Z15/4-Z29 `S=0.3333, S_TnI=0.6667`; 6-Z17/6-Z43 `S=0.4000`. Plus the guarantees: **all 23 Z-pairs separated**, **1000/1000** random transpositions align to `S=1`, both degenerate branches, and the advertised `4-Z15` / `4-Z29` MCP inputs resolve through the canonical Forte catalog. All 9 spectral tests and all 8 `GaMcpServer.Tests` tests pass; the full solution builds with 0 errors; pre-commit passed. The local all-project test run still encounters the pre-existing missing `naturalness_ranker.onnx` checkout fixture, outside this diff.

One finding: grouping `SetClass.Items` by ICV yields **24** homometric pairs, not the folklore 23 — the 24th is the degenerate {empty set, singleton} sharing the null ICV. The test excludes cardinality < 3 and asserts exactly 23.

## Scope

Query-time arithmetic only — **no schema change, no re-index** (retrieval wiring stays deferred per the note §6, same caveat as the ICV path). This ships the proven capability + the chatbot hook; the IX reference implementation is `GuitarAlchemist/ix` PR #252 (independent verification, same F3 gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
