### PR TITLE
Delegate key detection to KeyIdentificationService on MCP and F# closures

### DIFF
--- a/Common/GA.Business.DSL/Closures/BuiltinClosures/DomainClosures.fs
+++ b/Common/GA.Business.DSL/Closures/BuiltinClosures/DomainClosures.fs
@@ -4,6 +4,7 @@ open GA.Business.DSL.Closures.GaAsync
 open GA.Business.DSL.Closures.GaClosureRegistry
 open GA.Business.DSL.Types
 open GA.Business.DSL.Services
+open GA.Domain.Services.Tonal
 
 // ── Note / accidental helpers ─────────────────────────────────────────────────
 
@@ -305,34 +306,53 @@ let analyzeProgression : GaClosure =
                   if validPcs.IsEmpty then
                       return Error (GaError.DomainError "Could not parse any chord symbols")
                   else
-                      // Score every major and minor key.
-                      // Tiebreaker: prefer the key whose root matches the first chord.
-                      let firstPc = validPcs |> List.tryHead |> Option.defaultValue 0
-                      let keyRootPc, scaleName =
-                          [ for rpc in 0..11 do
-                              yield rpc, "major", scoreKey rpc majorOffsets validPcs
-                              yield rpc, "minor", scoreKey rpc minorOffsets validPcs ]
-                          |> List.maxBy (fun (rpc, _, s) -> s * 2 + (if rpc = firstPc then 1 else 0))
-                          |> fun (rpc, scale, _) -> rpc, scale
-                      let offsets = if scaleName = "major" then majorOffsets else minorOffsets
-                      let romans  = if scaleName = "major" then majorRomans  else minorRomans
-                      let keyName = conventionalKeyName keyRootPc
-                      let confidence =
-                          let matches = scoreKey keyRootPc offsets validPcs
-                          sprintf "%d/%d" matches validPcs.Length
-                      let symLine =
-                          parsed |> Array.map (fun p ->
-                              let s = p |> Option.map fst |> Option.defaultValue "?"
-                              sprintf "%-6s" s) |> String.concat " "
-                      let romLine =
-                          parsed |> Array.map (fun p ->
-                              let r = p |> Option.map (fun (_, pc) ->
-                                  romanFor keyRootPc offsets romans pc) |> Option.defaultValue "?"
-                              sprintf "%-6s" r) |> String.concat " "
-                      let result =
-                          sprintf "Key: %s %s  (confidence %s)\n%s\n%s"
-                              keyName scaleName confidence symLine romLine
-                      return Ok (box result)
+                      // Identify candidate keys via KeyIdentificationService
+                      let candidates = KeyIdentificationService.Identify(symbols)
+                      if candidates.Count = 0 then
+                          return Error (GaError.DomainError "Could not identify key for the given chords")
+                      else
+                          let firstPc = validPcs |> List.tryHead |> Option.defaultValue 0
+                          let bestCandidate =
+                              candidates
+                              |> Seq.sortByDescending (fun cand ->
+                                  let keyRoot = cand.Key.Split(' ').[0]
+                                  let rootStr, acc = splitNoteAcc keyRoot
+                                  let keyRootPc = (noteToSemitone rootStr + accToSemitone acc + 12) % 12
+                                  let firstPcMatch = if (keyRootPc + 12) % 12 = firstPc then 1 else 0
+                                  let isMajor = if cand.Key.EndsWith("major", System.StringComparison.OrdinalIgnoreCase) then 1 else 0
+                                  cand.MatchCount, firstPcMatch, isMajor)
+                              |> Seq.head
+
+                          let keyParts = bestCandidate.Key.Split(' ')
+                          let keyName = keyParts.[0]
+                          let scaleName = keyParts.[1]
+
+                          let keyRootStr, keyAcc = splitNoteAcc keyName
+                          let keyRootPc = (noteToSemitone keyRootStr + accToSemitone keyAcc + 12) % 12
+
+                          let offsets = if scaleName = "major" then majorOffsets else minorOffsets
+                          let romans  = if scaleName = "major" then majorRomans  else minorRomans
+
+                          let matches =
+                              symbols
+                              |> Array.filter (fun sym -> KeyIdentificationService.IsChordDiatonic(bestCandidate.Key, sym))
+                              |> Array.length
+
+                          let confidence = sprintf "%d/%d" matches symbols.Length
+
+                          let symLine =
+                              parsed |> Array.map (fun p ->
+                                  let s = p |> Option.map fst |> Option.defaultValue "?"
+                                  sprintf "%-6s" s) |> String.concat " "
+                          let romLine =
+                              parsed |> Array.map (fun p ->
+                                  let r = p |> Option.map (fun (_, pc) ->
+                                      romanFor keyRootPc offsets romans pc) |> Option.defaultValue "?"
+                                  sprintf "%-6s" r) |> String.concat " "
+                          let result =
+                              sprintf "Key: %s %s  (confidence %s)\n%s\n%s"
+                                  keyName scaleName confidence symLine romLine
+                          return Ok (box result)
           } }
 
 // ── Query / projection / join helpers ─────────────────────────────────────────
