### PR TITLE
test(qa): add held-out progression-to-voicing corpus

### DIFF
--- a/Tests/Common/GA.Business.ML.Tests/Corpus/CorpusPitchMath.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/CorpusPitchMath.cs
@@ -1,0 +1,129 @@
+namespace GA.Business.ML.Tests.Corpus;
+
+/// <summary>
+///     Pitch-class and fret arithmetic used to check that the corpus is
+///     self-consistent.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Deliberately independent of production code. #627 forbids duplicating
+///         key detection or harmonic analysis in the harness, and none of that
+///         happens here: this is note-name parsing, an interval table, and
+///         "open string + fret = sounding pitch". No key is inferred, no chord
+///         is analysed, no function is assigned.
+///     </para>
+///     <para>
+///         Independence is the point. If these helpers called
+///         <c>ChordVocabulary</c> or <c>KeyIdentificationService</c>, a defect in
+///         production would make wrong corpus data validate clean - exactly the
+///         circularity a held-out corpus exists to avoid.
+///     </para>
+/// </remarks>
+internal static class CorpusPitchMath
+{
+    private static readonly IReadOnlyDictionary<char, int> LetterPitchClass = new Dictionary<char, int>
+    {
+        ['C'] = 0, ['D'] = 2, ['E'] = 4, ['F'] = 5, ['G'] = 7, ['A'] = 9, ['B'] = 11
+    };
+
+    /// <summary>Semitones above the root for each corpus chord quality.</summary>
+    public static readonly IReadOnlyDictionary<string, int[]> QualityIntervals = new Dictionary<string, int[]>
+    {
+        ["major-triad"]       = [0, 4, 7],
+        ["minor-triad"]       = [0, 3, 7],
+        ["dominant-7"]        = [0, 4, 7, 10],
+        ["major-7"]           = [0, 4, 7, 11],
+        ["minor-7"]           = [0, 3, 7, 10],
+        ["half-diminished-7"] = [0, 3, 6, 10]
+    };
+
+    /// <summary>Diatonic letter step for each chord tone, parallel to <see cref="QualityIntervals" />.</summary>
+    public static readonly IReadOnlyDictionary<string, int[]> QualityLetterSteps = new Dictionary<string, int[]>
+    {
+        ["major-triad"]       = [0, 2, 4],
+        ["minor-triad"]       = [0, 2, 4],
+        ["dominant-7"]        = [0, 2, 4, 6],
+        ["major-7"]           = [0, 2, 4, 6],
+        ["minor-7"]           = [0, 2, 4, 6],
+        ["half-diminished-7"] = [0, 2, 4, 6]
+    };
+
+    /// <summary>Pitch class of a bare note name such as <c>C</c>, <c>Eb</c>, <c>F#</c>, <c>Bbb</c>.</summary>
+    public static int PitchClassOf(string noteName)
+    {
+        if (noteName.Length == 0 || !LetterPitchClass.TryGetValue(noteName[0], out var pc))
+            throw new FormatException($"'{noteName}' is not a note name");
+
+        foreach (var accidental in noteName.AsSpan(1))
+        {
+            pc += accidental switch
+            {
+                '#' => 1,
+                'b' => -1,
+                _ => throw new FormatException($"'{noteName}' has an unexpected accidental '{accidental}'")
+            };
+        }
+
+        return ((pc % 12) + 12) % 12;
+    }
+
+    /// <summary>MIDI number of a scientific-pitch name such as <c>E2</c> or <c>F#3</c>.</summary>
+    public static int MidiOf(string scientificPitch)
+    {
+        var octave = scientificPitch[^1] - '0';
+        if (octave is < 0 or > 9) throw new FormatException($"'{scientificPitch}' has no octave digit");
+
+        return ((octave + 1) * 12) + PitchClassOf(scientificPitch[..^1]);
+    }
+
+    /// <summary>Spells the chord tone <paramref name="semitones" /> above <paramref name="root" />.</summary>
+    /// <remarks>
+    ///     The letter step is what forces <c>Eb</c> rather than <c>D#</c> as the
+    ///     minor third of C. Same rule as the production
+    ///     <c>ChordSpelling.Spell</c>, re-derived here rather than called, for the
+    ///     independence reason in the type remarks.
+    /// </remarks>
+    public static string Spell(string root, int semitones, int letterSteps)
+    {
+        const string letters = "CDEFGAB";
+
+        var rootIndex = letters.IndexOf(root[0]);
+        if (rootIndex < 0) throw new FormatException($"'{root}' is not a note name");
+
+        var targetLetter = letters[(rootIndex + letterSteps) % 7];
+        var targetPc = (PitchClassOf(root) + semitones) % 12;
+        var delta = ((targetPc - LetterPitchClass[targetLetter]) % 12 + 12) % 12;
+
+        var accidental = delta switch
+        {
+            0 => "",
+            1 => "#",
+            2 => "##",
+            10 => "bb",
+            11 => "b",
+            _ => throw new InvalidOperationException(
+                $"{root} + {semitones} at letter step {letterSteps} needs {delta} accidentals")
+        };
+
+        return targetLetter + accidental;
+    }
+
+    /// <summary>Pitch classes actually sounded by a fretting, given the open strings.</summary>
+    public static IReadOnlySet<int> SoundedPitchClasses(
+        IReadOnlyList<string> openStrings,
+        IReadOnlyList<int?> fretsLowToHigh)
+    {
+        if (openStrings.Count != fretsLowToHigh.Count)
+        {
+            throw new ArgumentException(
+                $"{fretsLowToHigh.Count} frets for {openStrings.Count} strings", nameof(fretsLowToHigh));
+        }
+
+        var sounded = new HashSet<int>();
+        for (var i = 0; i < openStrings.Count; i++)
+            if (fretsLowToHigh[i] is { } fret)
+                sounded.Add((MidiOf(openStrings[i]) + fret) % 12);
+
+        return sounded;
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/JsonSchemaSubsetValidator.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/JsonSchemaSubsetValidator.cs
@@ -1,0 +1,282 @@
+namespace GA.Business.ML.Tests.Corpus;
+
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+/// <summary>
+///     A deliberately small JSON Schema validator covering exactly the keywords
+///     used by <c>progression-corpus.v1.schema.json</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Why hand-rolled rather than a NuGet validator: the corpus lives in a
+///         test project whose <c>.csproj</c> is a one-way-door path under
+///         <c>agent-blackbox.policy.json</c>. A ~200-line closed-world validator
+///         over a known keyword set is cheaper than a dependency change, and it
+///         keeps the schema load-bearing instead of decorative - the schema is
+///         the language-neutral contract other repos read, so it must actually
+///         be enforced against the data it describes.
+///     </para>
+///     <para>
+///         The closed world is the safety property. <see cref="SupportedKeywords" />
+///         is asserted against the schema document by
+///         <c>ProgressionCorpusLoaderTests</c>; if anyone adds <c>oneOf</c>,
+///         <c>if/then</c>, <c>$dynamicRef</c> or any other keyword this file does
+///         not implement, that test fails rather than the validator silently
+///         ignoring a constraint and reporting a false pass.
+///     </para>
+/// </remarks>
+internal static class JsonSchemaSubsetValidator
+{
+    /// <summary>
+    ///     Every keyword this validator understands. Annotation-only keywords
+    ///     (<c>$schema</c>, <c>$id</c>, <c>title</c>, <c>description</c>,
+    ///     <c>$defs</c>) are listed because they may legally appear, not because
+    ///     they constrain anything.
+    /// </summary>
+    public static readonly IReadOnlySet<string> SupportedKeywords = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "$schema", "$id", "$ref", "$defs", "title", "description",
+        "type", "const", "enum", "required", "properties", "additionalProperties",
+        "items", "minItems", "maxItems", "uniqueItems",
+        "minimum", "maximum", "minLength", "pattern"
+    };
+
+    /// <summary>Validates <paramref name="instance" /> against <paramref name="schema" />.</summary>
+    /// <returns>One message per violation, JSON-pointer prefixed. Empty means valid.</returns>
+    public static IReadOnlyList<string> Validate(JsonElement instance, JsonElement schema)
+    {
+        var errors = new List<string>();
+        Walk(instance, schema, schema, "#", errors);
+        return errors;
+    }
+
+    /// <summary>
+    ///     Collects every keyword appearing anywhere in a schema document, so a
+    ///     test can assert the document stays inside <see cref="SupportedKeywords" />.
+    /// </summary>
+    public static IReadOnlySet<string> CollectKeywords(JsonElement schema)
+    {
+        var found = new HashSet<string>(StringComparer.Ordinal);
+        Collect(schema);
+        return found;
+
+        // Only descends where a schema legally nests another schema. Keys under
+        // `properties` / `$defs` are author-chosen names, never keywords.
+        void Collect(JsonElement node)
+        {
+            if (node.ValueKind != JsonValueKind.Object) return;
+
+            foreach (var prop in node.EnumerateObject())
+            {
+                found.Add(prop.Name);
+                switch (prop.Name)
+                {
+                    case "properties":
+                    case "$defs":
+                        foreach (var sub in prop.Value.EnumerateObject()) Collect(sub.Value);
+                        break;
+                    case "items":
+                        Collect(prop.Value);
+                        break;
+                    case "additionalProperties":
+                        if (prop.Value.ValueKind == JsonValueKind.Object) Collect(prop.Value);
+                        break;
+                }
+            }
+        }
+    }
+
+    private static void Walk(JsonElement instance, JsonElement schema, JsonElement root, string path, List<string> errors)
+    {
+        if (schema.TryGetProperty("$ref", out var refNode))
+        {
+            var resolved = Resolve(root, refNode.GetString()!);
+            Walk(instance, resolved, root, path, errors);
+            return;
+        }
+
+        if (schema.TryGetProperty("type", out var typeNode) && !MatchesType(instance, typeNode))
+            errors.Add($"{path}: expected type {Describe(typeNode)}, found {instance.ValueKind}");
+
+        if (schema.TryGetProperty("const", out var constNode) && !JsonEquals(instance, constNode))
+            errors.Add($"{path}: expected const {constNode.GetRawText()}, found {instance.GetRawText()}");
+
+        if (schema.TryGetProperty("enum", out var enumNode) &&
+            !enumNode.EnumerateArray().Any(allowed => JsonEquals(instance, allowed)))
+            errors.Add($"{path}: {instance.GetRawText()} is not one of {enumNode.GetRawText()}");
+
+        switch (instance.ValueKind)
+        {
+            case JsonValueKind.Object:
+                ValidateObject(instance, schema, root, path, errors);
+                break;
+            case JsonValueKind.Array:
+                ValidateArray(instance, schema, root, path, errors);
+                break;
+            case JsonValueKind.String:
+                ValidateString(instance, schema, path, errors);
+                break;
+            case JsonValueKind.Number:
+                ValidateNumber(instance, schema, path, errors);
+                break;
+        }
+    }
+
+    private static void ValidateObject(JsonElement instance, JsonElement schema, JsonElement root, string path, List<string> errors)
+    {
+        if (schema.TryGetProperty("required", out var required))
+        {
+            foreach (var name in required.EnumerateArray().Select(e => e.GetString()!))
+                if (!instance.TryGetProperty(name, out _))
+                    errors.Add($"{path}: missing required property '{name}'");
+        }
+
+        var hasProperties = schema.TryGetProperty("properties", out var properties);
+
+        if (schema.TryGetProperty("additionalProperties", out var extra) &&
+            extra.ValueKind == JsonValueKind.False)
+        {
+            foreach (var prop in instance.EnumerateObject())
+                if (!hasProperties || !properties.TryGetProperty(prop.Name, out _))
+                    errors.Add($"{path}: unexpected property '{prop.Name}'");
+        }
+
+        if (!hasProperties) return;
+
+        foreach (var prop in instance.EnumerateObject())
+            if (properties.TryGetProperty(prop.Name, out var propSchema))
+                Walk(prop.Value, propSchema, root, $"{path}/{prop.Name}", errors);
+    }
+
+    private static void ValidateArray(JsonElement instance, JsonElement schema, JsonElement root, string path, List<string> errors)
+    {
+        var length = instance.GetArrayLength();
+
+        if (schema.TryGetProperty("minItems", out var min) && length < min.GetInt32())
+            errors.Add($"{path}: expected at least {min.GetInt32()} items, found {length}");
+
+        if (schema.TryGetProperty("maxItems", out var max) && length > max.GetInt32())
+            errors.Add($"{path}: expected at most {max.GetInt32()} items, found {length}");
+
+        if (schema.TryGetProperty("uniqueItems", out var unique) && unique.ValueKind == JsonValueKind.True)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var item in instance.EnumerateArray())
+                if (!seen.Add(Canonical(item)))
+                    errors.Add($"{path}: duplicate item {item.GetRawText()}");
+        }
+
+        if (!schema.TryGetProperty("items", out var itemSchema)) return;
+
+        var index = 0;
+        foreach (var item in instance.EnumerateArray())
+            Walk(item, itemSchema, root, $"{path}/{index++}", errors);
+    }
+
+    private static void ValidateString(JsonElement instance, JsonElement schema, string path, List<string> errors)
+    {
+        var value = instance.GetString() ?? string.Empty;
+
+        if (schema.TryGetProperty("minLength", out var minLength) && value.Length < minLength.GetInt32())
+            errors.Add($"{path}: expected minLength {minLength.GetInt32()}, found {value.Length}");
+
+        if (schema.TryGetProperty("pattern", out var pattern) &&
+            !Regex.IsMatch(value, pattern.GetString()!, RegexOptions.None, TimeSpan.FromSeconds(2)))
+            errors.Add($"{path}: '{value}' does not match pattern {pattern.GetString()}");
+    }
+
+    private static void ValidateNumber(JsonElement instance, JsonElement schema, string path, List<string> errors)
+    {
+        var value = instance.GetDouble();
+
+        if (schema.TryGetProperty("minimum", out var min) && value < min.GetDouble())
+            errors.Add($"{path}: {value} is below minimum {min.GetDouble()}");
+
+        if (schema.TryGetProperty("maximum", out var max) && value > max.GetDouble())
+            errors.Add($"{path}: {value} is above maximum {max.GetDouble()}");
+    }
+
+    private static JsonElement Resolve(JsonElement root, string pointer)
+    {
+        if (!pointer.StartsWith("#/", StringComparison.Ordinal))
+            throw new NotSupportedException($"only local '#/...' refs are supported, got '{pointer}'");
+
+        var node = root;
+        foreach (var segment in pointer[2..].Split('/'))
+        {
+            if (!node.TryGetProperty(segment, out node))
+                throw new InvalidOperationException($"unresolvable $ref segment '{segment}' in '{pointer}'");
+        }
+
+        return node;
+    }
+
+    private static bool MatchesType(JsonElement instance, JsonElement typeNode) =>
+        typeNode.ValueKind == JsonValueKind.Array
+            ? typeNode.EnumerateArray().Any(t => MatchesTypeName(instance, t.GetString()!))
+            : MatchesTypeName(instance, typeNode.GetString()!);
+
+    private static bool MatchesTypeName(JsonElement instance, string typeName) => typeName switch
+    {
+        "object"  => instance.ValueKind == JsonValueKind.Object,
+        "array"   => instance.ValueKind == JsonValueKind.Array,
+        "string"  => instance.ValueKind == JsonValueKind.String,
+        "boolean" => instance.ValueKind is JsonValueKind.True or JsonValueKind.False,
+        "null"    => instance.ValueKind == JsonValueKind.Null,
+        "number"  => instance.ValueKind == JsonValueKind.Number,
+        "integer" => instance.ValueKind == JsonValueKind.Number && instance.TryGetInt64(out _),
+        _         => throw new NotSupportedException($"unsupported type name '{typeName}'")
+    };
+
+    private static string Describe(JsonElement typeNode) =>
+        typeNode.ValueKind == JsonValueKind.Array
+            ? string.Join("|", typeNode.EnumerateArray().Select(t => t.GetString()))
+            : typeNode.GetString()!;
+
+    private static bool JsonEquals(JsonElement left, JsonElement right) =>
+        string.Equals(Canonical(left), Canonical(right), StringComparison.Ordinal);
+
+    /// <summary>Order-insensitive-for-objects textual form, used for equality and uniqueness.</summary>
+    private static string Canonical(JsonElement element)
+    {
+        var sb = new StringBuilder();
+        Append(element);
+        return sb.ToString();
+
+        void Append(JsonElement node)
+        {
+            switch (node.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    sb.Append('{');
+                    foreach (var prop in node.EnumerateObject().OrderBy(p => p.Name, StringComparer.Ordinal))
+                    {
+                        sb.Append(JsonSerializer.Serialize(prop.Name)).Append(':');
+                        Append(prop.Value);
+                        sb.Append(',');
+                    }
+
+                    sb.Append('}');
+                    break;
+                case JsonValueKind.Array:
+                    sb.Append('[');
+                    foreach (var item in node.EnumerateArray())
+                    {
+                        Append(item);
+                        sb.Append(',');
+                    }
+
+                    sb.Append(']');
+                    break;
+                case JsonValueKind.Number:
+                    sb.Append(node.GetDouble().ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+                    break;
+                default:
+                    sb.Append(node.GetRawText());
+                    break;
+            }
+        }
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpus.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpus.cs
@@ -38,6 +38,7 @@ internal static class ProgressionCorpus
 
     public const string CorpusFileName = "progression-corpus.v1.json";
     public const string SchemaFileName = "progression-corpus.v1.schema.json";
+    public const string ReadmeFileName = "README.md";
 
     /// <summary>The twelve coverage categories required by GuitarAlchemist/ga#627.</summary>
     public static readonly IReadOnlyList<string> RequiredCategories =
@@ -71,6 +72,13 @@ internal static class ProgressionCorpus
     public static string CorpusPath => Path.Combine(Directory, CorpusFileName);
 
     public static string SchemaPath => Path.Combine(Directory, SchemaFileName);
+
+    /// <summary>
+    ///     The hand-written case index that ships beside the data. It is the
+    ///     in-repo "list of all cases" #627 asks for, so it is held to the data
+    ///     by a test rather than by care.
+    /// </summary>
+    public static string ReadmePath => Path.Combine(Directory, ReadmeFileName);
 
     /// <summary>
     ///     Where the machine-readable pass/fail matrix lives, alongside the other

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpus.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpus.cs
@@ -1,0 +1,236 @@
+namespace GA.Business.ML.Tests.Corpus;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+///     Deterministic loader for the held-out progression-to-voicing evaluation
+///     corpus (GuitarAlchemist/ga#627, story #623).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The corpus is evaluation data, not production configuration: no
+///         runtime code path reads it, and it deliberately states what a
+///         musically correct system must answer rather than what the product
+///         currently does. Keeping it under the test project - and off the
+///         <c>Common/GA.Business.Config</c> production-config tree - is the
+///         separation #627 asks for.
+///     </para>
+///     <para>
+///         Determinism means three things here, each pinned by a test:
+///         the file is located the same way regardless of build configuration
+///         (repo-root marker walk, same pattern as <c>RoutingEvalHarness</c>);
+///         cases are required to be stored in ascending id order, so iteration
+///         order is the file order is the sorted order; and no ambient state
+///         (clock, environment, culture) reaches the parsed result.
+///     </para>
+///     <para>
+///         No <c>.csproj</c> change accompanies this loader on purpose - the
+///         corpus is read from source rather than copied to the output
+///         directory, because <c>**/*.csproj</c> is a one-way-door path under
+///         <c>agent-blackbox.policy.json</c>.
+///     </para>
+/// </remarks>
+internal static class ProgressionCorpus
+{
+    /// <summary>The <c>schema_version</c> this loader understands.</summary>
+    public const string SupportedSchemaVersion = "1.0.0";
+
+    public const string CorpusFileName = "progression-corpus.v1.json";
+    public const string SchemaFileName = "progression-corpus.v1.schema.json";
+
+    /// <summary>The twelve coverage categories required by GuitarAlchemist/ga#627.</summary>
+    public static readonly IReadOnlyList<string> RequiredCategories =
+    [
+        "major-ii-V-I",
+        "minor-ii-V-i",
+        "major-I-vi-IV-V",
+        "deceptive-cadence",
+        "borrowed-iv",
+        "borrowed-bVII",
+        "secondary-dominant",
+        "modal",
+        "starts-away-from-tonic",
+        "spelled-out-accidentals",
+        "alternate-tuning",
+        "ambiguous"
+    ];
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = false,
+        ReadCommentHandling = JsonCommentHandling.Disallow,
+        NumberHandling = JsonNumberHandling.Strict
+    };
+
+    /// <summary>Absolute path of the directory holding the corpus and its schema.</summary>
+    public static string Directory { get; } = Path.Combine(
+        RepoRoot(), "Tests", "Common", "GA.Business.ML.Tests", "Corpus", "Progressions");
+
+    public static string CorpusPath => Path.Combine(Directory, CorpusFileName);
+
+    public static string SchemaPath => Path.Combine(Directory, SchemaFileName);
+
+    /// <summary>
+    ///     Where the machine-readable pass/fail matrix lives, alongside the other
+    ///     <c>state/quality</c> snapshots this repo keeps under version control.
+    /// </summary>
+    public static string EvidenceDirectory { get; } =
+        Path.Combine(RepoRoot(), "state", "quality", "progression-corpus");
+
+    public static string MatrixPath => Path.Combine(EvidenceDirectory, "progression-corpus-matrix.json");
+
+    /// <summary>Reads the corpus file verbatim. Throws an actionable error when it is missing.</summary>
+    public static string ReadCorpusText() => ReadRequired(CorpusPath, "corpus");
+
+    /// <summary>Reads the schema file verbatim. Throws an actionable error when it is missing.</summary>
+    public static string ReadSchemaText() => ReadRequired(SchemaPath, "schema");
+
+    /// <summary>Parses the corpus into a <see cref="JsonDocument" /> for schema validation.</summary>
+    public static JsonDocument LoadDocument() => JsonDocument.Parse(ReadCorpusText());
+
+    /// <summary>Parses the schema into a <see cref="JsonDocument" />.</summary>
+    public static JsonDocument LoadSchemaDocument() => JsonDocument.Parse(ReadSchemaText());
+
+    /// <summary>
+    ///     Deserialises the corpus and enforces the two invariants that make
+    ///     iteration deterministic: a supported schema version, and cases stored
+    ///     in ascending ordinal id order.
+    /// </summary>
+    public static ProgressionCorpusFile Load()
+    {
+        var file = JsonSerializer.Deserialize<ProgressionCorpusFile>(ReadCorpusText(), Options)
+                   ?? throw new InvalidOperationException($"{CorpusPath} deserialised to null");
+
+        if (file.SchemaVersion != SupportedSchemaVersion)
+        {
+            throw new InvalidOperationException(
+                $"{CorpusFileName} declares schema_version '{file.SchemaVersion}' but this loader " +
+                $"supports '{SupportedSchemaVersion}'. A schema bump needs a matching loader change.");
+        }
+
+        var ids = file.Cases.Select(c => c.Id).ToList();
+        var sorted = ids.OrderBy(id => id, StringComparer.Ordinal).ToList();
+        if (!ids.SequenceEqual(sorted, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"{CorpusFileName} stores cases out of order. Cases must be written in ascending " +
+                $"ordinal id order so that file order, iteration order and sort order are the same " +
+                $"thing. Got [{string.Join(", ", ids)}].");
+        }
+
+        return file;
+    }
+
+    private static string ReadRequired(string path, string what)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"progression {what} not found at '{path}'. Expected it under " +
+                $"Tests/Common/GA.Business.ML.Tests/Corpus/Progressions (GuitarAlchemist/ga#627).",
+                path);
+        }
+
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    ///     Walks up from the test bin directory to the repository root, matching
+    ///     <c>RoutingEvalHarness.ResolveQualityDir</c> so both harnesses agree on
+    ///     what "the repo" means regardless of build-config nesting.
+    /// </summary>
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (System.IO.Directory.Exists(Path.Combine(dir.FullName, ".git")) ||
+                File.Exists(Path.Combine(dir.FullName, "AllProjects.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"no repository root (.git or AllProjects.slnx) above '{AppContext.BaseDirectory}'");
+    }
+}
+
+// ── Parsed shape. Property names map to snake_case via JsonNamingPolicy. ──────
+
+public sealed record ProgressionCorpusFile(
+    string Schema,
+    string SchemaVersion,
+    string CorpusId,
+    string CorpusVersion,
+    string Status,
+    bool HeldOut,
+    string Issue,
+    string ParentIssue,
+    string Description,
+    IReadOnlyList<ProgressionCase> Cases);
+
+public sealed record ProgressionCase(
+    string Id,
+    string Category,
+    string Title,
+    CaseInput Input,
+    CaseExpected Expected,
+    CaseForbidden Forbidden,
+    CaseUncertainty Uncertainty,
+    CasePins Pins,
+    CaseProvenance Provenance);
+
+public sealed record CaseInput(
+    IReadOnlyList<string> Chords,
+    IReadOnlyList<string> CanonicalChords,
+    string Instrument,
+    CaseTuning Tuning,
+    string? KeyHint,
+    IReadOnlyList<SpellingGroup> SpellingEquivalenceGroups);
+
+public sealed record SpellingGroup(string Canonical, IReadOnlyList<string> Spellings);
+
+public sealed record CaseTuning(string Id, string Name, IReadOnlyList<string> OpenStrings);
+
+public sealed record CaseExpected(
+    string TonalCenter,
+    IReadOnlyList<string> AcceptableTonalCenters,
+    IReadOnlyList<string> RomanNumerals,
+    IReadOnlyList<IReadOnlyList<string>> AlternativeRomanNumerals,
+    IReadOnlyList<string> Functions,
+    IReadOnlyList<ScaleFamily> ScaleFamilies,
+    IReadOnlyList<ChordTones> RequiredChordTones,
+    IReadOnlyList<string> ExplanationFacts,
+    VoicingSequence VoicingSequence,
+    string? Notes);
+
+public sealed record ScaleFamily(string Chord, IReadOnlyList<string> Acceptable);
+
+public sealed record ChordTones(
+    string Chord,
+    string Quality,
+    string Root,
+    int RootPitchClass,
+    IReadOnlyList<int> PitchClasses,
+    IReadOnlyList<string> Notes);
+
+public sealed record VoicingSequence(string TuningId, IReadOnlyList<VoicingFrame> Frames);
+
+public sealed record VoicingFrame(
+    string Chord,
+    string ShapeFamily,
+    IReadOnlyList<int?> FretsLowToHigh,
+    IReadOnlyList<int> SoundedPitchClasses);
+
+public sealed record CaseForbidden(IReadOnlyList<string> TonalCenters, IReadOnlyList<string> Facts);
+
+public sealed record CaseUncertainty(string ExpectedBehavior, int MinAlternatives, double? MaxConfidence);
+
+public sealed record CasePins(IReadOnlyList<int> Issues, string? Rationale);
+
+public sealed record CaseProvenance(string Source, string AddedIn, string Rationale);

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusLoaderTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusLoaderTests.cs
@@ -1,0 +1,123 @@
+namespace GA.Business.ML.Tests.Corpus;
+
+using System.Text.Json;
+
+/// <summary>
+///     Loader and schema-conformance gate for the held-out progression corpus
+///     (GuitarAlchemist/ga#627).
+/// </summary>
+/// <remarks>
+///     These tests are the corpus's own contract: the file must exist where the
+///     loader looks, parse deterministically, and satisfy every constraint the
+///     language-neutral schema states. They say nothing about whether the
+///     product answers the cases correctly - that is
+///     <see cref="ProgressionCorpusMatrixTests" />.
+/// </remarks>
+[TestFixture]
+public class ProgressionCorpusLoaderTests
+{
+    [Test]
+    public void SchemaFile_Exists() =>
+        Assert.That(File.Exists(ProgressionCorpus.SchemaPath), Is.True,
+            $"expected the corpus schema at {ProgressionCorpus.SchemaPath}");
+
+    [Test]
+    public void CorpusFile_Exists() =>
+        Assert.That(File.Exists(ProgressionCorpus.CorpusPath), Is.True,
+            $"expected the corpus at {ProgressionCorpus.CorpusPath}");
+
+    /// <summary>
+    ///     The in-repo validator implements a closed set of keywords. If the
+    ///     schema grows one it does not implement, the validator would silently
+    ///     ignore that constraint and report a false pass - so fail here first.
+    /// </summary>
+    [Test]
+    public void Schema_StaysInsideTheValidatorsSupportedKeywordSet()
+    {
+        using var schema = ProgressionCorpus.LoadSchemaDocument();
+        var used = JsonSchemaSubsetValidator.CollectKeywords(schema.RootElement);
+        var unsupported = used.Except(JsonSchemaSubsetValidator.SupportedKeywords).Order(StringComparer.Ordinal).ToList();
+
+        Assert.That(unsupported, Is.Empty,
+            "the schema uses keywords JsonSchemaSubsetValidator does not implement: " +
+            string.Join(", ", unsupported));
+    }
+
+    [Test]
+    public void Corpus_ValidatesAgainstItsSchema()
+    {
+        using var corpus = ProgressionCorpus.LoadDocument();
+        using var schema = ProgressionCorpus.LoadSchemaDocument();
+
+        var errors = JsonSchemaSubsetValidator.Validate(corpus.RootElement, schema.RootElement);
+
+        Assert.That(errors, Is.Empty,
+            "corpus violates progression-corpus.v1.schema.json:" + Environment.NewLine +
+            string.Join(Environment.NewLine, errors));
+    }
+
+    [Test]
+    public void Corpus_DeclaresTheSchemaFileItValidatesAgainst()
+    {
+        var corpus = ProgressionCorpus.Load();
+        Assert.Multiple(() =>
+        {
+            Assert.That(corpus.Schema, Is.EqualTo(ProgressionCorpus.SchemaFileName));
+            Assert.That(corpus.SchemaVersion, Is.EqualTo(ProgressionCorpus.SupportedSchemaVersion));
+            Assert.That(corpus.CorpusId, Is.EqualTo("progression-to-voicing"));
+            Assert.That(corpus.HeldOut, Is.True, "the corpus must be marked held-out");
+            Assert.That(corpus.Status, Is.EqualTo("draft"),
+                "v0.1.x-style drafts stay draft until the Phase 4 milestone of #623");
+        });
+    }
+
+    [Test]
+    public void Load_ReturnsAtLeastTwelveCases() =>
+        Assert.That(ProgressionCorpus.Load().Cases, Has.Count.GreaterThanOrEqualTo(12));
+
+    [Test]
+    public void Load_IsDeterministic()
+    {
+        var first = JsonSerializer.Serialize(ProgressionCorpus.Load());
+        var second = JsonSerializer.Serialize(ProgressionCorpus.Load());
+
+        Assert.That(second, Is.EqualTo(first), "two loads of the same file must be identical");
+    }
+
+    [Test]
+    public void Load_ReturnsCasesInAscendingIdOrder()
+    {
+        var ids = ProgressionCorpus.Load().Cases.Select(c => c.Id).ToList();
+
+        Assert.That(ids, Is.EqualTo(ids.OrderBy(id => id, StringComparer.Ordinal).ToList()),
+            "file order must equal sorted order so iteration is reproducible");
+    }
+
+    [Test]
+    public void Load_RejectsAnUnsupportedSchemaVersion()
+    {
+        // The guard lives in Load(); exercising it via a doctored copy would need
+        // a second file, so assert the constant the guard compares against is the
+        // one the corpus actually declares. Drift here is the failure mode.
+        using var corpus = ProgressionCorpus.LoadDocument();
+        Assert.That(corpus.RootElement.GetProperty("schema_version").GetString(),
+            Is.EqualTo(ProgressionCorpus.SupportedSchemaVersion));
+    }
+
+    /// <summary>
+    ///     Guards against mojibake. The corpus is read by C#, Python and (later)
+    ///     Rust tooling; smart quotes and en-dashes have already produced silent
+    ///     encoding damage in this repo's snapshot files.
+    /// </summary>
+    [Test]
+    public void CorpusAndSchema_AreAsciiOnly()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(ProgressionCorpus.ReadCorpusText().All(char.IsAscii), Is.True,
+                $"{ProgressionCorpus.CorpusFileName} must stay ASCII-only");
+            Assert.That(ProgressionCorpus.ReadSchemaText().All(char.IsAscii), Is.True,
+                $"{ProgressionCorpus.SchemaFileName} must stay ASCII-only");
+        });
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusMatrixTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusMatrixTests.cs
@@ -1,0 +1,481 @@
+namespace GA.Business.ML.Tests.Corpus;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GA.Business.ML.Agents;
+using GA.Business.ML.Agents.Skills;
+using GA.Domain.Core.Primitives.Notes;
+
+/// <summary>
+///     Runs the held-out corpus against the deterministic seams that exist
+///     today and reports a pass/fail matrix, without touching production
+///     behaviour.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The corpus states what a musically correct system must answer. The
+///         product does not answer all of it yet - #614, #567 and #554 are open.
+///         So this fixture does two separate jobs, and keeping them separate is
+///         what lets the expectations stay strict:
+///     </para>
+///     <list type="number">
+///         <item>
+///             It computes the matrix and writes it as machine-readable evidence
+///             (<c>state/quality/progression-corpus/progression-corpus-matrix.json</c>),
+///             recording every check as pass, fail or blocked with the issue it
+///             is blocked on.
+///         </item>
+///         <item>
+///             It gates on <em>movement</em> against the committed matrix: a
+///             check that passes today and fails tomorrow fails the build. A
+///             check that is failing today keeps failing without breaking the
+///             build, because the honest answer is "the product is wrong here",
+///             not "the expectation was too strict".
+///         </item>
+///     </list>
+///     <para>
+///         No key detection or harmonic analysis is re-implemented here. Each
+///         check calls one production seam and compares its output to corpus
+///         data. Where no seam exists yet, the check is recorded as
+///         <c>blocked</c> rather than quietly omitted.
+///     </para>
+///     <para>
+///         Regenerate the artifact after an intentional change with
+///         <c>GA_CORPUS_WRITE_MATRIX=1 dotnet test --filter
+///         FullyQualifiedName~ProgressionCorpusMatrixTests</c>, then commit the
+///         updated file.
+///     </para>
+/// </remarks>
+[TestFixture]
+public class ProgressionCorpusMatrixTests
+{
+    private const string Pass = "pass";
+    private const string Fail = "fail";
+    private const string Blocked = "blocked";
+
+    private const string WriteEnvVar = "GA_CORPUS_WRITE_MATRIX";
+
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static readonly JsonSerializerOptions ReadOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    /// <summary>Corpus quality label to the quality the improvisation seam should infer.</summary>
+    private static readonly IReadOnlyDictionary<string, ImprovisationSkill.QualityKind> ExpectedQualityKind =
+        new Dictionary<string, ImprovisationSkill.QualityKind>
+        {
+            ["major-triad"] = ImprovisationSkill.QualityKind.Major,
+            ["minor-triad"] = ImprovisationSkill.QualityKind.Minor,
+            ["dominant-7"] = ImprovisationSkill.QualityKind.Dominant7,
+            ["major-7"] = ImprovisationSkill.QualityKind.Major7,
+            ["minor-7"] = ImprovisationSkill.QualityKind.Minor7,
+            ["half-diminished-7"] = ImprovisationSkill.QualityKind.HalfDiminished
+        };
+
+    // ── The matrix ───────────────────────────────────────────────────────────
+
+    [Test]
+    public void Matrix_IsDeterministic()
+    {
+        var first = JsonSerializer.Serialize(BuildMatrix(), WriteOptions);
+        var second = JsonSerializer.Serialize(BuildMatrix(), WriteOptions);
+
+        Assert.That(second, Is.EqualTo(first),
+            "the matrix must depend only on the corpus and the seams, never on ambient state");
+    }
+
+    [Test]
+    public void Matrix_CoversEveryCaseAndEveryDeclaredCheck()
+    {
+        var matrix = BuildMatrix();
+        var corpus = ProgressionCorpus.Load();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matrix.Cases.Select(c => c.Id),
+                Is.EqualTo(corpus.Cases.Select(c => c.Id)),
+                "every corpus case must appear in the matrix, in corpus order");
+
+            foreach (var c in matrix.Cases)
+                Assert.That(c.Checks, Is.Not.Empty, $"{c.Id}: no checks recorded");
+
+            Assert.That(matrix.Totals.Pass + matrix.Totals.Fail + matrix.Totals.Blocked,
+                Is.EqualTo(matrix.Cases.Sum(c => c.Checks.Count)), "totals must reconcile");
+        });
+    }
+
+    /// <summary>
+    ///     Writes the evidence artifact. Opt-in, so an ordinary test run never
+    ///     dirties the working tree.
+    /// </summary>
+    [Test]
+    public void Matrix_WriteEvidenceArtifact()
+    {
+        if (Environment.GetEnvironmentVariable(WriteEnvVar) != "1")
+        {
+            Assert.Ignore($"set {WriteEnvVar}=1 to regenerate {ProgressionCorpus.MatrixPath}");
+            return;
+        }
+
+        System.IO.Directory.CreateDirectory(ProgressionCorpus.EvidenceDirectory);
+        File.WriteAllText(
+            ProgressionCorpus.MatrixPath,
+            JsonSerializer.Serialize(BuildMatrix(), WriteOptions) + Environment.NewLine);
+
+        TestContext.Out.WriteLine($"wrote {ProgressionCorpus.MatrixPath}");
+    }
+
+    /// <summary>
+    ///     The regression gate. Anything that passes in the committed matrix must
+    ///     still pass; anything that starts passing is reported so the artifact
+    ///     can be refreshed, but does not fail the build.
+    /// </summary>
+    [Test]
+    public void Matrix_HasNotRegressedAgainstTheCommittedArtifact()
+    {
+        if (!File.Exists(ProgressionCorpus.MatrixPath))
+        {
+            Assert.Fail(
+                $"no committed matrix at {ProgressionCorpus.MatrixPath}. " +
+                $"Generate it with {WriteEnvVar}=1 and commit the result.");
+        }
+
+        var committed = JsonSerializer.Deserialize<Matrix>(
+                            File.ReadAllText(ProgressionCorpus.MatrixPath), ReadOptions)
+                        ?? throw new InvalidOperationException("committed matrix deserialised to null");
+
+        var current = BuildMatrix();
+
+        var committedByKey = Flatten(committed);
+        var currentByKey = Flatten(current);
+
+        var missing = committedByKey.Keys.Except(currentByKey.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
+        var added = currentByKey.Keys.Except(committedByKey.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
+
+        var regressions = committedByKey
+            .Where(kv => kv.Value == Pass &&
+                         currentByKey.TryGetValue(kv.Key, out var now) && now != Pass)
+            .Select(kv => $"{kv.Key}: pass -> {currentByKey[kv.Key]}")
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        var improvements = committedByKey
+            .Where(kv => kv.Value != Pass &&
+                         currentByKey.TryGetValue(kv.Key, out var now) && now == Pass)
+            .Select(kv => $"{kv.Key}: {kv.Value} -> pass")
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var improvement in improvements)
+            TestContext.Out.WriteLine($"IMPROVED {improvement}");
+
+        if (improvements.Count > 0)
+        {
+            TestContext.Out.WriteLine(
+                $"{improvements.Count} check(s) now pass. Refresh the artifact with {WriteEnvVar}=1.");
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(regressions, Is.Empty,
+                "checks that used to pass now fail:" + Environment.NewLine +
+                string.Join(Environment.NewLine, regressions));
+            Assert.That(missing, Is.Empty,
+                $"checks in the committed matrix vanished (regenerate with {WriteEnvVar}=1): " +
+                string.Join(", ", missing));
+            Assert.That(added, Is.Empty,
+                $"new checks are not in the committed matrix (regenerate with {WriteEnvVar}=1): " +
+                string.Join(", ", added));
+        });
+    }
+
+    /// <summary>
+    ///     Reports the current state as readable output, so a run of this fixture
+    ///     is a usable status report and not only a gate.
+    /// </summary>
+    [Test]
+    public void Matrix_ReportCurrentState()
+    {
+        var matrix = BuildMatrix();
+
+        TestContext.Out.WriteLine(
+            $"progression corpus {matrix.CorpusVersion} - " +
+            $"{matrix.Totals.Pass} pass / {matrix.Totals.Fail} fail / {matrix.Totals.Blocked} blocked");
+
+        foreach (var c in matrix.Cases)
+        {
+            TestContext.Out.WriteLine($"  {c.Id} [{c.Category}]");
+            foreach (var check in c.Checks)
+            {
+                var suffix = check.BlockedOn is { Count: > 0 }
+                    ? $" (blocked on {string.Join(", ", check.BlockedOn.Select(i => "#" + i))})"
+                    : string.Empty;
+                TestContext.Out.WriteLine($"    {check.Status,-7} {check.CheckName}{suffix} :: {check.Observed}");
+            }
+        }
+
+        Assert.Pass();
+    }
+
+    // ── Matrix construction ──────────────────────────────────────────────────
+
+    private static Dictionary<string, string> Flatten(Matrix matrix) =>
+        matrix.Cases
+            .SelectMany(c => c.Checks.Select(ch => (Key: $"{c.Id}/{ch.CheckName}", ch.Status)))
+            .ToDictionary(x => x.Key, x => x.Status, StringComparer.Ordinal);
+
+    private static Matrix BuildMatrix()
+    {
+        var corpus = ProgressionCorpus.Load();
+        var cases = corpus.Cases.Select(BuildCase).ToList();
+        var all = cases.SelectMany(c => c.Checks).ToList();
+
+        return new Matrix(
+            Artifact: "progression-corpus-matrix",
+            ArtifactVersion: "1.0.0",
+            Issue: corpus.Issue,
+            ParentIssue: corpus.ParentIssue,
+            CorpusId: corpus.CorpusId,
+            CorpusVersion: corpus.CorpusVersion,
+            SchemaVersion: corpus.SchemaVersion,
+            Note: "Deterministic: no clock, no network, no randomness. Regenerate with " +
+                  $"{WriteEnvVar}=1. 'blocked' means no deterministic seam exists in this " +
+                  "assembly yet, not that the expectation is optional.",
+            Seams: Seams,
+            Totals: new Totals(
+                all.Count(c => c.Status == Pass),
+                all.Count(c => c.Status == Fail),
+                all.Count(c => c.Status == Blocked)),
+            Cases: cases);
+    }
+
+    private static readonly IReadOnlyList<Seam> Seams =
+    [
+        new("key.identify", "GA.Business.ML.Agents.KeyIdentificationService.Identify",
+            "Scores all 30 major/minor keys on root + triad quality. Cannot express modal centres."),
+        new("improvisation.quality", "GA.Business.ML.Agents.Skills.ImprovisationSkill.InferQuality",
+            "Classifies chord quality from the written symbol."),
+        new("improvisation.arpeggio", "GA.Business.ML.Agents.Skills.ImprovisationSkill.ArpeggioFor",
+            "Builds the canonical arpeggio symbol for a root plus quality."),
+        new("tuning.parse", "GA.Domain.Core.Primitives.Notes.PitchCollection.Parse",
+            "Parses scientific-pitch open strings into domain pitches.")
+    ];
+
+    private static MatrixCase BuildCase(ProgressionCase c)
+    {
+        var checks = new List<CheckResult>();
+        checks.AddRange(KeyChecks(c));
+        checks.AddRange(ImprovisationChecks(c));
+        checks.AddRange(SpellingChecks(c));
+        checks.Add(TuningCheck(c));
+        checks.AddRange(BlockedChecks());
+
+        return new MatrixCase(c.Id, c.Category, checks.OrderBy(x => x.CheckName, StringComparer.Ordinal).ToList());
+    }
+
+    private static IEnumerable<CheckResult> KeyChecks(ProgressionCase c)
+    {
+        var candidates = KeyIdentificationService.Identify(c.Input.CanonicalChords);
+        var topScore = candidates.Count == 0 ? 0 : candidates.Max(x => x.MatchCount);
+        var topTied = candidates.Where(x => x.MatchCount == topScore)
+            .Select(x => x.Key).Order(StringComparer.Ordinal).ToList();
+        var observed = topTied.Count == 0 ? "(no candidate)" : string.Join(" | ", topTied);
+
+        yield return new CheckResult(
+            "key.top_candidate_acceptable", "key.identify",
+            topTied.Intersect(c.Expected.AcceptableTonalCenters, StringComparer.OrdinalIgnoreCase).Any()
+                ? Pass : Fail,
+            $"top-tied: {observed}",
+            $"one of: {string.Join(" | ", c.Expected.AcceptableTonalCenters)}",
+            BlockedOn: null);
+
+        var forbiddenHits = topTied
+            .Intersect(c.Forbidden.TonalCenters, StringComparer.OrdinalIgnoreCase).ToList();
+
+        yield return new CheckResult(
+            "key.forbidden_center_excluded", "key.identify",
+            forbiddenHits.Count == 0 ? Pass : Fail,
+            forbiddenHits.Count == 0 ? $"top-tied: {observed}" : $"forbidden in top-tied: {string.Join(" | ", forbiddenHits)}",
+            $"none of: {string.Join(" | ", c.Forbidden.TonalCenters)}",
+            BlockedOn: null);
+
+        if (c.Uncertainty.ExpectedBehavior == "confident")
+        {
+            yield return new CheckResult(
+                "key.single_reading_when_confident", "key.identify",
+                topTied.Count == 1 ? Pass : Fail,
+                $"{topTied.Count} tied candidate(s): {observed}",
+                "exactly 1 top candidate",
+                BlockedOn: null);
+        }
+        else
+        {
+            var offersAll = c.Expected.AcceptableTonalCenters
+                .All(a => topTied.Contains(a, StringComparer.OrdinalIgnoreCase));
+
+            yield return new CheckResult(
+                "key.alternatives_when_ambiguous", "key.identify",
+                topTied.Count >= c.Uncertainty.MinAlternatives && offersAll ? Pass : Fail,
+                $"{topTied.Count} tied candidate(s): {observed}",
+                $"at least {c.Uncertainty.MinAlternatives}, including all of: " +
+                string.Join(" | ", c.Expected.AcceptableTonalCenters),
+                BlockedOn: null);
+        }
+    }
+
+    private static IEnumerable<CheckResult> ImprovisationChecks(ProgressionCase c)
+    {
+        var qualityMismatches = new List<string>();
+        var forbiddenArpeggios = new List<string>();
+
+        for (var i = 0; i < c.Input.CanonicalChords.Count; i++)
+        {
+            var symbol = c.Input.CanonicalChords[i];
+            var quality = ImprovisationSkill.InferQuality(symbol);
+            var expectedKind = ExpectedQualityKind[c.Expected.RequiredChordTones[i].Quality];
+
+            if (quality.Kind != expectedKind)
+                qualityMismatches.Add($"{symbol}: {quality.Kind} != {expectedKind}");
+
+            var arpeggio = ImprovisationSkill.ArpeggioFor(ImprovisationSkill.ExtractRoot(symbol), quality);
+            var hit = c.Forbidden.Facts.FirstOrDefault(f =>
+                arpeggio.Contains(f, StringComparison.OrdinalIgnoreCase));
+            if (hit is not null)
+                forbiddenArpeggios.Add($"{symbol} -> '{arpeggio}' contains forbidden '{hit}'");
+        }
+
+        yield return new CheckResult(
+            "improvisation.quality_from_written_symbol", "improvisation.quality",
+            qualityMismatches.Count == 0 ? Pass : Fail,
+            qualityMismatches.Count == 0 ? "all chord qualities classified from the written symbol"
+                : string.Join("; ", qualityMismatches),
+            "each chord's inferred quality matches the quality written in the symbol",
+            BlockedOn: null);
+
+        yield return new CheckResult(
+            "improvisation.arpeggio_symbol_is_canonical", "improvisation.arpeggio",
+            forbiddenArpeggios.Count == 0 ? Pass : Fail,
+            forbiddenArpeggios.Count == 0 ? "no arpeggio symbol matched a forbidden fact"
+                : string.Join("; ", forbiddenArpeggios),
+            "no arpeggio symbol contains a forbidden string (e.g. the #567 'Amm7' concatenation)",
+            BlockedOn: null);
+    }
+
+    private static IEnumerable<CheckResult> SpellingChecks(ProgressionCase c)
+    {
+        if (c.Input.SpellingEquivalenceGroups.Count == 0) yield break;
+
+        var disagreements = new List<string>();
+
+        foreach (var group in c.Input.SpellingEquivalenceGroups)
+        {
+            var reference = Fingerprint(group.Canonical);
+            foreach (var spelling in group.Spellings.Where(s => s != group.Canonical))
+            {
+                var actual = Fingerprint(spelling);
+                if (actual != reference)
+                    disagreements.Add($"'{spelling}' -> {actual} != '{group.Canonical}' -> {reference}");
+            }
+        }
+
+        yield return new CheckResult(
+            "spelling.equivalent_spellings_agree", "key.identify",
+            disagreements.Count == 0 ? Pass : Fail,
+            disagreements.Count == 0 ? "every spelling resolved identically to its canonical form"
+                : string.Join("; ", disagreements),
+            "spelled-out and shorthand accidentals resolve identically (GuitarAlchemist/ga#554)",
+            BlockedOn: disagreements.Count == 0 ? null : [554]);
+
+        static string Fingerprint(string chordSymbol)
+        {
+            var candidates = KeyIdentificationService.Identify([chordSymbol]);
+            if (candidates.Count == 0) return "(unparsed)";
+
+            var top = candidates.Max(x => x.MatchCount);
+            return string.Join(",", candidates.Where(x => x.MatchCount == top)
+                .Select(x => x.Key).Order(StringComparer.Ordinal));
+        }
+    }
+
+    private static CheckResult TuningCheck(ProgressionCase c)
+    {
+        var text = string.Join(" ", c.Input.Tuning.OpenStrings);
+        var expected = c.Input.Tuning.OpenStrings.Select(CorpusPitchMath.MidiOf).ToList();
+
+        if (!PitchCollection.TryParse(text, null, out var parsed))
+        {
+            return new CheckResult("tuning.domain_parses_open_strings", "tuning.parse", Fail,
+                $"PitchCollection.Parse rejected '{text}'", $"MIDI {string.Join(",", expected)}", null);
+        }
+
+        var actual = parsed.Select(p => p.MidiNote.Value).ToList();
+
+        return new CheckResult(
+            "tuning.domain_parses_open_strings", "tuning.parse",
+            actual.SequenceEqual(expected) ? Pass : Fail,
+            $"'{text}' -> MIDI {string.Join(",", actual)}",
+            $"MIDI {string.Join(",", expected)}",
+            BlockedOn: null);
+    }
+
+    /// <summary>
+    ///     Expectations the corpus states but no seam in this assembly can answer
+    ///     yet. Recorded rather than dropped, so the artifact shows the real size
+    ///     of the remaining work instead of a flattering subset.
+    /// </summary>
+    private static IEnumerable<CheckResult> BlockedChecks()
+    {
+        yield return BlockedCheck("analysis.roman_numerals",
+            "no seam produces Roman numerals for a progression", [623, 614]);
+        yield return BlockedCheck("analysis.chord_functions",
+            "no seam assigns harmonic function per chord", [623, 614]);
+        yield return BlockedCheck("analysis.scale_families",
+            "no seam produces per-chord scale choices in the context of a key", [623, 567]);
+        yield return BlockedCheck("explanation.required_facts",
+            "explanation grading needs the #623 orchestration path plus a judge", [623]);
+        yield return BlockedCheck("uncertainty.behavior",
+            "no seam reports alternatives, warnings or abstention for a progression", [623]);
+        yield return BlockedCheck("voicing.product_generates_valid_path",
+            "no seam generates a voicing path for a progression in a given tuning", [623]);
+
+        static CheckResult BlockedCheck(string name, string why, int[] blockedOn) =>
+            new(name, null, Blocked, why, "see the corpus expectation for this case", blockedOn);
+    }
+
+    // ── Artifact shape ───────────────────────────────────────────────────────
+
+    public sealed record Matrix(
+        string Artifact,
+        string ArtifactVersion,
+        string Issue,
+        string ParentIssue,
+        string CorpusId,
+        string CorpusVersion,
+        string SchemaVersion,
+        string Note,
+        IReadOnlyList<Seam> Seams,
+        Totals Totals,
+        IReadOnlyList<MatrixCase> Cases);
+
+    public sealed record Seam(string Id, string Implementation, string Notes);
+
+    public sealed record Totals(int Pass, int Fail, int Blocked);
+
+    public sealed record MatrixCase(string Id, string Category, IReadOnlyList<CheckResult> Checks);
+
+    /// <summary>One seam probe against one case. <c>CheckName</c> serialises as <c>check</c>.</summary>
+    public sealed record CheckResult(
+        [property: JsonPropertyName("check")] string CheckName,
+        string? Seam,
+        string Status,
+        string Observed,
+        string Expected,
+        IReadOnlyList<int>? BlockedOn);
+}

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusMatrixTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusMatrixTests.cs
@@ -237,6 +237,136 @@ public class ProgressionCorpusMatrixTests
         Assert.Pass();
     }
 
