### PR TITLE
chore(skills): add audited decision pilot

### DIFF
--- a/.claude/skills/decisions/SKILL.md
+++ b/.claude/skills/decisions/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: decisions
+description: Ask the agent to list all choices it made during the current work that it is not confident of. Manual-only; invoke with /decisions.
+disable-model-invocation: true
+---
+
+While working on this, which important decisions / choices did you make, that you are not confident about?
+
+Think about this deeply, reason about all the important decisions made, and think whether these decisions have any other great alternatives that we have not considered.
+
+DO NOT list out the choices / decisions where we already have the best possible solution.
+
+Only list out the decisions you are really unsure about.
+
+answer in short, in plain english. be very concise.

--- a/.claude/skills/decisions/agents/openai.yaml
+++ b/.claude/skills/decisions/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.claude/skills/next-decision/SKILL.md
+++ b/.claude/skills/next-decision/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: next-decision
+description: 'Drill open decisions one at a time — present the most important decision not yet clarified, give the top four choices, state a preference, ask the user. Use when the user says "next decision", "one decision at a time", or a plan has several unresolved choices. Differentiator: forward-looking; the decisions skill is retrospective (choices already made). Can be invoked with /next-decision.'
+---
+
+Work through open decisions ONE at a time.
+
+1. Present the most important decision we haven't clarified yet.
+2. Give the top four choices for it.
+3. Say which one you would prefer.
+4. Ask for the user's opinion. Then stop and wait.
+
+Be very concise. Once the user decides, record their answer (update the plan doc
+if one exists), then repeat with the next most important decision.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,16 @@ _Appended by `/correct` when the user corrects an approach. Persists across sess
 
 Per-repo config for the installed aihero/mattpocock engineering skills (`grill-with-docs`, `grill-me`, `to-prd`, `to-issues`, `tdd`, `improve-codebase-architecture`, `teach`), installed project-scoped into `.claude/skills/` via `npx skills@latest add mattpocock/skills --copy` (MIT; Socket/Snyk clean). Configured 2026-06-14 via `/setup-matt-pocock-skills`.
 
+Audited davidondrej pilot skills (`next-decision`, `decisions`) are vendored
+project-scoped under `.claude/skills/` from
+`davidondrej/skills@f2ce449939b4b46707bc8692cbf9f473b2d891e7` (MIT). Both
+are prompt-only and contain no scripts or executable assets: `next-decision`
+resolves one open choice at a time; `decisions` is a manual uncertainty audit
+and carries an installer-generated Codex manual-only policy. Do not bulk-update from
+`main`; re-audit and pin each upstream revision. `fable-safe-prompt`, broad
+system guardrails, destructive setup/production skills, and scheduler wrappers
+are intentionally excluded.
+
 ### Issue tracker
 
 GitHub Issues on `GuitarAlchemist/ga`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,16 @@ _Appended by `/correct` when the user corrects an approach. Persists across sess
 
 Per-repo config for the installed aihero/mattpocock engineering skills (`grill-with-docs`, `grill-me`, `to-prd`, `to-issues`, `tdd`, `improve-codebase-architecture`, `teach`), installed project-scoped into `.claude/skills/` via `npx skills@latest add mattpocock/skills --copy` (MIT; Socket/Snyk clean). Configured 2026-06-14 via `/setup-matt-pocock-skills`.
 
+Audited davidondrej pilot skills (`next-decision`, `decisions`) are vendored
+project-scoped under `.claude/skills/` from
+`davidondrej/skills@f2ce449939b4b46707bc8692cbf9f473b2d891e7` (MIT). Both
+are prompt-only and contain no scripts or executable assets: `next-decision`
+resolves one open choice at a time; `decisions` is a manual uncertainty audit
+and carries an installer-generated Codex manual-only policy. Do not bulk-update from
+`main`; re-audit and pin each upstream revision. `fable-safe-prompt`, broad
+system guardrails, destructive setup/production skills, and scheduler wrappers
+are intentionally excluded.
+
 ### Issue tracker
 
 GitHub Issues on `GuitarAlchemist/ga`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.


### PR DESCRIPTION
## Summary

- vendor the prompt-only `next-decision` and `decisions` skills project-scoped under `.claude/skills/`
- pin the audited upstream source to `davidondrej/skills@f2ce449939b4b46707bc8692cbf9f473b2d891e7`
- keep `decisions` manual-only through the installer-generated Codex policy
- document the intentionally excluded classifier-avoidance, destructive, scheduler, and broad system-hook skills

## Why

GA benefits from a very small decision-discipline pilot, but a bulk third-party skill install would create routing overlap and unnecessary authority. This PR isolates two script-free process skills so their triggering and value can be evaluated before any expansion.

## Validation

- upstream/local Git blob hashes matched before the repository whitespace normalization
- frontmatter folder/name validation passed
- `decisions` manual-only policy validation passed
- `Scripts/sync-agents-md.ps1` passed
- `git diff --cached --check` passed
- repository pre-commit hook passed

No runtime or product code changes.