@@ -649,48 +669,63 @@ let progressionCompletion : GaClosure =
                   if validPcs.IsEmpty then
                       return Error (GaError.DomainError "Could not parse any chord symbols")
                   else
-                      // Score every key; tiebreaker: prefer key whose root = first chord.
-                      let firstPc = validPcs |> List.tryHead |> Option.defaultValue 0
-                      let keyRootPc, scaleName =
-                          [ for rpc in 0..11 do
-                              yield rpc, "major", scoreKey rpc majorOffsets validPcs
-                              yield rpc, "minor", scoreKey rpc minorOffsets validPcs ]
-                          |> List.maxBy (fun (rpc, _, s) -> s * 2 + (if rpc = firstPc then 1 else 0))
-                          |> fun (rpc, scale, _) -> rpc, scale
-                      let keyName = conventionalKeyName keyRootPc
-                      // Diatonic chord name at a given scale degree index.
-                      let offsets   = if scaleName = "major" then majorOffsets else minorOffsets
-                      let qualities =
-                          if scaleName = "major"
-                          then [| ""; "m"; "m"; ""; ""; "m"; "dim" |]   // I ii iii IV V vi vii°
-                          else [| "m"; "dim"; ""; "m"; "m"; ""; "" |]   // i ii° III iv v VI VII
-                      let diatonicAt idx =
-                          let root = (keyRootPc + offsets.[idx]) % 12
-                          sprintf "%s%s" (conventionalKeyName root) qualities.[idx]
-                      // Build 2–3 cadence suggestions.
-                      let suggestions =
-                          if scaleName = "minor" then
-                              // V7 from harmonic minor (raised 7th → dominant 7th)
-                              let v7Name   = sprintf "%s7" (conventionalKeyName ((keyRootPc + 7) % 12))
-                              // ♭VII from natural minor
-                              let bviiName = conventionalKeyName ((keyRootPc + 10) % 12)
-                              // iv (minor subdominant)
-                              let ivName   = diatonicAt 3
-                              [ sprintf "  1. %-12s → authentic cadence (V7 → i)" v7Name
-                                sprintf "  2. %-12s → half cadence (♭VII → i loop)" bviiName
-                                sprintf "  3. %-12s → iv–V7–i turnaround" (sprintf "%s %s" ivName v7Name) ]
-                          else
-                              let vName  = diatonicAt 4   // V
-                              let ivName = diatonicAt 3   // IV
-                              let iiName = diatonicAt 1   // ii
-                              [ sprintf "  1. %-12s → authentic cadence (V → I)" vName
-                                sprintf "  2. %-12s → plagal cadence (IV → I)" ivName
-                                sprintf "  3. %-12s → ii–V–I approach" (sprintf "%s %s" iiName vName) ]
-                      let inputLine = String.concat " – " (Array.toList symbols)
-                      let result =
-                          sprintf "Progression: %s  (key: %s %s)\n\nSuggested completions:\n%s"
-                              inputLine keyName scaleName (String.concat "\n" suggestions)
-                      return Ok (box result)
+                      // Identify candidate keys via KeyIdentificationService
+                      let candidates = KeyIdentificationService.Identify(symbols)
+                      if candidates.Count = 0 then
+                          return Error (GaError.DomainError "Could not identify key for the given chords")
+                      else
+                          let firstPc = validPcs |> List.tryHead |> Option.defaultValue 0
+                          let bestCandidate =
+                              candidates
+                              |> Seq.sortByDescending (fun cand ->
+                                  let keyRoot = cand.Key.Split(' ').[0]
+                                  let rootStr, acc = splitNoteAcc keyRoot
+                                  let keyRootPc = (noteToSemitone rootStr + accToSemitone acc + 12) % 12
+                                  let firstPcMatch = if (keyRootPc + 12) % 12 = firstPc then 1 else 0
+                                  let isMajor = if cand.Key.EndsWith("major", System.StringComparison.OrdinalIgnoreCase) then 1 else 0
+                                  cand.MatchCount, firstPcMatch, isMajor)
+                              |> Seq.head
+
+                          let keyParts = bestCandidate.Key.Split(' ')
+                          let keyName = keyParts.[0]
+                          let scaleName = keyParts.[1]
+
+                          let keyRootStr, keyAcc = splitNoteAcc keyName
+                          let keyRootPc = (noteToSemitone keyRootStr + accToSemitone keyAcc + 12) % 12
+
+                          // Diatonic chord name at a given scale degree index.
+                          let offsets   = if scaleName = "major" then majorOffsets else minorOffsets
+                          let qualities =
+                              if scaleName = "major"
+                              then [| ""; "m"; "m"; ""; ""; "m"; "dim" |]   // I ii iii IV V vi vii°
+                              else [| "m"; "dim"; ""; "m"; "m"; ""; "" |]   // i ii° III iv v VI VII
+                          let diatonicAt idx =
+                              let root = (keyRootPc + offsets.[idx]) % 12
+                              sprintf "%s%s" (conventionalKeyName root) qualities.[idx]
+                          // Build 2–3 cadence suggestions.
+                          let suggestions =
+                              if scaleName = "minor" then
+                                  // V7 from harmonic minor (raised 7th → dominant 7th)
+                                  let v7Name   = sprintf "%s7" (conventionalKeyName ((keyRootPc + 7) % 12))
+                                  // ♭VII from natural minor
+                                  let bviiName = conventionalKeyName ((keyRootPc + 10) % 12)
+                                  // iv (minor subdominant)
+                                  let ivName   = diatonicAt 3
+                                  [ sprintf "  1. %-12s → authentic cadence (V7 → i)" v7Name
+                                    sprintf "  2. %-12s → half cadence (♭VII → i loop)" bviiName
+                                    sprintf "  3. %-12s → iv–V7–i turnaround" (sprintf "%s %s" ivName v7Name) ]
+                              else
+                                  let vName  = diatonicAt 4   // V
+                                  let ivName = diatonicAt 3   // IV
+                                  let iiName = diatonicAt 1   // ii
+                                  [ sprintf "  1. %-12s → authentic cadence (V → I)" vName
+                                    sprintf "  2. %-12s → plagal cadence (IV → I)" ivName
+                                    sprintf "  3. %-12s → ii–V–I approach" (sprintf "%s %s" iiName vName) ]
+                          let inputLine = String.concat " – " (Array.toList symbols)
+                          let result =
+                              sprintf "Progression: %s  (key: %s %s)\n\nSuggested completions:\n%s"
+                                  inputLine keyName scaleName (String.concat "\n" suggestions)
+                          return Ok (box result)
           } }
 
 // ── Registration ──────────────────────────────────────────────────────────────

