### PR TITLE
Fix ga_arpeggio_suggestions MCP tool arpeggio suffix concatenation and key-blind degree mapping

### DIFF
--- a/Common/GA.Business.ML/AssemblyInfo.cs
+++ b/Common/GA.Business.ML/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("GA.Business.ML.Tests")]
+[assembly: InternalsVisibleTo("GaMcpServer")]

--- a/GaMcpServer/Tools/GuitaristProblemTools.cs
+++ b/GaMcpServer/Tools/GuitaristProblemTools.cs
@@ -523,17 +523,52 @@ public static class GaArpeggioSuggestionsTool
                 };
             }
 
+            string scaleDegree;
             string modeName2;
             string notes;
 
             if (SuffixMatchesQuality(pattern[degIdx].Suffix, quality.Kind))
             {
+                scaleDegree = romans[degIdx];
                 var (_, m, n) = degreeModes[degIdx];
                 modeName2 = m;
                 notes = n;
             }
             else
             {
+                // Mismatched quality — secondary or borrowed/chromatic chord!
+                // Determine Roman numeral/degree label
+                if (!isMinor)
+                {
+                    // In a major key, we can identify specific secondary dominants:
+                    // (keyPc + offset) % 12 == chordPc
+                    var relativeOffset = (chordPc - keyPc + 12) % 12;
+                    if (relativeOffset == 9 && (quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7 || quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Major))
+                    {
+                        scaleDegree = quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7 ? "V/ii" : "secondary";
+                    }
+                    else if (relativeOffset == 2 && (quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7 || quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Major))
+                    {
+                        scaleDegree = quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7 ? "V/V" : "secondary";
+                    }
+                    else if (relativeOffset == 4 && (quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7 || quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Major))
+                    {
+                        scaleDegree = quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7 ? "V/vi" : "secondary";
+                    }
+                    else if (relativeOffset == 0 && quality.Kind == GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7)
+                    {
+                        scaleDegree = "V/IV";
+                    }
+                    else
+                    {
+                        scaleDegree = "secondary";
+                    }
+                }
+                else
+                {
+                    scaleDegree = "secondary";
+                }
+
                 var (m, n) = GetQualityModeAndNotes(quality.Kind);
                 modeName2 = m;
                 notes = n;
@@ -542,7 +577,7 @@ public static class GaArpeggioSuggestionsTool
             return new
             {
                 chord,
-                scaleDegree = romans[degIdx],
+                scaleDegree = scaleDegree,
                 arpeggio    = arpeggio,
                 mode        = modeName2,
                 notes

--- a/GaMcpServer/Tools/GuitaristProblemTools.cs
+++ b/GaMcpServer/Tools/GuitaristProblemTools.cs
@@ -453,33 +453,97 @@ public static class GaArpeggioSuggestionsTool
         var romans      = isMinor ? GuitaristHelpers.MinorRomans  : GuitaristHelpers.MajorRomans;
         var degreeModes = isMinor ? MinorDegreeModes : MajorDegreeModes;
 
+        bool SuffixMatchesQuality(string diatonicSuffix, GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind kind)
+        {
+            if (diatonicSuffix == "m")
+            {
+                return kind is GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Minor
+                            or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Minor7
+                            or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.MinorMajor7;
+            }
+            if (diatonicSuffix == "dim")
+            {
+                return kind is GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Diminished
+                            or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Diminished7
+                            or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.HalfDiminished;
+            }
+            // Diatonic suffix is "" (Major)
+            return kind is GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Major
+                        or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Major7
+                        or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.LydianMaj7
+                        or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7
+                        or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.AlteredDominant
+                        or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Altered
+                        or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.SuspendedDominant
+                        or GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Augmented;
+        }
+
+        (string Mode, string Notes) GetQualityModeAndNotes(GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind kind) =>
+            kind switch
+            {
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Major7 => ("Ionian (major)", "R, M2, M3, P4, P5, M6, M7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.LydianMaj7 => ("Lydian", "R, M2, M3, A4, P5, M6, M7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Major => ("Ionian (major)", "R, M2, M3, P4, P5, M6, M7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Dominant7 => ("Mixolydian", "R, M2, M3, P4, P5, M6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.AlteredDominant => ("Altered (Super Locrian)", "R, m2, m3, d4, d5, m6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Altered => ("Altered (Super Locrian)", "R, m2, m3, d4, d5, m6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.SuspendedDominant => ("Mixolydian", "R, M2, P4, P5, M6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Minor7 => ("Dorian", "R, M2, m3, P4, P5, M6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Minor => ("Aeolian (minor)", "R, M2, m3, P4, P5, m6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.MinorMajor7 => ("Melodic Minor", "R, M2, m3, P4, P5, M6, M7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.HalfDiminished => ("Locrian", "R, m2, m3, P4, d5, m6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Diminished => ("Locrian", "R, m2, m3, P4, d5, m6, m7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Diminished7 => ("Whole-Half Diminished", "R, M2, m3, P4, d5, m6, d7, M7"),
+                GA.Business.ML.Agents.Skills.ImprovisationSkill.QualityKind.Augmented => ("Whole Tone", "R, M2, M3, d5, m6, m7"),
+                _ => ("depends on context", "R, M2, M3, P5")
+            };
+
         var suggestions = chords.Select(chord =>
         {
             var chordPc = GuitaristHelpers.ChordRootPc(chord);
             if (chordPc < 0)
                 return new { chord, scaleDegree = "?", arpeggio = "?", mode = "unknown", notes = "" };
 
+            var root = GA.Business.ML.Agents.Skills.ImprovisationSkill.ExtractRoot(chord);
+            var quality = GA.Business.ML.Agents.Skills.ImprovisationSkill.InferQuality(chord);
+            var arpeggio = GA.Business.ML.Agents.Skills.ImprovisationSkill.ArpeggioFor(root, quality);
+
             // Find which scale degree this chord root matches.
             var degIdx = Array.FindIndex(offsets, o => (keyPc + o) % 12 == chordPc);
             if (degIdx < 0)
             {
-                // Chromatic chord — use generic major arpeggio suggestion.
+                // Chromatic chord — use generic arpeggio suggestion.
                 return new
                 {
                     chord,
                     scaleDegree = "chromatic",
-                    arpeggio    = chord + " (chromatic — outside key)",
+                    arpeggio    = arpeggio + " (chromatic — outside key)",
                     mode        = "depends on context",
                     notes       = "R, M2, M3, P5"
                 };
             }
 
-            var (arpeggioSuffix, modeName2, notes) = degreeModes[degIdx];
+            string modeName2;
+            string notes;
+
+            if (SuffixMatchesQuality(pattern[degIdx].Suffix, quality.Kind))
+            {
+                var (_, m, n) = degreeModes[degIdx];
+                modeName2 = m;
+                notes = n;
+            }
+            else
+            {
+                var (m, n) = GetQualityModeAndNotes(quality.Kind);
+                modeName2 = m;
+                notes = n;
+            }
+
             return new
             {
                 chord,
                 scaleDegree = romans[degIdx],
-                arpeggio    = chord + arpeggioSuffix,
+                arpeggio    = arpeggio,
                 mode        = modeName2,
                 notes
             };

--- a/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
+++ b/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
@@ -1,0 +1,90 @@
+namespace GaMcpServer.Tests;
+
+using System.Text.Json;
+using GaMcpServer.Tools;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class GuitaristProblemToolsTests
+{
+    private class SuggestionResult
+    {
+        public string Key { get; set; } = "";
+        public List<SuggestionItem> Suggestions { get; set; } = new();
+    }
+
+    private class SuggestionItem
+    {
+        public string Chord { get; set; } = "";
+        public string ScaleDegree { get; set; } = "";
+        public string Arpeggio { get; set; } = "";
+        public string Mode { get; set; } = "";
+        public string Notes { get; set; } = "";
+    }
+
+    [Test]
+    public async Task GaArpeggioSuggestions_DiatonicProgression_ReturnsCorrectArpeggiosAndModes()
+    {
+        // 1. Amm7 — root + full-suffix concatenation bug must be fixed.
+        // For Am, it must return "Am", not "Amm7" or similar.
+        var chords = new[] { "Am", "F", "C", "G" };
+        var json = await GaArpeggioSuggestionsTool.GaArpeggioSuggestions(chords, "C major");
+
+        var result = JsonSerializer.Deserialize<SuggestionResult>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Key, Is.EqualTo("C major"));
+        Assert.That(result.Suggestions, Has.Count.EqualTo(4));
+
+        var amItem = result.Suggestions[0];
+        Assert.That(amItem.Chord, Is.EqualTo("Am"));
+        Assert.That(amItem.ScaleDegree, Is.EqualTo("vi"));
+        Assert.That(amItem.Arpeggio, Is.EqualTo("Am"));
+        Assert.That(amItem.Mode, Is.EqualTo("Aeolian (minor)"));
+
+        var fItem = result.Suggestions[1];
+        Assert.That(fItem.Chord, Is.EqualTo("F"));
+        Assert.That(fItem.ScaleDegree, Is.EqualTo("IV"));
+        Assert.That(fItem.Arpeggio, Is.EqualTo("F"));
+        Assert.That(fItem.Mode, Is.EqualTo("Lydian"));
+    }
+
+    [Test]
+    public async Task GaArpeggioSuggestions_BorrowedChords_ClassifiedByWrittenQuality()
+    {
+        // 2. Key-blind degree mapping — wrong for borrowed / secondary chords must be fixed.
+        // Feed an A major chord in C major and it should NOT report Aeolian (with m3, putting a natural C against C#),
+        // it should report Ionian or Mixolydian (secondary dominant) and suggest A / A7 with M3.
+        var chords = new[] { "C", "A", "Dm", "G" };
+        var json = await GaArpeggioSuggestionsTool.GaArpeggioSuggestions(chords, "C major");
+
+        var result = JsonSerializer.Deserialize<SuggestionResult>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.That(result, Is.Not.Null);
+        var aItem = result.Suggestions[1];
+        Assert.That(aItem.Chord, Is.EqualTo("A"));
+        Assert.That(aItem.ScaleDegree, Is.EqualTo("vi"));
+        Assert.That(aItem.Arpeggio, Is.EqualTo("A"));
+        Assert.That(aItem.Mode, Is.EqualTo("Ionian (major)"));
+        Assert.That(aItem.Notes, Does.Contain("M3")); // Major 3rd (C# relative to A), NOT minor 3rd (m3)!
+        Assert.That(aItem.Notes, Does.Not.Contain("m3"));
+    }
+
+    [Test]
+    public async Task GaArpeggioSuggestions_SecondaryDominant_ClassifiedByWrittenQuality()
+    {
+        var chords = new[] { "C", "A7", "Dm", "G7" };
+        var json = await GaArpeggioSuggestionsTool.GaArpeggioSuggestions(chords, "C major");
+
+        var result = JsonSerializer.Deserialize<SuggestionResult>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.That(result, Is.Not.Null);
+        var a7Item = result.Suggestions[1];
+        Assert.That(a7Item.Chord, Is.EqualTo("A7"));
+        Assert.That(a7Item.ScaleDegree, Is.EqualTo("vi"));
+        Assert.That(a7Item.Arpeggio, Is.EqualTo("A7"));
+        Assert.That(a7Item.Mode, Is.EqualTo("Mixolydian"));
+        Assert.That(a7Item.Notes, Does.Contain("M3")); // Major 3rd (C# relative to A), NOT minor 3rd (m3)!
+        Assert.That(a7Item.Notes, Does.Not.Contain("m3"));
+    }
+}

--- a/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
+++ b/Tests/Apps/GaMcpServer.Tests/GuitaristProblemToolsTests.cs
@@ -27,22 +27,31 @@ public sealed class GuitaristProblemToolsTests
     {
         // 1. Amm7 — root + full-suffix concatenation bug must be fixed.
         // For Am, it must return "Am", not "Amm7" or similar.
-        var chords = new[] { "Am", "F", "C", "G" };
+        // Also: Preserve the written seventh quality: Am7 must produce Am7, not Am.
+        var chords = new[] { "Am", "Am7", "F", "C", "G" };
         var json = await GaArpeggioSuggestionsTool.GaArpeggioSuggestions(chords, "C major");
 
         var result = JsonSerializer.Deserialize<SuggestionResult>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Key, Is.EqualTo("C major"));
-        Assert.That(result.Suggestions, Has.Count.EqualTo(4));
+        Assert.That(result.Suggestions, Has.Count.EqualTo(5));
 
+        // Am (minor triad) must be "Am"
         var amItem = result.Suggestions[0];
         Assert.That(amItem.Chord, Is.EqualTo("Am"));
         Assert.That(amItem.ScaleDegree, Is.EqualTo("vi"));
         Assert.That(amItem.Arpeggio, Is.EqualTo("Am"));
         Assert.That(amItem.Mode, Is.EqualTo("Aeolian (minor)"));
 
-        var fItem = result.Suggestions[1];
+        // Am7 (minor seventh) must be "Am7" (preserving seventh)
+        var am7Item = result.Suggestions[1];
+        Assert.That(am7Item.Chord, Is.EqualTo("Am7"));
+        Assert.That(am7Item.ScaleDegree, Is.EqualTo("vi"));
+        Assert.That(am7Item.Arpeggio, Is.EqualTo("Am7"));
+        Assert.That(am7Item.Mode, Is.EqualTo("Aeolian (minor)"));
+
+        var fItem = result.Suggestions[2];
         Assert.That(fItem.Chord, Is.EqualTo("F"));
         Assert.That(fItem.ScaleDegree, Is.EqualTo("IV"));
         Assert.That(fItem.Arpeggio, Is.EqualTo("F"));
@@ -55,6 +64,7 @@ public sealed class GuitaristProblemToolsTests
         // 2. Key-blind degree mapping — wrong for borrowed / secondary chords must be fixed.
         // Feed an A major chord in C major and it should NOT report Aeolian (with m3, putting a natural C against C#),
         // it should report Ionian or Mixolydian (secondary dominant) and suggest A / A7 with M3.
+        // Also: A written A major chord in C major must not be labelled as diatonic vi; classify it explicitly as secondary/chromatic.
         var chords = new[] { "C", "A", "Dm", "G" };
         var json = await GaArpeggioSuggestionsTool.GaArpeggioSuggestions(chords, "C major");
 
@@ -63,7 +73,7 @@ public sealed class GuitaristProblemToolsTests
         Assert.That(result, Is.Not.Null);
         var aItem = result.Suggestions[1];
         Assert.That(aItem.Chord, Is.EqualTo("A"));
-        Assert.That(aItem.ScaleDegree, Is.EqualTo("vi"));
+        Assert.That(aItem.ScaleDegree, Is.EqualTo("secondary"), "quality-mismatched chord must not retain diatonic Roman numeral 'vi'");
         Assert.That(aItem.Arpeggio, Is.EqualTo("A"));
         Assert.That(aItem.Mode, Is.EqualTo("Ionian (major)"));
         Assert.That(aItem.Notes, Does.Contain("M3")); // Major 3rd (C# relative to A), NOT minor 3rd (m3)!
@@ -73,6 +83,7 @@ public sealed class GuitaristProblemToolsTests
     [Test]
     public async Task GaArpeggioSuggestions_SecondaryDominant_ClassifiedByWrittenQuality()
     {
+        // Also: A written A7 chord in C major must not be labelled as diatonic vi; classify it explicitly as V/ii.
         var chords = new[] { "C", "A7", "Dm", "G7" };
         var json = await GaArpeggioSuggestionsTool.GaArpeggioSuggestions(chords, "C major");
 
@@ -81,7 +92,7 @@ public sealed class GuitaristProblemToolsTests
         Assert.That(result, Is.Not.Null);
         var a7Item = result.Suggestions[1];
         Assert.That(a7Item.Chord, Is.EqualTo("A7"));
-        Assert.That(a7Item.ScaleDegree, Is.EqualTo("vi"));
+        Assert.That(a7Item.ScaleDegree, Is.EqualTo("V/ii"), "A7 acts as a secondary dominant of the ii chord, so it must be explicitly labeled as V/ii rather than diatonic vi");
         Assert.That(a7Item.Arpeggio, Is.EqualTo("A7"));
         Assert.That(a7Item.Mode, Is.EqualTo("Mixolydian"));
         Assert.That(a7Item.Notes, Does.Contain("M3")); // Major 3rd (C# relative to A), NOT minor 3rd (m3)!

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.103",
+    "version": "10.0.104",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.104",
+    "version": "10.0.103",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This change resolves two bugs in the ga_arpeggio_suggestions MCP tool: the Amm7 concatenation bug (root + full-suffix concatenation) and the key-blind degree mapping bug (incorrectly recommending key-diatonic modes/notes for borrowed or secondary chords). By utilizing ImprovisationSkill's robust quality classification and arpeggio naming logic from the GA.Business.ML library, we ensure correct and canonical output. Full integration tests have been added to GaMcpServer.Tests.

Fixes #567

---
*PR created automatically by Jules for task [3483423780975728752](https://jules.google.com/task/3483423780975728752) started by @spareilleux*