+    // ── Cells whose pass must mean what it says ──────────────────────────────
+
+    /// <summary>
+    ///     Negative control for the empty-seam-result path. "No forbidden centre
+    ///     appeared in the top tie" is vacuously true when the seam produced no
+    ///     candidate at all, so recording a pass there reports success for an
+    ///     input the product could not answer. It is worse than an odd cell on
+    ///     <c>pc-02</c>, whose sibling <c>key.top_candidate_acceptable</c> is
+    ///     already failing: a total parse regression would move neither cell and
+    ///     emit no gate signal at all.
+    /// </summary>
+    /// <remarks>
+    ///     Replayed rather than provoked, because no corpus case makes the seam
+    ///     return nothing today - which is why the false pass was invisible.
+    /// </remarks>
+    [Test]
+    public void ForbiddenCenterCell_FailsClosedOnAnEmptySeamResult()
+    {
+        Assert.That(KeyIdentificationService.Identify(["N.C."]), Is.Empty,
+            "the empty-result path must be reachable, or this control means nothing");
+
+        Assert.Multiple(() =>
+        {
+            foreach (var c in ProgressionCorpus.Load().Cases)
+            {
+                var cell = ForbiddenCenterCell(c, []);
+
+                Assert.That(cell.Status, Is.EqualTo(Fail),
+                    $"{c.Id}: an empty candidate set must not pass key.forbidden_center_excluded");
+                Assert.That(cell.Observed, Is.EqualTo("(no candidate)"),
+                    $"{c.Id}: the cell must say the seam answered nothing");
+            }
+        });
+    }
+
+    /// <summary>
+    ///     The discriminating half of the control above: failing closed must not
+    ///     become failing always. A non-empty result that avoids every forbidden
+    ///     centre still passes.
+    /// </summary>
+    [Test]
+    public void ForbiddenCenterCell_StillPassesOnACleanNonEmptyResult() =>
+        Assert.Multiple(() =>
+        {
+            foreach (var c in ProgressionCorpus.Load().Cases)
+            {
+                var acceptable = c.Expected.AcceptableTonalCenters[0];
+                var cell = ForbiddenCenterCell(c, [Candidate(acceptable)]);
+
+                Assert.That(cell.Status, Is.EqualTo(Pass),
+                    $"{c.Id}: '{acceptable}' is not forbidden, so the cell must still pass");
+            }
+        });
+
+    /// <summary>
+    ///     #623 and #614 replace the relative-key scoring tie with a functional
+    ///     reading. That collapse is the intended improvement, and it must not be
+    ///     scorable as a <c>pass -&gt; fail</c> product regression on the corpus's
+    ///     one ambiguity cell. Replays every tie width, including the collapsed
+    ///     and empty ones no seam can produce today.
+    /// </summary>
+    [Test]
+    public void AmbiguityCell_IsBlockedForEveryScoringTieWidth()
+    {
+        var ambiguous = ProgressionCorpus.Load().Cases
+            .Where(c => c.Uncertainty.ExpectedBehavior != "confident").ToList();
+
+        Assert.That(ambiguous, Is.Not.Empty, "#627 requires an intentionally ambiguous case");
+
+        IReadOnlyList<KeyIdentificationService.KeyCandidate>[] replays =
+        [
+            [],                                                             // seam parsed nothing
+            [Candidate("C major")],                                         // tie collapsed by the #623 fix
+            [Candidate("A minor"), Candidate("C major")],                   // today's accidental tie
+            [Candidate("A minor"), Candidate("C major"), Candidate("F major")]
+        ];
+
+        Assert.Multiple(() =>
+        {
+            foreach (var c in ambiguous)
+            foreach (var candidates in replays)
+            {
+                var cell = KeyChecks(c, candidates)
+                    .Single(x => x.CheckName == "key.alternatives_when_ambiguous");
+
+                Assert.That(cell.Status, Is.EqualTo(Blocked),
+                    $"{c.Id} with {candidates.Count} candidate(s): a bare scoring tie is not an " +
+                    "explicit alternatives or abstention signal, so it cannot be scored either way");
+                Assert.That(cell.BlockedOn, Is.EqualTo(new[] { 623 }),
+                    $"{c.Id}: the ambiguity seam is the one #623 has to supply");
+            }
+        });
+    }
+
+    /// <summary>
+    ///     The artifact must not contradict itself: a case cannot record
+    ///     "no seam reports alternatives, warnings or abstention" and a passing
+    ///     alternatives cell for the same seam in the same run.
+    /// </summary>
+    [Test]
+    public void AmbiguityCell_AgreesWithTheSiblingUncertaintyCell()
+    {
+        var matrix = BuildMatrix();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var c in matrix.Cases)
+            {
+                var alternatives = c.Checks.FirstOrDefault(x => x.CheckName == "key.alternatives_when_ambiguous");
+                if (alternatives is null) continue;
+
+                var uncertainty = c.Checks.Single(x => x.CheckName == "uncertainty.behavior");
+
+                Assert.That(alternatives.Status, Is.EqualTo(uncertainty.Status),
+                    $"{c.Id}: key.alternatives_when_ambiguous and uncertainty.behavior describe the " +
+                    "same missing capability and must report the same status");
+                Assert.That(alternatives.BlockedOn, Is.EqualTo(uncertainty.BlockedOn),
+                    $"{c.Id}: both cells wait on the same issue");
+            }
+        });
+    }
+
+    private static CheckResult ForbiddenCenterCell(
+        ProgressionCase c, IReadOnlyList<KeyIdentificationService.KeyCandidate> candidates) =>
+        KeyChecks(c, candidates).Single(x => x.CheckName == "key.forbidden_center_excluded");
+
+    /// <summary>A seam result standing in for one scored key, for replay only.</summary>
+    private static KeyIdentificationService.KeyCandidate Candidate(string key) =>
+        new(key, RelativeKey: string.Empty, MatchCount: 1, TotalChords: 1, DiatonicSet: []);
+
     // ── Matrix construction ──────────────────────────────────────────────────
 
     private static Dictionary<string, string> Flatten(Matrix matrix) =>