--- a/Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs
+++ b/Common/GA.Business.ML/Agents/Mcp/KeyIdentificationMcpTools.cs
@@ -2,6 +2,7 @@ namespace GA.Business.ML.Agents.Mcp;
 
 using System.ComponentModel;
 using GA.Business.ML.Agents;
+using GA.Domain.Services.Tonal;
 using ModelContextProtocol.Server;
 
 /// <summary>

--- a/Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/KeyIdentificationSkill.cs
@@ -1,6 +1,7 @@
 namespace GA.Business.ML.Agents.Skills;
 
 using System.Text;
+using GA.Domain.Services.Tonal;
 using Microsoft.Extensions.AI;
 
 /// <summary>

--- a/Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs
+++ b/Common/GA.Business.ML/Agents/Skills/ProgressionCompletionSkill.cs
@@ -2,6 +2,7 @@ namespace GA.Business.ML.Agents.Skills;
 
 using System.Text;
 using System.Text.RegularExpressions;
+using GA.Domain.Services.Tonal;
 using Microsoft.Extensions.AI;
 
 /// <summary>

--- a/Common/GA.Domain.Services/Tonal/KeyIdentificationService.cs
+++ b/Common/GA.Domain.Services/Tonal/KeyIdentificationService.cs
@@ -1,4 +1,4 @@
-namespace GA.Business.ML.Agents;
+namespace GA.Domain.Services.Tonal;
 
 using System.Collections.Frozen;
 using System.Text.RegularExpressions;
