### PR TITLE
feat(harness): add read-only work reconciliation snapshot

### DIFF
--- a/Scripts/reconcile_local_work.py
+++ b/Scripts/reconcile_local_work.py
@@ -23,8 +23,8 @@ from typing import Any, Protocol
 
 
 SNAPSHOT_CONTRACT = "ga-local-reconciliation-snapshot-v0.1"
-AFK_TASK_CONTRACT = "afk-task-state-v0.1"
-AFK_EVIDENCE_CONTRACT = "afk-evidence-manifest-v0.1"
+AFK_TASK_CONTRACT = "afk-task-state-v0.2"
+AFK_EVIDENCE_CONTRACT = "afk-evidence-manifest-v0.2"
 
 
 class Matcher(Protocol):
@@ -235,7 +235,7 @@ def _task_binding(repository: dict[str, Any]) -> dict[str, Any]:
     return {
         "status": "bound",
         "canonical": {
-            "schema_version": 1,
+            "schema_version": 2,
             "contract": AFK_TASK_CONTRACT,
             "task": {"repository": repository["id"], "issue": issue},
             "attempts": [],

--- a/Scripts/reconcile_local_work.py
+++ b/Scripts/reconcile_local_work.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Build a read-only snapshot of unfinished local Git work.
+
+The snapshot is a GA adapter over Agent Blackbox's canonical path matcher and
+AFK contract names. It discovers registered worktrees, then binds optional
+GitHub PR, live-presence, and historical Claude Code provenance. It never runs
+a mutating Git command and refuses to write its output inside a discovered
+worktree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+
+SNAPSHOT_CONTRACT = "ga-local-reconciliation-snapshot-v0.1"
+AFK_TASK_CONTRACT = "afk-task-state-v0.1"
+AFK_EVIDENCE_CONTRACT = "afk-evidence-manifest-v0.1"
+
+
+class Matcher(Protocol):
+    @classmethod
+    def matches_any(cls, path: str, patterns: list[str]) -> bool: ...
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def canonical_path(value: str | Path) -> str:
+    return str(Path(value).expanduser().resolve(strict=False))
+
+
+def _git(repository: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    return subprocess.run(
+        ["git", "-c", "core.quotepath=false", *args],
+        cwd=repository,
+        check=check,
+        capture_output=True,
+        env=environment,
+    )
+
+
+def _packet_id(repository_id: str, worktree: str) -> str:
+    identity = f"{repository_id}\0{os.path.normcase(worktree)}".encode("utf-8")
+    return f"local-{hashlib.sha256(identity).hexdigest()[:24]}"
+
+
+def _parse_worktree_records(raw: bytes) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    for token_bytes in raw.split(b"\0"):
+        if not token_bytes:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        token = token_bytes.decode("utf-8", errors="surrogateescape")
+        key, _, value = token.partition(" ")
+        if key in {"detached", "bare", "locked", "prunable"} and not value:
+            current[key] = True
+        else:
+            current[key] = value
+    if current:
+        records.append(current)
+    return records
+
+
+def _dirty_entries(worktree: Path, matcher: Matcher, path_classes: dict[str, list[str]]) -> list[dict[str, str]]:
+    raw = _git(worktree, "status", "--porcelain=v1", "-z", "--untracked-files=all").stdout
+    tokens = [item.decode("utf-8", errors="surrogateescape") for item in raw.split(b"\0") if item]
+    entries: list[dict[str, str]] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if len(token) < 4:
+            continue
+        status = token[:2]
+        paths = [token[3:]]
+        if "R" in status or "C" in status:
+            if index < len(tokens):
+                paths.append(tokens[index])
+                index += 1
+        for raw_path in paths:
+            path = raw_path.replace("\\", "/")
+            classification = "unknown"
+            for candidate in ("state", "generated", "source"):
+                patterns = path_classes.get(candidate, [])
+                if patterns and matcher.matches_any(path, patterns):
+                    classification = candidate
+                    break
+            entries.append({"status": status, "path": path, "classification": classification})
+    return sorted(entries, key=lambda item: (item["path"], item["status"]))
+
+
+def _dirty_digest(entries: list[dict[str, str]]) -> str:
+    canonical = json.dumps(entries, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _upstream_state(worktree: Path) -> tuple[str | None, int | None, int | None]:
+    upstream_result = _git(
+        worktree,
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+        check=False,
+    )
+    if upstream_result.returncode:
+        return None, None, None
+    upstream = upstream_result.stdout.decode("utf-8").strip()
+    counts = _git(worktree, "rev-list", "--left-right", "--count", f"HEAD...{upstream}")
+    left, right = counts.stdout.decode("ascii").strip().split()
+    return upstream, int(left), int(right)
+
+
+def _normalise_presence(presence: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not presence or not isinstance(presence.get("sessions"), list):
+        return []
+    sessions: list[dict[str, Any]] = []
+    for item in presence["sessions"]:
+        if not isinstance(item, dict) or item.get("state") != "live" or not item.get("worktree"):
+            continue
+        sessions.append({**item, "worktree": canonical_path(item["worktree"])})
+    return sessions
+
+
+def _owner_for(
+    worktree: str, branch: str | None, live_sessions: list[dict[str, Any]]
+) -> dict[str, Any]:
+    owners = [
+        session
+        for session in live_sessions
+        if os.path.normcase(session["worktree"]) == os.path.normcase(worktree)
+        and (not session.get("branch") or session.get("branch") == branch)
+    ]
+    if not owners:
+        return {"state": "unowned"}
+    if len(owners) > 1:
+        return {
+            "state": "contested",
+            "sessions": [item.get("session_id") for item in owners],
+        }
+    owner = owners[0]
+    return {
+        "state": "live",
+        "session_id": owner.get("session_id"),
+        "actor": owner.get("actor", "unknown"),
+    }
+
+
+def _provenance_for(
+    worktree: str, branch: str | None, historical_sessions: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    matches = []
+    for session in historical_sessions:
+        if not session.get("worktree"):
+            continue
+        if os.path.normcase(canonical_path(session["worktree"])) != os.path.normcase(worktree):
+            continue
+        if session.get("branch") and branch and session["branch"] != branch:
+            continue
+        matches.append(session)
+    return sorted(matches, key=lambda item: item.get("last_seen", ""), reverse=True)
+
+
+def _pr_for(repository_id: str, branch: str | None, head: str | None, prs: dict[str, Any]) -> dict[str, Any] | None:
+    if branch is None:
+        return None
+    candidates = prs.get(repository_id, []) if isinstance(prs, dict) else []
+    for pr in candidates:
+        if isinstance(pr, dict) and pr.get("headRefName") == branch:
+            return {
+                "number": pr.get("number"),
+                "url": pr.get("url"),
+                "is_draft": bool(pr.get("isDraft")),
+                "head_sha": pr.get("headRefOid"),
+                "head_matches": not pr.get("headRefOid") or pr.get("headRefOid") == head,
+            }
+    return None
+
+
+def _classification(
+    *,
+    contract_status: str,
+    missing: bool,
+    git_unavailable: bool,
+    detached: bool,
+    owner: dict[str, Any],
+    dirty: bool,
+    ahead: int | None,
+    behind: int | None,
+    pr: dict[str, Any] | None,
+) -> tuple[str, str]:
+    if contract_status != "pinned":
+        return "blocked", "repair the Agent Blackbox revision pin before acting"
+    if missing:
+        return "blocked", "inspect the missing worktree registration"
+    if git_unavailable:
+        return "blocked", "repair or prune the invalid worktree registration"
+    if owner.get("state") == "contested":
+        return "blocked", "resolve contested live ownership"
+    if owner.get("state") == "live":
+        return "active", "wait for or hand off from the live owner"
+    if detached and dirty:
+        return "quarantined", "bind detached dirty work to an issue before recovery"
+    if dirty:
+        return "active", "inspect dirty provenance and choose one bounded slice"
+    if behind and behind > 0:
+        return "blocked", "decide update strategy in a new isolated worktree"
+    if ahead and ahead > 0:
+        return "ready", "verify the local commits and publish or archive the slice"
+    if pr:
+        return "ready", "reconcile exact PR head and CI evidence"
+    return "archive", "archive the clean unbound lane if no owner needs it"
+
+
+def _task_binding(repository: dict[str, Any]) -> dict[str, Any]:
+    issue = repository.get("issue")
+    if not isinstance(issue, int) or issue < 1:
+        return {"status": "unbound"}
+    return {
+        "status": "bound",
+        "canonical": {
+            "schema_version": 1,
+            "contract": AFK_TASK_CONTRACT,
+            "task": {"repository": repository["id"], "issue": issue},
+            "attempts": [],
+        },
+    }
+
+
+def _missing_packet(repository: dict[str, Any], contract_status: str) -> dict[str, Any]:
+    worktree = canonical_path(repository["path"])
+    classification, next_action = _classification(
+        contract_status=contract_status,
+        missing=True,
+        git_unavailable=False,
+        detached=False,
+        owner={"state": "unowned"},
+        dirty=False,
+        ahead=None,
+        behind=None,
+        pr=None,
+    )
+    return {
+        "packet_id": _packet_id(repository["id"], worktree),
+        "repo": repository["id"],
+        "worktree": worktree,
+        "missing": True,
+        "git_unavailable": False,
+        "branch": None,
+        "upstream": None,
+        "head_sha": None,
+        "detached": False,
+        "ahead": None,
+        "behind": None,
+        "dirty_paths": [],
+        "dirty_digest": _dirty_digest([]),
+        "source_signature": "missing",
+        "pr": None,
+        "owner": {"state": "unowned"},
+        "provenance": [],
+        "task_binding": _task_binding(repository),
+        "classification": classification,
+        "next_action": next_action,
+    }
+
+
+def discover_repository(
+    repository: dict[str, Any],
+    *,
+    matcher: Matcher,
+    contract_status: str,
+    path_classes: dict[str, list[str]],
+    live_sessions: list[dict[str, Any]],
+    prs: dict[str, Any],
+    historical_sessions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    root = Path(repository["path"]).expanduser().resolve(strict=False)
+    if not root.is_dir():
+        return [_missing_packet(repository, contract_status)]
+    result = _git(root, "worktree", "list", "--porcelain", "-z", check=False)
+    if result.returncode:
+        return [_missing_packet(repository, contract_status)]
+
+    packets: list[dict[str, Any]] = []
+    for record in _parse_worktree_records(result.stdout):
+        worktree = canonical_path(record["worktree"])
+        path = Path(worktree)
+        missing = not path.is_dir()
+        git_unavailable = False
+        branch_ref = record.get("branch")
+        branch = branch_ref.removeprefix("refs/heads/") if branch_ref else None
+        detached = bool(record.get("detached")) or branch is None
+        head = record.get("HEAD")
+        dirty_paths: list[dict[str, str]] = []
+        upstream: str | None = None
+        ahead: int | None = None
+        behind: int | None = None
+        if not missing:
+            head_result = _git(path, "rev-parse", "HEAD", check=False)
+            if head_result.returncode:
+                git_unavailable = True
+            else:
+                head = head_result.stdout.decode("ascii").strip()
+                dirty_paths = _dirty_entries(path, matcher, path_classes)
+                upstream, ahead, behind = _upstream_state(path)
+        owner = _owner_for(worktree, branch, live_sessions)
+        pr = _pr_for(repository["id"], branch, head, prs)
+        classification, next_action = _classification(
+            contract_status=contract_status,
+            missing=missing,
+            git_unavailable=git_unavailable,
+            detached=detached,
+            owner=owner,
+            dirty=bool(dirty_paths),
+            ahead=ahead,
+            behind=behind,
+            pr=pr,
+        )
+        dirty_digest = _dirty_digest(dirty_paths)
+        packets.append(
+            {
+                "packet_id": _packet_id(repository["id"], worktree),
+                "repo": repository["id"],
+                "worktree": worktree,
+                "missing": missing,
+                "git_unavailable": git_unavailable,
+                "branch": branch,
+                "upstream": upstream,
+                "head_sha": head,
+                "detached": detached,
+                "ahead": ahead,
+                "behind": behind,
+                "dirty_paths": dirty_paths,
+                "dirty_digest": dirty_digest,
+                "source_signature": (
+                    f"unavailable:{head or 'unknown'}" if git_unavailable else f"{head or 'missing'}:{dirty_digest}"
+                ),
+                "pr": pr,
+                "owner": owner,
+                "provenance": _provenance_for(worktree, branch, historical_sessions),
+                "task_binding": _task_binding(repository),
+                "classification": classification,
+                "next_action": next_action,
+            }
+        )
+    return packets or [_missing_packet(repository, contract_status)]
+
+
+def build_snapshot(
+    config: dict[str, Any],
+    *,
+    matcher: Matcher,
+    contract_source: dict[str, Any],
+    presence: dict[str, Any] | None = None,
+    prs: dict[str, Any] | None = None,
+    historical_sessions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if config.get("schema_version") != 1 or not isinstance(config.get("repositories"), list):
+        raise ValueError("config must have schema_version 1 and a repositories array")
+    live_sessions = _normalise_presence(presence)
+    path_classes = config.get("path_classes") or {}
+    packets: list[dict[str, Any]] = []
+    for repository in config["repositories"]:
+        if not isinstance(repository, dict) or not repository.get("id") or not repository.get("path"):
+            raise ValueError("each repository needs id and path")
+        packets.extend(
+            discover_repository(
+                repository,
+                matcher=matcher,
+                contract_status=contract_source.get("status", "unavailable"),
+                path_classes=path_classes,
+                live_sessions=live_sessions,
+                prs=prs or {},
+                historical_sessions=historical_sessions or [],
+            )
+        )
+    packets.sort(key=lambda packet: (packet["repo"].lower(), packet["worktree"].lower()))
+    return {
+        "schema_version": 1,
+        "contract": SNAPSHOT_CONTRACT,
+        "generated_at": utc_now(),
+        "contract_source": contract_source,
+        "canonical_contracts": {
+            "task_state": AFK_TASK_CONTRACT,
+            "evidence": AFK_EVIDENCE_CONTRACT,
+        },
+        "packet_count": len(packets),
+        "packets": packets,
+    }
+
+
+def snapshot_is_stale(previous: dict[str, Any], current: dict[str, Any]) -> dict[str, Any]:
+    def signatures(snapshot: dict[str, Any]) -> dict[str, str]:
+        return {
+            packet["packet_id"]: packet["source_signature"]
+            for packet in snapshot.get("packets", [])
+            if isinstance(packet, dict) and packet.get("packet_id")
+        }
+
+    before = signatures(previous)
+    after = signatures(current)
+    changed = sorted(
+        packet_id for packet_id in set(before) | set(after) if before.get(packet_id) != after.get(packet_id)
+    )
+    return {"stale": bool(changed), "changed_packet_ids": changed}
+
+
+def read_claude_provenance(root: Path, days: int = 30) -> list[dict[str, Any]]:
+    if not root.is_dir():
+        return []
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    sessions: list[dict[str, Any]] = []
+    for path in root.rglob("*.jsonl"):
+        modified = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        if modified < cutoff:
+            continue
+        latest: dict[str, Any] | None = None
+        try:
+            with path.open("r", encoding="utf-8") as stream:
+                for line in stream:
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if event.get("isSidechain") or not event.get("cwd"):
+                        continue
+                    latest = {
+                        "session_id": event.get("sessionId") or path.stem,
+                        "actor": "claude-code",
+                        "state": "historical",
+                        "worktree": canonical_path(event["cwd"]),
+                        "branch": event.get("gitBranch"),
+                        "last_seen": event.get("timestamp") or modified.isoformat(),
+                        "source": str(path),
+                    }
+        except OSError:
+            continue
+        if latest:
+            sessions.append(latest)
+    return sessions
+
+
+def resolve_contract_source(config: dict[str, Any]) -> tuple[Matcher, dict[str, Any]]:
+    source = config.get("contract_source")
+    if not isinstance(source, dict) or not source.get("path") or not source.get("expected_revision"):
+        raise ValueError("config.contract_source needs path and expected_revision")
+    root = Path(source["path"]).expanduser().resolve(strict=False)
+    expected = source["expected_revision"]
+    observed = None
+    status = "unavailable"
+    module_path = root / "cli" / "git_path_matcher.py"
+    if root.is_dir():
+        result = _git(root, "rev-parse", "HEAD", check=False)
+        if result.returncode == 0:
+            observed = result.stdout.decode("ascii").strip()
+            status = "pinned" if observed == expected else "mismatch"
+            if status == "pinned" and _git(
+                root, "status", "--porcelain=v1", "--untracked-files=all"
+            ).stdout:
+                status = "dirty"
+    resolved_module = module_path.resolve(strict=False)
+    if root not in resolved_module.parents:
+        status = "invalid-path"
+    if status != "pinned" or not resolved_module.is_file():
+        raise RuntimeError(
+            f"Agent Blackbox contract source is {status}: expected {expected}, observed {observed}"
+        )
+    spec = importlib.util.spec_from_file_location("agent_blackbox_git_path_matcher", resolved_module)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load matcher from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.GitPathMatcher, {
+        "repository": source.get("repository", "GuitarAlchemist/agent-blackbox"),
+        "path": str(root),
+        "expected_revision": expected,
+        "observed_revision": observed,
+        "status": status,
+    }
+
+
+def fetch_prs(config: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for repository in config.get("repositories", []):
+        repository_id = repository.get("id")
+        if not repository_id:
+            continue
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--repo",
+                    repository_id,
+                    "--state",
+                    "open",
+                    "--limit",
+                    "100",
+                    "--json",
+                    "number,url,isDraft,headRefName,headRefOid",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            result[repository_id] = json.loads(completed.stdout) if completed.returncode == 0 else []
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError):
+            result[repository_id] = []
+    return result
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _assert_output_outside_worktrees(output: Path, snapshot: dict[str, Any]) -> None:
+    resolved = output.expanduser().resolve(strict=False)
+    for packet in snapshot["packets"]:
+        if packet.get("missing"):
+            continue
+        worktree = Path(packet["worktree"])
+        if resolved == worktree or worktree in resolved.parents:
+            raise ValueError(f"output must be outside discovered worktrees: {resolved}")
+
+
+def _write_json_atomic(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--check", type=Path, help="compare with a prior snapshot; writes nothing")
+    parser.add_argument("--presence-json", type=Path, help="normalized live-session presence snapshot")
+    parser.add_argument("--prs-json", type=Path, help="offline PR fixture; live gh lookup when omitted")
+    parser.add_argument(
+        "--claude-root",
+        type=Path,
+        default=Path.home() / ".claude" / "projects",
+        help="Claude Code JSONL root; only cwd/branch/session/timestamp metadata is read",
+    )
+    parser.add_argument("--no-claude", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.out and not args.check:
+        parser.error("one of --out or --check is required")
+
+    config = _load_json(args.config)
+    matcher, contract_source = resolve_contract_source(config)
+    presence = _load_json(args.presence_json) if args.presence_json else None
+    prs = _load_json(args.prs_json) if args.prs_json else fetch_prs(config)
+    historical = [] if args.no_claude else read_claude_provenance(args.claude_root)
+    snapshot = build_snapshot(
+        config,
+        matcher=matcher,
+        contract_source=contract_source,
+        presence=presence,
+        prs=prs,
+        historical_sessions=historical,
+    )
+    if args.check:
+        result = snapshot_is_stale(_load_json(args.check), snapshot)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result["stale"] else 0
+
+    assert args.out is not None
+    _assert_output_outside_worktrees(args.out, snapshot)
+    _write_json_atomic(args.out, snapshot)
+    print(f"wrote {args.out}: {snapshot['packet_count']} packet(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/test_reconcile_local_work.py
+++ b/Scripts/test_reconcile_local_work.py
@@ -64,7 +64,7 @@ class ReconcileLocalWorkTests(unittest.TestCase):
         self.config = {
             "schema_version": 1,
             "repositories": [
-                {"id": "GuitarAlchemist/test", "path": str(self.repo)},
+                {"id": "GuitarAlchemist/test", "path": str(self.repo), "issue": 7},
                 {"id": "GuitarAlchemist/missing", "path": str(self.root / "missing")},
             ],
             "path_classes": {
@@ -157,6 +157,10 @@ class ReconcileLocalWorkTests(unittest.TestCase):
         self.assertEqual(main["provenance"][0]["session_id"], "ended-1")
         self.assertEqual(main["dirty_paths"][0]["classification"], "source")
         self.assertEqual(main["classification"], "active")
+        self.assertEqual(snapshot["canonical_contracts"]["task_state"], "afk-task-state-v0.2")
+        self.assertEqual(snapshot["canonical_contracts"]["evidence"], "afk-evidence-manifest-v0.2")
+        self.assertEqual(main["task_binding"]["canonical"]["schema_version"], 2)
+        self.assertEqual(main["task_binding"]["canonical"]["contract"], "afk-task-state-v0.2")
 
         detached = lanes[str(self.detached.resolve())]
         self.assertTrue(detached["detached"])

--- a/Scripts/test_reconcile_local_work.py
+++ b/Scripts/test_reconcile_local_work.py
@@ -1,0 +1,269 @@
+"""Temporary-repository tests for the read-only reconciliation snapshot."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from Scripts.reconcile_local_work import (
+    build_snapshot,
+    read_claude_provenance,
+    resolve_contract_source,
+    snapshot_is_stale,
+)
+
+
+class FakeMatcher:
+    @classmethod
+    def matches_any(cls, path: str, patterns: list[str]) -> bool:
+        from fnmatch import fnmatch
+
+        normalized = path.replace("\\", "/")
+        return any(fnmatch(normalized, pattern.replace("**", "*")) for pattern in patterns)
+
+
+class ReconcileLocalWorkTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        self._git(self.repo, "init", "-b", "main")
+        self._git(self.repo, "config", "user.email", "test@example.com")
+        self._git(self.repo, "config", "user.name", "Test User")
+        (self.repo / "src").mkdir()
+        (self.repo / "src" / "app.py").write_text("base\n", encoding="utf-8")
+        self._git(self.repo, "add", ".")
+        self._git(self.repo, "commit", "-m", "base")
+        base = self._git(self.repo, "rev-parse", "HEAD").stdout.strip()
+        self._git(self.repo, "branch", "upstream", base)
+        self._git(self.repo, "branch", "--set-upstream-to=upstream", "main")
+        (self.repo / "src" / "app.py").write_text("head\n", encoding="utf-8")
+        self._git(self.repo, "add", ".")
+        self._git(self.repo, "commit", "-m", "ahead")
+
+        tree = self._git(self.repo, "rev-parse", f"{base}^{{tree}}").stdout.strip()
+        upstream = subprocess.run(
+            ["git", "commit-tree", tree, "-p", base],
+            cwd=self.repo,
+            input="upstream\n",
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        self._git(self.repo, "update-ref", "refs/heads/upstream", upstream)
+        (self.repo / "src" / "app.py").write_text("dirty\n", encoding="utf-8")
+
+        self.detached = self.root / "detached"
+        self._git(self.repo, "worktree", "add", "--detach", str(self.detached), "HEAD")
+
+        self.config = {
+            "schema_version": 1,
+            "repositories": [
+                {"id": "GuitarAlchemist/test", "path": str(self.repo)},
+                {"id": "GuitarAlchemist/missing", "path": str(self.root / "missing")},
+            ],
+            "path_classes": {
+                "state": ["state/**"],
+                "generated": ["**/*.generated.*"],
+                "source": ["**/*.py"],
+            },
+        }
+        self.contract = {
+            "repository": "GuitarAlchemist/agent-blackbox",
+            "expected_revision": "a" * 40,
+            "observed_revision": "a" * 40,
+            "status": "pinned",
+        }
+        self.presence = {
+            "sessions": [
+                {
+                    "session_id": "live-1",
+                    "actor": "claude-code",
+                    "state": "live",
+                    "worktree": str(self.repo),
+                    "branch": "main",
+                }
+            ]
+        }
+        self.prs = {
+            "GuitarAlchemist/test": [
+                {
+                    "number": 7,
+                    "headRefName": "main",
+                    "headRefOid": self._git(self.repo, "rev-parse", "HEAD").stdout.strip(),
+                    "isDraft": True,
+                    "url": "https://example.test/pr/7",
+                }
+            ]
+        }
+        self.claude = [
+            {
+                "session_id": "ended-1",
+                "actor": "claude-code",
+                "state": "historical",
+                "worktree": str(self.repo),
+                "branch": "main",
+                "last_seen": "2026-08-01T12:00:00Z",
+                "source": "session.jsonl",
+            }
+        ]
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    @staticmethod
+    def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+        )
+
+    @staticmethod
+    def _content_digest(root: Path) -> str:
+        digest = hashlib.sha256()
+        for path in sorted(item for item in root.rglob("*") if item.is_file() and ".git" not in item.parts):
+            digest.update(str(path.relative_to(root)).encode())
+            digest.update(path.read_bytes())
+        return digest.hexdigest()
+
+    def _snapshot(self) -> dict:
+        return build_snapshot(
+            self.config,
+            matcher=FakeMatcher,
+            contract_source=self.contract,
+            presence=self.presence,
+            prs=self.prs,
+            historical_sessions=self.claude,
+        )
+
+    def test_discovers_git_states_and_binds_ownership_pr_and_provenance(self) -> None:
+        before = self._content_digest(self.repo)
+        index_before = (self.repo / ".git" / "index").read_bytes()
+        snapshot = self._snapshot()
+        after = self._content_digest(self.repo)
+        self.assertEqual(before, after)
+        self.assertEqual(index_before, (self.repo / ".git" / "index").read_bytes())
+
+        lanes = {packet["worktree"]: packet for packet in snapshot["packets"]}
+        main = lanes[str(self.repo.resolve())]
+        self.assertEqual(main["branch"], "main")
+        self.assertEqual((main["ahead"], main["behind"]), (1, 1))
+        self.assertEqual(main["owner"]["session_id"], "live-1")
+        self.assertEqual(main["pr"]["number"], 7)
+        self.assertEqual(main["provenance"][0]["session_id"], "ended-1")
+        self.assertEqual(main["dirty_paths"][0]["classification"], "source")
+        self.assertEqual(main["classification"], "active")
+
+        detached = lanes[str(self.detached.resolve())]
+        self.assertTrue(detached["detached"])
+        self.assertIsNone(detached["branch"])
+
+        missing = next(packet for packet in snapshot["packets"] if packet["repo"] == "GuitarAlchemist/missing")
+        self.assertTrue(missing["missing"])
+        self.assertEqual(missing["classification"], "blocked")
+
+    def test_packet_ids_are_stable_and_dirty_changes_make_snapshot_stale(self) -> None:
+        first = self._snapshot()
+        second = self._snapshot()
+        self.assertEqual(
+            [packet["packet_id"] for packet in first["packets"]],
+            [packet["packet_id"] for packet in second["packets"]],
+        )
+        self.assertFalse(snapshot_is_stale(first, second)["stale"])
+
+        (self.repo / "new.txt").write_text("new dirty path\n", encoding="utf-8")
+        third = self._snapshot()
+        stale = snapshot_is_stale(first, third)
+        self.assertTrue(stale["stale"])
+        self.assertTrue(stale["changed_packet_ids"])
+
+    def test_contract_revision_mismatch_blocks_all_packets(self) -> None:
+        contract = dict(self.contract, observed_revision="b" * 40, status="mismatch")
+        snapshot = build_snapshot(
+            self.config,
+            matcher=FakeMatcher,
+            contract_source=contract,
+            presence=self.presence,
+            prs=self.prs,
+            historical_sessions=self.claude,
+        )
+        self.assertEqual(snapshot["contract_source"]["status"], "mismatch")
+        self.assertTrue(all(packet["classification"] == "blocked" for packet in snapshot["packets"]))
+
+    def test_registered_directory_that_is_not_a_worktree_is_blocked(self) -> None:
+        (self.detached / ".git").unlink()
+        snapshot = self._snapshot()
+        packet = next(
+            item for item in snapshot["packets"] if item["worktree"] == str(self.detached.resolve())
+        )
+        self.assertTrue(packet["git_unavailable"])
+        self.assertEqual(packet["classification"], "blocked")
+
+    def test_claude_provenance_reads_metadata_not_conversation_content(self) -> None:
+        claude_root = self.root / "claude"
+        claude_root.mkdir()
+        log = claude_root / "session.jsonl"
+        log.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "sessionId": "session-1",
+                    "cwd": str(self.repo),
+                    "gitBranch": "main",
+                    "timestamp": "2026-08-02T12:00:00Z",
+                    "message": {"content": "TOP-SECRET-CONVERSATION-CONTENT"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        sessions = read_claude_provenance(claude_root)
+        self.assertEqual(sessions[0]["session_id"], "session-1")
+        self.assertNotIn("TOP-SECRET", json.dumps(sessions))
+
+    def test_contract_matcher_loads_only_at_exact_git_revision(self) -> None:
+        dependency = self.root / "agent-blackbox"
+        (dependency / "cli").mkdir(parents=True)
+        self._git(dependency, "init", "-b", "main")
+        self._git(dependency, "config", "user.email", "test@example.com")
+        self._git(dependency, "config", "user.name", "Test User")
+        (dependency / "cli" / "git_path_matcher.py").write_text(
+            "class GitPathMatcher:\n"
+            "    @classmethod\n"
+            "    def matches_any(cls, path, patterns):\n"
+            "        return path in patterns\n",
+            encoding="utf-8",
+        )
+        self._git(dependency, "add", ".")
+        self._git(dependency, "commit", "-m", "matcher")
+        revision = self._git(dependency, "rev-parse", "HEAD").stdout.strip()
+        config = {
+            "contract_source": {
+                "path": str(dependency),
+                "expected_revision": revision,
+            }
+        }
+        matcher, source = resolve_contract_source(config)
+        self.assertTrue(matcher.matches_any("x", ["x"]))
+        self.assertEqual(source["status"], "pinned")
+
+        matcher_path = dependency / "cli" / "git_path_matcher.py"
+        matcher_path.write_text(matcher_path.read_text(encoding="utf-8") + "# dirty\n", encoding="utf-8")
+        with self.assertRaises(RuntimeError):
+            resolve_contract_source(config)
+        self._git(dependency, "add", ".")
+        self._git(dependency, "commit", "-m", "advance matcher")
+
+        (dependency / "README.md").write_text("new head\n", encoding="utf-8")
+        self._git(dependency, "add", ".")
+        self._git(dependency, "commit", "-m", "advance")
+        with self.assertRaises(RuntimeError):
+            resolve_contract_source(config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/tools/local-work-reconciliation.md
+++ b/docs/tools/local-work-reconciliation.md
@@ -21,7 +21,7 @@ vendor the matcher or schemas.
 The current draft integration revision is:
 
 ```text
-GuitarAlchemist/agent-blackbox@526eb4044b75d39d89481628ed1f5b42ccdf85b6
+GuitarAlchemist/agent-blackbox@b90839e457998089d30e2e7f4c73ea49511cdddc
 ```
 
 That revision belongs to stacked draft PR #51 and is not a released contract.
@@ -37,7 +37,7 @@ Use an operator-local JSON file outside the repositories being inspected:
   "contract_source": {
     "repository": "GuitarAlchemist/agent-blackbox",
     "path": "C:/path/to/agent-blackbox-contract-checkout",
-    "expected_revision": "526eb4044b75d39d89481628ed1f5b42ccdf85b6"
+    "expected_revision": "b90839e457998089d30e2e7f4c73ea49511cdddc"
   },
   "repositories": [
     {
@@ -54,9 +54,11 @@ Use an operator-local JSON file outside the repositories being inspected:
 }
 ```
 
-An `issue` creates a canonical empty `afk-task-state-v0.1` binding for that
-repository. A lane without an issue is explicitly `unbound`; the adapter does
-not invent issue ownership.
+An `issue` creates a canonical empty `afk-task-state-v0.2` binding for that
+repository. The snapshot also advertises `afk-evidence-manifest-v0.2`; the
+v0.2 contracts bind task identity, policy, budget, task state, lease, and exact
+Git revisions. A lane without an issue is explicitly `unbound`; the adapter
+does not invent issue ownership.
 
 ## Run and recheck
 

--- a/docs/tools/local-work-reconciliation.md
+++ b/docs/tools/local-work-reconciliation.md
@@ -1,0 +1,131 @@
+# Local-work reconciliation snapshot
+
+`Scripts/reconcile_local_work.py` is the read-only GA adapter for the Cloud
+Factory tracer bullet in GA #630. One invocation inventories registered Git
+worktrees across the configured repositories and binds the evidence needed to
+decide what may happen next.
+
+The command discovers dirty paths, ahead/behind state, detached and invalid
+registrations, open PRs, explicit live ownership, and historical Claude Code
+provenance. It emits observations only. It never checks out, cleans, resets,
+stashes, rebases, or writes into a discovered repository.
+
+## Canonical dependency
+
+Path semantics and AFK contract names remain owned by Agent Blackbox #44/#46.
+The configuration names an Agent Blackbox checkout and its full expected commit
+SHA. The command verifies `HEAD` exactly, then loads the matcher from that
+checkout. A missing or different revision fails before discovery; GA does not
+vendor the matcher or schemas.
+
+The current draft integration revision is:
+
+```text
+GuitarAlchemist/agent-blackbox@526eb4044b75d39d89481628ed1f5b42ccdf85b6
+```
+
+That revision belongs to stacked draft PR #51 and is not a released contract.
+Update the pin only after reviewing the new exact SHA.
+
+## Configuration
+
+Use an operator-local JSON file outside the repositories being inspected:
+
+```json
+{
+  "schema_version": 1,
+  "contract_source": {
+    "repository": "GuitarAlchemist/agent-blackbox",
+    "path": "C:/path/to/agent-blackbox-contract-checkout",
+    "expected_revision": "526eb4044b75d39d89481628ed1f5b42ccdf85b6"
+  },
+  "repositories": [
+    {
+      "id": "GuitarAlchemist/ga",
+      "path": "C:/path/to/ga",
+      "issue": 630
+    }
+  ],
+  "path_classes": {
+    "state": ["state/**", "**/state/**"],
+    "generated": ["**/bin/**", "**/obj/**", "**/*.generated.*"],
+    "source": ["**/*.cs", "**/*.fs", "**/*.py", "**/*.rs", "**/*.ts"]
+  }
+}
+```
+
+An `issue` creates a canonical empty `afk-task-state-v0.1` binding for that
+repository. A lane without an issue is explicitly `unbound`; the adapter does
+not invent issue ownership.
+
+## Run and recheck
+
+Write the snapshot to an operator-owned path outside every discovered worktree:
+
+```powershell
+python Scripts/reconcile_local_work.py `
+  --config C:\operator\reconciliation-config.json `
+  --presence-json C:\operator\live-presence.json `
+  --out C:\operator\reconciliation-snapshot.json
+```
+
+If `--prs-json` is omitted, the command reads open PR metadata through `gh`.
+`--presence-json` is a normalized snapshot with a `sessions` array; only entries
+whose `state` is `live` may own a lane. Ended sessions are provenance, never
+owners.
+
+By default, recent files below `~/.claude/projects` are scanned for only
+`sessionId`, `cwd`, `gitBranch`, and `timestamp`. Message content, tool calls,
+thinking, and attachments are never copied. Use `--no-claude` to disable this
+metadata scan or `--claude-root` for a fixture/location override.
+
+Before acting on a packet, re-run discovery in check mode:
+
+```powershell
+python Scripts/reconcile_local_work.py `
+  --config C:\operator\reconciliation-config.json `
+  --presence-json C:\operator\live-presence.json `
+  --check C:\operator\reconciliation-snapshot.json
+```
+
+Exit code `1` means at least one packet appeared, disappeared, changed `HEAD`,
+or changed its dirty-path digest. The prior snapshot is then stale and must not
+authorize a mutation.
+
+## Packet semantics
+
+Stable packet IDs hash repository identity plus canonical physical worktree.
+Source signatures bind `HEAD` and the sorted dirty-path digest. Classification
+is conservative:
+
+- `active`: a live owner or uncommitted work exists;
+- `ready`: clean local commits or a PR are available for bounded review;
+- `blocked`: missing/invalid registration, stale contract pin, behind branch, or
+  contested ownership;
+- `quarantined`: detached dirty state has no safe issue binding;
+- `archive`: clean, unbound, and no unfinished evidence.
+
+Classification is advice, not authority. Mutation still requires an uncontested
+Gaia/Galactic claim, an isolated worktree, an Agent Blackbox lease/budget, and
+exact-SHA postflight evidence.
+
+## Transcript boundary
+
+This command reconciles provenance, not conversations. Importing a ChatGPT
+Classic export or rendering a Claude transcript is a separate, explicit action
+because it copies conversation content. Claude rendering remains available via
+`Scripts/export_session_to_md.py`; a ChatGPT export should receive its own
+consentful adapter rather than being silently folded into the worktree scan.
+
+## Verification
+
+The test suite creates disposable Git repositories and never points a mutating
+test at an operator checkout:
+
+```powershell
+python -m unittest Scripts.test_reconcile_local_work -v
+```
+
+It covers dirty/ahead/behind/detached/missing/invalid lanes, PR and live-owner
+binding, stable IDs, stale detection, exact dependency pins, and the guarantee
+that Claude conversation content is excluded.


### PR DESCRIPTION
## Outcome

Adds the first read-only tracer bullet for #630: a deterministic local-work reconciliation snapshot across registered Git worktrees, open PRs, explicit live ownership, and metadata-only Claude Code provenance.

## Scope

- discovers dirty/ahead/behind/detached/missing/invalid worktree state without mutating any repository
- emits stable packet IDs, source signatures, conservative classifications, and stale-snapshot checks
- binds explicit live presence and open-PR evidence
- reads only Claude session metadata (`sessionId`, `cwd`, `gitBranch`, `timestamp`), never conversation/tool/thinking content
- fails closed unless the canonical Agent Blackbox checkout is clean and exactly pinned
- keeps all output outside discovered worktrees

This is deliberately a tracer bullet, not the complete #630 enforcement surface. Workflow/merge-gate changes remain a separate human-reviewed follow-up.

## Canonical dependency

- Agent Blackbox stacked PR #51: https://github.com/GuitarAlchemist/agent-blackbox/pull/51
- exact draft revision: `526eb4044b75d39d89481628ed1f5b42ccdf85b6`
- stack #52: PR #50 (canonical matcher) -> PR #51 (AFK contracts/postflight)
- Cloud Factory plan: #632

## Verification

- `python -m unittest Scripts.test_reconcile_local_work -v`: 6 passed
- `python -m compileall -q Scripts/reconcile_local_work.py Scripts/test_reconcile_local_work.py`: passed
- `python Scripts/audit-doc-links.py --ci`: no broken links in live docs (79 pre-existing archived-link findings)
- live tracer: 94 packets across GA, Demerzel, Agent Blackbox, ix, tars, and hari
- immediate live recheck: `stale: false`
- `dotnet build AllProjects.slnx -c Debug`: passed, 0 errors (150 existing warnings)

## Full-suite caveats

`dotnet test AllProjects.slnx --no-build` is not green in this Windows checkout for two unrelated environment/baseline failures:

1. `MlNaturalnessRankerTests.PredictNaturalness_ReturnsNonNeutralValue` cannot find the untracked `models/naturalness_ranker.onnx` fixture (1,690 ML tests passed, 22 skipped before the failure).
2. `GaApi.Tests` hit an NUnit adapter out-of-memory error while serializing XML after 10m29s (150 passed, 9 skipped before the adapter crash).

No autonomous merge. Keep this PR draft until the Agent Blackbox stack and independent review boundary are accepted.

Part of #630