@@ -293,9 +423,19 @@ public class ProgressionCorpusMatrixTests
         return new MatrixCase(c.Id, c.Category, checks.OrderBy(x => x.CheckName, StringComparer.Ordinal).ToList());
     }
 
-    private static IEnumerable<CheckResult> KeyChecks(ProgressionCase c)
+    private static IEnumerable<CheckResult> KeyChecks(ProgressionCase c) =>
+        KeyChecks(c, KeyIdentificationService.Identify(c.Input.CanonicalChords));
+
+    /// <summary>
+    ///     Scores the key cells from a seam result. The seam call is split out so
+    ///     a test can replay a synthetic result - in particular the empty result
+    ///     and the collapsed single reading - without waiting for the product to
+    ///     produce one. Neither state is reachable from any corpus case today,
+    ///     which is precisely why they went unscored.
+    /// </summary>
+    private static IEnumerable<CheckResult> KeyChecks(
+        ProgressionCase c, IReadOnlyList<KeyIdentificationService.KeyCandidate> candidates)
     {
-        var candidates = KeyIdentificationService.Identify(c.Input.CanonicalChords);
         var topScore = candidates.Count == 0 ? 0 : candidates.Max(x => x.MatchCount);
         var topTied = candidates.Where(x => x.MatchCount == topScore)
             .Select(x => x.Key).Order(StringComparer.Ordinal).ToList();
@@ -312,11 +452,17 @@ public class ProgressionCorpusMatrixTests
         var forbiddenHits = topTied
             .Intersect(c.Forbidden.TonalCenters, StringComparer.OrdinalIgnoreCase).ToList();
 
+        // Fails closed on an empty candidate set: "no forbidden centre appeared"
+        // is vacuously true when the seam answered nothing, and a pass there
+        // would report success for a total parse failure. See
+        // ForbiddenCenterCell_FailsClosedOnAnEmptySeamResult.
         yield return new CheckResult(
             "key.forbidden_center_excluded", "key.identify",
-            forbiddenHits.Count == 0 ? Pass : Fail,
-            forbiddenHits.Count == 0 ? $"top-tied: {observed}" : $"forbidden in top-tied: {string.Join(" | ", forbiddenHits)}",
-            $"none of: {string.Join(" | ", c.Forbidden.TonalCenters)}",
+            topTied.Count > 0 && forbiddenHits.Count == 0 ? Pass : Fail,
+            topTied.Count == 0 ? observed
+                : forbiddenHits.Count == 0 ? $"top-tied: {observed}"
+                : $"forbidden in top-tied: {string.Join(" | ", forbiddenHits)}",
+            $"at least one candidate, and none of: {string.Join(" | ", c.Forbidden.TonalCenters)}",
             BlockedOn: null);
 
         if (c.Uncertainty.ExpectedBehavior == "confident")
@@ -330,16 +476,23 @@ public class ProgressionCorpusMatrixTests
         }
         else
         {
-            var offersAll = c.Expected.AcceptableTonalCenters
-                .All(a => topTied.Contains(a, StringComparer.OrdinalIgnoreCase));
-
+            // #627 asks whether an ambiguous progression is answered with
+            // explicit alternatives or an abstention. No seam in this assembly
+            // reports either - which is what the sibling uncertainty.behavior
+            // cell already records as blocked on #623. The only thing observable
+            // here is a bare relative-key scoring tie, the same artefact that
+            // fails eleven key.single_reading_when_confident cells; scoring it as
+            // a pass would contradict that sibling cell and would turn the #623
+            // fix, which collapses the tie to one reading, into a build-failing
+            // pass -> fail regression. The tie width is deliberately kept out of
+            // this cell. See AmbiguityCell_IsBlockedForEveryScoringTieWidth.
             yield return new CheckResult(
-                "key.alternatives_when_ambiguous", "key.identify",
-                topTied.Count >= c.Uncertainty.MinAlternatives && offersAll ? Pass : Fail,
-                $"{topTied.Count} tied candidate(s): {observed}",
-                $"at least {c.Uncertainty.MinAlternatives}, including all of: " +
+                "key.alternatives_when_ambiguous", null, Blocked,
+                "no seam reports alternatives, warnings or abstention for a progression; " +
+                "a bare relative-key scoring tie is not an ambiguity signal",
+                $"at least {c.Uncertainty.MinAlternatives} explicit alternatives, including all of: " +
                 string.Join(" | ", c.Expected.AcceptableTonalCenters),
-                BlockedOn: null);
+                BlockedOn: [623]);
         }
     }
 

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusMatrixTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusMatrixTests.cs
@@ -79,6 +79,19 @@ public class ProgressionCorpusMatrixTests
             ["half-diminished-7"] = ImprovisationSkill.QualityKind.HalfDiminished
         };
 