@@ -26,7 +26,7 @@ public static partial class KeyIdentificationService
 
     // ── Internal chord quality model ──────────────────────────────────────────
 
-    private enum ChordQuality { Major, Minor, Diminished }
+    private enum ChordQuality { Major, Minor, Diminished, Dominant }
 
     // Natural major: I M, II m, III m, IV M, V M, VI m, VII dim
     private static readonly ChordQuality[] MajorPattern =
@@ -132,6 +132,16 @@ public static partial class KeyIdentificationService
         var rootStr = s.Length >= 2 && s[1] is '#' or 'b' ? s[..2] : s[..1];
         if (!RootPcMap.TryGetValue(rootStr, out var rootPc)) return null;
 
+        var isDominant = chord.Contains('7') &&
+                         !chord.Contains("maj", StringComparison.OrdinalIgnoreCase) &&
+                         !chord.Contains('m') &&
+                         !chord.Contains("dim", StringComparison.OrdinalIgnoreCase);
+
+        if (isDominant)
+        {
+            return (rootPc, ChordQuality.Dominant);
+        }
+
         var quality = s[rootStr.Length..].ToLowerInvariant() switch
         {
             "m"   => ChordQuality.Minor,
@@ -164,7 +174,24 @@ public static partial class KeyIdentificationService
             .Select(kd =>
             {
                 var matchCount = parsed.Count(chord =>
-                    kd.DiatonicTriads.Any(t => t.RootPc == chord.RootPc && t.Quality == chord.Quality));
+                    kd.DiatonicTriads.Any(t =>
+                    {
+                        if (t.RootPc != chord.RootPc) return false;
+                        if (chord.Quality == ChordQuality.Dominant)
+                        {
+                            var isMajorKey = kd.Name.Contains("major", StringComparison.OrdinalIgnoreCase);
+                            var idx = Array.FindIndex(kd.DiatonicTriads, x => x.RootPc == t.RootPc);
+                            if (isMajorKey)
+                            {
+                                return idx == 4 && t.Quality == ChordQuality.Major;
+                            }
+                            else
+                            {
+                                return (idx == 6 || idx == 4) && (t.Quality == ChordQuality.Major || t.Quality == ChordQuality.Minor);
+                            }
+                        }
+                        return t.Quality == chord.Quality;
+                    }));
 
                 return new KeyCandidate(
                     Key: kd.Name,
@@ -176,6 +203,38 @@ public static partial class KeyIdentificationService
             .Where(c => c.MatchCount > 0)
             .OrderByDescending(c => c.MatchCount)
             .ThenBy(c => c.Key)];
+    }
+
+    /// <summary>
+    /// Checks if a chord symbol is diatonic to a key.
+    /// </summary>
+    public static bool IsChordDiatonic(string keyName, string chordSymbol)
+    {
+        var keyData = AllKeys.FirstOrDefault(k => k.Name.Equals(keyName, StringComparison.OrdinalIgnoreCase));
+        if (keyData == null) return false;
+
+        var parsed = ParseChordRootAndQuality(chordSymbol);
+        if (!parsed.HasValue) return false;
+
+        var (rootPc, quality) = parsed.Value;
+        return keyData.DiatonicTriads.Any(t =>
+        {
+            if (t.RootPc != rootPc) return false;
+            if (quality == ChordQuality.Dominant)
+            {
+                var isMajorKey = keyData.Name.Contains("major", StringComparison.OrdinalIgnoreCase);
+                var idx = Array.FindIndex(keyData.DiatonicTriads, x => x.RootPc == t.RootPc);
+                if (isMajorKey)
+                {
+                    return idx == 4 && t.Quality == ChordQuality.Major;
+                }
+                else
+                {
+                    return (idx == 6 || idx == 4) && (t.Quality == ChordQuality.Major || t.Quality == ChordQuality.Minor);
+                }
+            }
+            return t.Quality == quality;
+        });
     }
 
     /// <summary>
@@ -208,6 +267,6 @@ public static partial class KeyIdentificationService
         return s.Replace("A#", "Bb").Replace("D#", "Eb").Replace("G#", "Ab");
     }
 
