### PR TITLE
chore(tools): pin DuckDB.NET.Data.Full 1.5.3 (ADR 0007 action 1)

### DIFF
--- a/Tools/GaDuckLens/GaDuckLens.csproj
+++ b/Tools/GaDuckLens/GaDuckLens.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.3.0" />
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/QualityLens/QualityLens.csproj
+++ b/Tools/QualityLens/QualityLens.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.3.0" />
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.3" />
     <PackageReference Include="Spectre.Console" Version="0.51.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Executes immediate action 1 of docs/adr/0007 (merged in #600): the single version bump that resolves #593's version-drift risk and satisfies MotherDuck's ≥1.4.0 floor from #597.

Two csproj lines (GaDuckLens, QualityLens — GaDomainInvariants has no DuckDB package ref). Both tools build clean; QualityLens smoke-run verified against the real persisted quality.duckdb (3 rows from live views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)