+    /// <summary>
+    ///     Snapshot of the committed artifact taken before any test can rewrite
+    ///     it, so <see cref="Matrix_WriteEvidenceArtifact" /> cannot influence the
+    ///     regression gate depending on which runs first.
+    /// </summary>
+    private string? _committedMatrixText;
+
+    [OneTimeSetUp]
+    public void CaptureCommittedMatrix() =>
+        _committedMatrixText = File.Exists(ProgressionCorpus.MatrixPath)
+            ? File.ReadAllText(ProgressionCorpus.MatrixPath)
+            : null;
+
     // ── The matrix ───────────────────────────────────────────────────────────
 
     [Test]
@@ -140,15 +153,15 @@ public class ProgressionCorpusMatrixTests
     [Test]
     public void Matrix_HasNotRegressedAgainstTheCommittedArtifact()
     {
-        if (!File.Exists(ProgressionCorpus.MatrixPath))
+        if (_committedMatrixText is null)
         {
             Assert.Fail(
                 $"no committed matrix at {ProgressionCorpus.MatrixPath}. " +
                 $"Generate it with {WriteEnvVar}=1 and commit the result.");
+            return;
         }
 
-        var committed = JsonSerializer.Deserialize<Matrix>(
-                            File.ReadAllText(ProgressionCorpus.MatrixPath), ReadOptions)
+        var committed = JsonSerializer.Deserialize<Matrix>(_committedMatrixText, ReadOptions)
                         ?? throw new InvalidOperationException("committed matrix deserialised to null");
 
         var current = BuildMatrix();

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusStructureTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusStructureTests.cs
@@ -1,0 +1,360 @@
+namespace GA.Business.ML.Tests.Corpus;
+
+/// <summary>
+///     Coverage and self-consistency invariants for the held-out progression
+///     corpus (GuitarAlchemist/ga#627).
+/// </summary>
+/// <remarks>
+///     Everything here is checkable without running any product code, which is
+///     what makes it a gate: the corpus must be structurally sound and
+///     musically self-consistent even while the product still fails several of
+///     its cases. Product results live in
+///     <see cref="ProgressionCorpusMatrixTests" />.
+/// </remarks>
+[TestFixture]
+public class ProgressionCorpusStructureTests
+{
+    private static ProgressionCorpusFile Corpus => Loaded.Value;
+
+    private static readonly Lazy<ProgressionCorpusFile> Loaded = new(ProgressionCorpus.Load);
+
+    private static IEnumerable<ProgressionCase> Cases => Corpus.Cases;
+
+    private static IEnumerable<TestCaseData> CaseSource() =>
+        ProgressionCorpus.Load().Cases.Select(c => new TestCaseData(c).SetName($"{{m}}({c.Id})"));
+
+    // ── Coverage: the twelve categories #627 enumerates ──────────────────────
+
+    [Test]
+    public void Corpus_HasAtLeastTwelveCases() =>
+        Assert.That(Cases.Count(), Is.GreaterThanOrEqualTo(12));
+
+    [Test]
+    public void CaseIds_AreUnique()
+    {
+        var duplicates = Cases.GroupBy(c => c.Id, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+
+        Assert.That(duplicates, Is.Empty, "duplicate case ids: " + string.Join(", ", duplicates));
+    }
+
+    [Test]
+    public void Corpus_CoversEveryRequiredCategory()
+    {
+        var present = Cases.Select(c => c.Category).ToHashSet(StringComparer.Ordinal);
+        var missing = ProgressionCorpus.RequiredCategories.Where(c => !present.Contains(c)).ToList();
+
+        Assert.That(missing, Is.Empty, "#627 requires these categories: " + string.Join(", ", missing));
+    }
+
+    // ── Regression pins required by #627 ─────────────────────────────────────
+
+    [TestCase(614)]
+    [TestCase(567)]
+    public void Corpus_PinsRequiredRegressionIssue(int issue)
+    {
+        var pinning = Cases.Where(c => c.Pins.Issues.Contains(issue)).Select(c => c.Id).ToList();
+
+        Assert.That(pinning, Is.Not.Empty,
+            $"#627 requires at least one case pinning GuitarAlchemist/ga#{issue}");
+    }
+
+    [Test]
+    public void Corpus_PinsAtLeastTwoCasesAcrossIssues614And567()
+    {
+        var pinning = Cases
+            .Where(c => c.Pins.Issues.Contains(614) || c.Pins.Issues.Contains(567))
+            .Select(c => c.Id).ToList();
+
+        Assert.That(pinning, Has.Count.GreaterThanOrEqualTo(2),
+            "'at least two cases must directly pin regressions from #614 and #567'; got " +
+            string.Join(", ", pinning));
+    }
+
+    [Test]
+    public void Corpus_PinsTheSpelledOutAccidentalRegression()
+    {
+        var pinning = Cases.Where(c => c.Pins.Issues.Contains(554)).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pinning, Is.Not.Empty, "no case pins GuitarAlchemist/ga#554");
+            Assert.That(pinning.SelectMany(c => c.Input.SpellingEquivalenceGroups).Count(),
+                Is.GreaterThanOrEqualTo(3),
+                "#554 names E-flat, B-flat and F-sharp; each needs a spelling group");
+        });
+    }
+
+    [Test]
+    public void EveryPinnedCase_ExplainsWhatItPins()
+    {
+        var unexplained = Cases
+            .Where(c => c.Pins.Issues.Count > 0 && string.IsNullOrWhiteSpace(c.Pins.Rationale))
+            .Select(c => c.Id).ToList();
+
+        Assert.That(unexplained, Is.Empty, "pins without rationale: " + string.Join(", ", unexplained));
+    }
+
+    [Test]
+    public void UnpinnedCases_CarryNoStrayRationale()
+    {
+        var stray = Cases
+            .Where(c => c.Pins.Issues.Count == 0 && c.Pins.Rationale is not null)
+            .Select(c => c.Id).ToList();
+
+        Assert.That(stray, Is.Empty, "rationale without pins: " + string.Join(", ", stray));
+    }
+
+    // ── Category-specific obligations ────────────────────────────────────────
+
+    [Test]
+    public void AlternateTuningCase_UsesANonStandardTuning()
+    {
+        var alternates = Cases.Where(c => c.Category == "alternate-tuning").ToList();
+
+        Assert.That(alternates, Is.Not.Empty, "#627 requires an alternate-tuning case");
+        Assert.Multiple(() =>
+        {
+            foreach (var c in alternates)
+            {
+                Assert.That(c.Input.Tuning.Id, Is.Not.EqualTo("standard"), c.Id);
+                Assert.That(c.Expected.VoicingSequence.TuningId, Is.EqualTo(c.Input.Tuning.Id),
+                    $"{c.Id}: the voicing must be realised in the case's own tuning");
+            }
+        });
+    }
+
+    /// <summary>
+    ///     "Ambiguous cases allow alternatives or abstention rather than one
+    ///     fabricated answer." A single confident reading must be a failing
+    ///     answer for this case, not a passing one.
+    /// </summary>
+    [Test]
+    public void AmbiguousCase_RefusesASingleConfidentAnswer()
+    {
+        var ambiguous = Cases.Where(c => c.Category == "ambiguous").ToList();
+
+        Assert.That(ambiguous, Is.Not.Empty, "#627 requires an intentionally ambiguous case");
+        Assert.Multiple(() =>
+        {
+            foreach (var c in ambiguous)
+            {
+                Assert.That(c.Uncertainty.ExpectedBehavior,
+                    Is.AnyOf("alternatives", "warn", "abstain"),
+                    $"{c.Id}: an ambiguous case cannot expect a confident single answer");
+
+                if (c.Uncertainty.ExpectedBehavior == "alternatives")
+                {
+                    Assert.That(c.Uncertainty.MinAlternatives, Is.GreaterThanOrEqualTo(2), c.Id);
+                    Assert.That(c.Expected.AcceptableTonalCenters, Has.Count.GreaterThanOrEqualTo(2),
+                        $"{c.Id}: at least two tonal centres must be acceptable");
+                    Assert.That(c.Uncertainty.MaxConfidence, Is.Not.Null.And.LessThan(1.0),
+                        $"{c.Id}: an ambiguous reading needs a confidence ceiling");
+                }
+            }
+        });
+    }
+
+    [Test]
+    public void ConfidentCases_ExpectExactlyOneTonalCentre()
+    {
+        var overloaded = Cases
+            .Where(c => c.Uncertainty.ExpectedBehavior == "confident" &&
+                        c.Expected.AcceptableTonalCenters.Count != 1)
+            .Select(c => c.Id).ToList();
+
+        Assert.That(overloaded, Is.Empty,
+            "a case cannot be both 'confident' and multi-answer: " + string.Join(", ", overloaded));
+    }
+
+    [Test]
+    public void SpelledOutAccidentalCase_ActuallyWritesAccidentalsOut()
+    {
+        var cases = Cases.Where(c => c.Category == "spelled-out-accidentals").ToList();
+
+        Assert.That(cases, Is.Not.Empty);
+        Assert.Multiple(() =>
+        {
+            foreach (var c in cases)
+            {
+                Assert.That(c.Input.Chords.Any(s =>
+                        s.Contains("flat", StringComparison.OrdinalIgnoreCase) ||
+                        s.Contains("sharp", StringComparison.OrdinalIgnoreCase)),
+                    Is.True, $"{c.Id}: no chord is actually spelled out");
+
+                Assert.That(c.Input.Chords, Is.Not.EqualTo(c.Input.CanonicalChords),
+                    $"{c.Id}: spelled-out input must differ from its shorthand");
+            }
+        });
+    }
+
+    // ── Per-case internal consistency ────────────────────────────────────────
+
+    [TestCaseSource(nameof(CaseSource))]
+    public void Case_PerChordArraysAreIndexAligned(ProgressionCase c)
+    {
+        var n = c.Input.Chords.Count;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(c.Input.CanonicalChords, Has.Count.EqualTo(n), "canonical_chords");
+            Assert.That(c.Expected.RomanNumerals, Has.Count.EqualTo(n), "roman_numerals");
+            Assert.That(c.Expected.Functions, Has.Count.EqualTo(n), "functions");
+            Assert.That(c.Expected.ScaleFamilies, Has.Count.EqualTo(n), "scale_families");
+            Assert.That(c.Expected.RequiredChordTones, Has.Count.EqualTo(n), "required_chord_tones");
+            Assert.That(c.Expected.VoicingSequence.Frames, Has.Count.EqualTo(n), "voicing frames");
+
+            foreach (var alternative in c.Expected.AlternativeRomanNumerals)
+                Assert.That(alternative, Has.Count.EqualTo(n), "alternative_roman_numerals");
+
+            for (var i = 0; i < n; i++)
+            {
+                var chord = c.Input.CanonicalChords[i];
+                Assert.That(c.Expected.ScaleFamilies[i].Chord, Is.EqualTo(chord), $"scale_families[{i}]");
+                Assert.That(c.Expected.RequiredChordTones[i].Chord, Is.EqualTo(chord), $"required_chord_tones[{i}]");
+                Assert.That(c.Expected.VoicingSequence.Frames[i].Chord, Is.EqualTo(chord), $"frames[{i}]");
+            }
+        });
+    }
+
+    [TestCaseSource(nameof(CaseSource))]
+    public void Case_ChordTonesMatchTheDeclaredQuality(ProgressionCase c)
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var tones in c.Expected.RequiredChordTones)
+            {
+                var intervals = CorpusPitchMath.QualityIntervals[tones.Quality];
+                var steps = CorpusPitchMath.QualityLetterSteps[tones.Quality];
+
+                Assert.That(CorpusPitchMath.PitchClassOf(tones.Root), Is.EqualTo(tones.RootPitchClass),
+                    $"{c.Id} {tones.Chord}: root_pitch_class");
+
+                var expectedPcs = intervals.Select(s => (tones.RootPitchClass + s) % 12).ToList();
+                Assert.That(tones.PitchClasses, Is.EqualTo(expectedPcs),
+                    $"{c.Id} {tones.Chord}: pitch classes for {tones.Quality}");
+
+                var expectedNotes = intervals
+                    .Select((s, i) => CorpusPitchMath.Spell(tones.Root, s, steps[i])).ToList();
+                Assert.That(tones.Notes, Is.EqualTo(expectedNotes),
+                    $"{c.Id} {tones.Chord}: note spellings for {tones.Quality}");
+            }
+        });
+    }
+
+    /// <summary>
+    ///     Fret arithmetic only: every fretted string is re-sounded against the
+    ///     case's own tuning and must produce exactly the declared chord tones.
+    ///     This is the check that makes the Drop C case fail loudly if anyone
+    ///     ever reads it under standard tuning.
+    /// </summary>
+    [TestCaseSource(nameof(CaseSource))]
+    public void Case_VoicingsSoundExactlyTheDeclaredChordTones(ProgressionCase c)
+    {
+        var openStrings = c.Input.Tuning.OpenStrings;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(c.Expected.VoicingSequence.TuningId, Is.EqualTo(c.Input.Tuning.Id),
+                $"{c.Id}: voicing tuning must be the case tuning");
+
+            for (var i = 0; i < c.Expected.VoicingSequence.Frames.Count; i++)
+            {
+                var frame = c.Expected.VoicingSequence.Frames[i];
+                var required = c.Expected.RequiredChordTones[i];
+
+                Assert.That(frame.FretsLowToHigh, Has.Count.EqualTo(openStrings.Count),
+                    $"{c.Id} {frame.Chord}: one fret entry per string");
+
+                var sounded = CorpusPitchMath.SoundedPitchClasses(openStrings, frame.FretsLowToHigh);
+
+                Assert.That(sounded.Order(), Is.EqualTo(frame.SoundedPitchClasses.Order()),
+                    $"{c.Id} {frame.Chord}: sounded_pitch_classes disagrees with the frets");
+                Assert.That(sounded.Order(), Is.EqualTo(required.PitchClasses.Distinct().Order()),
+                    $"{c.Id} {frame.Chord}: the voicing does not sound the chord");
+            }
+        });
+    }
+
+    [TestCaseSource(nameof(CaseSource))]
+    public void Case_VoicingsArePhysicallyPlayable(ProgressionCase c)
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var frame in c.Expected.VoicingSequence.Frames)
+            {
+                var fretted = frame.FretsLowToHigh.Where(f => f is > 0).Select(f => f!.Value).ToList();
+                if (fretted.Count == 0) continue;
+
+                Assert.That(fretted.Max() - fretted.Min(), Is.LessThanOrEqualTo(4),
+                    $"{c.Id} {frame.Chord}: fret span exceeds a four-fret hand position");
+                Assert.That(fretted.Max(), Is.LessThanOrEqualTo(12),
+                    $"{c.Id} {frame.Chord}: above the twelfth fret");
+            }
+        });
+    }
+
+    [TestCaseSource(nameof(CaseSource))]
+    public void Case_ForbiddenAnswersCannotAlsoBeAcceptable(ProgressionCase c)
+    {
+        var overlappingCentres = c.Expected.AcceptableTonalCenters
+            .Intersect(c.Forbidden.TonalCenters, StringComparer.OrdinalIgnoreCase).ToList();
+
+        var overlappingFacts = c.Expected.ExplanationFacts
+            .Intersect(c.Forbidden.Facts, StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(overlappingCentres, Is.Empty,
+                $"{c.Id}: tonal centre both acceptable and forbidden: {string.Join(", ", overlappingCentres)}");
+            Assert.That(overlappingFacts, Is.Empty,
+                $"{c.Id}: fact both required and forbidden: {string.Join(", ", overlappingFacts)}");
+            Assert.That(c.Expected.AcceptableTonalCenters, Does.Contain(c.Expected.TonalCenter),
+                $"{c.Id}: the primary tonal centre must be one of the acceptable answers");
+        });
+    }
+
+    [TestCaseSource(nameof(CaseSource))]
+    public void Case_CarriesProvenanceAndRationale(ProgressionCase c)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(c.Provenance.AddedIn, Is.EqualTo("GuitarAlchemist/ga#627"));
+            Assert.That(c.Provenance.Source, Is.Not.Empty);
+            Assert.That(c.Provenance.Rationale, Is.Not.Empty);
+        });
+    }
+
+    [TestCaseSource(nameof(CaseSource))]
+    public void Case_SpellingGroupsOfferARealAlternativeSpelling(ProgressionCase c)
+    {
+        Assert.Multiple(() =>
+        {
+            foreach (var group in c.Input.SpellingEquivalenceGroups)
+            {
+                Assert.That(group.Spellings, Does.Contain(group.Canonical),
+                    $"{c.Id}: group '{group.Canonical}' must include its own canonical form");
+                Assert.That(group.Spellings.Count(s => s != group.Canonical), Is.GreaterThanOrEqualTo(1),
+                    $"{c.Id}: group '{group.Canonical}' has no alternative spelling to test");
+            }
+        });
+    }
+
+    [Test]
+    public void Tunings_AreDeclaredConsistentlyAcrossCases()
+    {
+        var byId = Cases.Select(c => c.Input.Tuning)
+            .GroupBy(t => t.Id, StringComparer.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            foreach (var group in byId)
+            {
+                var distinct = group.Select(t => string.Join(" ", t.OpenStrings)).Distinct().ToList();
+                Assert.That(distinct, Has.Count.EqualTo(1),
+                    $"tuning '{group.Key}' is declared with different open strings: " +
+                    string.Join(" | ", distinct));
+            }
+        });
+    }
+}

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusStructureTests.cs
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/ProgressionCorpusStructureTests.cs
@@ -340,6 +340,78 @@ public class ProgressionCorpusStructureTests
         });
     }
 