-    [GeneratedRegex(@"\b[A-G][b#]?(m|dim|aug|maj)?\b", RegexOptions.None)]
+    [GeneratedRegex(@"\b[A-G][b#]?(?:m|dim|aug|maj|min|sus|add)?\d*(?:b5|#5|b9|#9|#11|b13)?\b", RegexOptions.IgnoreCase)]
     private static partial Regex ChordPattern();
 }

--- a/Common/GA.Domain.Services/Tonal/KeyIdentificationService.cs
+++ b/Common/GA.Domain.Services/Tonal/KeyIdentificationService.cs
@@ -132,17 +132,17 @@ public static partial class KeyIdentificationService
         var rootStr = s.Length >= 2 && s[1] is '#' or 'b' ? s[..2] : s[..1];
         if (!RootPcMap.TryGetValue(rootStr, out var rootPc)) return null;
 
+        var normalizedQuality = s[rootStr.Length..].ToLowerInvariant();
         var isDominant = chord.Contains('7') &&
-                         !chord.Contains("maj", StringComparison.OrdinalIgnoreCase) &&
-                         !chord.Contains('m') &&
-                         !chord.Contains("dim", StringComparison.OrdinalIgnoreCase);
+                         string.IsNullOrEmpty(normalizedQuality) &&
+                         !chord.Contains("maj", StringComparison.OrdinalIgnoreCase);
 
         if (isDominant)
         {
             return (rootPc, ChordQuality.Dominant);
         }
 
