### PR TITLE
feat(chatbot): scope memory to a session on the canonical chatbot host

### DIFF
--- a/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
+++ b/Apps/GaChatbot.Api/Controllers/ChatbotController.cs
@@ -31,6 +31,12 @@ public sealed class ChatbotController(
             return;
         }
 
+        // MUST run before StartAsync: issuing the session cookie writes a
+        // response header, and headers are read-only once the response is
+        // committed to the wire. Validation already ran above, so malformed
+        // requests still don't get a cookie.
+        var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
+
         Response.StatusCode = StatusCodes.Status200OK;
         Response.Headers.Append("Content-Type", "text/event-stream");
         Response.Headers.Append("Cache-Control", "no-cache");
@@ -46,7 +52,10 @@ public sealed class ChatbotController(
 
         try
         {
-            var chatRequest = new ChatExecutionRequest(message, ToConversationTurns(request.ConversationHistory));
+            var chatRequest = new ChatExecutionRequest(
+                message,
+                ToConversationTurns(request.ConversationHistory),
+                sessionId);
 
             await foreach (var update in chatApplicationService.ChatStreamAsync(chatRequest, cancellationToken))
             {
@@ -113,6 +122,11 @@ public sealed class ChatbotController(
             return BadRequest(new { error = "Message cannot be empty." });
         }
 
+        // Resolved after validation but before the concurrency gate: a caller
+        // turned away with 503 should still carry a session into their retry,
+        // otherwise a busy moment silently starts them a new conversation.
+        var sessionId = HttpChatSessionCookie.GetOrIssue(HttpContext);
+
         if (!await concurrencyGate.TryEnterAsync(cancellationToken))
         {
             return StatusCode(StatusCodes.Status503ServiceUnavailable,
@@ -123,7 +137,10 @@ public sealed class ChatbotController(
         {
             var sw = Stopwatch.StartNew();
             var response = await chatApplicationService.ChatAsync(
-                new ChatExecutionRequest(message, ToConversationTurns(request.ConversationHistory)),
+                new ChatExecutionRequest(
+                    message,
+                    ToConversationTurns(request.ConversationHistory),
+                    sessionId),
                 cancellationToken);
             sw.Stop();
 

--- a/Apps/GaChatbot.Api/Program.cs
+++ b/Apps/GaChatbot.Api/Program.cs
@@ -1,5 +1,6 @@
 using GaChatbot.Api.Extensions;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 {
@@ -47,6 +48,54 @@ if (allowedOrigins.Length > 0)
 }
 
 var app = builder.Build();
+
+// Trust X-Forwarded-* from the reverse proxy so Request.Scheme reflects the
+// CLIENT-facing scheme. Mirrors Apps/ga-server/GaApi/Program.cs.
+//
+// Why this host needs it: the deployment terminates TLS at the cloudflared
+// `ga-demos` tunnel and forwards to plain http://localhost:5252
+// (docs/runbooks/chatbot-deploy.md). Without this, Request.IsHttps is false on
+// EVERY production request, so HttpChatSessionCookie issues the session cookie
+// without `Secure` on https://demos.guitaralchemist.com — the cookie that keys
+// MemoryStore / ChatTranscriptStore partitions.
+//
+// Safety: forwarded headers are honoured only for requests that actually came
+// through the tunnel (CF-Connecting-IP present) AND only when a public host is
+// configured. Stray headers on direct/localhost requests are stripped, so a
+// dev proxy emitting a partial set can't talk the host into an https view of
+// itself — that would mint a Secure cookie the browser refuses to send back
+// over http, silently rotating the session on every turn.
+// Must run before UsePathBase so the whole pipeline sees the corrected scheme.
+var publicHost = builder.Configuration["Proxy:PublicHost"];
+app.Use(async (ctx, next) =>
+{
+    var isProxiedRequest = !string.IsNullOrEmpty(ctx.Request.Headers["CF-Connecting-IP"].ToString());
+    if (isProxiedRequest && !string.IsNullOrWhiteSpace(publicHost))
+    {
+        // The tunnel sets X-Forwarded-Proto but not X-Forwarded-Host; synthesise
+        // it so the forwarded host matches the configured public origin.
+        ctx.Request.Headers["X-Forwarded-Host"] = publicHost;
+    }
+    else
+    {
+        ctx.Request.Headers.Remove("X-Forwarded-Proto");
+        ctx.Request.Headers.Remove("X-Forwarded-Host");
+        ctx.Request.Headers.Remove("X-Forwarded-For");
+    }
+    await next();
+});
+var forwardedHeadersOptions = new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
+};
+if (!string.IsNullOrWhiteSpace(publicHost))
+{
+    forwardedHeadersOptions.AllowedHosts.Add(publicHost);
+}
+// Cloudflare can connect from any IP — clear the default localhost-only allowlist.
+forwardedHeadersOptions.KnownIPNetworks.Clear();
+forwardedHeadersOptions.KnownProxies.Clear();
+app.UseForwardedHeaders(forwardedHeadersOptions);
 
 // Optional path-base for hosting under a public host's sub-path
 // (e.g. demos.guitaralchemist.com/chatbot via Cloudflare Tunnel ingress

--- a/Apps/GaChatbot.Api/Program.cs
+++ b/Apps/GaChatbot.Api/Program.cs
@@ -1,4 +1,5 @@
 using GaChatbot.Api.Extensions;
+using Microsoft.AspNetCore.DataProtection;
 
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 {
@@ -15,6 +16,17 @@ builder.Logging.AddSimpleConsole();
 builder.Logging.AddDebug();
 
 builder.Services.AddControllers();
+// Data Protection backs the chat session cookie (HttpChatSessionCookie).
+// Unlike GaApi — which gets IDataProtectionProvider transitively from
+// AddAuthentication — this host registers no auth, so nothing else pulls
+// the service in and GetOrIssue would fail at request time.
+// SetApplicationName isolates the key ring from any other app sharing the
+// keys directory, so a cookie minted elsewhere can never Unprotect here.
+// Keys use the framework default location; if it isn't writable (some
+// container images) they are ephemeral and sessions rotate on restart —
+// acceptable for the anonymous demo, whose threat model already treats
+// rotation as expected.
+builder.Services.AddDataProtection().SetApplicationName("GaChatbot.Api");
 builder.Services.AddProblemDetails();
 builder.Services.AddHttpClient();
 builder.Services.AddTransient(_ => new HttpClient());

--- a/Apps/GaChatbot.Api/Services/HttpChatSessionCookie.cs
+++ b/Apps/GaChatbot.Api/Services/HttpChatSessionCookie.cs
@@ -1,0 +1,141 @@
+namespace GaChatbot.Api.Services;
+
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.DataProtection;
+
+/// <summary>
+/// Server-issued HTTP session cookie for the canonical public chatbot host.
+/// Gives the REST/SSE transport the same per-conversation isolation that
+/// SignalR's <c>Context.ConnectionId</c> gives GaApi's WebSocket transport,
+/// and that <c>GaApi.Services.HttpChatSessionCookie</c> gives GaApi's HTTP
+/// transport.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists here and not in a shared library:</b> cookie issuance
+/// is a transport concern, and the five-layer rule keeps transport in
+/// <c>Apps/</c>. Hoisting it into <c>GA.Business.Core.Orchestration</c>
+/// (the only library both hosts reference) would drag
+/// <c>Microsoft.AspNetCore.Http</c> into an orchestration-layer assembly.
+/// Each ASP.NET host therefore owns its own issuance; what the hosts share
+/// is the <i>opaque SessionId string</i> on
+/// <see cref="GA.Business.Core.Orchestration.Models.ChatRequest.SessionId"/>,
+/// which is already a layer-appropriate contract. Consolidation trigger: a
+/// third host needing this — then extract a shared web-primitives project
+/// rather than growing a third copy.
+/// </para>
+/// <para>
+/// <b>Why server-issued, not client-supplied:</b> a client-controlled session
+/// identifier is a forged-session-cross-pollution vector once
+/// <c>Memory:EnrichOnRetrieve=true</c> ships — a shape-only validator accepts
+/// attacker-chosen values, enabling session fixation (GaApi PR #163 security
+/// audit, VULN-001). The random session ID is therefore wrapped with
+/// <see cref="IDataProtector"/> (HMAC + AES-CBC from the app's data-protection
+/// key ring). The cookie carries the PROTECTED ciphertext; the inner ID is
+/// what we hand back as the SessionId. Tampering fails <c>Unprotect</c> with a
+/// <see cref="CryptographicException"/> and a fresh session is issued.
+/// </para>
+/// <para>
+/// <b>Path scoping under a path-base mount:</b> this host can be mounted
+/// under a prefix (<c>Chatbot:PathBase</c>, e.g.
+/// <c>demos.guitaralchemist.com/chatbot</c>) — see
+/// <c>ChatbotPathBaseTests</c>. The cookie Path is therefore
+/// <c>{PathBase}/api/chatbot</c>, not a hardcoded <c>/api/chatbot</c>: a
+/// hardcoded path would never be echoed back by the browser on the mounted
+/// deployment, silently rotating the session on every single turn — exactly
+/// the bug this class exists to fix.
+/// </para>
+/// <para>
+/// <b>Threat model:</b> rotation across browser sessions (cookie cleared, new
+/// incognito window) is by design — the same trade-off SignalR reconnect
+/// rotation makes. The cookie is a CONVENIENCE that keeps memory continuity
+/// across page reloads for an anonymous demo. Stable cross-device sessions
+/// require authentication, which is out of scope here.
+/// </para>
+/// </remarks>
+public static class HttpChatSessionCookie
+{
+    public const string CookieName = "ga_chat_session";
+
+    // Purpose is host-specific on purpose: a cookie minted by GaApi must not
+    // Unprotect here (and vice versa). The two hosts serve the same paths on
+    // different ports, so a shared purpose would let one host's session ID
+    // silently become the other's.
+    private const string ProtectorPurpose = "GaChatbot.Api.HttpChatSessionCookie.v1";
+
+    private const string CookiePathSuffix = "/api/chatbot";
+
+    private static readonly TimeSpan CookieLifetime = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// Returns the chat session ID for this HTTP request. If a valid
+    /// DataProtection-signed <c>ga_chat_session</c> cookie is present, its
+    /// inner value is returned. Otherwise a fresh 128-bit random ID is
+    /// generated, protected, and set on the outgoing response as a cookie.
+    /// </summary>
+    /// <remarks>
+    /// MUST be called before <c>Response.StartAsync()</c> on streaming
+    /// endpoints: appending a cookie mutates response headers, and headers
+    /// become read-only once the response is committed to the wire.
+    /// </remarks>
+    public static string GetOrIssue(HttpContext ctx)
+    {
+        var protector = ctx.RequestServices
+            .GetRequiredService<IDataProtectionProvider>()
+            .CreateProtector(ProtectorPurpose);
+
+        if (ctx.Request.Cookies.TryGetValue(CookieName, out var protectedValue)
+            && !string.IsNullOrEmpty(protectedValue))
+        {
+            try
+            {
+                var existing = protector.Unprotect(protectedValue);
+                if (IsValidInnerShape(existing)) return existing;
+                // Inner shape is unexpected (only reachable on schema drift) —
+                // fall through and reissue.
+            }
+            catch (CryptographicException)
+            {
+                // Tampered, forged, or signed with a now-rotated key — reissue.
+            }
+        }
+
+        var newId = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16))
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+
+        ctx.Response.Cookies.Append(CookieName, protector.Protect(newId), new CookieOptions
+        {
+            HttpOnly = true,
+            Secure   = ctx.Request.IsHttps,
+            SameSite = SameSiteMode.Lax,
+            MaxAge   = CookieLifetime,
+            Path     = ctx.Request.PathBase.HasValue
+                ? ctx.Request.PathBase.Value + CookiePathSuffix
+                : CookiePathSuffix,
+        });
+
+        return newId;
+    }
+
+    /// <summary>
+    /// Sanity check on the UNPROTECTED inner value. Defense in depth: even if
+    /// a DataProtection key were compromised, the inner shape must still look
+    /// like one of OUR issued IDs (base64url, 16–32 chars).
+    /// </summary>
+    private static bool IsValidInnerShape(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+        if (value.Length < 16 || value.Length > 32) return false;
+        foreach (var c in value)
+        {
+            var ok = (c >= 'A' && c <= 'Z')
+                  || (c >= 'a' && c <= 'z')
+                  || (c >= '0' && c <= '9')
+                  || c == '-' || c == '_';
+            if (!ok) return false;
+        }
+        return true;
+    }
+}

--- a/Apps/GaChatbot.Api/Services/HttpChatSessionCookie.cs
+++ b/Apps/GaChatbot.Api/Services/HttpChatSessionCookie.cs
@@ -46,6 +46,13 @@ using Microsoft.AspNetCore.DataProtection;
 /// the bug this class exists to fix.
 /// </para>
 /// <para>
+/// <b><c>Secure</c> depends on forwarded headers:</b> the flag follows
+/// <c>Request.IsHttps</c>, and the deployment terminates TLS at a cloudflared
+/// tunnel that forwards to plain HTTP. <c>Program.cs</c> must therefore
+/// register <c>UseForwardedHeaders</c> for this cookie to be <c>Secure</c> in
+/// production — pinned by <c>ForwardedHeadersSessionCookieTests</c>.
+/// </para>
+/// <para>
 /// <b>Threat model:</b> rotation across browser sessions (cookie cleared, new
 /// incognito window) is by design — the same trade-off SignalR reconnect
 /// rotation makes. The cookie is a CONVENIENCE that keeps memory continuity

--- a/Apps/GaChatbot.Api/Services/IChatApplicationService.cs
+++ b/Apps/GaChatbot.Api/Services/IChatApplicationService.cs
@@ -18,9 +18,21 @@ public interface IChatApplicationService
     Task<ChatbotStatus> GetStatusAsync(CancellationToken cancellationToken = default);
 }
 
+/// <param name="Message">The user's current turn.</param>
+/// <param name="History">Prior turns supplied by the caller, if any.</param>
+/// <param name="SessionId">
+/// Opaque per-conversation identifier resolved by the transport layer
+/// (<see cref="HttpChatSessionCookie"/> for this host). Flows through to
+/// <see cref="GA.Business.Core.Orchestration.Models.ChatRequest.SessionId"/>,
+/// which is what scopes <c>MemoryStore</c> reads/writes and
+/// <c>ChatTranscriptStore</c> turns to one conversation. <c>null</c> means
+/// "no session" — the orchestrator then mints a throwaway per-request ID, so
+/// nothing written during the turn is reachable from any later turn.
+/// </param>
 public sealed record ChatExecutionRequest(
     string Message,
-    List<ConversationTurn>? History = null);
+    List<ConversationTurn>? History = null,
+    string? SessionId = null);
 
 public sealed record ChatExecutionResult(
     string NaturalLanguageAnswer,

--- a/Apps/GaChatbot.Api/Services/ProductionChatOrchestratorClient.cs
+++ b/Apps/GaChatbot.Api/Services/ProductionChatOrchestratorClient.cs
@@ -11,11 +11,25 @@ public sealed class ProductionChatOrchestratorClient(IServiceProvider servicePro
         CancellationToken cancellationToken = default)
     {
         var orchestrator = serviceProvider.GetRequiredService<ProductionOrchestrator>();
-        return orchestrator.AnswerAsync(
-            new ChatRequest(
-                request.Message,
-                SessionId: null,
-                History: request.History),
-            cancellationToken);
+        return orchestrator.AnswerAsync(ToOrchestratorRequest(request), cancellationToken);
     }
+
+    /// <summary>
+    /// Maps this host's <see cref="ChatExecutionRequest"/> onto the
+    /// orchestrator's <see cref="ChatRequest"/>.
+    /// </summary>
+    /// <remarks>
+    /// Session identity MUST survive this hop. <c>ProductionOrchestrator</c>
+    /// substitutes a fresh <c>Guid</c> whenever it receives a null SessionId,
+    /// so dropping it here doesn't fail loudly — it silently gives every turn
+    /// its own memory partition, which reads as "the chatbot has amnesia" and
+    /// makes <c>Memory:EnrichOnRetrieve</c> a no-op on this host.
+    /// Exposed as a pure function so that invariant is directly testable
+    /// without standing up the orchestrator.
+    /// </remarks>
+    public static ChatRequest ToOrchestratorRequest(ChatExecutionRequest request) =>
+        new(
+            request.Message,
+            SessionId: request.SessionId,
+            History: request.History);
 }

--- a/Apps/GaChatbot.Api/appsettings.json
+++ b/Apps/GaChatbot.Api/appsettings.json
@@ -64,6 +64,9 @@
       ]
     }
   },
