### PR TITLE
Make Gemini issue triage failures non-blocking

### DIFF
--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -54,7 +54,8 @@ jobs:
       - name: 'Run Gemini issue analysis'
         id: 'gemini_analysis'
         if: |-
-          ${{ steps.get_labels.outputs.available_labels != '' }}
+          ${{ steps.get_labels.outputs.available_labels != '' && vars.GEMINI_TRIAGE_ENABLED != 'false' }}
+        continue-on-error: true
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
@@ -147,8 +148,53 @@ jobs:
       - name: 'Capture selected labels'
         id: 'capture_labels'
         if: always()
+        env:
+          AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
+          ISSUE_TITLE: '${{ github.event.issue.title }}'
+          GEMINI_OUTCOME: '${{ steps.gemini_analysis.outcome }}'
         run: |-
-          echo "selected_labels=${SELECTED_LABELS:-}" >> "$GITHUB_OUTPUT"
+          selected_labels="${SELECTED_LABELS:-}"
+
+          if [[ -z "${selected_labels}" ]]; then
+            fallback_labels="needs-triage"
+
+            case "${ISSUE_TITLE}" in
+              *"[Bug]"*|*"bug:"*|*"fix:"*)
+                fallback_labels="bug,${fallback_labels}"
+                ;;
+              *"[Spike]"*|*"[Research]"*)
+                fallback_labels="research,${fallback_labels}"
+                ;;
+              *"[Docs]"*|*"[Documentation]"*)
+                fallback_labels="documentation,${fallback_labels}"
+                ;;
+              *"[Cleanup]"*)
+                fallback_labels="cleanup,${fallback_labels}"
+                ;;
+              *"[TechDebt]"*|*"[Tech-Debt]"*)
+                fallback_labels="tech-debt,${fallback_labels}"
+                ;;
+            esac
+
+            selected_labels=""
+            IFS=',' read -ra candidates <<< "${fallback_labels}"
+            for label in "${candidates[@]}"; do
+              if [[ ",${AVAILABLE_LABELS}," == *",${label},"* ]]; then
+                if [[ -n "${selected_labels}" ]]; then
+                  selected_labels="${selected_labels},"
+                fi
+                selected_labels="${selected_labels}${label}"
+              fi
+            done
+          fi
+
+          echo "selected_labels=${selected_labels}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${GEMINI_OUTCOME}" == "failure" ]]; then
+            echo "::warning::Gemini issue analysis failed; deterministic fallback labels were used."
+          elif [[ "${GEMINI_OUTCOME}" == "skipped" ]]; then
+            echo "::notice::Gemini triage is disabled or unavailable; deterministic fallback labels were used."
+          fi
 
   label:
     runs-on: 'ubuntu-latest'
@@ -180,8 +226,8 @@ jobs:
           SELECTED_LABELS: '${{ needs.triage.outputs.selected_labels }}'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7.0.1
         with:
-          # Use the provided token so that the "gemini-cli" is the actor in the
-          # log for what changed the labels.
+          # Use the provided token so that the "gemini-cli" is the actor in
+          # the log for what changed the labels.
           github-token: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           script: |-
             // Parse the available labels


### PR DESCRIPTION
## What changed

- allows `google-github-actions/run-gemini-cli@v0` triage failures to continue without failing the reusable workflow;
- adds deterministic fallback labels based on issue-title prefixes;
- always retains `needs-triage` when the AI classifier produces no usable result;
- validates fallback labels against the repository's actual label set;
- emits a warning when Gemini fails and a notice when triage is disabled;
- supports temporarily disabling Gemini triage with `GEMINI_TRIAGE_ENABLED=false` while keeping deterministic labeling operational.

## Root cause

New issues such as #605, #606, and #607 successfully entered the dispatch workflow, but `Run Gemini issue analysis` failed. That failure propagated to the parent dispatch workflow, skipped label application, and triggered the misleading generic `unable to process your request` comment.

The issue content and scientific dependencies were not the immediate cause: unrelated issue #604 failed at the same Gemini triage step.

## Impact

Issue creation and deterministic labeling no longer depend on Gemini availability, authentication, quota, model compatibility, or action stability. Gemini remains an optional enhancement rather than a control-flow dependency.

## Validation

- parsed the updated workflow as YAML;
- verified the branch differs from `main` only in `.github/workflows/gemini-triage.yml`;
- exercised fallback selection for spike/research, bug, documentation, and unclassified issue titles;
- confirmed selected fallback labels are filtered against the repository's available labels.

## Follow-up

After merge, open or reopen a disposable issue to verify that a Gemini failure produces a successful workflow, fallback labels, and no generic failure comment. The separate scientific dependency remains: #606 should stay `not_ready` until #605 produces a useful latent representation.