-        var quality = s[rootStr.Length..].ToLowerInvariant() switch
+        var quality = normalizedQuality switch
         {
             "m"   => ChordQuality.Minor,
             "dim" => ChordQuality.Diminished,
@@ -263,7 +263,8 @@ public static partial class KeyIdentificationService
     // e.g. "G7" → "G", "Cmaj7" → "C", "Am7" → "Am", "Bdim7" → "Bdim", "A#m" → "Bbm"
     private static string NormalizeChord(string chord)
     {
-        var s = Regex.Replace(chord.Trim(), @"(maj|min|aug|sus|add)?\d+.*$", "", RegexOptions.IgnoreCase);
+        var s = Regex.Replace(chord.Trim(), "min", "m", RegexOptions.IgnoreCase);
+        s = Regex.Replace(s, @"(maj|aug|sus|add)?\d+.*$", "", RegexOptions.IgnoreCase);
         return s.Replace("A#", "Bb").Replace("D#", "Eb").Replace("G#", "Ab");
     }
 

--- a/GaMcpServer/Tools/GuitaristProblemTools.cs
+++ b/GaMcpServer/Tools/GuitaristProblemTools.cs
@@ -6,6 +6,7 @@ using Microsoft.FSharp.Core;
 using ModelContextProtocol.Server;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GA.Domain.Services.Tonal;
 
 using GaReg = GA.Business.DSL.Closures.GaClosureRegistry.GaClosureRegistry;
 
@@ -172,44 +173,45 @@ public static class GaKeyFromProgressionTool
         if (chords is not { Length: > 0 })
             return JsonSerializer.Serialize(new { error = "No chords provided." });
 
-        // Parse each chord to its root pitch class; ignore unrecognised symbols.
-        var chordPcs = chords
-            .Select(c => (chord: c, pc: GuitaristHelpers.ChordRootPc(c)))
-            .Where(x => x.pc >= 0)
+        var parsedCandidates = KeyIdentificationService.Identify(chords);
+        if (parsedCandidates.Count == 0)
+            return JsonSerializer.Serialize(new { error = "Could not parse or identify any candidate keys." });
+
+        var firstChordPc = GuitaristHelpers.ChordRootPc(chords[0]);
+
+        var candidates = parsedCandidates
+            .Select(c =>
+            {
+                var parts = c.Key.Split(' ');
+                var keyName = parts[0];
+                var mode = parts[1];
+                var keyRootPc = GuitaristHelpers.ChordRootPc(keyName);
+
+                var matchingChords = chords.Where(chord => KeyIdentificationService.IsChordDiatonic(c.Key, chord)).ToList();
+                var score = matchingChords.Count;
+
+                return new
+                {
+                    key = c.Key,
+                    mode,
+                    score,
+                    keyRootPc,
+                    matchingChords
+                };
+            })
+            .Where(x => x.score > 0)
+            .OrderByDescending(x => x.score)
+            .ThenByDescending(x => x.keyRootPc == firstChordPc ? 1 : 0)
+            .ThenByDescending(x => x.mode.Equals("major", StringComparison.OrdinalIgnoreCase) ? 1 : 0)
+            .Select(x => new
+            {
+                key = x.key,
+                mode = x.mode,
+                confidence = $"{x.score}/{chords.Length} ({x.score * 100 / chords.Length}%)",
+                matchingChords = x.matchingChords
+            })
+            .Take(3)
             .ToList();
-
-        if (chordPcs.Count == 0)
-            return JsonSerializer.Serialize(new { error = "Could not parse any chord roots." });
-
-        var pcs = chordPcs.Select(x => x.pc).ToList();
-
-        // Score all 24 keys (12 major + 12 minor).
-        var keyConfigs = new[]
-        {
-            (mode: "major", offsets: GuitaristHelpers.MajorOffsets, pattern: GuitaristHelpers.MajorPattern),
-            (mode: "minor", offsets: GuitaristHelpers.MinorOffsets, pattern: GuitaristHelpers.MinorPattern)
-        };
-
-        var candidates = (
-            from rootPc in Enumerable.Range(0, 12)
-            from cfg in keyConfigs
-            let diatonic = cfg.offsets.Select(o => (rootPc + o) % 12).ToHashSet()
-            let matchingChords = chords.Where(c =>
-            {
-                var pc = GuitaristHelpers.ChordRootPc(c);
-                return pc >= 0 && diatonic.Contains(pc);
-            }).ToList()
-            let score = matchingChords.Count
-            where score > 0
-            orderby score descending, (rootPc == pcs[0] ? 1 : 0) descending
-            select new
-            {
-                key            = GuitaristHelpers.KeyName(rootPc) + " " + cfg.mode,
-                mode           = cfg.mode,
-                confidence     = $"{score}/{chords.Length} ({score * 100 / chords.Length}%)",
-                matchingChords
-            }
-        ).Take(3).ToList();
 
         var best = candidates.FirstOrDefault();
         var result = new

--- a/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
+++ b/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
@@ -69,15 +69,18 @@ public sealed class GuitaristProblemToolsTests
     public async Task GaAnalyzeProgression_G7_C_LabelsG7AsV_And_C_AsI()
     {
         var analysis = await GaDslTool.GaAnalyzeProgression("G7 C");
+        var lines = analysis.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var chordLineIndex = Array.FindIndex(lines, line => line.StartsWith("G7", StringComparison.Ordinal));
+        Assert.That(chordLineIndex, Is.GreaterThanOrEqualTo(0), "Should contain a G7/C chord line");
 
-        // The expected analysis should identify C major and label G7 as V, C as I.
-        // It format matches:
-        // Key: C major  (confidence 2/2)
-        // G7     C
-        // V      I
-        Assert.That(analysis, Does.Contain("Key: C major"), "Should identify C major");
-        Assert.That(analysis, Does.Contain("G7"), "Should contain G7 in chords line");
-        Assert.That(analysis, Does.Contain("V"), "Should label G7 as V");
-        Assert.That(analysis, Does.Contain("I"), "Should label C as I");
+        var chords = lines[chordLineIndex].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var functions = lines[chordLineIndex + 1].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var mappings = chords.Zip(functions).Select(pair => $"{pair.First}->{pair.Second}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(analysis, Does.Contain("Key: C major"), "Should identify C major");
+            Assert.That(mappings, Is.EqualTo(new[] { "G7->V", "C->I" }));
+        });
     }
 }