+  "Proxy": {
+    "PublicHost": "demos.guitaralchemist.com"
+  },
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:5173",

--- a/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
+++ b/Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs
@@ -301,7 +301,16 @@ public class ProductionOrchestrator(
         return response;
     }
 
-    public async Task<ChatResponse> AnswerAsync(ChatRequest req, CancellationToken ct = default)
+    /// <remarks>
+    /// <c>virtual</c> so a host adapter test can substitute a stub orchestrator
+    /// and assert on the <see cref="ChatRequest"/> it actually receives. Without
+    /// that seam the session-identity invariant on
+    /// <c>GaChatbot.Api.Services.ProductionChatOrchestratorClient.AnswerAsync</c>
+    /// is only pinned on a helper nothing forces that method to call — a gap an
+    /// independent review closed by re-inlining the original defect with the
+    /// whole suite still green. See <c>ProductionChatOrchestratorClientTests</c>.
+    /// </remarks>
+    public virtual async Task<ChatResponse> AnswerAsync(ChatRequest req, CancellationToken ct = default)
     {
         using var activity = ChatbotActivitySource.StartActivity(ChatbotActivitySource.OrchestratorAnswer, req.Message);
         var sw = Stopwatch.StartNew();

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotControllerSessionScopeTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotControllerSessionScopeTests.cs
@@ -1,0 +1,200 @@
+namespace GaChatbot.Api.Tests.Controllers;
+
+using System.Net.Http.Json;
+using GA.Business.Core.Orchestration.Models;
+using GA.Business.Core.Orchestration.Trace;
+using GaChatbot.Api.Services;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+/// <summary>
+/// End-to-end contract for chatbot session scoping on the canonical public
+/// host: the transport must resolve a stable per-conversation identity and
+/// hand it to the application service, which is what ultimately scopes
+/// <c>MemoryStore</c> and <c>ChatTranscriptStore</c> to one conversation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this slice, <c>ChatExecutionRequest</c> had no session dimension
+/// and <c>ProductionChatOrchestratorClient</c> passed
+/// <c>SessionId: null</c> to the orchestrator unconditionally, so
+/// <c>ProductionOrchestrator</c> minted a throwaway <c>Guid</c> per request.
+/// Every turn — including consecutive turns from the same guitarist — landed
+/// in its own memory partition, and <c>Memory:EnrichOnRetrieve</c> could
+/// never surface anything on this host.
+/// </para>
+/// <para>
+/// These tests assert the behaviour a user experiences (same browser =&gt; same
+/// session, different browsers =&gt; different sessions), not the cookie
+/// mechanics — those are pinned by <c>HttpChatSessionCookieTests</c>.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class ChatbotControllerSessionScopeTests
+{
+    [Test]
+    public async Task Chat_IssuesSessionAndPassesItToTheApplicationService()
+    {
+        var chatService = new CapturingChatApplicationService();
+        using var factory = CreateFactory(chatService);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/chatbot/chat", new { message = "What key is Am F C G in?" });
+        response.EnsureSuccessStatusCode();
+
+        Assert.That(chatService.Requests, Has.Count.EqualTo(1));
+        Assert.That(chatService.Requests[0].SessionId, Is.Not.Null.And.Not.Empty,
+            "Without a SessionId the orchestrator mints a throwaway Guid, so nothing the " +
+            "guitarist says is reachable from their next turn.");
+    }
+
+    [Test]
+    public async Task Chat_SameBrowserAcrossTurns_KeepsOneSession()
+    {
+        var chatService = new CapturingChatApplicationService();
+        using var factory = CreateFactory(chatService);
+        // HandleCookies (the default) makes the client behave like a browser:
+        // it stores the Set-Cookie from turn 1 and replays it on turn 2.
+        using var client = factory.CreateClient();
+
+        (await client.PostAsJsonAsync("/api/chatbot/chat", new { message = "Notes in C major?" }))
+            .EnsureSuccessStatusCode();
+        (await client.PostAsJsonAsync("/api/chatbot/chat", new { message = "And its relative minor?" }))
+            .EnsureSuccessStatusCode();
+
+        Assert.That(chatService.Requests, Has.Count.EqualTo(2));
+        Assert.Multiple(() =>
+        {
+            // Assert non-null FIRST: "both turns agree" is vacuously true when
+            // both are null, which is precisely the broken state this slice
+            // fixes. Without this guard the test passes on the bug.
+            Assert.That(chatService.Requests[0].SessionId, Is.Not.Null.And.Not.Empty);
+            Assert.That(chatService.Requests[1].SessionId, Is.EqualTo(chatService.Requests[0].SessionId),
+                "Consecutive turns from one browser must share a session — that continuity is " +
+                "what lets the chatbot recall the conversation it is already having.");
+        });
+    }
+
+    [Test]
+    public async Task Chat_DifferentBrowsers_GetDifferentSessions()
+    {
+        var chatService = new CapturingChatApplicationService();
+        using var factory = CreateFactory(chatService);
+        using var browserA = factory.CreateClient();
+        using var browserB = factory.CreateClient();
+
+        (await browserA.PostAsJsonAsync("/api/chatbot/chat", new { message = "Notes in C major?" }))
+            .EnsureSuccessStatusCode();
+        (await browserB.PostAsJsonAsync("/api/chatbot/chat", new { message = "Notes in C major?" }))
+            .EnsureSuccessStatusCode();
+
+        Assert.That(chatService.Requests, Has.Count.EqualTo(2));
+        Assert.That(chatService.Requests[1].SessionId, Is.Not.EqualTo(chatService.Requests[0].SessionId),
+            "Two unrelated visitors to the public demo must not share a memory partition.");
+    }
+
+    [Test]
+    public async Task ChatStream_IssuesSessionBeforeCommittingTheSseResponse()
+    {
+        var chatService = new CapturingChatApplicationService();
+        using var factory = CreateFactory(chatService);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/chatbot/chat/stream", new { message = "Notes in C major?" });
+        response.EnsureSuccessStatusCode();
+        await response.Content.ReadAsStringAsync();
+
+        Assert.That(chatService.Requests, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(chatService.Requests[0].SessionId, Is.Not.Null.And.Not.Empty);
+            // Appending a cookie after Response.StartAsync throws because the
+            // headers are already on the wire; the SSE path must resolve the
+            // session first. A Set-Cookie here proves it did.
+            Assert.That(response.Headers.TryGetValues("Set-Cookie", out _), Is.True,
+                "The streaming endpoint must issue its session cookie before committing headers.");
+        });
+    }
+
+    [Test]
+    public void ToOrchestratorRequest_PreservesSessionIdentity()
+    {
+        // The adapter hop is where session identity was being dropped. It fails
+        // silently — ProductionOrchestrator substitutes a fresh Guid for a null
+        // SessionId — so pin it directly.
+        var mapped = ProductionChatOrchestratorClient.ToOrchestratorRequest(
+            new ChatExecutionRequest("Notes in C major?", History: null, SessionId: "session-abc"));
+
+        Assert.That(mapped.SessionId, Is.EqualTo("session-abc"));
+    }
+
+    [Test]
+    public void ToOrchestratorRequest_CarriesMessageAndHistoryThrough()
+    {
+        List<ConversationTurn> history = [new("user", "Notes in C major?", DateTimeOffset.UnixEpoch)];
+
+        var mapped = ProductionChatOrchestratorClient.ToOrchestratorRequest(
+            new ChatExecutionRequest("And its relative minor?", history, SessionId: "session-abc"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mapped.Message, Is.EqualTo("And its relative minor?"));
+            Assert.That(mapped.History, Is.EqualTo(history));
+        });
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(IChatApplicationService chatService) =>
+        new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder => builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IChatApplicationService>();
+                services.AddSingleton(chatService);
+            }));
+
+    private sealed class CapturingChatApplicationService : IChatApplicationService
+    {
+        private readonly List<ChatExecutionRequest> _requests = [];
+        private readonly Lock _gate = new();
+
+        public IReadOnlyList<ChatExecutionRequest> Requests
+        {
+            get { lock (_gate) return [.. _requests]; }
+        }
+
+        public Task<ChatExecutionResult> ChatAsync(
+            ChatExecutionRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Capture(request);
+            return Task.FromResult(new ChatExecutionResult(
+                "captured answer",
+                new AgentRoutingMetadata("fake-agent", 0.75f, "fake-route")));
+        }
+
+        public async IAsyncEnumerable<ChatStreamUpdate> ChatStreamAsync(
+            ChatExecutionRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            Capture(request);
+            yield return new ChatStreamUpdate(Routing: new AgentRoutingMetadata("fake-agent", 0.75f, "fake-route"));
+            yield return new ChatStreamUpdate("captured answer");
+            await Task.Yield();
+            yield return new ChatStreamUpdate(IsCompleted: true);
+        }
+
+        public Task<GaChatbot.Api.Controllers.ChatbotStatus> GetStatusAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GaChatbot.Api.Controllers.ChatbotStatus
+            {
+                IsAvailable = true,
+                Message = "fake ready",
+                Timestamp = DateTime.UtcNow
+            });
+
+        private void Capture(ChatExecutionRequest request)
+        {
+            lock (_gate) _requests.Add(request);
+        }
+    }
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
@@ -1,5 +1,7 @@
 namespace GaChatbot.Api.Tests.Controllers;
 
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Net.Http.Json;
 using GaChatbot.Api.Services;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -45,10 +47,22 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 /// when the run skips the build, and stops the shell it runs in from reddening
 /// it while the shipped file is intact.
 /// </para>
