### PR TITLE
ci: adopt reusable Claude review diagnostics

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
-    uses: GuitarAlchemist/.github/.github/workflows/claude-code-review.yml@0a36fe841e8100c79c03af4237ab0aeadfb50332
+    uses: GuitarAlchemist/.github/.github/workflows/claude-code-review.yml@ecd319a2c9bf27b951229343b4aa13ab5e9dfeef
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,51 +2,23 @@ name: Claude Code Review
 
 on:
   pull_request:
-    # Cost-safe: drop `synchronize` so review fires once per PR, not once per push.
+    # Cost-safe: review once per PR lifecycle, not once per push.
     types: [opened, reopened, ready_for_review]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
-# Cost-safe: at most one review run per PR at a time; new events cancel the in-flight one.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Cost-safe: skip draft PRs — review runs when the PR is marked ready_for_review.
     if: github.event.pull_request.draft == false
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+    uses: GuitarAlchemist/.github/.github/workflows/claude-code-review.yml@0a36fe841e8100c79c03af4237ab0aeadfb50332
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Outcome

Replaces the duplicated inline Claude review job with the organization-owned reusable workflow pinned to hotfix merge SHA `ecd319a2c9bf27b951229343b4aa13ab5e9dfeef`.

## Why

The shared workflow sanitizes and classifies zero-turn provider failures, emits a durable diagnostic, and prevents an external outage from masquerading as a repository regression. Full Claude output remains disabled.

## Live probe evidence

The first run successfully invoked the reusable workflow and exposed a missing-classifier checkout defect. Organization PR #40 fixed that defect with two green control-plane checks; this branch now pins the hotfix merge.

GitHub intentionally skips Claude's own review when a PR changes its review workflow until that workflow is on the default branch. The next ordinary PR is the first full provider probe.

Protected workflow path; human review required.

Contributes to GuitarAlchemist/.github#38.