--- a/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
+++ b/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
@@ -1,0 +1,83 @@
+namespace GaMcpServer.Tests;
+
+using System.Text.Json;
+using System.Threading.Tasks;
+using GaMcpServer.Tools;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class GuitaristProblemToolsTests
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        // Force F# closure module initializers to run before MCP tools are called.
+        GA.Business.DSL.GaClosureBootstrap.init();
+    }
+
+    [Test]
+    public void GaKeyFromProgression_TextbookCadences_ReturnsExpectedBestGuess()
+    {
+        var testCases = new[]
+        {
+            (Chords: new[] { "Dm7", "G7" },         ExpectedKey: "C major"),
+            (Chords: new[] { "Dm7", "G7", "Cmaj7" }, ExpectedKey: "C major"),
+            (Chords: new[] { "Am7", "D7", "Gmaj7" }, ExpectedKey: "G major"),
+            (Chords: new[] { "Em7", "A7", "Dmaj7" }, ExpectedKey: "D major"),
+            (Chords: new[] { "Dm", "G" },           ExpectedKey: "C major"),
+            (Chords: new[] { "G7", "C" },           ExpectedKey: "C major"),
+            (Chords: new[] { "F", "G", "C" },       ExpectedKey: "C major"),
+            (Chords: new[] { "C", "Am", "F" },       ExpectedKey: "C major")
+        };
+
+        foreach (var tc in testCases)
+        {
+            var json = GaKeyFromProgressionTool.GaKeyFromProgression(tc.Chords);
+            using var doc = JsonDocument.Parse(json);
+            var bestGuess = doc.RootElement.GetProperty("bestGuess").GetString();
+
+            Assert.That(bestGuess, Is.EqualTo(tc.ExpectedKey),
+                $"Chords [{string.Join(", ", tc.Chords)}] should have resolved to best guess key '{tc.ExpectedKey}' but got '{bestGuess}'");
+        }
+    }
+
+    [Test]
+    public async Task GaAnalyzeProgression_TextbookCadences_ReturnsExpectedKey()
+    {
+        var testCases = new[]
+        {
+            (Progression: "Dm7 G7",         ExpectedKey: "C major"),
+            (Progression: "Dm7 G7 Cmaj7",   ExpectedKey: "C major"),
+            (Progression: "Am7 D7 Gmaj7",   ExpectedKey: "G major"),
+            (Progression: "Em7 A7 Dmaj7",   ExpectedKey: "D major"),
+            (Progression: "Dm G",           ExpectedKey: "C major"),
+            (Progression: "G7 C",           ExpectedKey: "C major"),
+            (Progression: "F G C",           ExpectedKey: "C major"),
+            (Progression: "C Am F",         ExpectedKey: "C major")
+        };
+
+        foreach (var tc in testCases)
+        {
+            var analysis = await GaDslTool.GaAnalyzeProgression(tc.Progression);
+
+            Assert.That(analysis, Does.Contain($"Key: {tc.ExpectedKey}"),
+                $"Progression '{tc.Progression}' should contain 'Key: {tc.ExpectedKey}' in analysis. Analysis:\n{analysis}");
+        }
+    }
+
+    [Test]
+    public async Task GaAnalyzeProgression_G7_C_LabelsG7AsV_And_C_AsI()
+    {
+        var analysis = await GaDslTool.GaAnalyzeProgression("G7 C");
+
+        // The expected analysis should identify C major and label G7 as V, C as I.
+        // It format matches:
+        // Key: C major  (confidence 2/2)
+        // G7     C
+        // V      I
+        Assert.That(analysis, Does.Contain("Key: C major"), "Should identify C major");
+        Assert.That(analysis, Does.Contain("G7"), "Should contain G7 in chords line");
+        Assert.That(analysis, Does.Contain("V"), "Should label G7 as V");
+        Assert.That(analysis, Does.Contain("I"), "Should label C as I");
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationMcpToolsTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationMcpToolsTests.cs
@@ -1,6 +1,7 @@
 namespace GA.Business.ML.Tests.Unit;
 
 using GA.Business.ML.Agents.Mcp;
+using GA.Domain.Services.Tonal;
 
 [TestFixture]
 public class KeyIdentificationMcpToolsTests
@@ -180,6 +181,33 @@ public class KeyIdentificationMcpToolsTests
             Assert.That(result.Error.IndexOf('\r'), Is.EqualTo(-1));
             Assert.That(result.Error.IndexOf(esc),  Is.EqualTo(-1));
             Assert.That(result.Error.All(c => !char.IsControl(c)), Is.True);
+        }
+    }
+
+    [Test]
+    public void IdentifyKey_TextbookCadences_ReturnsExpectedKeys()
+    {
+        var testCases = new[]
+        {
+            (Query: "Dm7 G7",         ExpectedKey: "C major"),
+            (Query: "Dm7 G7 Cmaj7",   ExpectedKey: "C major"),
+            (Query: "Am7 D7 Gmaj7",   ExpectedKey: "G major"),
+            (Query: "Em7 A7 Dmaj7",   ExpectedKey: "D major"),
+            (Query: "Dm G",           ExpectedKey: "C major"),
+            (Query: "G7 C",           ExpectedKey: "C major"),
+            (Query: "F G C",           ExpectedKey: "C major"),
+            (Query: "C Am F",         ExpectedKey: "C major")
+        };
+
+        foreach (var tc in testCases)
+        {
+            var result = KeyIdentificationMcpTools.IdentifyKey(tc.Query);
+            Assert.That(result.Error, Is.Null, $"Query '{tc.Query}' failed with error: {result.Error}");
+            Assert.That(result.TopCandidates, Is.Not.Empty, $"Query '{tc.Query}' returned no top candidates.");
+
+            var matchedKeys = result.TopCandidates.Select(c => c.Key).ToList();
+            Assert.That(matchedKeys, Contains.Item(tc.ExpectedKey),
+                $"Query '{tc.Query}' should have identified key '{tc.ExpectedKey}' among top candidates but got {string.Join(", ", matchedKeys)}");
         }
     }
 

