### PR TITLE
fix(dashboard): stop the quality scorecard reading an advisory snapshot as a live regression

### DIFF
--- a/ReactComponents/ga-react-components/src/dev-data/parsers.test.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.test.ts
@@ -13,6 +13,7 @@ import {
     extractPrRefs,
     extractDocRefs,
     parseValueCatalog,
+    classifyQualitySnapshot,
 } from './parsers';
 
 describe('categorize', () => {
@@ -505,5 +506,83 @@ describe('parseValueCatalog', () => {
 
     it('returns empty array for empty input', () => {
         expect(parseValueCatalog('')).toEqual([]);
+    });
+});
+
+describe('classifyQualitySnapshot', () => {
+    const NOW = new Date('2026-08-09T12:00:00Z');
+    const FRESH = '2026-08-09T00:00:00Z';   // 0.5 days before NOW
+    const OLD = '2026-07-20T12:00:00Z';     // 20 days before NOW
+
+    // Rule 0 — no adverse signal. Preserves the pre-change behaviour exactly:
+    // a snapshot the scorecard never reported must not start appearing.
+    it('returns ok when the snapshot carries no oracle_status', () => {
+        expect(classifyQualitySnapshot('chatbot-qa', { emitted_at: FRESH }, NOW).kind).toBe('ok');
+    });
+
+    it('returns ok when oracle_status is ok, however old the snapshot is', () => {
+        const v = classifyQualitySnapshot('invariants', { emitted_at: OLD, oracle_status: 'ok' }, NOW);
+        expect(v.kind).toBe('ok');
+    });
+
+    // Rule A — advisory.
+    it('classifies a fresh advisory snapshot as advisory, never a regression', () => {
+        const v = classifyQualitySnapshot('maintain-gate', { emitted_at: FRESH, oracle_status: 'warn', advisory: true }, NOW);
+        expect(v.kind).toBe('advisory');
+    });
+
+    it('advisory wins over staleness (a stale advisory is still advisory)', () => {
+        const v = classifyQualitySnapshot('maintain-gate', { emitted_at: OLD, oracle_status: 'warn', advisory: true }, NOW);
+        expect(v.kind).toBe('advisory');
+    });
+
+    it('reads advisory dynamically — advisory:false is not exempt', () => {
+        // ga#428 flips maintain-gate to advisory:false at IX Phase-3b; the
+        // classifier must follow the field, not assume it stays true.
+        const v = classifyQualitySnapshot('maintain-gate', { emitted_at: FRESH, oracle_status: 'warn', advisory: false }, NOW);
+        expect(v.kind).toBe('regression');
+    });
+
+    // Rule B — staleness.
+    it('classifies a snapshot older than the DEFAULT 7-day threshold as stale', () => {
+        // staleAfterDays deliberately not injected — this pins the default,
+        // which mirrors ix-quality-trend's DEFAULT_STALE_AFTER_DAYS = 7.
+        const v = classifyQualitySnapshot('readme-drift', { emitted_at: OLD, oracle_status: 'error' }, NOW);
+        expect(v.kind).toBe('stale');
+        expect(v.label).toBe('readme-drift: oracle_status=error');
+    });
+
+    it('treats absent or unparseable emitted_at as stale — never fresh', () => {
+        expect(classifyQualitySnapshot('x', { oracle_status: 'warn' }, NOW).kind).toBe('stale');
+        expect(classifyQualitySnapshot('x', { emitted_at: 'not-a-date', oracle_status: 'warn' }, NOW).kind).toBe('stale');
+    });
+
+    it('honours an injected staleAfterDays threshold', () => {
+        const snap = { emitted_at: OLD, oracle_status: 'warn' };
+        expect(classifyQualitySnapshot('x', snap, NOW, 30).kind).toBe('regression');
+        expect(classifyQualitySnapshot('x', snap, NOW, 1).kind).toBe('stale');
+    });
+
+    // Rule C — live regression.
+    it('classifies a fresh, binding, non-ok snapshot as a regression', () => {
+        expect(classifyQualitySnapshot('embeddings', { emitted_at: FRESH, oracle_status: 'warn' }, NOW).kind).toBe('regression');
+        expect(classifyQualitySnapshot('readme-drift', { emitted_at: FRESH, oracle_status: 'error' }, NOW).kind).toBe('regression');
+    });
+
+    // Label + age. The label is a PUBLISHED string with four rendering
+    // consumers — it must stay byte-identical to the pre-change one.
+    it('keeps the published label identical to the pre-change string', () => {
+        const v = classifyQualitySnapshot('maintain-gate', { emitted_at: OLD, oracle_status: 'warn', advisory: true }, NOW);
+        expect(v.label).toBe('maintain-gate: oracle_status=warn');
+    });
+
+    it('reports ageDays from emitted_at, and null when it is unknown', () => {
+        expect(classifyQualitySnapshot('x', { emitted_at: OLD, oracle_status: 'warn' }, NOW).ageDays).toBeCloseTo(20, 5);
+        expect(classifyQualitySnapshot('x', { oracle_status: 'warn' }, NOW).ageDays).toBeNull();
+    });
+
+    it('tolerates a non-object payload without throwing', () => {
+        expect(classifyQualitySnapshot('x', null, NOW).kind).toBe('ok');
+        expect(classifyQualitySnapshot('x', 'garbage', NOW).kind).toBe('ok');
     });
 });

--- a/ReactComponents/ga-react-components/src/dev-data/parsers.test.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.test.ts
@@ -531,7 +531,7 @@ describe('classifyQualitySnapshot', () => {
         expect(v.kind).toBe('advisory');
     });
 
-    it('advisory wins over staleness (a stale advisory is still advisory)', () => {
+    it('demotes an advisory snapshot regardless of its age', () => {
         const v = classifyQualitySnapshot('maintain-gate', { emitted_at: OLD, oracle_status: 'warn', advisory: true }, NOW);
         expect(v.kind).toBe('advisory');
     });
@@ -543,30 +543,30 @@ describe('classifyQualitySnapshot', () => {
         expect(v.kind).toBe('regression');
     });
 
-    // Rule B — staleness.
-    it('classifies a snapshot older than the DEFAULT 7-day threshold as stale', () => {
-        // staleAfterDays deliberately not injected — this pins the default,
-        // which mirrors ix-quality-trend's DEFAULT_STALE_AFTER_DAYS = 7.
-        const v = classifyQualitySnapshot('readme-drift', { emitted_at: OLD, oracle_status: 'error' }, NOW);
-        expect(v.kind).toBe('stale');
-        expect(v.label).toBe('readme-drift: oracle_status=error');
-    });
-
-    it('treats absent or unparseable emitted_at as stale — never fresh', () => {
-        expect(classifyQualitySnapshot('x', { oracle_status: 'warn' }, NOW).kind).toBe('stale');
-        expect(classifyQualitySnapshot('x', { emitted_at: 'not-a-date', oracle_status: 'warn' }, NOW).kind).toBe('stale');
-    });
-
-    it('honours an injected staleAfterDays threshold', () => {
-        const snap = { emitted_at: OLD, oracle_status: 'warn' };
-        expect(classifyQualitySnapshot('x', snap, NOW, 30).kind).toBe('regression');
-        expect(classifyQualitySnapshot('x', snap, NOW, 1).kind).toBe('stale');
-    });
-
-    // Rule C — live regression.
-    it('classifies a fresh, binding, non-ok snapshot as a regression', () => {
+    // Rule B — binding non-ok verdict.
+    it('classifies a binding, non-ok snapshot as a regression', () => {
         expect(classifyQualitySnapshot('embeddings', { emitted_at: FRESH, oracle_status: 'warn' }, NOW).kind).toBe('regression');
         expect(classifyQualitySnapshot('readme-drift', { emitted_at: FRESH, oracle_status: 'error' }, NOW).kind).toBe('regression');
+    });
+
+    // Age must never demote. An earlier draft demoted anything older than a
+    // fixed 7 days; 7 days is exactly readme-drift's weekly producer cadence,
+    // so that rule silently moved a genuine red verdict out of regressions[]
+    // ~20h after it shipped. Classification is now a pure function of the
+    // snapshot's own fields — age is reported, never acted on.
+    it('never demotes a binding non-ok snapshot on age alone, however old', () => {
+        const snap = { emitted_at: OLD, oracle_status: 'error' };
+        expect(classifyQualitySnapshot('readme-drift', snap, NOW).kind).toBe('regression');
+        for (const later of ['2026-09-15T12:00:00Z', '2027-01-01T12:00:00Z', '2030-01-01T12:00:00Z']) {
+            expect(classifyQualitySnapshot('readme-drift', snap, new Date(later)).kind).toBe('regression');
+        }
+    });
+
+    it('keeps a non-ok snapshot with absent or unparseable emitted_at a regression', () => {
+        // Unknown freshness must fail TOWARD reporting on this surface: a
+        // binding bad verdict may not vanish because its timestamp is missing.
+        expect(classifyQualitySnapshot('x', { oracle_status: 'warn' }, NOW).kind).toBe('regression');
+        expect(classifyQualitySnapshot('x', { emitted_at: 'not-a-date', oracle_status: 'warn' }, NOW).kind).toBe('regression');
     });
 
     // Label + age. The label is a PUBLISHED string with four rendering

--- a/ReactComponents/ga-react-components/src/dev-data/parsers.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.ts
@@ -527,3 +527,70 @@ export function isMaintainStale(ageHours: number | null, maxAgeHours = 36): bool
     if (ageHours == null) return true;
     return ageHours > maxAgeHours;
 }
+
+// ── Quality scorecard classification (ix#244) ───────────────────────────
+// `gatherQuality()` (vite.config.ts), published at /dev-data/quality and
+// /dev-data/manifest, used to promote every non-ok `oracle_status` straight
+// into `regressions[]`. That reads two very different things as live
+// regressions: a verdict the producer itself marks non-binding
+// (`advisory: true`), and a feed that stopped emitting weeks ago. The
+// maintain-gate tile already tells those states apart (parseMaintainGate /
+// maintainAgeHours / isMaintainStale above); this seam is the same freshness
+// and advisory semantics, reused by the second reader of the same files.
+//
+// Reclassify, never drop: `regressions[]` is a published number with four
+// rendering consumers, so a demoted entry keeps its exact label and moves to
+// `stale_or_advisory[]` rather than disappearing.
+
+/** How a quality snapshot should be reported on the published scorecard. */
+export type QualitySnapshotKind = 'regression' | 'stale' | 'advisory' | 'ok';
+
+export interface QualitySnapshotClassification {
+    /** Published label — byte-identical to the pre-change `regressions[]` entry. */
+    label: string;
+    kind: QualitySnapshotKind;
+    /** Days since `emitted_at`; null when it is absent or unparseable. */
+    ageDays: number | null;
+}
+
+/**
+ * Classify one quality snapshot for the published scorecard.
+ *
+ * Rules, applied in order:
+ *   0. `oracle_status` absent or `'ok'` ⇒ `'ok'`. No adverse signal to report;
+ *      preserves the pre-change behaviour exactly, so a domain the scorecard
+ *      never surfaced does not start appearing under a new key. (Domains that
+ *      emit no `oracle_status` at all stay invisible — a separate silent-rot
+ *      gap, deliberately not widened here.)
+ *   A. `advisory === true` ⇒ `'advisory'`. The producer declares the verdict
+ *      non-binding and the maintain-gate contract has a MUST clause to present
+ *      it that way. Read dynamically: it flips to false at IX Phase-3b
+ *      (ga#428) and this must follow the field, never assume it.
+ *   B. older than `staleAfterDays`, or `emitted_at` absent/unparseable ⇒
+ *      `'stale'`. Unknown freshness counts as stale — the same green-but-dead
+ *      guard as `isMaintainStale`. The default mirrors ix-quality-trend's
+ *      `DEFAULT_STALE_AFTER_DAYS = 7`.
+ *   C. otherwise ⇒ `'regression'`: a live, binding, non-ok verdict.
+ *
+ * A and B are independently sufficient by design — neither may silently rot
+ * into a no-op behind the other. `now` and `staleAfterDays` are injected for
+ * testability.
+ */
+export function classifyQualitySnapshot(
+    domain: string,
+    data: unknown,
+    now: Date = new Date(),
+    staleAfterDays = 7,
+): QualitySnapshotClassification {
+    const record = (data && typeof data === 'object' ? data : {}) as Record<string, unknown>;
+    const status = typeof record.oracle_status === 'string' ? record.oracle_status : undefined;
+    const emittedAt = typeof record.emitted_at === 'string' ? record.emitted_at : undefined;
+    const ageHours = maintainAgeHours(emittedAt, now);
+    const ageDays = ageHours === null ? null : ageHours / 24;
+    const label = `${domain}: oracle_status=${status}`;
+
+    if (!status || status === 'ok') return { label, kind: 'ok', ageDays };
+    if (record.advisory === true) return { label, kind: 'advisory', ageDays };
+    if (ageDays === null || ageDays > staleAfterDays) return { label, kind: 'stale', ageDays };
+    return { label, kind: 'regression', ageDays };
+}

--- a/ReactComponents/ga-react-components/src/dev-data/parsers.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/parsers.ts
@@ -531,25 +531,44 @@ export function isMaintainStale(ageHours: number | null, maxAgeHours = 36): bool
 // ── Quality scorecard classification (ix#244) ───────────────────────────
 // `gatherQuality()` (vite.config.ts), published at /dev-data/quality and
 // /dev-data/manifest, used to promote every non-ok `oracle_status` straight
-// into `regressions[]`. That reads two very different things as live
-// regressions: a verdict the producer itself marks non-binding
-// (`advisory: true`), and a feed that stopped emitting weeks ago. The
-// maintain-gate tile already tells those states apart (parseMaintainGate /
-// maintainAgeHours / isMaintainStale above); this seam is the same freshness
-// and advisory semantics, reused by the second reader of the same files.
+// into `regressions[]`. That read the maintain-gate verdict — which the
+// producer itself marks non-binding via `advisory: true` — as a live
+// regression, republished daily off a file frozen since 2026-07-20.
 //
 // Reclassify, never drop: `regressions[]` is a published number with four
 // rendering consumers, so a demoted entry keeps its exact label and moves to
 // `stale_or_advisory[]` rather than disappearing.
+//
+// SCOPE — advisory only, deliberately. An earlier draft of this seam also
+// demoted snapshots older than a fixed 7-day threshold. That threshold is
+// unsafe as a wall-clock rule: GA's producers emit on different cadences, and
+// 7 days is exactly `readme-drift`'s (`.github/workflows/readme-drift-sensor.yml`
+// runs weekly, Mondays 08:00 UTC). It would have demoted that producer's
+// genuine, currently-red `oracle_status=error` roughly 20 hours after the rule
+// shipped, and — since nothing renders `stale_or_advisory[]` yet — hidden a
+// real failure entirely. Telling "stale" from "live" needs a per-domain
+// expected-cadence signal, not a single wall-clock constant; that is its own
+// slice. Until it exists, a non-ok verdict that is not producer-declared
+// advisory stays a regression, however old it is: fail toward reporting.
+// The published key keeps the name `stale_or_advisory` — it is the demotion
+// bucket, and the cadence-aware slice will add the `'stale'` kind to it.
 
-/** How a quality snapshot should be reported on the published scorecard. */
-export type QualitySnapshotKind = 'regression' | 'stale' | 'advisory' | 'ok';
+/**
+ * How a quality snapshot should be reported on the published scorecard.
+ *
+ * No `'stale'` member: staleness is not classified here (see SCOPE above).
+ */
+export type QualitySnapshotKind = 'regression' | 'advisory' | 'ok';
 
 export interface QualitySnapshotClassification {
     /** Published label — byte-identical to the pre-change `regressions[]` entry. */
     label: string;
     kind: QualitySnapshotKind;
-    /** Days since `emitted_at`; null when it is absent or unparseable. */
+    /**
+     * Days since `emitted_at`; null when it is absent or unparseable.
+     * Reported for context only — it is NOT an input to `kind`. Published as
+     * `age_days` (snake_case at the payload boundary) by `gatherQuality()`.
+     */
     ageDays: number | null;
 }
 
@@ -566,21 +585,17 @@ export interface QualitySnapshotClassification {
  *      non-binding and the maintain-gate contract has a MUST clause to present
  *      it that way. Read dynamically: it flips to false at IX Phase-3b
  *      (ga#428) and this must follow the field, never assume it.
- *   B. older than `staleAfterDays`, or `emitted_at` absent/unparseable ⇒
- *      `'stale'`. Unknown freshness counts as stale — the same green-but-dead
- *      guard as `isMaintainStale`. The default mirrors ix-quality-trend's
- *      `DEFAULT_STALE_AFTER_DAYS = 7`.
- *   C. otherwise ⇒ `'regression'`: a live, binding, non-ok verdict.
+ *   B. otherwise ⇒ `'regression'`: a binding, non-ok verdict.
  *
- * A and B are independently sufficient by design — neither may silently rot
- * into a no-op behind the other. `now` and `staleAfterDays` are injected for
- * testability.
+ * The result is a pure function of the snapshot's own fields, so it is stable
+ * over wall-clock time: no entry can change bucket without the data or this
+ * code changing. `now` is injected only to make the reported `ageDays`
+ * deterministic under test.
  */
 export function classifyQualitySnapshot(
     domain: string,
     data: unknown,
     now: Date = new Date(),
-    staleAfterDays = 7,
 ): QualitySnapshotClassification {
     const record = (data && typeof data === 'object' ? data : {}) as Record<string, unknown>;
     const status = typeof record.oracle_status === 'string' ? record.oracle_status : undefined;
@@ -591,6 +606,5 @@ export function classifyQualitySnapshot(
 
     if (!status || status === 'ok') return { label, kind: 'ok', ageDays };
     if (record.advisory === true) return { label, kind: 'advisory', ageDays };
-    if (ageDays === null || ageDays > staleAfterDays) return { label, kind: 'stale', ageDays };
     return { label, kind: 'regression', ageDays };
 }

--- a/ReactComponents/ga-react-components/src/dev-data/qualityScorecard.test.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/qualityScorecard.test.ts
@@ -16,6 +16,13 @@
 // this a reproduction of the reported defect rather than a synthetic fixture),
 // and it couples the expected counts to the tree. When a producer's committed
 // verdict changes, the expectations below change with it.
+//
+// NOTE: `legacyRegressions()` models the `oracle_status` producer only — the
+// one this change classifies. `gatherQuality()` has a second, unclassified
+// producer of `regressions[]` (the prior-vs-latest `metric_value` comparison,
+// vite.config.ts:127-137), which emits nothing on today's tree. So the
+// set-equality guard below proves the CLASSIFIER is loss-free, not that the
+// whole published `regressions[]` is set-preserved.
 
 import { describe, it, expect } from 'vitest';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
@@ -24,17 +31,22 @@ import { classifyQualitySnapshot } from './parsers';
 import type { QualitySnapshotClassification } from './parsers';
 
 const QUALITY_DIR = path.resolve(__dirname, '../../../../state/quality');
+const VITE_CONFIG = path.resolve(__dirname, '../../vite.config.ts');
 
-// Frozen clocks. The tree is real, so a live `new Date()` would silently
-// re-classify domains as their snapshots age past the staleness threshold and
-// this guard would flip on a calendar boundary instead of on a code change.
+// Frozen clocks. The tree is real, so a live `new Date()` would make the
+// reported ages drift and the assertions below flip on a calendar boundary
+// instead of on a code change.
 //
 // AUDIT_NOW is the instant the ix#244 baseline (3 regressions) was measured.
 const AUDIT_NOW = new Date('2026-08-09T12:00:00Z');
 // FRESH_NOW is a clock at which the maintain-gate snapshot (emitted
-// 2026-07-20T10:37Z) is 0.6 days old, i.e. well inside the staleness window.
-// It isolates rule A (advisory) from rule B (stale): only A can fire here.
+// 2026-07-20T10:37Z) is 0.6 days old. It pins that the demotion comes from
+// `advisory: true` alone and owes nothing to the snapshot being old.
 const FRESH_NOW = new Date('2026-07-21T00:00:00Z');
+// The exact instant readme-drift's committed snapshot (emitted
+// 2026-08-03T11:21:18.864Z) turns 7 days old — the boundary at which a fixed
+// 7-day staleness rule would have demoted a genuine red verdict.
+const CADENCE_BOUNDARY_NOW = new Date('2026-08-10T11:21:19Z');
 
 interface TreeEntry { domain: string; data: Record<string, unknown> }
 
@@ -108,7 +120,7 @@ describe('published quality scorecard', () => {
         ]);
     });
 
-    it('does not report an advisory, stale snapshot as a regression', () => {
+    it('does not report the advisory snapshot as a regression', () => {
         const { regressions, staleOrAdvisory } = classifyAll(entries, AUDIT_NOW);
         expect(regressions).not.toContain('maintain-gate: oracle_status=warn');
         expect(staleOrAdvisory.map((e) => e.domain)).toEqual(['maintain-gate']);
@@ -142,13 +154,59 @@ describe('published quality scorecard', () => {
     });
 
     it('advisory alone demotes it, even when the snapshot is fresh', () => {
-        // At FRESH_NOW rule B cannot fire, so this pins rule A as independently
-        // sufficient — it must not rot into a no-op hidden behind staleness.
+        // The demotion must come from `advisory: true`, not from the snapshot
+        // happening to be old. At FRESH_NOW it is 0.6 days old and still moves.
         const { regressions, staleOrAdvisory } = classifyAll(entries, FRESH_NOW);
         const gate = staleOrAdvisory.find((e) => e.domain === 'maintain-gate');
         expect(gate).toBeDefined();
-        expect(gate!.ageDays!).toBeLessThan(7);
+        expect(gate!.ageDays!).toBeLessThan(1);
         expect(gate!.kind).toBe('advisory');
         expect(regressions).not.toContain('maintain-gate: oracle_status=warn');
+    });
+
+    // ── Time stability ──────────────────────────────────────────────────
+    // readme-drift emits weekly (.github/workflows/readme-drift-sensor.yml,
+    // Mondays 08:00 UTC) and its newest committed snapshot is a genuine
+    // `oracle_status=error`. A fixed 7-day staleness rule would demote it —
+    // out of the only array any consumer renders — the moment it turned 7
+    // days old, and every week thereafter that the producer ran late or was
+    // skipped. This is the guard for that: classification depends on the
+    // snapshot's fields, never on the wall clock.
+    it('keeps readme-drift a live regression at the 7-day cadence boundary', () => {
+        const { regressions, staleOrAdvisory } = classifyAll(entries, CADENCE_BOUNDARY_NOW);
+        const drift = entries.find((e) => e.domain === 'readme-drift')!;
+        // Confirm the clock really is past the boundary, so this is not a
+        // vacuous assertion if the committed snapshot is ever refreshed.
+        expect(classifyQualitySnapshot('readme-drift', drift.data, CADENCE_BOUNDARY_NOW).ageDays!).toBeGreaterThan(7);
+        expect(regressions).toContain('readme-drift: oracle_status=error');
+        expect(staleOrAdvisory.map((e) => e.domain)).toEqual(['maintain-gate']);
+    });
+
+    it('publishes the same split however far the clock advances', () => {
+        const baseline = classifyAll(entries, AUDIT_NOW);
+        for (const later of ['2026-08-10T11:21:19Z', '2026-09-15T12:00:00Z', '2027-06-01T12:00:00Z']) {
+            const { regressions, staleOrAdvisory } = classifyAll(entries, new Date(later));
+            expect(regressions).toEqual(baseline.regressions);
+            expect(staleOrAdvisory.map((e) => `${e.domain}/${e.kind}`))
+                .toEqual(baseline.staleOrAdvisory.map((e) => `${e.domain}/${e.kind}`));
+        }
+    });
+
+    // ── Published key naming ────────────────────────────────────────────
+    // `/dev-data/quality` and `/dev-data/manifest` are published surfaces that
+    // agent readers fetch; every multi-word key they emit is snake_case
+    // (`generated_at`, `eta_minutes`, `age_hours` on the sibling maintain-gate
+    // route). The internal classification field is camelCase `ageDays`, so the
+    // payload boundary in gatherQuality() must rename it. No test imports
+    // vite.config.ts (GA #643), so this guards the real file as source text.
+    it('publishes the age field as age_days, not ageDays, on both surfaces', () => {
+        const src = readFileSync(VITE_CONFIG, 'utf-8');
+        const gatherQuality = src.slice(src.indexOf('function gatherQuality('), src.indexOf('interface ActivityEntry'));
+        expect(gatherQuality).toContain('age_days: verdict.ageDays');
+        expect(gatherQuality).not.toMatch(/\bageDays\s*:/);
+        // Both published surfaces embed the whole gatherQuality() return
+        // object, so neither can omit or rename the key independently.
+        expect(src).toContain('...gatherQuality()');
+        expect(src).toContain('quality: gatherQuality(),');
     });
 });

--- a/ReactComponents/ga-react-components/src/dev-data/qualityScorecard.test.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/qualityScorecard.test.ts
@@ -1,0 +1,154 @@
+// qualityScorecard.test — integration guard for the published quality
+// scorecard (`gatherQuality()` in vite.config.ts, served at /dev-data/quality
+// and /dev-data/manifest).
+//
+// ix#244: the scorecard promoted every non-ok `oracle_status` straight into
+// `regressions[]`. The maintain-gate snapshot self-declares `advisory: true`
+// and its producer has been skipping since 2026-07-20, so a non-binding,
+// long-dead verdict was published as a live regression alongside two real
+// ones. This suite reads the REAL committed `state/quality/` tree — the same
+// pattern maintainGate.test.ts uses — and pins the reclassification:
+//   before: regressions = 3, no stale_or_advisory collection
+//   after:  regressions = 2, stale_or_advisory = [maintain-gate]
+// with set-equality between the two, so nothing is dropped, only relabelled.
+//
+// NOTE: asserting against real committed data is deliberate (it is what makes
+// this a reproduction of the reported defect rather than a synthetic fixture),
+// and it couples the expected counts to the tree. When a producer's committed
+// verdict changes, the expectations below change with it.
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { classifyQualitySnapshot } from './parsers';
+import type { QualitySnapshotClassification } from './parsers';
+
+const QUALITY_DIR = path.resolve(__dirname, '../../../../state/quality');
+
+// Frozen clocks. The tree is real, so a live `new Date()` would silently
+// re-classify domains as their snapshots age past the staleness threshold and
+// this guard would flip on a calendar boundary instead of on a code change.
+//
+// AUDIT_NOW is the instant the ix#244 baseline (3 regressions) was measured.
+const AUDIT_NOW = new Date('2026-08-09T12:00:00Z');
+// FRESH_NOW is a clock at which the maintain-gate snapshot (emitted
+// 2026-07-20T10:37Z) is 0.6 days old, i.e. well inside the staleness window.
+// It isolates rule A (advisory) from rule B (stale): only A can fire here.
+const FRESH_NOW = new Date('2026-07-21T00:00:00Z');
+
+interface TreeEntry { domain: string; data: Record<string, unknown> }
+
+/**
+ * Mirrors the snapshot selection in `gatherQuality()` (vite.config.ts:106-142):
+ * `last.json` when present, otherwise the newest `YYYY-MM-DD.json`. Only the
+ * *selection* is duplicated here; the classification — the behaviour under
+ * test — is imported from the shared seam.
+ */
+function readQualityTree(): TreeEntry[] {
+    const out: TreeEntry[] = [];
+    for (const entry of readdirSync(QUALITY_DIR, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const subDir = path.join(QUALITY_DIR, entry.name);
+        const lastJson = path.join(subDir, 'last.json');
+        let raw: string | null = null;
+        if (existsSync(lastJson)) {
+            raw = readFileSync(lastJson, 'utf-8');
+        } else {
+            const dated = readdirSync(subDir).filter((f) => /^\d{4}-\d{2}-\d{2}\.json$/.test(f)).sort();
+            const latest = dated[dated.length - 1];
+            if (latest) raw = readFileSync(path.join(subDir, latest), 'utf-8');
+        }
+        if (raw === null) continue;
+        try {
+            out.push({ domain: entry.name, data: JSON.parse(raw) as Record<string, unknown> });
+        } catch {
+            out.push({ domain: entry.name, data: { error: 'parse_failed' } });
+        }
+    }
+    return out;
+}
+
+/** The pre-change rule, verbatim from vite.config.ts:145-146 at 7aa1695. */
+function legacyRegressions(entries: TreeEntry[]): string[] {
+    const out: string[] = [];
+    for (const { domain, data } of entries) {
+        const status = data.oracle_status;
+        if (status && status !== 'ok') out.push(`${domain}: oracle_status=${status}`);
+    }
+    return out;
+}
+
+/** The post-change split, exactly as gatherQuality() routes it. */
+function classifyAll(entries: TreeEntry[], now: Date) {
+    const regressions: string[] = [];
+    const staleOrAdvisory: Array<{ domain: string } & QualitySnapshotClassification> = [];
+    for (const { domain, data } of entries) {
+        const verdict = classifyQualitySnapshot(domain, data, now);
+        if (verdict.kind === 'regression') regressions.push(verdict.label);
+        else if (verdict.kind !== 'ok') staleOrAdvisory.push({ domain, ...verdict });
+    }
+    return { regressions, staleOrAdvisory };
+}
+
+describe('published quality scorecard', () => {
+    const entries = readQualityTree();
+
+    it('reads the real committed state/quality tree', () => {
+        const domains = entries.map((e) => e.domain);
+        expect(domains).toContain('maintain-gate');
+        expect(domains).toContain('embeddings');
+        expect(domains).toContain('readme-drift');
+    });
+
+    it('the pre-change rule reports 3 regressions (the ix#244 baseline)', () => {
+        expect(legacyRegressions(entries)).toEqual([
+            'embeddings: oracle_status=warn',
+            'maintain-gate: oracle_status=warn',
+            'readme-drift: oracle_status=error',
+        ]);
+    });
+
+    it('does not report an advisory, stale snapshot as a regression', () => {
+        const { regressions, staleOrAdvisory } = classifyAll(entries, AUDIT_NOW);
+        expect(regressions).not.toContain('maintain-gate: oracle_status=warn');
+        expect(staleOrAdvisory.map((e) => e.domain)).toEqual(['maintain-gate']);
+        expect(regressions).toHaveLength(2);
+    });
+
+    it('keeps the two live regressions untouched', () => {
+        const { regressions } = classifyAll(entries, AUDIT_NOW);
+        expect(regressions).toEqual([
+            'embeddings: oracle_status=warn',
+            'readme-drift: oracle_status=error',
+        ]);
+    });
+
+    it('records the demoted entry as advisory, with its real age and label', () => {
+        const { staleOrAdvisory } = classifyAll(entries, AUDIT_NOW);
+        expect(staleOrAdvisory).toHaveLength(1);
+        expect(staleOrAdvisory[0].kind).toBe('advisory');
+        expect(staleOrAdvisory[0].label).toBe('maintain-gate: oracle_status=warn');
+        expect(staleOrAdvisory[0].ageDays).not.toBeNull();
+        expect(staleOrAdvisory[0].ageDays!).toBeGreaterThan(20);
+    });
+
+    // The §5.2 guardrail: /dev-data/quality is a PUBLISHED surface with four
+    // rendering consumers. Reclassify, never silently drop.
+    it('loses nothing — regressions ∪ stale_or_advisory equals the pre-change set', () => {
+        const { regressions, staleOrAdvisory } = classifyAll(entries, AUDIT_NOW);
+        const after = [...new Set([...regressions, ...staleOrAdvisory.map((e) => e.label)])].sort();
+        const before = [...new Set(legacyRegressions(entries))].sort();
+        expect(after).toEqual(before);
+    });
+
+    it('advisory alone demotes it, even when the snapshot is fresh', () => {
+        // At FRESH_NOW rule B cannot fire, so this pins rule A as independently
+        // sufficient — it must not rot into a no-op hidden behind staleness.
+        const { regressions, staleOrAdvisory } = classifyAll(entries, FRESH_NOW);
+        const gate = staleOrAdvisory.find((e) => e.domain === 'maintain-gate');
+        expect(gate).toBeDefined();
+        expect(gate!.ageDays!).toBeLessThan(7);
+        expect(gate!.kind).toBe('advisory');
+        expect(regressions).not.toContain('maintain-gate: oracle_status=warn');
+    });
+});

--- a/ReactComponents/ga-react-components/src/dev-data/qualityScorecard.test.ts
+++ b/ReactComponents/ga-react-components/src/dev-data/qualityScorecard.test.ts
@@ -43,10 +43,18 @@ const AUDIT_NOW = new Date('2026-08-09T12:00:00Z');
 // 2026-07-20T10:37Z) is 0.6 days old. It pins that the demotion comes from
 // `advisory: true` alone and owes nothing to the snapshot being old.
 const FRESH_NOW = new Date('2026-07-21T00:00:00Z');
-// The exact instant readme-drift's committed snapshot (emitted
-// 2026-08-03T11:21:18.864Z) turns 7 days old — the boundary at which a fixed
-// 7-day staleness rule would have demoted a genuine red verdict.
-const CADENCE_BOUNDARY_NOW = new Date('2026-08-10T11:21:19Z');
+// The instant the SELECTED readme-drift snapshot turns 7 days old — the
+// boundary at which a fixed 7-day staleness rule would have demoted a genuine
+// red verdict. Derived from that snapshot's own `emitted_at`, never pinned to
+// an absolute date: the sensor rewrites this domain weekly (Mondays 08:00
+// UTC), so a hard-coded instant would stop proving anything — and then fail
+// spuriously, reporting a tiny age against a 7-day floor — the first time the
+// producer runs. Deriving it makes the `> 7` precondition true by
+// construction, and keeps holding if readme-drift's cadence ever changes.
+const SEVEN_DAYS_MS = 7 * 86_400_000;
+function cadenceBoundaryNow(snapshot: Record<string, unknown>): Date {
+    return new Date(Date.parse(snapshot.emitted_at as string) + SEVEN_DAYS_MS + 1_000);
+}
 
 interface TreeEntry { domain: string; data: Record<string, unknown> }
 
@@ -173,11 +181,12 @@ describe('published quality scorecard', () => {
     // skipped. This is the guard for that: classification depends on the
     // snapshot's fields, never on the wall clock.
     it('keeps readme-drift a live regression at the 7-day cadence boundary', () => {
-        const { regressions, staleOrAdvisory } = classifyAll(entries, CADENCE_BOUNDARY_NOW);
         const drift = entries.find((e) => e.domain === 'readme-drift')!;
+        const boundaryNow = cadenceBoundaryNow(drift.data);
+        const { regressions, staleOrAdvisory } = classifyAll(entries, boundaryNow);
         // Confirm the clock really is past the boundary, so this is not a
         // vacuous assertion if the committed snapshot is ever refreshed.
-        expect(classifyQualitySnapshot('readme-drift', drift.data, CADENCE_BOUNDARY_NOW).ageDays!).toBeGreaterThan(7);
+        expect(classifyQualitySnapshot('readme-drift', drift.data, boundaryNow).ageDays!).toBeGreaterThan(7);
         expect(regressions).toContain('readme-drift: oracle_status=error');
         expect(staleOrAdvisory.map((e) => e.domain)).toEqual(['maintain-gate']);
     });

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -5,8 +5,8 @@ import * as path from 'path'
 import { createReadStream, existsSync, statSync, readFileSync, readdirSync, appendFileSync } from 'fs'
 import { execFileSync, spawn } from 'child_process'
 import type { Plugin } from 'vite'
-import { parseBacklog, extractDocTitle, binActivityByDay, projectLoopsGoals, parseValueCatalog, parseMaintainGate, maintainAgeHours, isMaintainStale } from './src/dev-data/parsers'
-import type { BacklogPayload, LoopsGoalsProjection } from './src/dev-data/parsers'
+import { parseBacklog, extractDocTitle, binActivityByDay, projectLoopsGoals, parseValueCatalog, parseMaintainGate, maintainAgeHours, isMaintainStale, classifyQualitySnapshot } from './src/dev-data/parsers'
+import type { BacklogPayload, LoopsGoalsProjection, QualitySnapshotKind } from './src/dev-data/parsers'
 
 // Load ALL env vars (not just VITE_*) from .env.local for proxy auth injection
 try {
@@ -97,11 +97,13 @@ function devDataPlugin(): Plugin {
     const repoRoot = path.resolve(__dirname, '../..');
 
     interface QualityEntry { source: string; data: unknown }
-    function gatherQuality(): { domains: Record<string, QualityEntry>; regressions: string[] } {
+    interface StaleOrAdvisoryEntry { domain: string; kind: Exclude<QualitySnapshotKind, 'regression' | 'ok'>; ageDays: number | null; label: string }
+    function gatherQuality(): { domains: Record<string, QualityEntry>; regressions: string[]; stale_or_advisory: StaleOrAdvisoryEntry[] } {
         const qualityDir = path.join(repoRoot, 'state', 'quality');
         const domains: Record<string, QualityEntry> = {};
         const regressions: string[] = [];
-        if (!existsSync(qualityDir)) return { domains, regressions };
+        const staleOrAdvisory: StaleOrAdvisoryEntry[] = [];
+        if (!existsSync(qualityDir)) return { domains, regressions, stale_or_advisory: staleOrAdvisory };
 
         for (const entry of readdirSync(qualityDir, { withFileTypes: true })) {
             if (!entry.isDirectory()) continue;
@@ -142,11 +144,20 @@ function devDataPlugin(): Plugin {
             }
             if (chosen) {
                 domains[entry.name] = chosen;
-                const status = (chosen.data as Record<string, unknown>).oracle_status;
-                if (status && status !== 'ok') regressions.push(`${entry.name}: oracle_status=${status}`);
+                // ix#244: an advisory (producer-declared non-binding) or stale
+                // snapshot is reclassified, not dropped — the entry keeps its
+                // label and moves to stale_or_advisory[] so nothing leaves the
+                // published payload. Freshness/advisory semantics are shared
+                // with the /dev-data/maintain-gate tile via parsers.ts.
+                const verdict = classifyQualitySnapshot(entry.name, chosen.data);
+                if (verdict.kind === 'regression') {
+                    regressions.push(verdict.label);
+                } else if (verdict.kind !== 'ok') {
+                    staleOrAdvisory.push({ domain: entry.name, kind: verdict.kind, ageDays: verdict.ageDays, label: verdict.label });
+                }
             }
         }
-        return { domains, regressions };
+        return { domains, regressions, stale_or_advisory: staleOrAdvisory };
     }
 
     interface ActivityEntry { sha: string; short_sha: string; author: string; date: string; subject: string }

--- a/ReactComponents/ga-react-components/vite.config.ts
+++ b/ReactComponents/ga-react-components/vite.config.ts
@@ -97,7 +97,11 @@ function devDataPlugin(): Plugin {
     const repoRoot = path.resolve(__dirname, '../..');
 
     interface QualityEntry { source: string; data: unknown }
-    interface StaleOrAdvisoryEntry { domain: string; kind: Exclude<QualitySnapshotKind, 'regression' | 'ok'>; ageDays: number | null; label: string }
+    // Published payload shape: snake_case keys at the boundary, matching every
+    // other /dev-data/* key this file emits (`generated_at`, `eta_minutes`,
+    // `age_hours` on the sibling /dev-data/maintain-gate route). The internal
+    // camelCase `ageDays` is renamed to `age_days` on the way out.
+    interface StaleOrAdvisoryEntry { domain: string; kind: Exclude<QualitySnapshotKind, 'regression' | 'ok'>; age_days: number | null; label: string }
     function gatherQuality(): { domains: Record<string, QualityEntry>; regressions: string[]; stale_or_advisory: StaleOrAdvisoryEntry[] } {
         const qualityDir = path.join(repoRoot, 'state', 'quality');
         const domains: Record<string, QualityEntry> = {};
@@ -144,16 +148,17 @@ function devDataPlugin(): Plugin {
             }
             if (chosen) {
                 domains[entry.name] = chosen;
-                // ix#244: an advisory (producer-declared non-binding) or stale
-                // snapshot is reclassified, not dropped — the entry keeps its
-                // label and moves to stale_or_advisory[] so nothing leaves the
-                // published payload. Freshness/advisory semantics are shared
-                // with the /dev-data/maintain-gate tile via parsers.ts.
+                // ix#244: an advisory snapshot (one the producer itself marks
+                // non-binding) is reclassified, not dropped — the entry keeps
+                // its label and moves to stale_or_advisory[] so nothing leaves
+                // the published payload. Advisory is the only demotion this
+                // slice makes; see the SCOPE note on classifyQualitySnapshot
+                // for why staleness needs a per-domain cadence signal first.
                 const verdict = classifyQualitySnapshot(entry.name, chosen.data);
                 if (verdict.kind === 'regression') {
                     regressions.push(verdict.label);
                 } else if (verdict.kind !== 'ok') {
-                    staleOrAdvisory.push({ domain: entry.name, kind: verdict.kind, ageDays: verdict.ageDays, label: verdict.label });
+                    staleOrAdvisory.push({ domain: entry.name, kind: verdict.kind, age_days: verdict.ageDays, label: verdict.label });
                 }
             }
         }


### PR DESCRIPTION
## Summary

The quality scorecard promoted **every** non-`ok` `oracle_status` straight into the published
`regressions[]`. That read two very different things as live regressions: a verdict the producer
itself marks `advisory: true` (non-binding until IX Phase-3b), and a feed that stopped emitting
weeks ago. `state/quality/maintain-gate/last.json` has been republished as a fresh regression
every day since its producer last ran on 2026-07-20, carrying
`summary: "metric evidence missing — cannot decide"`.

This slice adds a pure `classifyQualitySnapshot()` seam in `src/dev-data/parsers.ts` and delegates
to it from `gatherQuality()` in `vite.config.ts`. Classification is a **pure function of the
snapshot's own fields** — no wall clock:

- rule 0 — no adverse `oracle_status` → `ok` (pre-change behaviour, unchanged)
- rule A — `advisory === true` → `advisory`
- otherwise → `regression`

`advisory` is read **dynamically** (`record.advisory === true`), not special-cased by domain, so
the ga#428 Phase-3b flip to `advisory: false` is honoured automatically. A non-`ok` verdict that is
not producer-declared advisory stays a regression **however old it is**, and a missing or
unparseable `emitted_at` no longer demotes it — the classifier fails toward reporting.

**Reclassify, never drop.** A demoted entry keeps its exact label and moves to a new
`stale_or_advisory[]` key in the same payload, so `regressions ∪ stale_or_advisory` stays
set-equal to the pre-change `regressions[]`. Nothing leaves the published surface.

`Refs GuitarAlchemist/ix#244` — see **This does not close ix#244** below.

## Impact

The published `/dev-data/quality` and `/dev-data/manifest` payloads change as follows, verified
live against a running dev server on both routes:

```
/dev-data/quality
  regressions       (2): ["embeddings: oracle_status=warn",
                          "readme-drift: oracle_status=error"]
  stale_or_advisory (1): [{"domain":"maintain-gate","kind":"advisory",
                           "age_days":20.281586238425927,
                           "label":"maintain-gate: oracle_status=warn"}]
  literal "ageDays" present: false   |   literal "age_days" present: true

/dev-data/manifest   (under `quality`)
  regressions       (2): same
  stale_or_advisory (1): same, age_days 20.281586909722222
  literal "ageDays" present: false   |   literal "age_days" present: true
```

`regressions[]` goes 3 → 2; `maintain-gate` moves to `stale_or_advisory[]` with its label
**byte-identical**. `age_days` is snake_case at the payload boundary (matching every other
multi-word `/dev-data/*` key and the sibling `/dev-data/maintain-gate` route's `age_hours`);
`QualitySnapshotClassification.ageDays` stays camelCase as TypeScript internals. Both surfaces
embed the same `gatherQuality()` return object, so they cannot drift.

## Scope — four files, all frontend

```
 ReactComponents/ga-react-components/src/dev-data/parsers.ts               ( +81)  production
 ReactComponents/ga-react-components/vite.config.ts                        ( +23/−7) production
 ReactComponents/ga-react-components/src/dev-data/parsers.test.ts          ( +79)  test
 ReactComponents/ga-react-components/src/dev-data/qualityScorecard.test.ts (+221)  test (added)
```

Three commits, linear, from `7aa169512eacc9e8173718a221414c105c483cae`. No file under
`state/quality/` is touched — the fix is loader-side, as ix#244's durable option 2 prescribes and
as its "flag, don't edit the frozen snapshots" constraint requires. No contract, schema, workflow,
`.NET` project, dependency manifest, or UI renderer is touched. This probe is empty across the
whole slice:

```
git diff --name-only 7aa1695 949b8271 -- state/ docs/ .github/ Scripts/ governance/ \
  Common/ Apps/ '*.slnx' '*.props' '*.json' 'ga.loop-policy.json'
→ (empty)
```

**One-way doors: none.** No schema, OPTIC-K dimension, public API, pricing, migration, or
re-index. Reversibility is a pure revert.

## Baseline / direction / guardrail / reversibility (Karpathy rule 6)

- **baseline** at `7aa1695`: `regressions = 3`, no `stale_or_advisory` key; an earlier draft of
  this slice was additionally time-unstable (`regressions` 2 today → 1 from 2026-08-10T11:21:19Z
  → 0 from 2026-08-17) and published `ageDays`.
- **direction**: `regressions = 2` and `stale_or_advisory = 1` at **every** clock probed
  (2026-08-09 … 2027-06-01); published key `age_days`.
- **guardrail**: committed time-stability tests, a source-level guard on the payload boundary, and
  the set-equality assertion `regressions ∪ stale_or_advisory` == the pre-change set, all asserted
  against the real committed `state/quality/` tree.
- **reversibility**: pure revert; no data migration, no schema bump, no re-index.

## ⚠️ CI does not run this evidence

**No CI job executes the vitest suite.** `grep -ln "vitest\|npm test\|npm run test" .github/workflows/*.yml`
returns nothing. `ci.yml`'s `build-frontend` job installs this package's deps only so rollup can
resolve cross-package lazy imports, then lints and builds **`Apps/ga-client`** — and that lint step
carries `continue-on-error: true`.

A green check set on this PR therefore says **nothing** about this change. Every figure below is
local evidence with no CI counterpart. Please do not read the checks as verification.

## Key test output

Reproduced independently at the exact published commit `949b8271`, in the clone, immediately
before publication — and previously reproduced independently by the R5 spec review:

| Command | Result | Exit |
|---|---|---|
| `npx vitest run src/dev-data/qualityScorecard.test.ts` | **10 passed (10)**, 1 file | 0 |
| `npx vitest run src/dev-data` | **88 passed (88)**, 3 files | 0 |
| `npx vitest run src/dev-data src/components/Summary/MaintainGateCard.test.tsx` | **91 passed (91)**, 4 files | 0 |
| `npm run test:unit` (full frontend unit suite) | **216 passed (216)**, 13 files | 0 |
| `npm run build` | **✓ built in 27.80s** | 0 |
| `npx eslint` on the 3 changed `src/dev-data` files | **0 problems** | 0 |
| `npm run lint` (repo-wide) | 188 problems (124 errors, 64 warnings) | 1 |

The repo-wide 188 is **pre-existing and unchanged** — identical at the slice base `7aa1695` and at
this commit. It was attributed precisely rather than asserted: the parent's version of the one
changed file lints to 0 problems, same as this version, so the slice's contribution to the lint
total is provably zero. The six `no-unused-vars` errors in `vite.config.ts` are all present at
`7aa1695`. The `css-syntax-error` minify warning and the `esbuild`/`oxc` deprecation notices are
pre-existing toolchain noise.

**Discriminating RED controls** (mutants run against untracked copies, then deleted): re-introducing
the removed staleness rule turns the suite red on the *behavioural* assertions
(`expected [] to include 'readme-drift: oracle_status=error'`) on both the current tree and a
simulated post-refresh tree; removing the advisory rule turns it red
(`expected [] to deeply equal [ 'maintain-gate' ]`); reverting the boundary rename to `ageDays`
turns the naming guard red. The guards are not vacuous.

`dotnet build` / `dotnet test` were deliberately not run: the slice touches four `.ts` files and
zero `.cs`/`.fs`/project files, so the .NET solution cannot observe it. Recorded as an omission
rather than implied.

## No UI captures — and why

There are none, deliberately. This change alters the **published JSON payloads**, and per F2 below
**nothing renders `stale_or_advisory[]` yet**, so there is no visual delta to capture. The live
payload captures from both routes under **Impact** are the substitute, and they were verified
against a running dev server.

## This does not close ix#244

`Refs GuitarAlchemist/ix#244` — deliberately **`Refs`, not `Fixes`**. ix#244 stays **open**. Two
independent reasons:

1. **F2 — the headline symptom is only half-cleared.** ix#244 asks for a state that *"renders
   neutral, not DEGRADED"*. This slice removes maintain-gate from the `regressions[]` banner
   (3 → 2), but the per-domain chip in `OverviewSection`, `DevelopmentSection` and `ManifestViewer`
   derives its colour from `deriveTileStatus()` (`src/utils/qualityStatus.ts`), which reads
   `oracle_status` and **does not read `advisory`** — so maintain-gate still renders amber.
   Compounding that, `stale_or_advisory[]` has **zero rendering consumers**. The demoted entry is
   published but invisible.
2. **F1 — the *absent/stale/skipped* half is unimplemented.** Only the producer-declared `advisory`
   half ships. The stale half was deliberately dropped: the drafted 7-day rule collided exactly
   with `readme-drift`'s weekly cadence and would have hidden a genuinely red producer. The reason
   is written into production source as a 20-line `SCOPE` comment on `classifyQualitySnapshot`.
   Telling "stale" from "live" needs a per-domain expected-cadence signal, which is its own slice.

Follow-up issues will be filed in this repo for **F1** and **F2** and cross-linked to ix#244.

Also **referenced, not closed**:

- **#643** — *vite.config.ts is a 3,005-line untested production backend disguised as build config*.
  Directly relevant: the committed test guards `vite.config.ts` as **source text** because no test
  can import it, which is exactly #643's complaint. This PR narrows that gap; it does not close it.
- **#428** — *first real /auto-optimize iteration + ix maintain-gate*. The slice reads
  `record.advisory` dynamically, so #428's Phase-3b flip to `advisory: false` is honoured with no
  further change here.

## Residuals — all non-blocking, none introduced by this slice

- **F3 — the suite is coupled to live committed data. Accepted trade, disclosed here on purpose.**
  If `readme-drift`'s verdict is ever fixed to `oracle_status: "ok"`, three tests go red, including
  the cadence guard. The test file states this deliberately: *"asserting against real committed
  data is deliberate… When a producer's committed verdict changes, the expectations below change
  with it."* **A maintainer who hits that red should know it is expected, not a freshness bug.**
  No issue is being filed, because filing one would misrepresent a design choice as a defect.
- **F4 / N3** — `cadenceBoundaryNow` does `snapshot.emitted_at as string` while the production
  classifier narrows with `typeof … === 'string'`. Fails safe (RED, never vacuously green) but the
  diagnostic is opaque (`actual value must be number or bigint, received "object"`). Cosmetic,
  test-only, one line.
- **N1 — correction to an earlier internal disclosure, carried forward as open.** An earlier
  handoff claimed no remaining expectation could be invalidated by a producer refresh. **That is
  not accurate.** `qualityScorecard.test.ts:152` asserts `ageDays > 20` at a pinned instant against
  maintain-gate's `last.json`; if that producer resumes, it fails with
  `expected 0.25 to be greater than 20` while the behaviour under test is entirely correct. It does
  not block: maintain-gate's producer has been skipping since 2026-07-20 with no schedule, so the
  exposure is contingent rather than date-certain, and it is pre-existing at the parent commit. The
  remedy is the same one line — derive from `gate.data.emitted_at`.
- **N2** — the anti-vacuity precondition is now true by construction, and one retained inline
  comment still describes the old hard-coded form. No loss of discriminating power (the two
  behavioural assertions do that work, and both were turned red under mutation). One-line comment
  update, P3.
- Longer-standing and untouched: non-string `oracle_status` silently dropped; `gatherQuality()`'s
  second, unclassified `metric_value`-delta producer of `regressions[]`; divergent `advisory`
  fail-safe defaults between the two readers.

## Test plan

Committed with the slice — 19 new tests across two files (12 unit + 7 integration), plus the
cadence-boundary guard:

- **Classifier unit tests** (`parsers.test.ts`) — rule 0 / rule A / regression ordering;
  `reads advisory dynamically — advisory:false is not exempt`;
  `never demotes a binding non-ok snapshot on age alone, however old` (probes 2026-09-15,
  2027-01-01, 2030-01-01); `keeps a non-ok snapshot with absent or unparseable emitted_at a
  regression` (fail toward reporting).
- **Integration tests against the real committed `state/quality/` tree**
  (`qualityScorecard.test.ts`) — the 3 → 2 split with maintain-gate demoted; set-equality of
  `regressions ∪ stale_or_advisory` against the pre-change set with a byte-identical label;
  `publishes the same split however far the clock advances` (re-runs at 2026-08-10, 2026-09-15,
  2027-06-01); `keeps readme-drift a live regression at the 7-day cadence boundary`, whose clock is
  derived from the selected snapshot's own `emitted_at` (+7d +1s) so it is neither pinned to a
  calendar date nor vacuous after a refresh.
- **Payload-boundary guard** — `vite.config.ts` is asserted as **source text** (no test can import
  it, per #643): `age_days` published, `ageDays` absent, and both `gatherQuality()` call sites
  pinned.
- **Manual verification** — both published routes queried against a live dev server; captures under
  **Impact**.

Reviewer focus, in priority order: (1) the classification rules in
`classifyQualitySnapshot` and their ordering; (2) the `age_days` boundary rename; (3) whether the
F1 staleness deferral is the right call — the `SCOPE` comment argues it is, and shipping the
drafted rule would have hidden a live red producer.

---

Reviewed twice pre-publication (standards + spec), both `APPROVE` with zero blockers. Squash-merge
please, matching this repo's convention; the branch needs manual deletion because
`deleteBranchOnMerge` is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