+/// <para>
+/// <c>ShippedRunbook_CookieAssertion_TestsTheSessionCookieNotTheWholeHeaderBlock</c>
+/// extends that same "guard the shipped artefact" idea to the operator-side
+/// check. Nothing in this process runs
+/// <c>docs/runbooks/chatbot-deploy.md</c>, so its step-6 assertion — the only
+/// check that can observe the PUBLIC cookie losing <c>Secure</c> — had no
+/// oracle at all, and the response it inspects can carry several
+/// <c>Set-Cookie</c> headers of which only one is the session cookie.
+/// </para>
 /// </remarks>
 [TestFixture]
 public class ForwardedHeadersSessionCookieTests
 {
+    /// <summary>Name of the step-6 assertion this fixture lifts out of the runbook.</summary>
+    private const string RunbookAssertionName = "Assert-GaChatSessionSecure";
+
     [Test]
     public async Task ChatBehindTheTunnel_IssuesASecureSessionCookie()
     {
@@ -119,6 +133,110 @@ public class ForwardedHeadersSessionCookieTests
             "forwarded-header guard takes the strip branch on every request — including tunnel " +
             "traffic — so the Program.cs fix is inert in production and the public session " +
             "cookie silently loses Secure again. See docs/runbooks/chatbot-deploy.md step 4.");
+    }
+
+    [Test]
+    public void ShippedRunbook_CookieAssertion_TestsTheSessionCookieNotTheWholeHeaderBlock()
+    {
+        var assertion = ShippedRunbookCookieAssertion();
+
+        // The cookies that are NOT the session cookie are the likelier ones to
+        // be Secure — Cloudflare issues __cf_bm / cf_clearance Secure whenever
+        // the zone emits them. An assertion that joins the headers and matches
+        // /secure/ therefore reports success on this exact pair while the
+        // session cookie, the only one that matters here, ships bare.
+        const string cloudflareDecoy =
+            "__cf_bm=Jd8n3o.decoy; path=/; domain=.guitaralchemist.com; HttpOnly; Secure; SameSite=None";
+        const string bareSession =
+            "ga_chat_session=6f1c9d2e-4a70-4f5b-9d21-0b2c3e4f5a61; path=/api/chatbot; samesite=lax; httponly";
+        const string secureSession = bareSession + "; secure";
+
+        var bare = RunShippedRunbookAssertion(assertion, cloudflareDecoy, bareSession);
+        var secure = RunShippedRunbookAssertion(assertion, cloudflareDecoy, secureSession);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bare.ExitCode, Is.Not.Zero,
+                "docs/runbooks/chatbot-deploy.md step 6 accepted a response whose ga_chat_session cookie " +
+                "carries no Secure attribute, because another cookie in the same response does. Step 6 " +
+                "must select the ga_chat_session Set-Cookie header before asserting Secure on it — " +
+                "otherwise a deploy that silently dropped Secure passes its own regression check.");
+            Assert.That(bare.Stderr, Does.Contain("lacks Secure"),
+                "Step 6 must name the failure it found; the operator acts on that message.");
+            Assert.That(secure.ExitCode, Is.Zero,
+                "Step 6 rejected a genuinely Secure session cookie, which would block a healthy deploy. " +
+                $"stderr: {secure.Stderr}");
+        });
+    }
+
+    /// <summary>
+    /// Lifts the step-6 cookie assertion out of the shipped runbook so it can be
+    /// executed rather than merely read.
+    /// </summary>
+    private static string ShippedRunbookCookieAssertion()
+    {
+        var runbook = TestPaths.RepositoryPath("docs", "runbooks", "chatbot-deploy.md");
+        var lines = File.ReadAllLines(runbook);
+
+        var start = Array.FindIndex(
+            lines,
+            line => line.StartsWith($"function {RunbookAssertionName}", StringComparison.Ordinal));
+        Assert.That(start, Is.GreaterThanOrEqualTo(0),
+            $"{runbook} no longer defines a column-0 '{RunbookAssertionName}' function. Step 6's cookie " +
+            "assertion is the only check that can see the public session cookie lose Secure, so it stays " +
+            "in a named function this guard can execute; inlining it back into the procedure removes the " +
+            "only oracle the runbook has.");
+
+        // The body's braces are balanced and none appear inside its strings or
+        // regexes; an unbalanced edit falls through to the failure below.
+        var depth = 0;
+        for (var i = start; i < lines.Length; i++)
+        {
+            depth += lines[i].Count(c => c == '{') - lines[i].Count(c => c == '}');
+            if (depth == 0) return string.Join(Environment.NewLine, lines[start..(i + 1)]);
+        }
+
+        Assert.Fail($"{RunbookAssertionName} in {runbook} is never closed.");
+        return string.Empty;
+    }
+
+    private static (int ExitCode, string Stderr) RunShippedRunbookAssertion(
+        string assertion,
+        params string[] setCookieHeaders)
+    {
+        var headers = string.Join(", ", setCookieHeaders.Select(h => $"'{h.Replace("'", "''")}'"));
+        var script = Path.Combine(Path.GetTempPath(), $"ga-runbook-cookie-{Guid.NewGuid():N}.ps1");
+        File.WriteAllText(script, string.Join(Environment.NewLine,
+            assertion,
+            $"{RunbookAssertionName} -SetCookieHeaders @({headers})"));
+
+        try
+        {
+            using var pwsh = Process.Start(new ProcessStartInfo("pwsh")
+            {
+                ArgumentList = { "-NoProfile", "-NonInteractive", "-File", script },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            }) ?? throw new InvalidOperationException("pwsh produced no process handle.");
+
+            var stdout = pwsh.StandardOutput.ReadToEndAsync();
+            var stderr = pwsh.StandardError.ReadToEnd();
+            pwsh.WaitForExit();
+            stdout.GetAwaiter().GetResult();
+            return (pwsh.ExitCode, stderr);
+        }
+        catch (Win32Exception e)
+        {
+            // A skip here would make the guard vacuous on exactly the machines
+            // that run the deploy, so this fails instead. pwsh is already a hard
+            // dependency of the repo (Scripts/*.ps1, .githooks/pre-commit).
+            Assert.Fail($"pwsh could not be launched, so the shipped runbook assertion was never executed: {e.Message}");
+            return (0, string.Empty);
+        }
+        finally
+        {
+            File.Delete(script);
+        }
     }
 
     private static HttpRequestMessage ChatRequest(bool cloudflare, string forwardedProto)

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
@@ -28,11 +28,22 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 /// the guard that keeps them apart.
 /// </para>
 /// <para>
-/// The fixture deliberately supplies no <c>Proxy:PublicHost</c> of its own: it
-/// reads the value the host ships in <c>Apps/GaChatbot.Api/appsettings.json</c>
-/// (<c>TestWebApplicationFactory</c> points the content root at the app source
-/// directory). Overriding it here would prove the middleware works when handed
-/// a public host while leaving the deployment free to stop supplying one.
+/// The fixture deliberately supplies no <c>Proxy:PublicHost</c> of its own, so
+/// the host under test resolves whatever configuration reaches it. Overriding
+/// it here would prove the middleware works when handed a public host while
+/// leaving the deployment free to stop supplying one.
+/// </para>
+/// <para>
+/// What reaches the host is NOT
+/// <c>Apps/GaChatbot.Api/appsettings.json</c> read live: <c>Program.cs</c> pins
+/// <c>ContentRootPath</c> to <c>AppContext.BaseDirectory</c>, which overrides
+/// <c>TestWebApplicationFactory</c>'s <c>UseContentRoot</c>, so the host reads
+/// the copy MSBuild refreshes into the TEST project's output on every build —
+/// and an ambient <c>Proxy__PublicHost</c> environment variable still outranks
+/// that copy. <c>ShippedConfiguration_SuppliesTheProxyPublicHost</c> therefore
+/// reads the shipped file straight off disk instead: that keeps it meaningful
+/// when the run skips the build, and stops the shell it runs in from reddening
+/// it while the shipped file is intact.
 /// </para>
 /// </remarks>
 [TestFixture]
@@ -92,12 +103,19 @@ public class ForwardedHeadersSessionCookieTests
     [Test]
     public void ShippedConfiguration_SuppliesTheProxyPublicHost()
     {
-        using var factory = CreateFactory();
+        // Read the shipped file itself rather than the host's resolved
+        // configuration — see the class remarks for why the host is the wrong
+        // oracle for a claim about what the deployment ships.
+        var shipped = new ConfigurationBuilder()
+            .AddJsonFile(TestPaths.RepositoryPath("Apps", "GaChatbot.Api", "appsettings.json"))
+            .Build();
 
-        var publicHost = factory.Services.GetRequiredService<IConfiguration>()["Proxy:PublicHost"];
+        var publicHost = shipped["Proxy:PublicHost"];
 
-        Assert.That(publicHost, Is.Not.Null.And.Not.Empty,
-            "Apps/GaChatbot.Api/appsettings.json must ship Proxy:PublicHost. Without it the " +
+        // Program.cs:73 and :91 both branch on IsNullOrWhiteSpace, so a
+        // whitespace-only value is as inert as a missing one.
+        Assert.That(string.IsNullOrWhiteSpace(publicHost), Is.False,
+            "Apps/GaChatbot.Api/appsettings.json must ship a non-blank Proxy:PublicHost. Without it the " +
             "forwarded-header guard takes the strip branch on every request — including tunnel " +
             "traffic — so the Program.cs fix is inert in production and the public session " +
             "cookie silently loses Secure again. See docs/runbooks/chatbot-deploy.md step 4.");
@@ -130,9 +148,10 @@ public class ForwardedHeadersSessionCookieTests
             .WithWebHostBuilder(builder =>
             {
                 // No Proxy:PublicHost override on purpose — see the class remarks.
-                // The shipped appsettings.json value is what mirrors the deployed
-                // cloudflared ingress (docs/runbooks/chatbot-deploy.md:24), and it
-                // is what these tests must depend on.
+                // The deployed value must reach the host through the same
+                // configuration path production uses (docs/runbooks/chatbot-deploy.md:24);
+                // a test setting here would keep these tests green after the
+                // deployment stopped supplying one.
                 builder.ConfigureTestServices(services =>
                 {
                     // The chat provider is irrelevant here — only the cookie the

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using GaChatbot.Api.Services;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -26,12 +27,17 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 /// branch; this fixture pins the deployed one, and the spoof test below pins
 /// the guard that keeps them apart.
 /// </para>
+/// <para>
+/// The fixture deliberately supplies no <c>Proxy:PublicHost</c> of its own: it
+/// reads the value the host ships in <c>Apps/GaChatbot.Api/appsettings.json</c>
+/// (<c>TestWebApplicationFactory</c> points the content root at the app source
+/// directory). Overriding it here would prove the middleware works when handed
+/// a public host while leaving the deployment free to stop supplying one.
+/// </para>
 /// </remarks>
 [TestFixture]
 public class ForwardedHeadersSessionCookieTests
 {
-    private const string PublicHost = "demos.guitaralchemist.com";
-
     [Test]
     public async Task ChatBehindTheTunnel_IssuesASecureSessionCookie()
     {
@@ -83,6 +89,20 @@ public class ForwardedHeadersSessionCookieTests
         Assert.That(SessionSetCookie(response), Does.Not.Contain("secure").IgnoreCase);
     }
 
+    [Test]
+    public void ShippedConfiguration_SuppliesTheProxyPublicHost()
+    {
+        using var factory = CreateFactory();
+
+        var publicHost = factory.Services.GetRequiredService<IConfiguration>()["Proxy:PublicHost"];
+
+        Assert.That(publicHost, Is.Not.Null.And.Not.Empty,
+            "Apps/GaChatbot.Api/appsettings.json must ship Proxy:PublicHost. Without it the " +
+            "forwarded-header guard takes the strip branch on every request — including tunnel " +
+            "traffic — so the Program.cs fix is inert in production and the public session " +
+            "cookie silently loses Secure again. See docs/runbooks/chatbot-deploy.md step 4.");
+    }
+
     private static HttpRequestMessage ChatRequest(bool cloudflare, string forwardedProto)
     {
         var request = new HttpRequestMessage(HttpMethod.Post, "/api/chatbot/chat")
@@ -109,9 +129,10 @@ public class ForwardedHeadersSessionCookieTests
         new TestWebApplicationFactory()
             .WithWebHostBuilder(builder =>
             {
-                // Mirrors the deployed cloudflared ingress
-                // (docs/runbooks/chatbot-deploy.md:24).
-                builder.UseSetting("Proxy:PublicHost", PublicHost);
+                // No Proxy:PublicHost override on purpose — see the class remarks.
+                // The shipped appsettings.json value is what mirrors the deployed
+                // cloudflared ingress (docs/runbooks/chatbot-deploy.md:24), and it
+                // is what these tests must depend on.
                 builder.ConfigureTestServices(services =>
                 {
                     // The chat provider is irrelevant here — only the cookie the

--- a/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs
@@ -1,0 +1,150 @@
+namespace GaChatbot.Api.Tests.Controllers;
+
+using System.Net.Http.Json;
+using GaChatbot.Api.Services;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+/// <summary>
+/// Pins the <c>Secure</c> attribute of the chat session cookie under the
+/// deployed proxy topology.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>HttpChatSessionCookie</c> sets <c>Secure = ctx.Request.IsHttps</c>, and
+/// the deployment terminates TLS at a cloudflared tunnel that forwards to
+/// <c>http://localhost:5252</c> (<c>docs/runbooks/chatbot-deploy.md</c>).
+/// Without <c>UseForwardedHeaders</c>, <c>IsHttps</c> is false on EVERY
+/// production request, so the public cookie on
+/// <c>https://demos.guitaralchemist.com</c> ships without <c>Secure</c> —
+/// the gap the independent standards review filed as F-1.
+/// </para>
+/// <para>
+/// <c>GetOrIssue_PlainHttp_DoesNotMarkCookieSecure</c> pins the dev-convenience
+/// branch; this fixture pins the deployed one, and the spoof test below pins
+/// the guard that keeps them apart.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class ForwardedHeadersSessionCookieTests
+{
+    private const string PublicHost = "demos.guitaralchemist.com";
+
+    [Test]
+    public async Task ChatBehindTheTunnel_IssuesASecureSessionCookie()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(ChatRequest(cloudflare: true, forwardedProto: "https"));
+        response.EnsureSuccessStatusCode();
+
+        Assert.That(SessionSetCookie(response), Does.Contain("secure").IgnoreCase,
+            "Behind the TLS-terminating tunnel the origin hop is plain HTTP, so the session " +
+            "cookie is only Secure if X-Forwarded-Proto is honoured. This cookie keys private " +
+            "conversational memory the moment Memory:EnrichOnRetrieve flips.");
+    }
+
+    [Test]
+    public async Task ChatBehindTheTunnel_KeepsTheCookieHttpOnlyAndPathScoped()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.SendAsync(ChatRequest(cloudflare: true, forwardedProto: "https"));
+        response.EnsureSuccessStatusCode();
+
+        var setCookie = SessionSetCookie(response);
+        Assert.Multiple(() =>
+        {
+            // Honouring the forwarded scheme must not disturb the rest of the
+            // cookie shape — in particular the PathBase-aware Path.
+            Assert.That(setCookie, Does.Contain("httponly").IgnoreCase);
+            Assert.That(setCookie, Does.Contain("path=/api/chatbot").IgnoreCase);
+        });
+    }
+
+    [Test]
+    public async Task DirectRequestSpoofingForwardedProto_DoesNotGetASecureCookie()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        // No CF-Connecting-IP: a direct caller (or a dev proxy emitting a
+        // partial forwarded-header set) must not be able to talk the host into
+        // an https view of itself. Otherwise local http development gets a
+        // Secure cookie the browser then refuses to send back, silently
+        // rotating the session on every turn.
+        var response = await client.SendAsync(ChatRequest(cloudflare: false, forwardedProto: "https"));
+        response.EnsureSuccessStatusCode();
+
+        Assert.That(SessionSetCookie(response), Does.Not.Contain("secure").IgnoreCase);
+    }
+
+    private static HttpRequestMessage ChatRequest(bool cloudflare, string forwardedProto)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/chatbot/chat")
+        {
+            Content = JsonContent.Create(new { message = "Notes in C major?" })
+        };
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Proto", forwardedProto);
+        if (cloudflare) request.Headers.TryAddWithoutValidation("CF-Connecting-IP", "203.0.113.7");
+        return request;
+    }
+
+    private static string SessionSetCookie(HttpResponseMessage response)
+    {
+        Assert.That(response.Headers.TryGetValues("Set-Cookie", out var values), Is.True,
+            "Expected the chat endpoint to issue a session cookie.");
+        var cookie = values!.FirstOrDefault(v =>
+            v.StartsWith(HttpChatSessionCookie.CookieName + "=", StringComparison.Ordinal));
+        Assert.That(cookie, Is.Not.Null,
+            $"Expected a {HttpChatSessionCookie.CookieName} Set-Cookie header.");
+        return cookie!;
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory() =>
+        new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                // Mirrors the deployed cloudflared ingress
+                // (docs/runbooks/chatbot-deploy.md:24).
+                builder.UseSetting("Proxy:PublicHost", PublicHost);
+                builder.ConfigureTestServices(services =>
+                {
+                    // The chat provider is irrelevant here — only the cookie the
+                    // transport emits is under test.
+                    services.RemoveAll<IChatApplicationService>();
+                    services.AddSingleton<IChatApplicationService, StubChatApplicationService>();
+                });
+            });
+
+    private sealed class StubChatApplicationService : IChatApplicationService
+    {
+        public Task<ChatExecutionResult> ChatAsync(
+            ChatExecutionRequest request,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatExecutionResult(
+                "stub answer",
+                new GA.Business.Core.Orchestration.Models.AgentRoutingMetadata("fake-agent", 0.75f, "fake-route")));
+
+        public async IAsyncEnumerable<ChatStreamUpdate> ChatStreamAsync(
+            ChatExecutionRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield return new ChatStreamUpdate("stub answer");
+            await Task.Yield();
+            yield return new ChatStreamUpdate(IsCompleted: true);
+        }
+
+        public Task<GaChatbot.Api.Controllers.ChatbotStatus> GetStatusAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GaChatbot.Api.Controllers.ChatbotStatus
+            {
+                IsAvailable = true,
+                Message = "stub ready",
+                Timestamp = DateTime.UtcNow
+            });
+    }
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Services/HttpChatSessionCookieTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Services/HttpChatSessionCookieTests.cs
@@ -1,0 +1,164 @@
+namespace GaChatbot.Api.Tests.Services;
+
+using GaChatbot.Api.Services;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Pins the session-identity contract for the canonical public chatbot host's
+/// HTTP transport: a browser that keeps its cookie keeps its session, a
+/// browser without one gets a fresh session, and a forged cookie cannot
+/// pin the caller onto a session of their choosing.
+/// </summary>
+[TestFixture]
+public class HttpChatSessionCookieTests
+{
+    private static HttpContext NewHttpContext(
+        bool https = true,
+        string? applicationName = null,
+        string pathBase = "")
+    {
+        var services = new ServiceCollection();
+        // Ephemeral, per-context key ring. SetApplicationName forces isolation
+        // between contexts so the cross-key-ring negative test is meaningful.
+        services.AddDataProtection()
+            .SetApplicationName(applicationName ?? $"GaChatbotApiTest-{Guid.NewGuid():N}");
+
+        var ctx = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        ctx.Request.Scheme = https ? "https" : "http";
+        ctx.Request.PathBase = pathBase;
+        return ctx;
+    }
+
+    private static string IssuedCookieValue(HttpContext ctx)
+    {
+        var setCookie = ctx.Response.Headers["Set-Cookie"].ToString();
+        var start = setCookie.IndexOf(HttpChatSessionCookie.CookieName + "=", StringComparison.Ordinal);
+        Assert.That(start, Is.GreaterThanOrEqualTo(0), "Expected a Set-Cookie header for the chat session.");
+        var valueStart = start + HttpChatSessionCookie.CookieName.Length + 1;
+        var end = setCookie.IndexOf(';', valueStart);
+        return end < 0 ? setCookie[valueStart..] : setCookie[valueStart..end];
+    }
+
+    [Test]
+    public void GetOrIssue_FirstRequest_IssuesProtectedCookieAndReturnsInnerId()
+    {
+        var ctx = NewHttpContext();
+
+        var sessionId = HttpChatSessionCookie.GetOrIssue(ctx);
+
+        var setCookie = ctx.Response.Headers["Set-Cookie"].ToString();
+        Assert.Multiple(() =>
+        {
+            Assert.That(sessionId, Is.Not.Null.And.Not.Empty);
+            Assert.That(sessionId.Length, Is.GreaterThanOrEqualTo(16),
+                "Inner ID should be >= 16 chars (128 bits, base64url-encoded).");
+            Assert.That(setCookie, Does.Contain(HttpChatSessionCookie.CookieName));
+            Assert.That(setCookie, Does.Not.Contain(sessionId),
+                "The cookie must carry DataProtection ciphertext, not the raw inner ID — " +
+                "otherwise a caller can read and replay another session's identifier.");
+            Assert.That(setCookie, Does.Contain("httponly").IgnoreCase);
+            Assert.That(setCookie, Does.Contain("samesite=lax").IgnoreCase);
+            Assert.That(setCookie, Does.Contain("secure").IgnoreCase);
+            Assert.That(setCookie, Does.Contain("path=/api/chatbot").IgnoreCase);
+        });
+    }
+
+    [Test]
+    public void GetOrIssue_PlainHttp_DoesNotMarkCookieSecure()
+    {
+        var ctx = NewHttpContext(https: false);
+
+        HttpChatSessionCookie.GetOrIssue(ctx);
+
+        Assert.That(ctx.Response.Headers["Set-Cookie"].ToString(), Does.Not.Contain("secure").IgnoreCase,
+            "Secure on a plain-HTTP dev request would make the cookie undeliverable.");
+    }
+
+    [Test]
+    public void GetOrIssue_ExistingValidCookie_ReturnsSameSessionAndDoesNotReissue()
+    {
+        const string appName = "GaChatbotApiTest-stable";
+        var first = NewHttpContext(applicationName: appName);
+        var firstId = HttpChatSessionCookie.GetOrIssue(first);
+        var cookie = IssuedCookieValue(first);
+
+        var second = NewHttpContext(applicationName: appName);
+        second.Request.Headers.Cookie = $"{HttpChatSessionCookie.CookieName}={cookie}";
+
+        var secondId = HttpChatSessionCookie.GetOrIssue(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(secondId, Is.EqualTo(firstId),
+                "A returning browser must land on the same session — that continuity is the " +
+                "whole point of scoping chatbot memory per conversation.");
+            Assert.That(second.Response.Headers["Set-Cookie"].ToString(), Is.Empty,
+                "A valid cookie must not be reissued; reissuing would rotate the session.");
+        });
+    }
+
+    [Test]
+    public void GetOrIssue_TwoFreshBrowsers_GetDistinctSessions()
+    {
+        const string appName = "GaChatbotApiTest-distinct";
+
+        var a = HttpChatSessionCookie.GetOrIssue(NewHttpContext(applicationName: appName));
+        var b = HttpChatSessionCookie.GetOrIssue(NewHttpContext(applicationName: appName));
+
+        Assert.That(a, Is.Not.EqualTo(b),
+            "Two unrelated visitors must not share a memory partition.");
+    }
+
+    [Test]
+    public void GetOrIssue_ForgedCookie_IsRejectedAndFreshSessionIssued()
+    {
+        var ctx = NewHttpContext();
+        // Attacker-chosen value with a valid-looking inner shape. Shape-only
+        // validation would accept it and pin the caller onto a chosen session.
+        ctx.Request.Headers.Cookie = $"{HttpChatSessionCookie.CookieName}=AAAAAAAAAAAAAAAAAAAAAA";
+
+        var sessionId = HttpChatSessionCookie.GetOrIssue(ctx);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sessionId, Is.Not.EqualTo("AAAAAAAAAAAAAAAAAAAAAA"));
+            Assert.That(ctx.Response.Headers["Set-Cookie"].ToString(),
+                Does.Contain(HttpChatSessionCookie.CookieName),
+                "A rejected cookie must be replaced with a server-issued one.");
+        });
+    }
+
+    [Test]
+    public void GetOrIssue_CookieFromAnotherKeyRing_IsRejected()
+    {
+        var issuer = NewHttpContext(applicationName: "GaChatbotApiTest-ring-a");
+        HttpChatSessionCookie.GetOrIssue(issuer);
+        var foreignCookie = IssuedCookieValue(issuer);
+
+        var ctx = NewHttpContext(applicationName: "GaChatbotApiTest-ring-b");
+        ctx.Request.Headers.Cookie = $"{HttpChatSessionCookie.CookieName}={foreignCookie}";
+
+        HttpChatSessionCookie.GetOrIssue(ctx);
+
+        Assert.That(ctx.Response.Headers["Set-Cookie"].ToString(),
+            Does.Contain(HttpChatSessionCookie.CookieName),
+            "A cookie signed by a different key ring must not Unprotect into a usable session.");
+    }
+
+    [Test]
+    public void GetOrIssue_UnderPathBase_ScopesCookieToTheMountedPrefix()
+    {
+        // This host is mounted under /chatbot on demos.guitaralchemist.com
+        // (Chatbot:PathBase — see ChatbotPathBaseTests). A cookie pinned to a
+        // hardcoded /api/chatbot would never be sent back by the browser
+        // there, silently rotating the session on every turn.
+        var ctx = NewHttpContext(pathBase: "/chatbot");
+
+        HttpChatSessionCookie.GetOrIssue(ctx);
+
+        Assert.That(ctx.Response.Headers["Set-Cookie"].ToString(),
+            Does.Contain("path=/chatbot/api/chatbot").IgnoreCase);
+    }
+}

--- a/Tests/Apps/GaChatbot.Api.Tests/Services/ProductionChatOrchestratorClientTests.cs
+++ b/Tests/Apps/GaChatbot.Api.Tests/Services/ProductionChatOrchestratorClientTests.cs
@@ -1,0 +1,95 @@
+namespace GaChatbot.Api.Tests.Services;
+
+using GA.Business.Core.Orchestration.Models;
+using GA.Business.Core.Orchestration.Services;
+using GaChatbot.Api.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Pins session identity on the REAL adapter path
+/// (<see cref="ProductionChatOrchestratorClient.AnswerAsync"/>), not on the
+/// pure mapping helper it happens to call today.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ToOrchestratorRequest_PreservesSessionIdentity</c>
+/// (<c>ChatbotControllerSessionScopeTests</c>) guards the body of a
+/// <c>public static</c> function. Nothing forced <c>AnswerAsync</c> to call it,
+/// so re-inlining the original defect —
+/// <c>new ChatRequest(request.Message, SessionId: null, History: request.History)</c>
+/// — restored the exact pre-fix bug with the whole suite still green
+/// (independent spec review 2026-08-08, mutant M1).
+/// </para>
+/// <para>
+/// This test closes that gap by driving the real <c>AnswerAsync</c> against a
+/// stub orchestrator and asserting on the <see cref="ChatRequest"/> the
+/// orchestrator actually receives. It fails on M1 and on any future call path
+/// that skips the mapping helper.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class ProductionChatOrchestratorClientTests
+{
+    [Test]
+    public async Task AnswerAsync_ForwardsSessionIdToTheOrchestrator()
+    {
+        var orchestrator = new CapturingOrchestrator();
+        var client = new ProductionChatOrchestratorClient(ProviderFor(orchestrator));
+
+        await client.AnswerAsync(
+            new ChatExecutionRequest("Notes in C major?", History: null, SessionId: "session-abc"));
+
+        Assert.That(orchestrator.Captured, Is.Not.Null,
+            "The adapter must actually reach the orchestrator.");
+        Assert.That(orchestrator.Captured!.SessionId, Is.EqualTo("session-abc"),
+            "ProductionOrchestrator substitutes a fresh Guid for a null SessionId, so dropping " +
+            "the session on this hop fails silently: every turn gets its own MemoryStore / " +
+            "ChatTranscriptStore partition and the chatbot cannot recall its own conversation.");
+    }
+
+    [Test]
+    public async Task AnswerAsync_CarriesMessageAndHistoryToTheOrchestrator()
+    {
+        List<ConversationTurn> history = [new("user", "Notes in C major?", DateTimeOffset.UnixEpoch)];
+        var orchestrator = new CapturingOrchestrator();
+        var client = new ProductionChatOrchestratorClient(ProviderFor(orchestrator));
+
+        await client.AnswerAsync(
+            new ChatExecutionRequest("And its relative minor?", history, SessionId: "session-abc"));
+
+        Assert.That(orchestrator.Captured, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(orchestrator.Captured!.Message, Is.EqualTo("And its relative minor?"));
+            Assert.That(orchestrator.Captured!.History, Is.EqualTo(history));
+        });
+    }
+
+    private static IServiceProvider ProviderFor(ProductionOrchestrator orchestrator)
+    {
+        var services = new ServiceCollection();
+        // The adapter resolves the concrete type, so the stub must be
+        // registered under it — the same registration shape as
+        // ChatbotOrchestrationExtensions.AddChatbotOrchestration.
+        services.AddSingleton(orchestrator);
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Records the <see cref="ChatRequest"/> the adapter hands over. Only the
+    /// two dependencies the primary constructor eagerly enumerates
+    /// (<c>orchestratorSkills</c>, <c>chatHooks</c>) need real values; the
+    /// overridden <c>AnswerAsync</c> touches none of the rest.
+    /// </summary>
+    private sealed class CapturingOrchestrator() : ProductionOrchestrator(
+        null!, null!, null!, null!, null!, [], [], null!, null!, null!, null!, null!, null!, null!)
+    {
+        public ChatRequest? Captured { get; private set; }
+
+        public override Task<ChatResponse> AnswerAsync(ChatRequest req, CancellationToken ct = default)
+        {
+            Captured = req;
+            return Task.FromResult(new ChatResponse("stub answer", []));
+        }
+    }
+}

--- a/docs/runbooks/chatbot-deploy.md
+++ b/docs/runbooks/chatbot-deploy.md
@@ -96,20 +96,41 @@ Invoke-RestMethod `
 #    guard takes the strip branch, Request.IsHttps stays false, and the cookie
 #    ships without Secure — a silent failure neither the status check (step 5)
 #    nor the trace shape above can see.
+#
+#    A Set-Cookie block can hold more than one cookie, and the cookies that are
+#    NOT ga_chat_session are the likelier ones to be Secure: Cloudflare's
+#    __cf_bm / cf_clearance are issued Secure whenever the zone emits them, and
+#    anything the app starts setting later lands in the same block. So the
+#    assertion has to pick the ga_chat_session header out of the set and test
+#    THAT header. Matching /secure/ across the joined block reports success off
+#    somebody else's cookie while the session cookie ships bare — the exact
+#    silent pass this step exists to prevent.
+function Assert-GaChatSessionSecure {
+  param([string[]] $SetCookieHeaders)
+
+  # -cmatch: cookie names are case-sensitive, mirroring the ordinal match in
+  # ForwardedHeadersSessionCookieTests.SessionSetCookie.
+  $session = @($SetCookieHeaders) | Where-Object { $_ -cmatch '^ga_chat_session=' } | Select-Object -First 1
+  if (-not $session) {
+    throw "No ga_chat_session cookie issued. Got: $(@($SetCookieHeaders) -join ' | ')"
+  }
+  # Whole attribute, not a substring: the protected session id is base64url and
+  # could otherwise spell 'secure' by accident.
+  if ($session -notmatch '(?i)(^|;)\s*secure\s*(;|$)') {
+    throw "Session cookie lacks Secure — check Proxy:PublicHost in Apps/GaChatbot.Api/appsettings.json. Got: $session"
+  }
+}
+
 $cookieProbe = Invoke-WebRequest `
   -Uri https://demos.guitaralchemist.com/api/chatbot/chat `
   -Method POST `
   -ContentType 'application/json' `
   -Body (@{ Message = 'cookie probe' } | ConvertTo-Json) `
   -UseBasicParsing
-$setCookie = @($cookieProbe.Headers['Set-Cookie']) -join '; '
-if ($setCookie -notmatch 'ga_chat_session=') {
-  throw "No ga_chat_session cookie issued. Got: $setCookie"
-}
-if ($setCookie -notmatch '(?i)secure') {
-  throw "Session cookie lacks Secure — check Proxy:PublicHost in Apps/GaChatbot.Api/appsettings.json. Got: $setCookie"
-}
+Assert-GaChatSessionSecure -SetCookieHeaders @($cookieProbe.Headers['Set-Cookie'])
 ```
+
+`Assert-GaChatSessionSecure` is not decoration: `ShippedRunbook_CookieAssertion_TestsTheSessionCookieNotTheWholeHeaderBlock` in `Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs` lifts this exact function out of this file and runs it against a two-cookie fixture. Renaming or inlining it turns that guard red with an actionable message; changing what it asserts turns it red on behaviour.
 
 The probe should show the 6-step canonical shape:
 `chat.request → orchestration.answer → orchestration.route → agent.semantic_result → notation.vextab → response.emit`,

--- a/docs/runbooks/chatbot-deploy.md
+++ b/docs/runbooks/chatbot-deploy.md
@@ -57,9 +57,13 @@ $env:ASPNETCORE_URLS = 'http://localhost:5252'
 # Proxy__PublicHost is NOT set here: it ships as 'demos.guitaralchemist.com' in
 # Apps/GaChatbot.Api/appsettings.json. It is the host the forwarded-header guard
 # pins X-Forwarded-Host to, and it is what makes the session cookie Secure behind
-# the TLS-terminating tunnel. Do NOT blank or unset it — every tunnel request then
-# takes the strip branch and the public cookie silently ships without Secure.
-# Override it only if the public hostname moves, and change appsettings.json with it.
+# the TLS-terminating tunnel. Never set it to an empty or whitespace value in
+# this shell — environment variables outrank appsettings.json, so a blank one
+# makes every tunnel request take the strip branch and the public cookie
+# silently ships without Secure. UNSETTING it is the safe action, not the
+# dangerous one: the shipped appsettings.json value applies again. Step 6
+# asserts the cookie really kept Secure. If the public hostname moves, change
+# appsettings.json — not this block.
 Start-Process -FilePath dotnet `
   -ArgumentList 'run --project Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --no-build' `
   -WindowStyle Hidden `
@@ -86,6 +90,25 @@ Invoke-RestMethod `
   Select-Object -ExpandProperty steps |
   Select-Object name, status, @{n='agentId';e={$_.attributes.'agent.id'}} |
   Format-Table -AutoSize
+
+#    Same surface, but assert the session cookie survived the tunnel WITH
+#    Secure. If Proxy:PublicHost is missing or blanked, the forwarded-header
+#    guard takes the strip branch, Request.IsHttps stays false, and the cookie
+#    ships without Secure — a silent failure neither the status check (step 5)
+#    nor the trace shape above can see.
+$cookieProbe = Invoke-WebRequest `
+  -Uri https://demos.guitaralchemist.com/api/chatbot/chat `
+  -Method POST `
+  -ContentType 'application/json' `
+  -Body (@{ Message = 'cookie probe' } | ConvertTo-Json) `
+  -UseBasicParsing
+$setCookie = @($cookieProbe.Headers['Set-Cookie']) -join '; '
+if ($setCookie -notmatch 'ga_chat_session=') {
+  throw "No ga_chat_session cookie issued. Got: $setCookie"
+}
+if ($setCookie -notmatch '(?i)secure') {
+  throw "Session cookie lacks Secure — check Proxy:PublicHost in Apps/GaChatbot.Api/appsettings.json. Got: $setCookie"
+}
 ```
 
 The probe should show the 6-step canonical shape:
@@ -122,6 +145,7 @@ Cloudflare ingress is unchanged by a rollback — only the local process binary 
 | Step 6 returns 400 `"Message cannot be empty."` | body field name is `Message`, not `prompt` (case-sensitive) | this runbook now sends `Message`; fork callers should mirror it |
 | Probe returns answer but `agentId = skill.modes` or fallback | new build not actually running (cached process) OR cascade not configured | check `gachatbot-api.log` head for "Now listening on: 5252" and verify env vars |
 | `/api/chatbot/chat` returns 404 | `Chatbot__PathBase` env var missing | step 4 — must be set BEFORE Start-Process |
+| Step 6 throws `Session cookie lacks Secure`, or public chat answers but the session resets every turn | `Proxy:PublicHost` missing/blank in `Apps/GaChatbot.Api/appsettings.json`, or a blank `Proxy__PublicHost` exported in the launch shell — the forwarded-header guard takes the strip branch | restore `Proxy.PublicHost` in `appsettings.json` (it ships as `demos.guitaralchemist.com`), `Remove-Item Env:\Proxy__PublicHost` if it is set, then repeat steps 3–4 and re-run the step 6 cookie assertion |
 | Rollback step says `$oldSha` is null or unset | step 2's `$oldSha = (git rev-parse HEAD).Trim()` was skipped | recover the prior sha from `git reflog show HEAD` or the deployment journal; this runbook captures it pre-pull |
 | Ollama timeout cascades produce `orchestration.fallback` step | Ollama is down OR no cascade configured | verify `ollama:11434` reachable AND `AI__CascadeProvider=mistral` set with valid `MISTRAL_API_KEY` |
 

--- a/docs/runbooks/chatbot-deploy.md
+++ b/docs/runbooks/chatbot-deploy.md
@@ -54,6 +54,12 @@ dotnet build Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --nologo
 $env:Chatbot__PathBase = '/chatbot'
 $env:AI__CascadeProvider = 'mistral'      # optional but recommended; needs MISTRAL_API_KEY
 $env:ASPNETCORE_URLS = 'http://localhost:5252'
+# Proxy__PublicHost is NOT set here: it ships as 'demos.guitaralchemist.com' in
+# Apps/GaChatbot.Api/appsettings.json. It is the host the forwarded-header guard
+# pins X-Forwarded-Host to, and it is what makes the session cookie Secure behind
+# the TLS-terminating tunnel. Do NOT blank or unset it — every tunnel request then
+# takes the strip branch and the public cookie silently ships without Secure.
+# Override it only if the public hostname moves, and change appsettings.json with it.
 Start-Process -FilePath dotnet `
   -ArgumentList 'run --project Apps/GaChatbot.Api/GaChatbot.Api.csproj -c Release --no-build' `
   -WindowStyle Hidden `


### PR DESCRIPTION
## What this is

Session-scoped chat memory for `GaChatbot.Api` — the host that serves the public demo at `demos.guitaralchemist.com/chatbot/` — plus the proxy-awareness and test hardening that make the fix hold behind the Cloudflare tunnel.

Five commits, `972c277c1..c97d1701f`, branched from `97cefe333` (an ancestor of current `main`).

## Why

`ProductionChatOrchestratorClient` passed `SessionId: null` to the orchestrator unconditionally, and `ChatExecutionRequest` had no session dimension. `ProductionOrchestrator` substitutes a fresh `Guid` for a null `SessionId`, so every turn — including consecutive turns from the same guitarist — landed in its own `MemoryStore` / `ChatTranscriptStore` partition. The failure is silent: nothing errors, the chatbot simply cannot recall the conversation it is already having, and `Memory:EnrichOnRetrieve` is a no-op on this host regardless of configuration.

The storage layer (session-scoped `MemoryStore`), the SignalR transport and the GaApi HTTP transport were already plumbed. This host never was.

## The five commits

1. **`972c277c1` feat — scope memory to a session on the canonical chatbot host.** Adds `HttpChatSessionCookie`: a server-issued, DataProtection-signed session cookie. Server-issued rather than client-supplied, so a caller cannot pin themselves onto a chosen session. Cookie `Path` honours `Request.PathBase` so the session survives the `/chatbot` path-base mount instead of rotating each turn. Registers Data Protection explicitly — unlike GaApi this host has no `AddAuthentication`, so nothing else pulled `IDataProtectionProvider` in and cookie issuance would have failed at request time. Threads `SessionId` through `ChatExecutionRequest`. 13 new tests.

2. **`8eeeffefd` fix — pin the adapter session hop; make the session cookie `Secure` behind the tunnel.** Two findings from independent review of `972c277c`:
   - The adapter hop was pinned on a helper nothing forced the production path to call — re-inlining the original defect inside `ProductionChatOrchestratorClient.AnswerAsync` restored the exact pre-fix bug with the whole suite green. `ProductionOrchestrator.AnswerAsync` is now `virtual` so a stub orchestrator can observe the `ChatRequest` the real adapter hands over.
   - `HttpChatSessionCookie` set `Secure = Request.IsHttps`, but the deployment terminates TLS at the `cloudflared` ga-demos tunnel and forwards to plain `http://localhost:5252`, so `IsHttps` was false on every production request and the public cookie shipped without `Secure`. Registers `UseForwardedHeaders` mirroring `Apps/ga-server/GaApi/Program.cs`, gated on `CF-Connecting-IP` plus a configured `Proxy:PublicHost` so a direct caller or a partial dev-proxy header set cannot talk the host into an https view of itself.
   
   5 new tests; red captured before the fix.

3. **`125c9fdcf` test — pin the shipped `Proxy:PublicHost` so deleting it fails the suite.** The fixture supplied its own `Proxy:PublicHost` via `UseSetting`, so it could only prove the middleware works when handed a public host — never that the deployment supplies one. Deleting the `Proxy` block from `appsettings.json` left the suite green while production silently lost `Secure` again.

4. **`44db34c79` test — read the shipped `Proxy:PublicHost` off disk so the guard cannot pass vacuously.** The mechanism claimed in (3) was false: `Program.cs` pins `ContentRootPath` to `AppContext.BaseDirectory`, which overrides `UseContentRoot`, so the host read the MSBuild copy in the test project's output — and an ambient `Proxy__PublicHost` outranked even that. Now reads the shipped file directly through the existing `TestPaths.RepositoryPath` seam and asserts production's own predicate (`IsNullOrWhiteSpace`, per `Program.cs`). Three mutants probed before and after; both false mechanism comments replaced.

5. **`c97d1701f` test — make runbook step 6 assert `Secure` on the session cookie, not on the header block.** Step 6 joined every `Set-Cookie` header into one string, so `/secure/` matched Cloudflare's `__cf_bm` cookie and the check never looked at `ga_chat_session` at all — a deploy that silently dropped `Secure` passed its own regression check. The C# fixture was measured *not* affected (`SessionSetCookie` has selected the session header by ordinal prefix since `8eeeffef`), so the fix went to the runbook only. The assertion now lives in a named function that a test lifts out of the markdown and executes under `pwsh`, so it has an oracle for the first time.

## Scope

The canonical REST/SSE chat surface only. `AgUiChatController` and `A2AController` still pass no session; they carry their own identity (`ThreadId` / `contextId`) and are a separate slice.

Full branch inventory vs `main` — 12 files, +1092/−10:

```
Apps/GaChatbot.Api/Controllers/ChatbotController.cs                             |  21 +-
Apps/GaChatbot.Api/Program.cs                                                   |  61 ++
Apps/GaChatbot.Api/Services/HttpChatSessionCookie.cs                            | 148 ++++
Apps/GaChatbot.Api/Services/IChatApplicationService.cs                          |  14 +-
Apps/GaChatbot.Api/Services/ProductionChatOrchestratorClient.cs                 |  26 +-
Apps/GaChatbot.Api/appsettings.json                                             |   3 +
Common/GA.Business.Core.Orchestration/Services/ProductionOrchestrator.cs        |  11 +-
Tests/Apps/GaChatbot.Api.Tests/Controllers/ChatbotControllerSessionScopeTests.cs| 200 +++++
Tests/Apps/GaChatbot.Api.Tests/Controllers/ForwardedHeadersSessionCookieTests.cs| 308 +++++++
Tests/Apps/GaChatbot.Api.Tests/Services/HttpChatSessionCookieTests.cs           | 164 ++++
Tests/Apps/GaChatbot.Api.Tests/Services/ProductionChatOrchestratorClientTests.cs|  95 +++
docs/runbooks/chatbot-deploy.md                                                 |  51 ++
```

Zero file overlap with `main`'s 25 changed files since the branch point, and zero file overlap with all 19 currently open PRs (checked file-by-file via the PR files API).

## Test evidence

Run at `c97d1701f` on a clean tree, immediately before publication:

```
dotnet build Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj -c Debug
  → Build succeeded. 18 Warning(s), 0 Error(s)   [exit 0]

dotnet test ... --no-build --filter "FullyQualifiedName~ForwardedHeadersSessionCookieTests"
  → Passed! Failed: 0, Passed: 5, Skipped: 0, Total: 5   [exit 0]

dotnet test Tests/Apps/GaChatbot.Api.Tests/GaChatbot.Api.Tests.csproj --no-build -c Debug
  → Passed! Failed: 0, Passed: 127, Skipped: 1, Total: 128, Duration: 1m 29s   [exit 0]
```

All 18 build warnings are pre-existing (`NU1608` FSharp.Core restore constraints, `IDE0301`/`IDE0305`, `CA2255`, `CS9113`); none names a file this branch changes.

## Review status

Fresh independent Standards and Spec/adversarial reviews both APPROVE this exact head (`c97d1701f`). Earlier rounds' findings are addressed in-branch: R2 Standards S-1 / Spec SPEC-1 by commit 3, and R4 Standards M-1/L-1/L-2/NIT and R4 Spec M-1/L-1/L-2/L-3/NIT by commit 4.

## Known residuals — disclosed, not resolved here

- **The live demo returns 502.** `https://demos.guitaralchemist.com/api/chatbot/status` returns 502 Bad Gateway; the Cloudflare edge itself is up. This is the runbook's own "GaChatbot.Api not running on :5252" condition — a **separately owned operational outage**, not a defect in this candidate. It is tracked by issue #647 (`[post-merge-smoke] Live demo regression on 980c715`) and draft PR #648. Consequence for this PR: the documented live-tunnel smoke steps 5–6 could **not** be exercised against the live deployment, so they remain unverified end-to-end. The Cloudflare cookie claim in commit 5's comments is therefore stated conditionally ("whenever the zone emits them") — no `__cf_bm` appeared on either probed response.
- **Historical residual:** commit `125c9fdcf`'s message repeats the content-root claim that `44db34c79` proved false. It is left unamended deliberately (no history rewrite) and corrected in the later commit message and in the code comments.
- `dotnet format --verify-no-changes` exits 0 on the changed file; project-wide it exits 2 on pre-existing `ENDOFLINE` findings in files this branch does not touch.

## Issue linkage

**No GitHub issue is claimed fixed or closed by this PR.** The driver was the P0 `memory-session-scope` item in `BACKLOG.md`; no GitHub issue matching that work was found, so no closing keyword is used. Issue #647 / PR #648 are referenced above only as the separately owned outage context, not as work this PR resolves.

## Merge expectation

This PR is opened **ready for review and deliberately not merged**. It requires one independent approving review from someone other than the author.