--- a/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationServiceTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationServiceTests.cs
@@ -105,6 +105,11 @@ public class KeyIdentificationServiceTests
         Assert.That(top[0].MatchCount, Is.EqualTo(4));
     }
 
+    [TestCase("C major", "AM7")]
+    [TestCase("Bb major", "GMIN7")]
+    public void IsChordDiatonic_UppercaseMinorQuality_IsParsedAsMinor(string key, string chord) =>
+        Assert.That(KeyIdentificationService.IsChordDiatonic(key, chord), Is.True);
+
     // ── Empty / no-match cases ────────────────────────────────────────────────
 
     [Test]

--- a/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationServiceTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Unit/KeyIdentificationServiceTests.cs
@@ -1,6 +1,7 @@
 namespace GA.Business.ML.Tests.Unit;
 
 using GA.Business.ML.Agents;
+using GA.Domain.Services.Tonal;
 using NUnit.Framework;
 
 [TestFixture]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.103",
+    "version": "10.0.104",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.104",
+    "version": "10.0.103",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Relocates KeyIdentificationService to GA.Domain.Services, refactors C# MCP tools and F# closures to delegate key detection to it, adds dominant seventh support, and adds comprehensive regression tests for textbook cadences.

Fixes #614

---
*PR created automatically by Jules for task [13824242442048306677](https://jules.google.com/task/13824242442048306677) started by @spareilleux*