+    // ── The hand-written case index beside the data ──────────────────────────
+
+    /// <summary>
+    ///     The README case table is the only part of this corpus that is written
+    ///     by hand next to machine-generated data, which makes it the one place
+    ///     the published evidence can drift from the data silently - and it did:
+    ///     <c>pc-11</c>'s progression was reworked in the data commit while the
+    ///     table kept publishing the removed one. This makes agreement structural
+    ///     rather than clerical.
+    /// </summary>
+    [Test]
+    public void ReadmeCaseTable_AgreesWithTheCorpus()
+    {
+        var rows = ReadmeCaseRows();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows.Select(r => r.Id), Is.EqualTo(Cases.Select(c => c.Id)),
+                "the README case table must list every corpus case, in corpus order");
+
+            foreach (var c in Cases)
+            {
+                var row = rows.FirstOrDefault(r => r.Id == c.Id);
+                if (row is null) continue;
+
+                Assert.That(row.Progression, Is.EqualTo(RenderProgression(c.Input.Chords)),
+                    $"{c.Id}: README progression disagrees with input.chords");
+                Assert.That(row.Pins, Is.EqualTo(RenderPins(c.Pins.Issues)),
+                    $"{c.Id}: README pins column disagrees with pins.issues");
+            }
+        });
+
+        static string RenderProgression(IReadOnlyList<string> chords) =>
+            chords.Any(s => s.Contains(' '))
+                ? string.Join(" ", chords.Select(s => $"\"{s}\""))
+                : string.Join(" ", chords);
+
+        static string RenderPins(IReadOnlyList<int> issues) =>
+            issues.Count == 0 ? "-" : string.Join(", ", issues.Select(i => $"#{i}"));
+    }
+
+    /// <summary>Rows of the README's "twelve cases" table, in file order.</summary>
+    private static IReadOnlyList<ReadmeRow> ReadmeCaseRows()
+    {
+        var rows = new List<ReadmeRow>();
+        var inCaseTable = false;
+
+        foreach (var line in File.ReadAllLines(ProgressionCorpus.ReadmePath))
+        {
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                inCaseTable = line.Contains("cases", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inCaseTable || !line.StartsWith("| `", StringComparison.Ordinal)) continue;
+
+            var cells = line.Trim('|').Split('|').Select(x => x.Trim()).ToList();
+            Assert.That(cells, Has.Count.EqualTo(6),
+                $"unexpected README case-table row shape: {line}");
+
+            rows.Add(new ReadmeRow(cells[0].Trim('`'), cells[2], cells[5]));
+        }
+
+        Assert.That(rows, Is.Not.Empty,
+            $"no case rows found in {ProgressionCorpus.ReadmePath}");
+
+        return rows;
+    }
+
+    private sealed record ReadmeRow(string Id, string Progression, string Pins);
+
     [Test]
     public void Tunings_AreDeclaredConsistentlyAcrossCases()
     {

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/README.md
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/README.md
@@ -43,7 +43,7 @@ reads it, and it lives under the test project rather than
 | `pc-08-modal-dorian-vamp` | modal | Dm7 Em7 Dm7 Em7 | standard | D dorian | - |
 | `pc-09-starts-off-tonic` | starts away from tonic | Fmaj7 Em7 Dm7 G7 Cmaj7 | standard | C major | #614 |
 | `pc-10-spelled-out-accidentals` | spelled-out accidentals | "F minor 7" "B-flat 7" "E-flat major 7" | standard | Eb major | #554 |
-| `pc-11-drop-c-alternate-tuning` | alternate tuning | Cm Ab Eb Bb | **Drop C** | C minor | - |
+| `pc-11-drop-c-alternate-tuning` | alternate tuning | Cm Fm Ab G | **Drop C** | C minor | - |
 | `pc-12-ambiguous-relative-pair` | ambiguous | Am F C G | standard | C major *or* A minor | - |
 
 Two cases pin #614 and three pin #567, satisfying "at least two cases must

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/README.md
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/README.md
@@ -1,0 +1,120 @@
+# Progression-to-voicing evaluation corpus (v1, draft)
+
+Held-out deterministic evaluation corpus for the progression-to-voicing vertical
+slice. Added by [GuitarAlchemist/ga#627](https://github.com/GuitarAlchemist/ga/issues/627)
+under story [#623](https://github.com/GuitarAlchemist/ga/issues/623).
+
+| File | What it is |
+|---|---|
+| `progression-corpus.v1.schema.json` | Language-neutral contract. The document other repos and other languages read. |
+| `progression-corpus.v1.json` | The twelve cases. |
+| `../ProgressionCorpus.cs` | Deterministic loader. |
+| `../JsonSchemaSubsetValidator.cs` | Closed-world validator for the keyword subset the schema uses. |
+| `../CorpusPitchMath.cs` | Note/fret arithmetic, independent of production code. |
+| `../ProgressionCorpusLoaderTests.cs` | The corpus parses and satisfies its schema. |
+| `../ProgressionCorpusStructureTests.cs` | Coverage and self-consistency invariants. |
+| `../ProgressionCorpusMatrixTests.cs` | Runs the corpus against today's deterministic seams; emits the evidence artifact. |
+| `state/quality/progression-corpus/progression-corpus-matrix.json` | Machine-readable pass/fail matrix. Also the regression baseline. |
+
+## The rule that makes this useful
+
+**Expectations state what a musically correct system must answer. They are not
+trimmed to what the product currently does.** Several cases fail today, on
+purpose, because [#614](https://github.com/GuitarAlchemist/ga/issues/614),
+[#567](https://github.com/GuitarAlchemist/ga/issues/567) and
+[#554](https://github.com/GuitarAlchemist/ga/issues/554) are open. Weakening an
+expectation to turn a red cell green destroys the only thing the corpus is for.
+
+This is evaluation data, not production configuration. Nothing in the runtime
+reads it, and it lives under the test project rather than
+`Common/GA.Business.Config` so that stays true.
+
+## The twelve cases
+
+| id | category | progression | tuning | expected centre | pins |
+|---|---|---|---|---|---|
+| `pc-01-major-ii-v-i` | major ii-V-I | Dm7 G7 Cmaj7 | standard | C major | #614 |
+| `pc-02-minor-ii-v-i` | minor ii-V-i | Bm7b5 E7 Am | standard | A minor | - |
+| `pc-03-major-i-vi-iv-v` | I-vi-IV-V | C Am F G | standard | C major | #567 |
+| `pc-04-deceptive-cadence` | deceptive cadence | C F G7 Am | standard | C major | - |
+| `pc-05-borrowed-iv` | borrowed iv | C F Fm C | standard | C major | #567 |
+| `pc-06-borrowed-bvii` | borrowed bVII | C Bb F C | standard | C major | - |
+| `pc-07-secondary-dominant` | secondary dominant | C E7 Am F G7 C | standard | C major | #567 |
+| `pc-08-modal-dorian-vamp` | modal | Dm7 Em7 Dm7 Em7 | standard | D dorian | - |
+| `pc-09-starts-off-tonic` | starts away from tonic | Fmaj7 Em7 Dm7 G7 Cmaj7 | standard | C major | #614 |
+| `pc-10-spelled-out-accidentals` | spelled-out accidentals | "F minor 7" "B-flat 7" "E-flat major 7" | standard | Eb major | #554 |
+| `pc-11-drop-c-alternate-tuning` | alternate tuning | Cm Ab Eb Bb | **Drop C** | C minor | - |
+| `pc-12-ambiguous-relative-pair` | ambiguous | Am F C G | standard | C major *or* A minor | - |
+
+Two cases pin #614 and three pin #567, satisfying "at least two cases must
+directly pin regressions from #614 and #567". `pc-10` pins #554 and carries
+spelling groups for all three accidentals that issue names (E-flat, B-flat,
+F-sharp) - the F-sharp group is present even though F#m is not in the
+progression, because they share one parse boundary.
+
+Two cases are deliberately unsatisfiable by any current seam:
+
+- **`pc-08`** expects the modal centre `D dorian`. `KeyIdentificationService`
+  knows 30 major/minor keys and cannot express a mode. `C major` - the parent
+  key - is listed as *forbidden*, because answering the parent key is exactly
+  the error this case exists to catch.
+- **`pc-12`** expects two readings. A single confident answer fails the case
+  even when that answer is `C major`.
+
+## Per-case contract
+
+Every case records, per `progression-corpus.v1.schema.json`:
+
+- stable `id` and the corpus `schema_version`;
+- `input.chords` (as a user would type them), `input.canonical_chords`,
+  `input.instrument`, `input.tuning`, `input.key_hint`;
+- `expected.tonal_center` plus `expected.acceptable_tonal_centers`;
+- `expected.roman_numerals`, `expected.alternative_roman_numerals`,
+  `expected.functions`;
+- `expected.scale_families` - acceptable scale/arpeggio families per chord;
+- `expected.required_chord_tones` - quality, root, pitch classes, spelled notes;
+- `forbidden.tonal_centers` and `forbidden.facts`;
+- `uncertainty.expected_behavior` (`confident` / `alternatives` / `warn` /
+  `abstain`), `min_alternatives`, `max_confidence`;
+- `expected.voicing_sequence` - one complete valid realisation in the case's own
+  tuning;
+- `expected.explanation_facts`;
+- `pins` and `provenance`.
+
+## Generation and verification
+
+Pitch classes, note spellings and fret numbers are machine generated from the
+chord symbols and then re-verified from the other direction by
+`ProgressionCorpusStructureTests`: every fretting is re-sounded against the
+case's declared open strings and must produce exactly the declared chord tones.
+That is fret arithmetic only - the harness re-implements no key detection and no
+harmonic analysis, and `CorpusPitchMath` deliberately calls no production code so
+a defect there cannot validate wrong corpus data.
+
+## Running it
+
+```bash
+# structure, loader and schema conformance + the current pass/fail matrix
+dotnet test Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj \
+  --filter "FullyQualifiedName~ProgressionCorpus"
+
+# human-readable status report
+dotnet test Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj \
+  --filter "FullyQualifiedName~Matrix_ReportCurrentState" \
+  --logger "console;verbosity=detailed"
+
+# regenerate the evidence artifact after an intentional change, then commit it
+GA_CORPUS_WRITE_MATRIX=1 dotnet test Tests/Common/GA.Business.ML.Tests/GA.Business.ML.Tests.csproj \
+  --filter "FullyQualifiedName~ProgressionCorpusMatrixTests"
+```
+
+The matrix test gates on *movement*: a check that passes today and fails
+tomorrow fails the build; a check that is already failing keeps failing without
+breaking it. Checks with no seam at all are recorded as `blocked` with the issue
+they wait on, so the artifact shows the real size of the remaining work rather
+than a flattering subset.
+
+## Status
+
+`status: draft`. Following this repo's contract convention, v0.1.x-style drafts
+are not frozen. Freeze at the Phase 4 milestone of #623, not before.

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/progression-corpus.v1.json
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/progression-corpus.v1.json
@@ -1,0 +1,3189 @@
+{
+  "schema": "progression-corpus.v1.schema.json",
+  "schema_version": "1.0.0",
+  "corpus_id": "progression-to-voicing",
+  "corpus_version": "1.0.0",
+  "status": "draft",
+  "held_out": true,
+  "issue": "GuitarAlchemist/ga#627",
+  "parent_issue": "GuitarAlchemist/ga#623",
+  "description": "Held-out deterministic evaluation corpus for the progression-to-voicing vertical slice. Expectations state what a musically correct system must answer; they are deliberately NOT trimmed to what production currently does. Pitch classes, note spellings and voicing frets are machine generated from the chord symbols and re-verified by the loader tests.",
+  "cases": [
+    {
+      "id": "pc-01-major-ii-v-i",
+      "category": "major-ii-V-I",
+      "title": "Major ii-V-I in C",
+      "input": {
+        "chords": [
+          "Dm7",
+          "G7",
+          "Cmaj7"
+        ],
+        "canonical_chords": [
+          "Dm7",
+          "G7",
+          "Cmaj7"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major"
+        ],
+        "roman_numerals": [
+          "ii7",
+          "V7",
+          "Imaj7"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "predominant",
+          "dominant",
+          "tonic"
+        ],
+        "scale_families": [
+          {
+            "chord": "Dm7",
+            "acceptable": [
+              "D Dorian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "G7",
+            "acceptable": [
+              "G Mixolydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Cmaj7",
+            "acceptable": [
+              "C Ionian",
+              "C major",
+              "C Lydian"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "Dm7",
+            "quality": "minor-7",
+            "root": "D",
+            "root_pitch_class": 2,
+            "pitch_classes": [
+              2,
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "D",
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "G7",
+            "quality": "dominant-7",
+            "root": "G",
+            "root_pitch_class": 7,
+            "pitch_classes": [
+              7,
+              11,
+              2,
+              5
+            ],
+            "notes": [
+              "G",
+              "B",
+              "D",
+              "F"
+            ]
+          },
+          {
+            "chord": "Cmaj7",
+            "quality": "major-7",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7,
+              11
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G",
+              "B"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "ii-V-I",
+          "G7 resolves to Cmaj7",
+          "the tritone B-F resolves to C-E"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "Dm7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                5,
+                7,
+                5,
+                6,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                2,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "G7",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                3,
+                5,
+                3,
+                4,
+                3,
+                3
+              ],
+              "sounded_pitch_classes": [
+                2,
+                5,
+                7,
+                11
+              ]
+            },
+            {
+              "chord": "Cmaj7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                4,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7,
+                11
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "D major",
+          "D minor",
+          "G major"
+        ],
+        "facts": [
+          "G7 is the tonic",
+          "the key is D minor",
+          "the key is D major"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [
+          614
+        ],
+        "rationale": "#614 reports Dm7 G7 Cmaj7 detected as D minor by the MCP root-only scorer; the authoritative KeyIdentificationService scores C major 3/3."
+      },
+      "provenance": {
+        "source": "Canonical jazz cadence; the exact prefix tabulated in GuitarAlchemist/ga#614.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "The single most common functional cadence, and the case the first-chord tie-break is structurally worst at."
+      }
+    },
+    {
+      "id": "pc-02-minor-ii-v-i",
+      "category": "minor-ii-V-i",
+      "title": "Minor ii-V-i in A minor",
+      "input": {
+        "chords": [
+          "Bm7b5",
+          "E7",
+          "Am"
+        ],
+        "canonical_chords": [
+          "Bm7b5",
+          "E7",
+          "Am"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "A minor",
+        "acceptable_tonal_centers": [
+          "A minor"
+        ],
+        "roman_numerals": [
+          "iim7b5",
+          "V7",
+          "i"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "predominant",
+          "dominant",
+          "tonic"
+        ],
+        "scale_families": [
+          {
+            "chord": "Bm7b5",
+            "acceptable": [
+              "B Locrian",
+              "B Locrian natural 2",
+              "A harmonic minor"
+            ]
+          },
+          {
+            "chord": "E7",
+            "acceptable": [
+              "E Phrygian dominant",
+              "A harmonic minor",
+              "E altered"
+            ]
+          },
+          {
+            "chord": "Am",
+            "acceptable": [
+              "A Aeolian",
+              "A harmonic minor",
+              "A natural minor"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "Bm7b5",
+            "quality": "half-diminished-7",
+            "root": "B",
+            "root_pitch_class": 11,
+            "pitch_classes": [
+              11,
+              2,
+              5,
+              9
+            ],
+            "notes": [
+              "B",
+              "D",
+              "F",
+              "A"
+            ]
+          },
+          {
+            "chord": "E7",
+            "quality": "dominant-7",
+            "root": "E",
+            "root_pitch_class": 4,
+            "pitch_classes": [
+              4,
+              8,
+              11,
+              2
+            ],
+            "notes": [
+              "E",
+              "G#",
+              "B",
+              "D"
+            ]
+          },
+          {
+            "chord": "Am",
+            "quality": "minor-triad",
+            "root": "A",
+            "root_pitch_class": 9,
+            "pitch_classes": [
+              9,
+              0,
+              4
+            ],
+            "notes": [
+              "A",
+              "C",
+              "E"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "minor ii-V-i",
+          "E7 carries the raised leading tone G#",
+          "G# comes from A harmonic minor, not A natural minor"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "Bm7b5",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                2,
+                3,
+                2,
+                3,
+                null
+              ],
+              "sounded_pitch_classes": [
+                2,
+                5,
+                9,
+                11
+              ]
+            },
+            {
+              "chord": "E7",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                0,
+                2,
+                0,
+                1,
+                0,
+                0
+              ],
+              "sounded_pitch_classes": [
+                2,
+                4,
+                8,
+                11
+              ]
+            },
+            {
+              "chord": "Am",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                0,
+                2,
+                2,
+                1,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                9
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "B minor",
+          "E major",
+          "C major"
+        ],
+        "facts": [
+          "E minor is the dominant",
+          "the key is B minor",
+          "G natural is the leading tone"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [],
+        "rationale": null
+      },
+      "provenance": {
+        "source": "Textbook minor cadence; mirrors #614 row \"Em7 A7 Dmaj7\" in the minor domain.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "The dominant is chromatic to the natural-minor scale, so a diatonic-only key scorer must still land on A minor rather than the key that happens to contain G#."
+      }
+    },
+    {
+      "id": "pc-03-major-i-vi-iv-v",
+      "category": "major-I-vi-IV-V",
+      "title": "I-vi-IV-V in C major",
+      "input": {
+        "chords": [
+          "C",
+          "Am",
+          "F",
+          "G"
+        ],
+        "canonical_chords": [
+          "C",
+          "Am",
+          "F",
+          "G"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major"
+        ],
+        "roman_numerals": [
+          "I",
+          "vi",
+          "IV",
+          "V"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "tonic",
+          "tonic-substitute",
+          "predominant",
+          "dominant"
+        ],
+        "scale_families": [
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Am",
+            "acceptable": [
+              "A Aeolian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "F",
+            "acceptable": [
+              "F Lydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "G",
+            "acceptable": [
+              "G Mixolydian",
+              "C major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          },
+          {
+            "chord": "Am",
+            "quality": "minor-triad",
+            "root": "A",
+            "root_pitch_class": 9,
+            "pitch_classes": [
+              9,
+              0,
+              4
+            ],
+            "notes": [
+              "A",
+              "C",
+              "E"
+            ]
+          },
+          {
+            "chord": "F",
+            "quality": "major-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "G",
+            "quality": "major-triad",
+            "root": "G",
+            "root_pitch_class": 7,
+            "pitch_classes": [
+              7,
+              11,
+              2
+            ],
+            "notes": [
+              "G",
+              "B",
+              "D"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "I-vi-IV-V",
+          "Am is the relative minor of C major",
+          "the arpeggio over Am is Am7"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            },
+            {
+              "chord": "Am",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                0,
+                2,
+                2,
+                1,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                9
+              ]
+            },
+            {
+              "chord": "F",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                1,
+                3,
+                3,
+                2,
+                1,
+                1
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "G",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                3,
+                5,
+                5,
+                4,
+                3,
+                3
+              ],
+              "sounded_pitch_classes": [
+                2,
+                7,
+                11
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "A major",
+          "F major",
+          "G major"
+        ],
+        "facts": [
+          "Amm7",
+          "Am is borrowed",
+          "A minor is the tonic key"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [
+          567
+        ],
+        "rationale": "#567 reports ArpeggioFor concatenating root + full suffix, producing \"Amm7\" for Am at degree vi in C major. This case forbids that string and requires the canonical \"Am7\"."
+      },
+      "provenance": {
+        "source": "The \"50s\" progression; Am-in-C-major is the exact input in the #567 report.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "Cheap, unambiguous key, but the vi chord is the concatenation bug's trigger, so the case is both a baseline and a regression pin."
+      }
+    },
+    {
+      "id": "pc-04-deceptive-cadence",
+      "category": "deceptive-cadence",
+      "title": "Deceptive cadence V-vi in C major",
+      "input": {
+        "chords": [
+          "C",
+          "F",
+          "G7",
+          "Am"
+        ],
+        "canonical_chords": [
+          "C",
+          "F",
+          "G7",
+          "Am"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major"
+        ],
+        "roman_numerals": [
+          "I",
+          "IV",
+          "V7",
+          "vi"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "tonic",
+          "predominant",
+          "dominant",
+          "deceptive-resolution"
+        ],
+        "scale_families": [
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "F",
+            "acceptable": [
+              "F Lydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "G7",
+            "acceptable": [
+              "G Mixolydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Am",
+            "acceptable": [
+              "A Aeolian",
+              "C major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          },
+          {
+            "chord": "F",
+            "quality": "major-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "G7",
+            "quality": "dominant-7",
+            "root": "G",
+            "root_pitch_class": 7,
+            "pitch_classes": [
+              7,
+              11,
+              2,
+              5
+            ],
+            "notes": [
+              "G",
+              "B",
+              "D",
+              "F"
+            ]
+          },
+          {
+            "chord": "Am",
+            "quality": "minor-triad",
+            "root": "A",
+            "root_pitch_class": 9,
+            "pitch_classes": [
+              9,
+              0,
+              4
+            ],
+            "notes": [
+              "A",
+              "C",
+              "E"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "deceptive cadence",
+          "V-vi",
+          "the expected resolution to C is withheld",
+          "Am shares C and E with C major"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            },
+            {
+              "chord": "F",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                1,
+                3,
+                3,
+                2,
+                1,
+                1
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "G7",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                3,
+                5,
+                3,
+                4,
+                3,
+                3
+              ],
+              "sounded_pitch_classes": [
+                2,
+                5,
+                7,
+                11
+              ]
+            },
+            {
+              "chord": "Am",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                5,
+                7,
+                7,
+                5,
+                5,
+                5
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                9
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "A minor",
+          "A major",
+          "G major"
+        ],
+        "facts": [
+          "Am is the tonic",
+          "authentic cadence",
+          "the progression ends on I"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [],
+        "rationale": null
+      },
+      "provenance": {
+        "source": "Standard voice-leading pedagogy (V-vi interrupted cadence).",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "The final chord is not the tonic, so any system that infers the key from the last chord - a common shortcut - fails here."
+      }
+    },
+    {
+      "id": "pc-05-borrowed-iv",
+      "category": "borrowed-iv",
+      "title": "Borrowed minor iv in C major",
+      "input": {
+        "chords": [
+          "C",
+          "F",
+          "Fm",
+          "C"
+        ],
+        "canonical_chords": [
+          "C",
+          "F",
+          "Fm",
+          "C"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major"
+        ],
+        "roman_numerals": [
+          "I",
+          "IV",
+          "iv",
+          "I"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "tonic",
+          "predominant",
+          "borrowed-predominant",
+          "tonic"
+        ],
+        "scale_families": [
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "F",
+            "acceptable": [
+              "F Lydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Fm",
+            "acceptable": [
+              "F Dorian",
+              "F Aeolian",
+              "F melodic minor"
+            ]
+          },
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          },
+          {
+            "chord": "F",
+            "quality": "major-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "Fm",
+            "quality": "minor-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              8,
+              0
+            ],
+            "notes": [
+              "F",
+              "Ab",
+              "C"
+            ]
+          },
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "modal interchange",
+          "iv is borrowed from C minor",
+          "Fm introduces Ab, which is outside C major",
+          "Ab resolves down by semitone to G"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            },
+            {
+              "chord": "F",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                1,
+                3,
+                3,
+                2,
+                1,
+                1
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "Fm",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                1,
+                3,
+                3,
+                1,
+                1,
+                1
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                8
+              ]
+            },
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "F major",
+          "F minor",
+          "Ab major"
+        ],
+        "facts": [
+          "Fm is diatonic to C major",
+          "F Lydian fits Fm",
+          "play A natural over Fm",
+          "the key changes to F minor"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [
+          567
+        ],
+        "rationale": "#567 reports key-blind degree mapping: the degree index is found by root pitch class only, so Fm at scale degree IV is still classified as IV/Lydian and A natural is recommended against the chord's Ab. This case forbids exactly that."
+      },
+      "provenance": {
+        "source": "Modal-interchange pedagogy; the failure shape described in GuitarAlchemist/ga#567 -2.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "F and Fm share a root, so only written quality distinguishes them. A root-only classifier cannot tell them apart at all."
+      }
+    },
+    {
+      "id": "pc-06-borrowed-bvii",
+      "category": "borrowed-bVII",
+      "title": "Borrowed bVII in C major",
+      "input": {
+        "chords": [
+          "C",
+          "Bb",
+          "F",
+          "C"
+        ],
+        "canonical_chords": [
+          "C",
+          "Bb",
+          "F",
+          "C"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major"
+        ],
+        "roman_numerals": [
+          "I",
+          "bVII",
+          "IV",
+          "I"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "tonic",
+          "borrowed-subtonic",
+          "predominant",
+          "tonic"
+        ],
+        "scale_families": [
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Bb",
+            "acceptable": [
+              "Bb Lydian",
+              "C Mixolydian",
+              "F major"
+            ]
+          },
+          {
+            "chord": "F",
+            "acceptable": [
+              "F Lydian",
+              "C major",
+              "F major"
+            ]
+          },
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          },
+          {
+            "chord": "Bb",
+            "quality": "major-triad",
+            "root": "Bb",
+            "root_pitch_class": 10,
+            "pitch_classes": [
+              10,
+              2,
+              5
+            ],
+            "notes": [
+              "Bb",
+              "D",
+              "F"
+            ]
+          },
+          {
+            "chord": "F",
+            "quality": "major-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "bVII",
+          "Bb is borrowed from C Mixolydian",
+          "Bb is a whole step below the tonic",
+          "there is no leading tone B natural in Bb"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            },
+            {
+              "chord": "Bb",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                1,
+                3,
+                3,
+                3,
+                null
+              ],
+              "sounded_pitch_classes": [
+                2,
+                5,
+                10
+              ]
+            },
+            {
+              "chord": "F",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                1,
+                3,
+                3,
+                2,
+                1,
+                1
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "Bb major",
+          "F major",
+          "G minor"
+        ],
+        "facts": [
+          "Bb is diatonic to C major",
+          "Bbdim",
+          "the key is Bb major",
+          "B natural is a chord tone of Bb"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [],
+        "rationale": null
+      },
+      "provenance": {
+        "source": "Mixolydian-inflected rock cadence (I-bVII-IV-I).",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "Diatonic-count key scoring is drawn toward F major here, because C, Bb and F are all diatonic to F. Only the tonic function of C disambiguates."
+      }
+    },
+    {
+      "id": "pc-07-secondary-dominant",
+      "category": "secondary-dominant",
+      "title": "Secondary dominant V7/vi in C major",
+      "input": {
+        "chords": [
+          "C",
+          "E7",
+          "Am",
+          "F",
+          "G7",
+          "C"
+        ],
+        "canonical_chords": [
+          "C",
+          "E7",
+          "Am",
+          "F",
+          "G7",
+          "C"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major"
+        ],
+        "roman_numerals": [
+          "I",
+          "V7/vi",
+          "vi",
+          "IV",
+          "V7",
+          "I"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "tonic",
+          "secondary-dominant",
+          "tonic-substitute",
+          "predominant",
+          "dominant",
+          "tonic"
+        ],
+        "scale_families": [
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "E7",
+            "acceptable": [
+              "E Phrygian dominant",
+              "A harmonic minor",
+              "E altered",
+              "E Mixolydian b9 b13"
+            ]
+          },
+          {
+            "chord": "Am",
+            "acceptable": [
+              "A Aeolian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "F",
+            "acceptable": [
+              "F Lydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "G7",
+            "acceptable": [
+              "G Mixolydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          },
+          {
+            "chord": "E7",
+            "quality": "dominant-7",
+            "root": "E",
+            "root_pitch_class": 4,
+            "pitch_classes": [
+              4,
+              8,
+              11,
+              2
+            ],
+            "notes": [
+              "E",
+              "G#",
+              "B",
+              "D"
+            ]
+          },
+          {
+            "chord": "Am",
+            "quality": "minor-triad",
+            "root": "A",
+            "root_pitch_class": 9,
+            "pitch_classes": [
+              9,
+              0,
+              4
+            ],
+            "notes": [
+              "A",
+              "C",
+              "E"
+            ]
+          },
+          {
+            "chord": "F",
+            "quality": "major-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "G7",
+            "quality": "dominant-7",
+            "root": "G",
+            "root_pitch_class": 7,
+            "pitch_classes": [
+              7,
+              11,
+              2,
+              5
+            ],
+            "notes": [
+              "G",
+              "B",
+              "D",
+              "F"
+            ]
+          },
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "secondary dominant",
+          "V7/vi",
+          "E7 tonicises Am",
+          "G# is the leading tone of A and is outside C major"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            },
+            {
+              "chord": "E7",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                0,
+                2,
+                0,
+                1,
+                0,
+                0
+              ],
+              "sounded_pitch_classes": [
+                2,
+                4,
+                8,
+                11
+              ]
+            },
+            {
+              "chord": "Am",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                0,
+                2,
+                2,
+                1,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                9
+              ]
+            },
+            {
+              "chord": "F",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                1,
+                3,
+                3,
+                2,
+                1,
+                1
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "G7",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                3,
+                5,
+                3,
+                4,
+                3,
+                3
+              ],
+              "sounded_pitch_classes": [
+                2,
+                5,
+                7,
+                11
+              ]
+            },
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "E major",
+          "A minor",
+          "A major"
+        ],
+        "facts": [
+          "E Phrygian fits E7",
+          "G natural is a chord tone of E7",
+          "E7 is diatonic to C major",
+          "the key modulates to A minor"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [
+          567
+        ],
+        "rationale": "#567 -2: any secondary dominant gets confidently wrong advice because degree mapping ignores written quality - E7 at degree iii would be sent to E Phrygian, whose G natural contradicts the chord's G#."
+      },
+      "provenance": {
+        "source": "Standard tonicisation pedagogy; the \"secondary dominant\" failure named in #567.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "Longest case in the corpus (6 chords) and the one where a single chromatic chord must not drag the global key away from C."
+      }
+    },
+    {
+      "id": "pc-08-modal-dorian-vamp",
+      "category": "modal",
+      "title": "D Dorian modal vamp",
+      "input": {
+        "chords": [
+          "Dm7",
+          "Em7",
+          "Dm7",
+          "Em7"
+        ],
+        "canonical_chords": [
+          "Dm7",
+          "Em7",
+          "Dm7",
+          "Em7"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "D dorian",
+        "acceptable_tonal_centers": [
+          "D dorian"
+        ],
+        "roman_numerals": [
+          "i7",
+          "ii7",
+          "i7",
+          "ii7"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "modal-tonic",
+          "modal-colour",
+          "modal-tonic",
+          "modal-colour"
+        ],
+        "scale_families": [
+          {
+            "chord": "Dm7",
+            "acceptable": [
+              "D Dorian"
+            ]
+          },
+          {
+            "chord": "Em7",
+            "acceptable": [
+              "D Dorian",
+              "E Phrygian"
+            ]
+          },
+          {
+            "chord": "Dm7",
+            "acceptable": [
+              "D Dorian"
+            ]
+          },
+          {
+            "chord": "Em7",
+            "acceptable": [
+              "D Dorian",
+              "E Phrygian"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "Dm7",
+            "quality": "minor-7",
+            "root": "D",
+            "root_pitch_class": 2,
+            "pitch_classes": [
+              2,
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "D",
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "Em7",
+            "quality": "minor-7",
+            "root": "E",
+            "root_pitch_class": 4,
+            "pitch_classes": [
+              4,
+              7,
+              11,
+              2
+            ],
+            "notes": [
+              "E",
+              "G",
+              "B",
+              "D"
+            ]
+          },
+          {
+            "chord": "Dm7",
+            "quality": "minor-7",
+            "root": "D",
+            "root_pitch_class": 2,
+            "pitch_classes": [
+              2,
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "D",
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "Em7",
+            "quality": "minor-7",
+            "root": "E",
+            "root_pitch_class": 4,
+            "pitch_classes": [
+              4,
+              7,
+              11,
+              2
+            ],
+            "notes": [
+              "E",
+              "G",
+              "B",
+              "D"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "modal",
+          "D Dorian",
+          "the characteristic note is the natural 6th, B",
+          "there is no dominant chord and no functional cadence",
+          "the parent major scale is C major but the tonal centre is D"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "Dm7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                5,
+                7,
+                5,
+                6,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                2,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "Em7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                7,
+                9,
+                7,
+                8,
+                null
+              ],
+              "sounded_pitch_classes": [
+                2,
+                4,
+                7,
+                11
+              ]
+            },
+            {
+              "chord": "Dm7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                5,
+                7,
+                5,
+                6,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                2,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "Em7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                7,
+                9,
+                7,
+                8,
+                null
+              ],
+              "sounded_pitch_classes": [
+                2,
+                4,
+                7,
+                11
+              ]
+            }
+          ]
+        },
+        "notes": "The parent key is C major, but C major is a FORBIDDEN answer here: reporting the parent key as the tonal centre is the exact error this case exists to catch."
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "C major",
+          "D minor",
+          "A minor"
+        ],
+        "facts": [
+          "Bb",
+          "D natural minor",
+          "D Aeolian",
+          "the progression is a ii-V in C"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [],
+        "rationale": null
+      },
+      "provenance": {
+        "source": "Modal-jazz vamp idiom (So What family), reduced to two chords.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "A modal centre is not one of the 30 major/minor keys, so this case deliberately exceeds what a major/minor-only key scorer can express. It is held-out precisely to keep that gap visible."
+      }
+    },
+    {
+      "id": "pc-09-starts-off-tonic",
+      "category": "starts-away-from-tonic",
+      "title": "Progression beginning on IV in C major",
+      "input": {
+        "chords": [
+          "Fmaj7",
+          "Em7",
+          "Dm7",
+          "G7",
+          "Cmaj7"
+        ],
+        "canonical_chords": [
+          "Fmaj7",
+          "Em7",
+          "Dm7",
+          "G7",
+          "Cmaj7"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major"
+        ],
+        "roman_numerals": [
+          "IVmaj7",
+          "iii7",
+          "ii7",
+          "V7",
+          "Imaj7"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "predominant",
+          "tonic-substitute",
+          "predominant",
+          "dominant",
+          "tonic"
+        ],
+        "scale_families": [
+          {
+            "chord": "Fmaj7",
+            "acceptable": [
+              "F Lydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Em7",
+            "acceptable": [
+              "E Phrygian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Dm7",
+            "acceptable": [
+              "D Dorian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "G7",
+            "acceptable": [
+              "G Mixolydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "Cmaj7",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "Fmaj7",
+            "quality": "major-7",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              9,
+              0,
+              4
+            ],
+            "notes": [
+              "F",
+              "A",
+              "C",
+              "E"
+            ]
+          },
+          {
+            "chord": "Em7",
+            "quality": "minor-7",
+            "root": "E",
+            "root_pitch_class": 4,
+            "pitch_classes": [
+              4,
+              7,
+              11,
+              2
+            ],
+            "notes": [
+              "E",
+              "G",
+              "B",
+              "D"
+            ]
+          },
+          {
+            "chord": "Dm7",
+            "quality": "minor-7",
+            "root": "D",
+            "root_pitch_class": 2,
+            "pitch_classes": [
+              2,
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "D",
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "G7",
+            "quality": "dominant-7",
+            "root": "G",
+            "root_pitch_class": 7,
+            "pitch_classes": [
+              7,
+              11,
+              2,
+              5
+            ],
+            "notes": [
+              "G",
+              "B",
+              "D",
+              "F"
+            ]
+          },
+          {
+            "chord": "Cmaj7",
+            "quality": "major-7",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7,
+              11
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G",
+              "B"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "the progression starts on IV, not I",
+          "descending ii-V-I approach",
+          "the tonic arrives only at the end"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "Fmaj7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                8,
+                10,
+                9,
+                10,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "Em7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                7,
+                9,
+                7,
+                8,
+                null
+              ],
+              "sounded_pitch_classes": [
+                2,
+                4,
+                7,
+                11
+              ]
+            },
+            {
+              "chord": "Dm7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                5,
+                7,
+                5,
+                6,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                2,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "G7",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                3,
+                5,
+                3,
+                4,
+                3,
+                3
+              ],
+              "sounded_pitch_classes": [
+                2,
+                5,
+                7,
+                11
+              ]
+            },
+            {
+              "chord": "Cmaj7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                4,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7,
+                11
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "F major",
+          "E minor",
+          "D minor",
+          "G major"
+        ],
+        "facts": [
+          "the key is F major",
+          "Fmaj7 is the tonic",
+          "the first chord determines the key"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [
+          614
+        ],
+        "rationale": "#614 shows \"F G C\" detected as F major because the tie-break favours the first chord's root. This case generalises that row: the first chord is IV and must not become the tonic."
+      },
+      "provenance": {
+        "source": "Generalisation of the \"F G C -> F major\" row in GuitarAlchemist/ga#614.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "Isolates the first-chord tie-break defect from the quality-blind defect: every chord here is quality-distinct and diatonic, so only the tie-break can go wrong."
+      }
+    },
+    {
+      "id": "pc-10-spelled-out-accidentals",
+      "category": "spelled-out-accidentals",
+      "title": "ii-V-I in E-flat major written with spelled-out accidentals",
+      "input": {
+        "chords": [
+          "F minor 7",
+          "B-flat 7",
+          "E-flat major 7"
+        ],
+        "canonical_chords": [
+          "Fm7",
+          "Bb7",
+          "Ebmaj7"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": [
+          {
+            "canonical": "Ebmaj7",
+            "spellings": [
+              "Ebmaj7",
+              "E-flat maj7",
+              "E flat maj7",
+              "E-flatmaj7"
+            ]
+          },
+          {
+            "canonical": "Bb7",
+            "spellings": [
+              "Bb7",
+              "B-flat 7",
+              "B flat 7",
+              "B-flat7"
+            ]
+          },
+          {
+            "canonical": "F#m",
+            "spellings": [
+              "F#m",
+              "F-sharp minor",
+              "F sharp minor",
+              "F-sharpm"
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "tonal_center": "Eb major",
+        "acceptable_tonal_centers": [
+          "Eb major"
+        ],
+        "roman_numerals": [
+          "ii7",
+          "V7",
+          "Imaj7"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "predominant",
+          "dominant",
+          "tonic"
+        ],
+        "scale_families": [
+          {
+            "chord": "Fm7",
+            "acceptable": [
+              "F Dorian",
+              "Eb major"
+            ]
+          },
+          {
+            "chord": "Bb7",
+            "acceptable": [
+              "Bb Mixolydian",
+              "Eb major"
+            ]
+          },
+          {
+            "chord": "Ebmaj7",
+            "acceptable": [
+              "Eb Ionian",
+              "Eb major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "Fm7",
+            "quality": "minor-7",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              8,
+              0,
+              3
+            ],
+            "notes": [
+              "F",
+              "Ab",
+              "C",
+              "Eb"
+            ]
+          },
+          {
+            "chord": "Bb7",
+            "quality": "dominant-7",
+            "root": "Bb",
+            "root_pitch_class": 10,
+            "pitch_classes": [
+              10,
+              2,
+              5,
+              8
+            ],
+            "notes": [
+              "Bb",
+              "D",
+              "F",
+              "Ab"
+            ]
+          },
+          {
+            "chord": "Ebmaj7",
+            "quality": "major-7",
+            "root": "Eb",
+            "root_pitch_class": 3,
+            "pitch_classes": [
+              3,
+              7,
+              10,
+              2
+            ],
+            "notes": [
+              "Eb",
+              "G",
+              "Bb",
+              "D"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "E-flat major has three flats",
+          "ii-V-I",
+          "E-flat and Eb are the same chord",
+          "B-flat and Bb are the same chord"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "Fm7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                8,
+                10,
+                8,
+                9,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                3,
+                5,
+                8
+              ]
+            },
+            {
+              "chord": "Bb7",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                6,
+                8,
+                6,
+                7,
+                6,
+                6
+              ],
+              "sounded_pitch_classes": [
+                2,
+                5,
+                8,
+                10
+              ]
+            },
+            {
+              "chord": "Ebmaj7",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                6,
+                8,
+                7,
+                8,
+                null
+              ],
+              "sounded_pitch_classes": [
+                2,
+                3,
+                7,
+                10
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "E major",
+          "B major",
+          "F major",
+          "C# minor"
+        ],
+        "facts": [
+          "E major",
+          "four sharps",
+          "the key is E major",
+          "B major is the dominant"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [
+          554
+        ],
+        "rationale": "#554: spelled-out accidentals silently truncate to the natural note (\"E-flat major\" -> E major) and the system then fabricates a key signature. Every spelling group below must resolve identically to its canonical shorthand."
+      },
+      "provenance": {
+        "source": "GuitarAlchemist/ga#554 repro, lifted from a key question into a progression.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "#554 names E-flat, B-flat and F-sharp plus spacing variants; all three accidentals are pinned here even though F# is not in the progression, because the parse boundary is shared."
+      }
+    },
+    {
+      "id": "pc-11-drop-c-alternate-tuning",
+      "category": "alternate-tuning",
+      "title": "i-iv-VI-V in C minor, Drop C tuning",
+      "input": {
+        "chords": [
+          "Cm",
+          "Fm",
+          "Ab",
+          "G"
+        ],
+        "canonical_chords": [
+          "Cm",
+          "Fm",
+          "Ab",
+          "G"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "drop-c",
+          "name": "Drop C",
+          "open_strings": [
+            "C2",
+            "G2",
+            "C3",
+            "F3",
+            "A3",
+            "D4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C minor",
+        "acceptable_tonal_centers": [
+          "C minor"
+        ],
+        "roman_numerals": [
+          "i",
+          "iv",
+          "VI",
+          "V"
+        ],
+        "alternative_roman_numerals": [],
+        "functions": [
+          "tonic",
+          "predominant",
+          "submediant",
+          "dominant"
+        ],
+        "scale_families": [
+          {
+            "chord": "Cm",
+            "acceptable": [
+              "C Aeolian",
+              "C natural minor",
+              "C harmonic minor"
+            ]
+          },
+          {
+            "chord": "Fm",
+            "acceptable": [
+              "F Dorian",
+              "F Aeolian",
+              "C natural minor"
+            ]
+          },
+          {
+            "chord": "Ab",
+            "acceptable": [
+              "Ab Lydian",
+              "C natural minor"
+            ]
+          },
+          {
+            "chord": "G",
+            "acceptable": [
+              "G Phrygian dominant",
+              "C harmonic minor",
+              "G altered"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "Cm",
+            "quality": "minor-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              3,
+              7
+            ],
+            "notes": [
+              "C",
+              "Eb",
+              "G"
+            ]
+          },
+          {
+            "chord": "Fm",
+            "quality": "minor-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              8,
+              0
+            ],
+            "notes": [
+              "F",
+              "Ab",
+              "C"
+            ]
+          },
+          {
+            "chord": "Ab",
+            "quality": "major-triad",
+            "root": "Ab",
+            "root_pitch_class": 8,
+            "pitch_classes": [
+              8,
+              0,
+              3
+            ],
+            "notes": [
+              "Ab",
+              "C",
+              "Eb"
+            ]
+          },
+          {
+            "chord": "G",
+            "quality": "major-triad",
+            "root": "G",
+            "root_pitch_class": 7,
+            "pitch_classes": [
+              7,
+              11,
+              2
+            ],
+            "notes": [
+              "G",
+              "B",
+              "D"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "Drop C tuning is C G C F A D low to high",
+          "the sixth string is a major third below standard E",
+          "strings five to one are standard tuning transposed down a whole step",
+          "the V chord is G major, not G minor",
+          "B natural is the leading tone and comes from C harmonic minor"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "drop-c",
+          "frames": [
+            {
+              "chord": "Cm",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                5,
+                7,
+                7,
+                6,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                3,
+                7
+              ]
+            },
+            {
+              "chord": "Fm",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                10,
+                12,
+                12,
+                11,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                8
+              ]
+            },
+            {
+              "chord": "Ab",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                1,
+                3,
+                3,
+                3,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                3,
+                8
+              ]
+            },
+            {
+              "chord": "G",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                0,
+                2,
+                2,
+                2,
+                null
+              ],
+              "sounded_pitch_classes": [
+                2,
+                7,
+                11
+              ]
+            }
+          ]
+        }
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "Eb major",
+          "C major",
+          "G major"
+        ],
+        "facts": [
+          "standard tuning",
+          "E A D G B E",
+          "Bb is the leading tone",
+          "drop D",
+          "the key is Eb major",
+          "Gm is the dominant"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "confident",
+        "min_alternatives": 1,
+        "max_confidence": null
+      },
+      "pins": {
+        "issues": [],
+        "rationale": null
+      },
+      "provenance": {
+        "source": "Drop-C is the alternate tuning already modelled by AlternateTuningsSkill (C - G - C - F - A - D); the harmony is the harmonic-minor i-iv-VI-V cadence.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "The only case whose fret numbers are wrong under standard tuning, so it fails loudly if the tuning is ignored rather than silently sounding plausible. The major V is deliberate: it makes C minor unambiguous, so this case cannot be confused with the relative-pair ambiguity of pc-12, which uses the same i-VI-III-VII interval pattern this case avoids."
+      }
+    },
+    {
+      "id": "pc-12-ambiguous-relative-pair",
+      "category": "ambiguous",
+      "title": "Ambiguous vi-IV-I-V / i-VI-III-VII",
+      "input": {
+        "chords": [
+          "Am",
+          "F",
+          "C",
+          "G"
+        ],
+        "canonical_chords": [
+          "Am",
+          "F",
+          "C",
+          "G"
+        ],
+        "instrument": "guitar",
+        "tuning": {
+          "id": "standard",
+          "name": "Standard E",
+          "open_strings": [
+            "E2",
+            "A2",
+            "D3",
+            "G3",
+            "B3",
+            "E4"
+          ]
+        },
+        "key_hint": null,
+        "spelling_equivalence_groups": []
+      },
+      "expected": {
+        "tonal_center": "C major",
+        "acceptable_tonal_centers": [
+          "C major",
+          "A minor"
+        ],
+        "roman_numerals": [
+          "vi",
+          "IV",
+          "I",
+          "V"
+        ],
+        "alternative_roman_numerals": [
+          [
+            "i",
+            "VI",
+            "III",
+            "VII"
+          ]
+        ],
+        "functions": [
+          "tonic-substitute",
+          "predominant",
+          "tonic",
+          "dominant"
+        ],
+        "scale_families": [
+          {
+            "chord": "Am",
+            "acceptable": [
+              "A Aeolian",
+              "C major",
+              "A natural minor"
+            ]
+          },
+          {
+            "chord": "F",
+            "acceptable": [
+              "F Lydian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "C",
+            "acceptable": [
+              "C Ionian",
+              "C major"
+            ]
+          },
+          {
+            "chord": "G",
+            "acceptable": [
+              "G Mixolydian",
+              "C major"
+            ]
+          }
+        ],
+        "required_chord_tones": [
+          {
+            "chord": "Am",
+            "quality": "minor-triad",
+            "root": "A",
+            "root_pitch_class": 9,
+            "pitch_classes": [
+              9,
+              0,
+              4
+            ],
+            "notes": [
+              "A",
+              "C",
+              "E"
+            ]
+          },
+          {
+            "chord": "F",
+            "quality": "major-triad",
+            "root": "F",
+            "root_pitch_class": 5,
+            "pitch_classes": [
+              5,
+              9,
+              0
+            ],
+            "notes": [
+              "F",
+              "A",
+              "C"
+            ]
+          },
+          {
+            "chord": "C",
+            "quality": "major-triad",
+            "root": "C",
+            "root_pitch_class": 0,
+            "pitch_classes": [
+              0,
+              4,
+              7
+            ],
+            "notes": [
+              "C",
+              "E",
+              "G"
+            ]
+          },
+          {
+            "chord": "G",
+            "quality": "major-triad",
+            "root": "G",
+            "root_pitch_class": 7,
+            "pitch_classes": [
+              7,
+              11,
+              2
+            ],
+            "notes": [
+              "G",
+              "B",
+              "D"
+            ]
+          }
+        ],
+        "explanation_facts": [
+          "C major and A minor are relative keys and share all four chords",
+          "there is no G# and therefore no dominant of A minor",
+          "the progression is genuinely ambiguous"
+        ],
+        "voicing_sequence": {
+          "tuning_id": "standard",
+          "frames": [
+            {
+              "chord": "Am",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                0,
+                2,
+                2,
+                1,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                9
+              ]
+            },
+            {
+              "chord": "F",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                1,
+                3,
+                3,
+                2,
+                1,
+                1
+              ],
+              "sounded_pitch_classes": [
+                0,
+                5,
+                9
+              ]
+            },
+            {
+              "chord": "C",
+              "shape_family": "A",
+              "frets_low_to_high": [
+                null,
+                3,
+                5,
+                5,
+                5,
+                null
+              ],
+              "sounded_pitch_classes": [
+                0,
+                4,
+                7
+              ]
+            },
+            {
+              "chord": "G",
+              "shape_family": "E",
+              "frets_low_to_high": [
+                3,
+                5,
+                5,
+                4,
+                3,
+                3
+              ],
+              "sounded_pitch_classes": [
+                2,
+                7,
+                11
+              ]
+            }
+          ]
+        },
+        "notes": "A system that returns exactly one tonal centre with high confidence FAILS this case even if that centre is C major."
+      },
+      "forbidden": {
+        "tonal_centers": [
+          "F major",
+          "G major",
+          "D minor"
+        ],
+        "facts": [
+          "unambiguously",
+          "the key is definitely",
+          "confidence 100%"
+        ]
+      },
+      "uncertainty": {
+        "expected_behavior": "alternatives",
+        "min_alternatives": 2,
+        "max_confidence": 0.8
+      },
+      "pins": {
+        "issues": [],
+        "rationale": null
+      },
+      "provenance": {
+        "source": "The relative-major/minor ambiguity built into the four-chord pop loop.",
+        "added_in": "GuitarAlchemist/ga#627",
+        "rationale": "The corpus needs one case where a single confident answer is itself the failure. A correct system offers both readings, warns, or abstains."
+      }
+    }
+  ]
+}

--- a/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/progression-corpus.v1.schema.json
+++ b/Tests/Common/GA.Business.ML.Tests/Corpus/Progressions/progression-corpus.v1.schema.json
@@ -1,0 +1,359 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guitaralchemist.com/schemas/progression-corpus.v1.schema.json",
+  "title": "Progression-to-voicing evaluation corpus, v1 (draft)",
+  "description": "Language-neutral contract for the held-out deterministic progression-to-voicing evaluation corpus introduced by GuitarAlchemist/ga#627 under story #623. This is evaluation data, NOT production configuration: nothing in the runtime reads it. Expectations describe what a musically correct system must answer and are deliberately not trimmed to current product behaviour. STATUS: draft (v0.1.x convention) - not frozen; freeze only at the Phase 4 milestone of #623. NOTE FOR IMPLEMENTERS: the in-repo validator (JsonSchemaSubsetValidator) implements a bounded subset of JSON Schema - type, const, enum, required, properties, additionalProperties (boolean), items, minItems, maxItems, uniqueItems, minimum, maximum, minLength, pattern, $ref into $defs. Keep this document inside that subset; ProgressionCorpusLoaderTests fails if an unsupported keyword appears.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "corpus_id",
+    "corpus_version",
+    "status",
+    "held_out",
+    "issue",
+    "parent_issue",
+    "description",
+    "cases"
+  ],
+  "properties": {
+    "schema": { "const": "progression-corpus.v1.schema.json" },
+    "schema_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "corpus_id": { "const": "progression-to-voicing" },
+    "corpus_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "status": { "enum": ["draft", "frozen"] },
+    "held_out": { "type": "boolean" },
+    "issue": { "type": "string", "minLength": 1 },
+    "parent_issue": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "cases": {
+      "type": "array",
+      "minItems": 12,
+      "items": { "$ref": "#/$defs/case" }
+    }
+  },
+  "$defs": {
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "category", "title", "input", "expected", "forbidden", "uncertainty", "pins", "provenance"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^pc-[0-9]{2}-[a-z0-9-]+$" },
+        "category": { "$ref": "#/$defs/category" },
+        "title": { "type": "string", "minLength": 1 },
+        "input": { "$ref": "#/$defs/input" },
+        "expected": { "$ref": "#/$defs/expected" },
+        "forbidden": { "$ref": "#/$defs/forbidden" },
+        "uncertainty": { "$ref": "#/$defs/uncertainty" },
+        "pins": { "$ref": "#/$defs/pins" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      }
+    },
+
+    "category": {
+      "description": "The twelve required coverage categories of GuitarAlchemist/ga#627. Every value must be used by at least one case; the loader tests enforce that.",
+      "enum": [
+        "major-ii-V-I",
+        "minor-ii-V-i",
+        "major-I-vi-IV-V",
+        "deceptive-cadence",
+        "borrowed-iv",
+        "borrowed-bVII",
+        "secondary-dominant",
+        "modal",
+        "starts-away-from-tonic",
+        "spelled-out-accidentals",
+        "alternate-tuning",
+        "ambiguous"
+      ]
+    },
+
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chords", "canonical_chords", "instrument", "tuning", "key_hint", "spelling_equivalence_groups"],
+      "properties": {
+        "chords": {
+          "description": "The progression exactly as a user would type it - may use spelled-out accidentals.",
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 8,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "canonical_chords": {
+          "description": "Shorthand equivalents of `chords`, index-aligned. Identical to `chords` unless the case exercises alternative spellings.",
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 8,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "instrument": { "enum": ["guitar"] },
+        "tuning": { "$ref": "#/$defs/tuning" },
+        "key_hint": { "type": ["string", "null"] },
+        "spelling_equivalence_groups": {
+          "description": "Sets of chord spellings that MUST resolve identically. A group's canonical member need not appear in the progression - #554 names E-flat, B-flat and F-sharp, and all three share one parse boundary.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/spelling_group" }
+        }
+      }
+    },
+
+    "spelling_group": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonical", "spellings"],
+      "properties": {
+        "canonical": { "type": "string", "minLength": 1 },
+        "spellings": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+
+    "tuning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "open_strings"],
+      "properties": {
+        "id": { "enum": ["standard", "drop-c"] },
+        "name": { "type": "string", "minLength": 1 },
+        "open_strings": {
+          "description": "Scientific-pitch open strings, lowest string first.",
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 8,
+          "items": { "type": "string", "pattern": "^[A-G](#|b)?[0-9]$" }
+        }
+      }
+    },
+
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tonal_center",
+        "acceptable_tonal_centers",
+        "roman_numerals",
+        "alternative_roman_numerals",
+        "functions",
+        "scale_families",
+        "required_chord_tones",
+        "explanation_facts",
+        "voicing_sequence"
+      ],
+      "properties": {
+        "tonal_center": { "type": "string", "minLength": 1 },
+        "acceptable_tonal_centers": {
+          "description": "Every tonal centre a correct system may return. A modal centre such as 'D dorian' is allowed here even though no current seam can express it - that gap is reported, never papered over.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "roman_numerals": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "alternative_roman_numerals": {
+          "description": "Additional complete readings that are also acceptable (used by the ambiguous case).",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "functions": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/function" }
+        },
+        "scale_families": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/scale_family" }
+        },
+        "required_chord_tones": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/chord_tones" }
+        },
+        "explanation_facts": {
+          "description": "Facts an explanation must convey. Graded by a later explanation judge; this task only pins them as data.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "voicing_sequence": { "$ref": "#/$defs/voicing_sequence" },
+        "notes": { "type": "string", "minLength": 1 }
+      }
+    },
+
+    "function": {
+      "enum": [
+        "tonic",
+        "tonic-substitute",
+        "predominant",
+        "dominant",
+        "secondary-dominant",
+        "borrowed-predominant",
+        "borrowed-subtonic",
+        "deceptive-resolution",
+        "modal-tonic",
+        "modal-colour",
+        "submediant",
+        "mediant",
+        "subtonic"
+      ]
+    },
+
+    "scale_family": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chord", "acceptable"],
+      "properties": {
+        "chord": { "type": "string", "minLength": 1 },
+        "acceptable": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+
+    "chord_tones": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chord", "quality", "root", "root_pitch_class", "pitch_classes", "notes"],
+      "properties": {
+        "chord": { "type": "string", "minLength": 1 },
+        "quality": {
+          "enum": ["major-triad", "minor-triad", "dominant-7", "major-7", "minor-7", "half-diminished-7"]
+        },
+        "root": { "type": "string", "pattern": "^[A-G](#|b)?$" },
+        "root_pitch_class": { "type": "integer", "minimum": 0, "maximum": 11 },
+        "pitch_classes": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": { "type": "integer", "minimum": 0, "maximum": 11 }
+        },
+        "notes": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[A-G](#|##|b|bb)?$" }
+        }
+      }
+    },
+
+    "voicing_sequence": {
+      "description": "At least one complete valid realisation of the progression. Fret numbers are validated against the case tuning by fret arithmetic only - no harmonic analysis is re-implemented in the harness.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tuning_id", "frames"],
+      "properties": {
+        "tuning_id": { "enum": ["standard", "drop-c"] },
+        "frames": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/voicing_frame" }
+        }
+      }
+    },
+
+    "voicing_frame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chord", "shape_family", "frets_low_to_high", "sounded_pitch_classes"],
+      "properties": {
+        "chord": { "type": "string", "minLength": 1 },
+        "shape_family": { "enum": ["E", "A"] },
+        "frets_low_to_high": {
+          "description": "One entry per string, lowest string first. null means the string is muted.",
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 8,
+          "items": { "type": ["integer", "null"], "minimum": 0, "maximum": 24 }
+        },
+        "sounded_pitch_classes": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": { "type": "integer", "minimum": 0, "maximum": 11 }
+        }
+      }
+    },
+
+    "forbidden": {
+      "description": "Answers that are factually wrong for this case. A system that emits any of these fails the case regardless of what else it gets right.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tonal_centers", "facts"],
+      "properties": {
+        "tonal_centers": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "facts": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+
+    "uncertainty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expected_behavior", "min_alternatives", "max_confidence"],
+      "properties": {
+        "expected_behavior": {
+          "description": "confident = one answer is required; alternatives = more than one reading must be offered; warn = a caveat must be surfaced; abstain = the system must decline rather than guess.",
+          "enum": ["confident", "alternatives", "warn", "abstain"]
+        },
+        "min_alternatives": { "type": "integer", "minimum": 1, "maximum": 4 },
+        "max_confidence": { "type": ["number", "null"], "minimum": 0, "maximum": 1 }
+      }
+    },
+
+    "pins": {
+      "description": "Open GA issues whose regression this case pins. #627 requires at least two cases pinning #614 and #567.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issues", "rationale"],
+      "properties": {
+        "issues": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "integer", "minimum": 1 }
+        },
+        "rationale": { "type": ["string", "null"], "minLength": 1 }
+      }
+    },
+
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "added_in", "rationale"],
+      "properties": {
+        "source": { "type": "string", "minLength": 1 },
+        "added_in": { "const": "GuitarAlchemist/ga#627" },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/state/quality/progression-corpus/progression-corpus-matrix.json
+++ b/state/quality/progression-corpus/progression-corpus-matrix.json
@@ -1,0 +1,1309 @@
+{
+  "artifact": "progression-corpus-matrix",
+  "artifact_version": "1.0.0",
+  "issue": "GuitarAlchemist/ga#627",
+  "parent_issue": "GuitarAlchemist/ga#623",
+  "corpus_id": "progression-to-voicing",
+  "corpus_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "note": "Deterministic: no clock, no network, no randomness. Regenerate with GA_CORPUS_WRITE_MATRIX=1. \u0027blocked\u0027 means no deterministic seam exists in this assembly yet, not that the expectation is optional.",
+  "seams": [
+    {
+      "id": "key.identify",
+      "implementation": "GA.Business.ML.Agents.KeyIdentificationService.Identify",
+      "notes": "Scores all 30 major/minor keys on root \u002B triad quality. Cannot express modal centres."
+    },
+    {
+      "id": "improvisation.quality",
+      "implementation": "GA.Business.ML.Agents.Skills.ImprovisationSkill.InferQuality",
+      "notes": "Classifies chord quality from the written symbol."
+    },
+    {
+      "id": "improvisation.arpeggio",
+      "implementation": "GA.Business.ML.Agents.Skills.ImprovisationSkill.ArpeggioFor",
+      "notes": "Builds the canonical arpeggio symbol for a root plus quality."
+    },
+    {
+      "id": "tuning.parse",
+      "implementation": "GA.Domain.Core.Primitives.Notes.PitchCollection.Parse",
+      "notes": "Parses scientific-pitch open strings into domain pitches."
+    }
+  ],
+  "totals": {
+    "pass": 52,
+    "fail": 21,
+    "blocked": 72
+  },
+  "cases": [
+    {
+      "id": "pc-01-major-ii-v-i",
+      "category": "major-ii-V-I",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "none of: D major | D minor | G major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): A minor | C major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "one of: C major"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-02-minor-ii-v-i",
+      "category": "minor-ii-V-i",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A major | E minor | F# minor | G major",
+          "expected": "none of: B minor | E major | C major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "4 tied candidate(s): A major | E minor | F# minor | G major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "top-tied: A major | E minor | F# minor | G major",
+          "expected": "one of: A minor"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-03-major-i-vi-iv-v",
+      "category": "major-I-vi-IV-V",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "none of: A major | F major | G major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): A minor | C major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "one of: C major"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-04-deceptive-cadence",
+      "category": "deceptive-cadence",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "forbidden in top-tied: A minor",
+          "expected": "none of: A minor | A major | G major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): A minor | C major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "one of: C major"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-05-borrowed-iv",
+      "category": "borrowed-iv",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "forbidden in top-tied: F major",
+          "expected": "none of: F major | F minor | Ab major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "4 tied candidate(s): A minor | C major | D minor | F major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major | D minor | F major",
+          "expected": "one of: C major"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-06-borrowed-bvii",
+      "category": "borrowed-bVII",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "forbidden in top-tied: F major",
+          "expected": "none of: Bb major | F major | G minor"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): D minor | F major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "top-tied: D minor | F major",
+          "expected": "one of: C major"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-07-secondary-dominant",
+      "category": "secondary-dominant",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "forbidden in top-tied: A minor",
+          "expected": "none of: E major | A minor | A major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): A minor | C major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "one of: C major"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-08-modal-dorian-vamp",
+      "category": "modal",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "forbidden in top-tied: A minor | C major",
+          "expected": "none of: C major | D minor | A minor"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): A minor | C major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "top-tied: A minor | C major",
+          "expected": "one of: D dorian"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-09-starts-off-tonic",
+      "category": "starts-away-from-tonic",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "none of: F major | E minor | D minor | G major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): A minor | C major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "one of: C major"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-10-spelled-out-accidentals",
+      "category": "spelled-out-accidentals",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: C minor | Eb major",
+          "expected": "none of: E major | B major | F major | C# minor"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "2 tied candidate(s): C minor | Eb major",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: C minor | Eb major",
+          "expected": "one of: Eb major"
+        },
+        {
+          "check": "spelling.equivalent_spellings_agree",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "\u0027E-flat maj7\u0027 -\u003E A major,Ab minor,B major,C# minor,Cb major,E major,F# minor,G# minor != \u0027Ebmaj7\u0027 -\u003E Ab major,Bb major,C minor,Eb major,F minor,G minor; \u0027E flat maj7\u0027 -\u003E A major,Ab minor,B major,C# minor,Cb major,E major,F# minor,G# minor != \u0027Ebmaj7\u0027 -\u003E Ab major,Bb major,C minor,Eb major,F minor,G minor; \u0027E-flatmaj7\u0027 -\u003E A major,Ab minor,B major,C# minor,Cb major,E major,F# minor,G# minor != \u0027Ebmaj7\u0027 -\u003E Ab major,Bb major,C minor,Eb major,F minor,G minor; \u0027B-flat 7\u0027 -\u003E Ab minor,B major,C# minor,Cb major,D# minor,E major,Eb minor,F# major,G# minor,Gb major != \u0027Bb7\u0027 -\u003E Bb major,C minor,D minor,Eb major,F major,G minor; \u0027B flat 7\u0027 -\u003E Ab minor,B major,C# minor,Cb major,D# minor,E major,Eb minor,F# major,G# minor,Gb major != \u0027Bb7\u0027 -\u003E Bb major,C minor,D minor,Eb major,F major,G minor; \u0027B-flat7\u0027 -\u003E Ab minor,B major,C# minor,Cb major,D# minor,E major,Eb minor,F# major,G# minor,Gb major != \u0027Bb7\u0027 -\u003E Bb major,C minor,D minor,Eb major,F major,G minor; \u0027F-sharp minor\u0027 -\u003E A minor,Bb major,C major,D minor,F major,G minor != \u0027F#m\u0027 -\u003E A major,B minor,C# minor,D major,E major,F# minor; \u0027F sharp minor\u0027 -\u003E A minor,Bb major,C major,D minor,F major,G minor != \u0027F#m\u0027 -\u003E A major,B minor,C# minor,D major,E major,F# minor; \u0027F-sharpm\u0027 -\u003E A minor,Bb major,C major,D minor,F major,G minor != \u0027F#m\u0027 -\u003E A major,B minor,C# minor,D major,E major,F# minor",
+          "expected": "spelled-out and shorthand accidentals resolve identically (GuitarAlchemist/ga#554)",
+          "blocked_on": [
+            554
+          ]
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-11-drop-c-alternate-tuning",
+      "category": "alternate-tuning",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "forbidden in top-tied: Eb major",
+          "expected": "none of: Eb major | C major | G major"
+        },
+        {
+          "check": "key.single_reading_when_confident",
+          "seam": "key.identify",
+          "status": "fail",
+          "observed": "4 tied candidate(s): Ab major | C minor | Eb major | F minor",
+          "expected": "exactly 1 top candidate"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: Ab major | C minor | Eb major | F minor",
+          "expected": "one of: C minor"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027C2 G2 C3 F3 A3 D4\u0027 -\u003E MIDI 36,43,48,53,57,62",
+          "expected": "MIDI 36,43,48,53,57,62"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pc-12-ambiguous-relative-pair",
+      "category": "ambiguous",
+      "checks": [
+        {
+          "check": "analysis.chord_functions",
+          "status": "blocked",
+          "observed": "no seam assigns harmonic function per chord",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.roman_numerals",
+          "status": "blocked",
+          "observed": "no seam produces Roman numerals for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            614
+          ]
+        },
+        {
+          "check": "analysis.scale_families",
+          "status": "blocked",
+          "observed": "no seam produces per-chord scale choices in the context of a key",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623,
+            567
+          ]
+        },
+        {
+          "check": "explanation.required_facts",
+          "status": "blocked",
+          "observed": "explanation grading needs the #623 orchestration path plus a judge",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "improvisation.arpeggio_symbol_is_canonical",
+          "seam": "improvisation.arpeggio",
+          "status": "pass",
+          "observed": "no arpeggio symbol matched a forbidden fact",
+          "expected": "no arpeggio symbol contains a forbidden string (e.g. the #567 \u0027Amm7\u0027 concatenation)"
+        },
+        {
+          "check": "improvisation.quality_from_written_symbol",
+          "seam": "improvisation.quality",
+          "status": "pass",
+          "observed": "all chord qualities classified from the written symbol",
+          "expected": "each chord\u0027s inferred quality matches the quality written in the symbol"
+        },
+        {
+          "check": "key.alternatives_when_ambiguous",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "2 tied candidate(s): A minor | C major",
+          "expected": "at least 2, including all of: C major | A minor"
+        },
+        {
+          "check": "key.forbidden_center_excluded",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "none of: F major | G major | D minor"
+        },
+        {
+          "check": "key.top_candidate_acceptable",
+          "seam": "key.identify",
+          "status": "pass",
+          "observed": "top-tied: A minor | C major",
+          "expected": "one of: C major | A minor"
+        },
+        {
+          "check": "tuning.domain_parses_open_strings",
+          "seam": "tuning.parse",
+          "status": "pass",
+          "observed": "\u0027E2 A2 D3 G3 B3 E4\u0027 -\u003E MIDI 40,45,50,55,59,64",
+          "expected": "MIDI 40,45,50,55,59,64"
+        },
+        {
+          "check": "uncertainty.behavior",
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        },
+        {
+          "check": "voicing.product_generates_valid_path",
+          "status": "blocked",
+          "observed": "no seam generates a voicing path for a progression in a given tuning",
+          "expected": "see the corpus expectation for this case",
+          "blocked_on": [
+            623
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/state/quality/progression-corpus/progression-corpus-matrix.json
+++ b/state/quality/progression-corpus/progression-corpus-matrix.json
@@ -30,9 +30,9 @@
     }
   ],
   "totals": {
-    "pass": 52,
+    "pass": 51,
     "fail": 21,
-    "blocked": 72
+    "blocked": 73
   },
   "cases": [
     {
@@ -97,7 +97,7 @@
           "seam": "key.identify",
           "status": "pass",
           "observed": "top-tied: A minor | C major",
-          "expected": "none of: D major | D minor | G major"
+          "expected": "at least one candidate, and none of: D major | D minor | G major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -202,7 +202,7 @@
           "seam": "key.identify",
           "status": "pass",
           "observed": "top-tied: A major | E minor | F# minor | G major",
-          "expected": "none of: B minor | E major | C major"
+          "expected": "at least one candidate, and none of: B minor | E major | C major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -307,7 +307,7 @@
           "seam": "key.identify",
           "status": "pass",
           "observed": "top-tied: A minor | C major",
-          "expected": "none of: A major | F major | G major"
+          "expected": "at least one candidate, and none of: A major | F major | G major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -412,7 +412,7 @@
           "seam": "key.identify",
           "status": "fail",
           "observed": "forbidden in top-tied: A minor",
-          "expected": "none of: A minor | A major | G major"
+          "expected": "at least one candidate, and none of: A minor | A major | G major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -517,7 +517,7 @@
           "seam": "key.identify",
           "status": "fail",
           "observed": "forbidden in top-tied: F major",
-          "expected": "none of: F major | F minor | Ab major"
+          "expected": "at least one candidate, and none of: F major | F minor | Ab major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -622,7 +622,7 @@
           "seam": "key.identify",
           "status": "fail",
           "observed": "forbidden in top-tied: F major",
-          "expected": "none of: Bb major | F major | G minor"
+          "expected": "at least one candidate, and none of: Bb major | F major | G minor"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -727,7 +727,7 @@
           "seam": "key.identify",
           "status": "fail",
           "observed": "forbidden in top-tied: A minor",
-          "expected": "none of: E major | A minor | A major"
+          "expected": "at least one candidate, and none of: E major | A minor | A major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -832,7 +832,7 @@
           "seam": "key.identify",
           "status": "fail",
           "observed": "forbidden in top-tied: A minor | C major",
-          "expected": "none of: C major | D minor | A minor"
+          "expected": "at least one candidate, and none of: C major | D minor | A minor"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -937,7 +937,7 @@
           "seam": "key.identify",
           "status": "pass",
           "observed": "top-tied: A minor | C major",
-          "expected": "none of: F major | E minor | D minor | G major"
+          "expected": "at least one candidate, and none of: F major | E minor | D minor | G major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -1042,7 +1042,7 @@
           "seam": "key.identify",
           "status": "pass",
           "observed": "top-tied: C minor | Eb major",
-          "expected": "none of: E major | B major | F major | C# minor"
+          "expected": "at least one candidate, and none of: E major | B major | F major | C# minor"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -1157,7 +1157,7 @@
           "seam": "key.identify",
           "status": "fail",
           "observed": "forbidden in top-tied: Eb major",
-          "expected": "none of: Eb major | C major | G major"
+          "expected": "at least one candidate, and none of: Eb major | C major | G major"
         },
         {
           "check": "key.single_reading_when_confident",
@@ -1259,17 +1259,19 @@
         },
         {
           "check": "key.alternatives_when_ambiguous",
-          "seam": "key.identify",
-          "status": "pass",
-          "observed": "2 tied candidate(s): A minor | C major",
-          "expected": "at least 2, including all of: C major | A minor"
+          "status": "blocked",
+          "observed": "no seam reports alternatives, warnings or abstention for a progression; a bare relative-key scoring tie is not an ambiguity signal",
+          "expected": "at least 2 explicit alternatives, including all of: C major | A minor",
+          "blocked_on": [
+            623
+          ]
         },
         {
           "check": "key.forbidden_center_excluded",
           "seam": "key.identify",
           "status": "pass",
           "observed": "top-tied: A minor | C major",
-          "expected": "none of: F major | G major | D minor"
+          "expected": "at least one candidate, and none of: F major | G major | D minor"
         },
         {
           "check": "key.top_candidate_acceptable",


### PR DESCRIPTION
## Summary

- adds a versioned, language-neutral 12-case progression-to-voicing corpus;
- adds an explicit JSON schema, deterministic loader, structural validation, and machine-readable evidence matrix;
- covers the required tonal, enharmonic, ambiguity, regression, and alternate-tuning categories;
- keeps production music-theory, ranking, chatbot, MCP, and voicing behavior unchanged;
- closes three evidence-layer false-success paths found by independent review.

## Scope

- Whole slice: 10 files, +6836/-0 from `97cefe333508e480bf945b1ca887d7fb5218e68a`.
- Review-finding correction: 5 files, +267/-32 from `45f7705a80209705a305d3a7556768cca9c7a253`.
- Exact reviewed head: `d9cbc06835c567ae56354cbbfd6f1bb00bc4e6c1`.
- No production, project, workflow, policy, or protected-path files changed.

## Validation

- Focused corpus suite: 117 passed, 1 opt-in writer test skipped.
- Owning project: 1807 passed, 23 skipped, with one pre-existing missing-ONNX failure reproduced at the parent; zero candidate-attributable failures.
- `bash Scripts/cloud-validate.sh`: 125/125 green. This lane does not currently execute the corpus tests, which is disclosed as follow-up work.
- Evidence matrix independently regenerated twice and byte-identical to the committed artifact: 51 pass / 21 fail / 73 blocked across 145 cells.
- Fresh independent Standards review: APPROVE.
- Fresh independent Spec/adversarial review: APPROVE.
- Exact review clones remained clean.

## Current gaps

The evidence artifact reports current deterministic seam coverage without changing production behavior. Remaining product gaps stay linked to #614, #567, and #554; this PR does not claim those behaviors are implemented.

Fixes #627
Related #623
